### PR TITLE
feat(quiz): restore arsnova.click import support

### DIFF
--- a/apps/frontend/src/app/features/quiz/data/quiz-import-examples.spec.ts
+++ b/apps/frontend/src/app/features/quiz/data/quiz-import-examples.spec.ts
@@ -77,7 +77,7 @@ describe('Quiz example imports (all formats)', () => {
     const service = TestBed.inject(QuizStoreService);
 
     for (const fixture of fixtures) {
-      const imported = service.importQuiz(fixture.payload);
+      const imported = service.importQuiz(fixture.payload).quiz;
       const expectedQuestionCount = fixture.payload.quiz.questions.length;
 
       expect(imported.id).toBeTruthy();
@@ -126,7 +126,7 @@ describe('Quiz example imports (all formats)', () => {
     const service = TestBed.inject(QuizStoreService);
 
     for (const fixture of fixtures) {
-      const imported = service.importQuiz(fixture.payload);
+      const imported = service.importQuiz(fixture.payload).quiz;
       const firstQuestion = imported.questions[0];
       expect(firstQuestion).toBeTruthy();
 
@@ -149,9 +149,9 @@ describe('Quiz example imports (all formats)', () => {
     const service = TestBed.inject(QuizStoreService);
 
     for (const fixture of fixtures) {
-      const imported = service.importQuiz(fixture.payload);
+      const imported = service.importQuiz(fixture.payload).quiz;
       const exported = service.exportQuiz(imported.id);
-      const roundtrip = service.importQuiz(exported);
+      const roundtrip = service.importQuiz(exported).quiz;
 
       expect(roundtrip.id).not.toBe(imported.id);
       expect(roundtrip.name).toBe(imported.name);

--- a/apps/frontend/src/app/features/quiz/data/quiz-import-normalizer.ts
+++ b/apps/frontend/src/app/features/quiz/data/quiz-import-normalizer.ts
@@ -1,0 +1,450 @@
+import { QUIZ_EXPORT_VERSION, type Difficulty, type QuizExport } from '@arsnova/shared-types';
+
+type JsonRecord = Record<string, unknown>;
+type ImportedQuiz = QuizExport['quiz'];
+type ImportedQuestion = ImportedQuiz['questions'][number];
+type ImportedAnswer = ImportedQuestion['answers'][number];
+
+const CLICK_TEAM_NAME_LIMIT = 8;
+
+export type QuizImportWarningKind =
+  | 'skipped_question'
+  | 'mapped_question'
+  | 'simplified_question'
+  | 'ignored_quiz_options';
+
+export interface QuizImportWarning {
+  kind: QuizImportWarningKind;
+  message: string;
+  detail?: string;
+  questionNumber?: number;
+  questionText?: string;
+}
+
+interface MappedQuestionResult {
+  question: ImportedQuestion;
+  warnings: QuizImportWarning[];
+}
+
+export interface NormalizedQuizImportPayload {
+  payload: unknown;
+  sourceQuiz?: ImportedQuiz;
+  warnings: QuizImportWarning[];
+}
+
+export function normalizeQuizImportPayload(payload: unknown): NormalizedQuizImportPayload {
+  if (!isRecord(payload) || !looksLikeArsnovaClickExport(payload)) {
+    return { payload, warnings: [] };
+  }
+
+  return convertArsnovaClickExport(payload);
+}
+
+function looksLikeArsnovaClickExport(value: JsonRecord): boolean {
+  return typeof value['name'] === 'string' && Array.isArray(value['questionList']);
+}
+
+function convertArsnovaClickExport(source: JsonRecord): NormalizedQuizImportPayload {
+  const name = readRequiredString(source['name'], 'Quiz-Name');
+  const description = readOptionalString(source['description']);
+  const sessionConfig = isRecord(source['sessionConfig']) ? source['sessionConfig'] : null;
+  const teamSettings = mapTeamSettings(sessionConfig);
+  const allowCustomNicknames = mapAllowCustomNicknames(sessionConfig);
+  const readingPhaseEnabled = readBoolean(sessionConfig?.['readingConfirmationEnabled']) ?? true;
+  const questionsRaw = source['questionList'];
+
+  if (!Array.isArray(questionsRaw)) {
+    throw new Error('arsnova.click-Export ohne gueltige questionList.');
+  }
+
+  const warnings: QuizImportWarning[] = [];
+  const ignoredQuizOptionLabels = collectIgnoredQuizOptionLabels(source);
+  if (ignoredQuizOptionLabels.length > 0) {
+    warnings.push({
+      kind: 'ignored_quiz_options',
+      message:
+        'Einige Quiz-Einstellungen wie Musik, Anzeige oder Namensvorgaben wurden nicht übernommen.',
+      detail: `Nicht uebernommene Felder: ${ignoredQuizOptionLabels.join(', ')}`,
+    });
+  }
+
+  const questions: ImportedQuestion[] = [];
+  for (const [index, question] of questionsRaw.entries()) {
+    const questionText =
+      isRecord(question) && typeof question['questionText'] === 'string'
+        ? readOptionalString(question['questionText'])
+        : undefined;
+
+    try {
+      const mapped = mapQuestion(question, index);
+      questions.push(mapped.question);
+      warnings.push(...mapped.warnings);
+    } catch (error) {
+      warnings.push({
+        kind: 'skipped_question',
+        questionNumber: index + 1,
+        questionText,
+        message:
+          error instanceof Error ? error.message : 'Diese Frage konnte nicht übernommen werden.',
+      });
+    }
+  }
+
+  const sourceQuiz: ImportedQuiz = {
+    name,
+    ...(description ? { description } : {}),
+    motifImageUrl: null,
+    showLeaderboard: true,
+    allowCustomNicknames,
+    defaultTimer: null,
+    timerScaleByDifficulty: true,
+    enableSoundEffects: true,
+    enableRewardEffects: true,
+    enableMotivationMessages: true,
+    enableEmojiReactions: true,
+    anonymousMode: false,
+    teamMode: teamSettings.teamMode,
+    teamCount: teamSettings.teamCount,
+    teamAssignment: teamSettings.teamAssignment,
+    teamNames: teamSettings.teamNames,
+    backgroundMusic: null,
+    nicknameTheme: 'HIGH_SCHOOL',
+    bonusTokenCount: null,
+    readingPhaseEnabled,
+    questions,
+  };
+
+  return {
+    payload: {
+      exportVersion: QUIZ_EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      quiz: sourceQuiz,
+    } satisfies QuizExport,
+    sourceQuiz,
+    warnings,
+  };
+}
+
+function collectIgnoredQuizOptionLabels(source: JsonRecord): string[] {
+  const ignored = new Set<string>();
+  const sessionConfig = isRecord(source['sessionConfig']) ? source['sessionConfig'] : null;
+  const nicks = isRecord(sessionConfig?.['nicks']) ? sessionConfig['nicks'] : null;
+
+  addIfPresent(source, ignored, 'origin');
+  addIfPresent(source, ignored, 'state');
+  addIfPresent(source, ignored, 'currentQuestionIndex');
+  addIfPresent(source, ignored, 'currentStartTimestamp');
+  addIfPresent(source, ignored, 'sentQuestionIndex');
+  addIfPresent(source, ignored, 'readingConfirmationRequested');
+  addIfPresent(source, ignored, 'questionCount');
+  addIfPresent(sessionConfig, ignored, 'sessionConfig.confidenceSliderEnabled');
+  addIfPresent(sessionConfig, ignored, 'sessionConfig.showResponseProgress');
+  addIfPresent(sessionConfig, ignored, 'sessionConfig.theme');
+  addIfPresent(sessionConfig, ignored, 'sessionConfig.leaderboardAlgorithm');
+  addIfPresent(sessionConfig, ignored, 'sessionConfig.music');
+  addIfPresent(nicks, ignored, 'sessionConfig.nicks.maxMembersPerGroup');
+  addIfPresent(nicks, ignored, 'sessionConfig.nicks.selectedNicks');
+
+  return [...ignored];
+}
+
+function mapTeamSettings(
+  sessionConfig: JsonRecord | null,
+): Pick<ImportedQuiz, 'teamMode' | 'teamCount' | 'teamAssignment' | 'teamNames'> {
+  const nicks = isRecord(sessionConfig?.['nicks']) ? sessionConfig['nicks'] : null;
+  const groupsRaw = Array.isArray(nicks?.['memberGroups']) ? nicks['memberGroups'] : [];
+  const teamNames = groupsRaw
+    .map((group) => (isRecord(group) ? readOptionalString(group['name']) : undefined))
+    .filter((name): name is string => typeof name === 'string' && name.length > 0)
+    .slice(0, CLICK_TEAM_NAME_LIMIT);
+
+  const teamMode = teamNames.length >= 2;
+  return {
+    teamMode,
+    teamCount: teamMode ? teamNames.length : null,
+    teamAssignment: readBoolean(nicks?.['autoJoinToGroup']) === true ? 'AUTO' : 'MANUAL',
+    teamNames: teamMode ? teamNames : [],
+  };
+}
+
+function mapAllowCustomNicknames(sessionConfig: JsonRecord | null): boolean {
+  const nicks = isRecord(sessionConfig?.['nicks']) ? sessionConfig['nicks'] : null;
+  const blockIllegalNicks = readBoolean(nicks?.['blockIllegalNicks']);
+  return blockIllegalNicks === undefined ? false : !blockIllegalNicks;
+}
+
+function mapQuestion(value: unknown, index: number): MappedQuestionResult {
+  if (!isRecord(value)) {
+    throw new Error('Diese Frage ist unvollständig.');
+  }
+
+  const questionNumber = index + 1;
+  const questionText = readOptionalString(value['questionText']);
+  const sourceType = readOptionalString(value['TYPE']) ?? readOptionalString(value['type']);
+  const text = readRequiredString(value['questionText'], `Frage ${questionNumber}`);
+  const timer = normalizeTimer(value['timer']);
+  const difficulty = mapDifficulty(value['difficulty']);
+  const warnings = collectQuestionWarnings(value, questionNumber, questionText);
+
+  switch (sourceType) {
+    case 'SingleChoiceQuestion':
+      return {
+        question: {
+          text,
+          type: 'SINGLE_CHOICE',
+          difficulty,
+          order: index,
+          ...(timer === undefined ? {} : { timer }),
+          answers: mapChoiceAnswers(value, 'SINGLE_CHOICE'),
+          enabled: true,
+        },
+        warnings,
+      };
+    case 'YesNoSingleChoiceQuestion':
+    case 'TrueFalseSingleChoiceQuestion':
+      warnings.push({
+        kind: 'mapped_question',
+        questionNumber,
+        questionText,
+        message: 'Wurde als normale Single-Choice-Frage importiert.',
+        detail: sourceType,
+      });
+      return {
+        question: {
+          text,
+          type: 'SINGLE_CHOICE',
+          difficulty,
+          order: index,
+          ...(timer === undefined ? {} : { timer }),
+          answers: mapChoiceAnswers(value, 'SINGLE_CHOICE'),
+          enabled: true,
+        },
+        warnings,
+      };
+    case 'MultipleChoiceQuestion':
+      return {
+        question: {
+          text,
+          type: 'MULTIPLE_CHOICE',
+          difficulty,
+          order: index,
+          ...(timer === undefined ? {} : { timer }),
+          answers: mapChoiceAnswers(value, 'MULTIPLE_CHOICE'),
+          enabled: true,
+        },
+        warnings,
+      };
+    case 'SurveyQuestion':
+      return {
+        question: {
+          text,
+          type: 'SURVEY',
+          difficulty,
+          order: index,
+          ...(timer === undefined ? {} : { timer }),
+          answers: mapSurveyAnswers(value, false),
+          enabled: true,
+        },
+        warnings,
+      };
+    case 'ABCDSurveyQuestion':
+      warnings.push({
+        kind: 'mapped_question',
+        questionNumber,
+        questionText,
+        message: 'Wurde als normale Umfrage importiert.',
+        detail: sourceType,
+      });
+      return {
+        question: {
+          text,
+          type: 'SURVEY',
+          difficulty,
+          order: index,
+          ...(timer === undefined ? {} : { timer }),
+          answers: mapSurveyAnswers(value, true),
+          enabled: true,
+        },
+        warnings,
+      };
+    case 'FreeTextQuestion':
+      return {
+        question: {
+          text,
+          type: 'FREETEXT',
+          difficulty,
+          order: index,
+          ...(timer === undefined ? {} : { timer }),
+          answers: [],
+          enabled: true,
+        },
+        warnings,
+      };
+    case 'RangedQuestion':
+      throw new Error('Dieser Fragetyp wird in arsnova.eu noch nicht unterstützt.');
+    default:
+      throw new Error('Dieser Fragetyp wird in arsnova.eu noch nicht unterstützt.');
+  }
+}
+
+function collectQuestionWarnings(
+  question: JsonRecord,
+  questionNumber: number,
+  questionText?: string,
+): QuizImportWarning[] {
+  const ignored = new Set<string>();
+
+  addIfPresent(question, ignored, 'displayAnswerText');
+  addIfPresent(question, ignored, 'showOneAnswerPerRow');
+  addIfPresent(question, ignored, 'multipleSelectionEnabled');
+  addIfPresent(question, ignored, 'tags');
+  addIfPresent(question, ignored, 'requiredForToken');
+
+  const answers = Array.isArray(question['answerOptionList']) ? question['answerOptionList'] : [];
+  let hasFreeTextAnswerConfig = false;
+  for (const answer of answers) {
+    if (!isRecord(answer)) continue;
+    if (
+      Object.hasOwn(answer, 'configCaseSensitive') ||
+      Object.hasOwn(answer, 'configTrimWhitespaces') ||
+      Object.hasOwn(answer, 'configUseKeywords') ||
+      Object.hasOwn(answer, 'configUsePunctuation')
+    ) {
+      hasFreeTextAnswerConfig = true;
+    }
+  }
+
+  const warnings: QuizImportWarning[] = [];
+  if (ignored.size > 0) {
+    warnings.push({
+      kind: 'simplified_question',
+      questionNumber,
+      questionText,
+      message: 'Zusatzoptionen dieser Frage wurden nicht übernommen.',
+      detail: [...ignored].join(', '),
+    });
+  }
+
+  if (hasFreeTextAnswerConfig) {
+    warnings.push({
+      kind: 'simplified_question',
+      questionNumber,
+      questionText,
+      message: 'Sonderregeln für Freitext-Antworten wurden nicht übernommen.',
+      detail: 'configCaseSensitive, configTrimWhitespaces, configUseKeywords, configUsePunctuation',
+    });
+  }
+
+  return warnings;
+}
+
+function mapChoiceAnswers(
+  question: JsonRecord,
+  targetType: 'SINGLE_CHOICE' | 'MULTIPLE_CHOICE',
+): ImportedAnswer[] {
+  const answers = readAnswerList(question['answerOptionList']);
+  const correctCount = answers.filter((answer) => answer.isCorrect).length;
+
+  if (answers.length < 2) {
+    throw new Error('Es werden mindestens zwei Antwortoptionen benötigt.');
+  }
+
+  if (targetType === 'SINGLE_CHOICE' && correctCount !== 1) {
+    throw new Error('Es muss genau eine richtige Antwort geben.');
+  }
+
+  if (targetType === 'MULTIPLE_CHOICE' && correctCount < 1) {
+    throw new Error('Es muss mindestens eine richtige Antwort geben.');
+  }
+
+  return answers;
+}
+
+function mapSurveyAnswers(question: JsonRecord, useAbcdFallback: boolean): ImportedAnswer[] {
+  const answers = useAbcdFallback
+    ? readAnswerList(question['answerOptionList'], ['A', 'B', 'C', 'D'])
+    : readAnswerList(question['answerOptionList']);
+
+  if (answers.length < 2) {
+    throw new Error('Es werden mindestens zwei Antwortoptionen benötigt.');
+  }
+
+  return answers.map((answer) => ({ ...answer, isCorrect: false }));
+}
+
+function readAnswerList(value: unknown, fallbackTexts: string[] = []): ImportedAnswer[] {
+  if (!Array.isArray(value)) {
+    if (fallbackTexts.length > 0) {
+      return fallbackTexts.map((text) => ({ text, isCorrect: false }));
+    }
+    throw new Error('Die Antwortoptionen sind unvollständig.');
+  }
+
+  const answers = value.map((answer, answerIndex) => mapAnswer(answer, answerIndex));
+  return answers.length > 0 || fallbackTexts.length === 0
+    ? answers
+    : fallbackTexts.map((text) => ({ text, isCorrect: false }));
+}
+
+function mapAnswer(value: unknown, answerIndex: number): ImportedAnswer {
+  if (!isRecord(value)) {
+    throw new Error(`Antwort ${answerIndex + 1} ist unvollständig.`);
+  }
+
+  const text = readOptionalString(value['answerText']);
+  if (!text) {
+    throw new Error(`Antwort ${answerIndex + 1} hat keinen gültigen Text.`);
+  }
+
+  return {
+    text,
+    isCorrect: readBoolean(value['isCorrect']) ?? false,
+  };
+}
+
+function mapDifficulty(value: unknown): Difficulty {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'MEDIUM';
+  }
+  if (value <= 3) return 'EASY';
+  if (value <= 7) return 'MEDIUM';
+  return 'HARD';
+}
+
+function normalizeTimer(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const rounded = Math.round(value);
+  return rounded >= 5 && rounded <= 300 ? rounded : undefined;
+}
+
+function readRequiredString(value: unknown, label: string): string {
+  const normalized = readOptionalString(value);
+  if (!normalized) {
+    throw new Error(`${label} ist unvollständig.`);
+  }
+  return normalized;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function addIfPresent(value: JsonRecord | null, target: Set<string>, key: string): void {
+  if (value && Object.hasOwn(value, key)) {
+    target.add(key);
+  }
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/frontend/src/app/features/quiz/data/quiz-store.service.spec.ts
+++ b/apps/frontend/src/app/features/quiz/data/quiz-store.service.spec.ts
@@ -428,10 +428,10 @@ describe('QuizStoreService', () => {
     const imported = service.importQuiz(exported);
 
     expect(exported.exportVersion).toBeGreaterThanOrEqual(1);
-    expect(imported.id).not.toBe(created.id);
-    expect(imported.name).toBe('Export Quiz');
-    expect(imported.questions[0]?.type).toBe('RATING');
-    expect(imported.questions[0]?.ratingMax).toBe(10);
+    expect(imported.quiz.id).not.toBe(created.id);
+    expect(imported.quiz.name).toBe('Export Quiz');
+    expect(imported.quiz.questions[0]?.type).toBe('RATING');
+    expect(imported.quiz.questions[0]?.ratingMax).toBe(10);
   });
 
   it('exportiert enabled:false und stellt den Zustand nach Import wieder her', () => {
@@ -458,10 +458,137 @@ describe('QuizStoreService', () => {
     expect((ausExport as { enabled?: boolean }).enabled).toBe(false);
 
     const imported = service.importQuiz(exported);
-    const aus = imported.questions.find((q) => q.text === 'Aus');
+    const aus = imported.quiz.questions.find((q) => q.text === 'Aus');
     expect(aus?.enabled).toBe(false);
-    const an = imported.questions.find((q) => q.text === 'An');
+    const an = imported.quiz.questions.find((q) => q.text === 'An');
     expect(an?.enabled).toBe(true);
+  });
+
+  it('importiert arsnova.click-Exporte ueber einen Kompatibilitaetsfilter', () => {
+    const service = TestBed.inject(QuizStoreService);
+
+    const imported = service.importQuiz({
+      name: 'Click Import',
+      description: 'Aus arsnova.click',
+      sessionConfig: {
+        readingConfirmationEnabled: false,
+        nicks: {
+          memberGroups: [{ name: 'Team Rot' }, { name: 'Team Blau' }],
+          autoJoinToGroup: true,
+          blockIllegalNicks: true,
+        },
+      },
+      questionList: [
+        {
+          TYPE: 'SingleChoiceQuestion',
+          timer: 30,
+          questionText: 'Eine richtige Antwort',
+          answerOptionList: [
+            { answerText: 'A', isCorrect: false },
+            { answerText: 'B', isCorrect: true },
+          ],
+          difficulty: 2,
+        },
+        {
+          TYPE: 'ABCDSurveyQuestion',
+          timer: 15,
+          questionText: 'Feedback',
+          answerOptionList: [
+            { answerText: 'A' },
+            { answerText: 'B' },
+            { answerText: 'C' },
+            { answerText: 'D' },
+          ],
+          difficulty: 5,
+        },
+        {
+          TYPE: 'FreeTextQuestion',
+          timer: 45,
+          questionText: 'Offene Rueckmeldung',
+          answerOptionList: [
+            {
+              answerText: 'Paris',
+              configCaseSensitive: false,
+            },
+          ],
+          difficulty: 8,
+        },
+      ],
+    });
+
+    expect(imported.quiz.name).toBe('Click Import');
+    expect(imported.quiz.description).toBe('Aus arsnova.click');
+    expect(imported.quiz.settings.readingPhaseEnabled).toBe(false);
+    expect(imported.quiz.settings.allowCustomNicknames).toBe(false);
+    expect(imported.quiz.settings.teamMode).toBe(true);
+    expect(imported.quiz.settings.teamCount).toBe(2);
+    expect(imported.quiz.settings.teamAssignment).toBe('AUTO');
+    expect(imported.quiz.settings.teamNames).toEqual(['Team Rot', 'Team Blau']);
+    expect(imported.quiz.questions.map((question) => question.type)).toEqual([
+      'SINGLE_CHOICE',
+      'SURVEY',
+      'FREETEXT',
+    ]);
+    expect(imported.quiz.questions[0]?.difficulty).toBe('EASY');
+    expect(imported.quiz.questions[1]?.difficulty).toBe('MEDIUM');
+    expect(imported.quiz.questions[2]?.difficulty).toBe('HARD');
+    expect(imported.quiz.questions[0]?.timer).toBe(30);
+    expect(imported.quiz.questions[1]?.answers.every((answer) => !answer.isCorrect)).toBe(true);
+    expect(imported.quiz.questions[2]?.answers).toEqual([]);
+    expect(imported.warnings.some((warning) => warning.kind === 'mapped_question')).toBe(true);
+    expect(
+      imported.warnings.some(
+        (warning) =>
+          warning.questionNumber === 2 &&
+          warning.message === 'Wurde als normale Umfrage importiert.',
+      ),
+    ).toBe(true);
+    expect(
+      imported.warnings.some(
+        (warning) =>
+          warning.questionNumber === 3 &&
+          warning.message === 'Sonderregeln für Freitext-Antworten wurden nicht übernommen.',
+      ),
+    ).toBe(true);
+  });
+
+  it('importiert arsnova.click trotz nicht unterstuetzter Typen mit Warnhinweis', () => {
+    const service = TestBed.inject(QuizStoreService);
+
+    const imported = service.importQuiz({
+      name: 'Teilweise kompatibel',
+      questionList: [
+        {
+          TYPE: 'RangedQuestion',
+          questionText: 'Schaetzfrage',
+          rangeMin: 0,
+          rangeMax: 1000,
+          correctValue: 420,
+        },
+        {
+          TYPE: 'SingleChoiceQuestion',
+          questionText: 'Bleibt erhalten',
+          answerOptionList: [
+            { answerText: 'A', isCorrect: true },
+            { answerText: 'B', isCorrect: false },
+          ],
+        },
+      ],
+    });
+
+    expect(imported.quiz.name).toBe('Teilweise kompatibel');
+    expect(imported.quiz.questions).toHaveLength(1);
+    expect(imported.quiz.questions[0]?.text).toBe('Bleibt erhalten');
+    expect(imported.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'skipped_question',
+          questionNumber: 1,
+          questionText: 'Schaetzfrage',
+          message: 'Dieser Fragetyp wird in arsnova.eu noch nicht unterstützt.',
+        }),
+      ]),
+    );
   });
 
   it('getUploadPayload: deaktivierte Fragen fehlen, Reihenfolge wird neu nummeriert', () => {

--- a/apps/frontend/src/app/features/quiz/data/quiz-store.service.ts
+++ b/apps/frontend/src/app/features/quiz/data/quiz-store.service.ts
@@ -43,6 +43,8 @@ import {
   getDemoQuizSeedFingerprint,
   normalizeDemoQuizLocale,
 } from './demo-quiz-payload';
+import { normalizeQuizImportPayload, type QuizImportWarning } from './quiz-import-normalizer';
+export type { QuizImportWarning } from './quiz-import-normalizer';
 
 export type SupportedQuestionType =
   | 'MULTIPLE_CHOICE'
@@ -128,6 +130,11 @@ export interface QuizSummary {
   /** Server-Quiz-ID nach letztem quiz.upload (Bonus-Codes in der Sammlung). */
   lastServerQuizId: string | null;
   lastServerQuizAccessProof: string | null;
+}
+
+export interface QuizImportResult {
+  quiz: QuizDocument;
+  warnings: QuizImportWarning[];
 }
 
 /**
@@ -910,47 +917,76 @@ export class QuizStoreService implements OnDestroy {
     return parsed.data;
   }
 
-  importQuiz(payload: unknown, overrideId?: string): QuizDocument {
-    const parsed = QuizImportSchema.safeParse(payload);
-    if (!parsed.success) {
-      const issue = parsed.error.issues[0];
-      const message = issue
-        ? `${formatQuizImportIssuePath(issue.path)}: ${issue.message}`
-        : $localize`Ungültige Import-Datei.`;
+  importQuiz(payload: unknown, overrideId?: string): QuizImportResult {
+    let normalizedPayload: unknown;
+    let normalizedSourceQuiz: QuizExport['quiz'] | undefined;
+    let warnings: QuizImportWarning[];
+    try {
+      ({
+        payload: normalizedPayload,
+        sourceQuiz: normalizedSourceQuiz,
+        warnings,
+      } = normalizeQuizImportPayload(payload));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : $localize`Ungültige Import-Datei.`;
+      throw new Error(`Import fehlgeschlagen: ${message}`, { cause: error });
+    }
+
+    let quizData: QuizExport['quiz'];
+    if (normalizedSourceQuiz) {
+      quizData = normalizedSourceQuiz;
+    } else {
+      const parsed = QuizImportSchema.safeParse(normalizedPayload);
+      if (!parsed.success) {
+        const issue = parsed.error.issues[0];
+        const message = issue
+          ? `${formatQuizImportIssuePath(issue.path)}: ${issue.message}`
+          : $localize`Ungültige Import-Datei.`;
+        throw new Error(`Import fehlgeschlagen: ${message}`);
+      }
+      quizData = parsed.data.quiz;
+    }
+
+    const metadata = QuizMetadataSchema.safeParse({
+      name: quizData.name.trim(),
+      description: normalizeDescription(quizData.description),
+      motifImageUrl: normalizeMotifImageUrlInput(quizData.motifImageUrl),
+    });
+    if (!metadata.success) {
+      const message = metadata.error.issues[0]?.message ?? $localize`Ungültige Import-Datei.`;
       throw new Error(`Import fehlgeschlagen: ${message}`);
     }
 
     const now = new Date().toISOString();
     const imported: QuizDocument = {
       id: overrideId ?? generateUuid(),
-      name: parsed.data.quiz.name,
-      description: normalizeDescription(parsed.data.quiz.description) ?? null,
-      motifImageUrl: parsed.data.quiz.motifImageUrl ?? null,
+      name: metadata.data.name,
+      description: metadata.data.description ?? null,
+      motifImageUrl: metadata.data.motifImageUrl ?? null,
       createdAt: now,
       updatedAt: now,
       ...this.currentQuizUpdateSource(),
       settings: parseQuizSettings({
-        showLeaderboard: parsed.data.quiz.showLeaderboard,
-        allowCustomNicknames: parsed.data.quiz.allowCustomNicknames,
-        defaultTimer: parsed.data.quiz.defaultTimer ?? null,
-        timerScaleByDifficulty: parsed.data.quiz.timerScaleByDifficulty ?? true,
-        enableSoundEffects: parsed.data.quiz.enableSoundEffects,
-        enableRewardEffects: parsed.data.quiz.enableRewardEffects,
-        enableMotivationMessages: parsed.data.quiz.enableMotivationMessages,
-        enableEmojiReactions: parsed.data.quiz.enableEmojiReactions,
-        anonymousMode: parsed.data.quiz.anonymousMode,
-        teamMode: parsed.data.quiz.teamMode,
-        teamCount: parsed.data.quiz.teamCount ?? null,
-        teamAssignment: parsed.data.quiz.teamAssignment,
-        teamNames: parsed.data.quiz.teamNames ?? [],
-        backgroundMusic: parsed.data.quiz.backgroundMusic ?? null,
-        nicknameTheme: parsed.data.quiz.nicknameTheme,
-        bonusTokenCount: parsed.data.quiz.bonusTokenCount ?? null,
-        readingPhaseEnabled: parsed.data.quiz.readingPhaseEnabled ?? true,
-        preset:
-          ((parsed.data.quiz as Record<string, unknown>)['preset'] as QuizPreset) ?? 'PLAYFUL',
+        showLeaderboard: quizData.showLeaderboard,
+        allowCustomNicknames: quizData.allowCustomNicknames,
+        defaultTimer: quizData.defaultTimer ?? null,
+        timerScaleByDifficulty: quizData.timerScaleByDifficulty ?? true,
+        enableSoundEffects: quizData.enableSoundEffects,
+        enableRewardEffects: quizData.enableRewardEffects,
+        enableMotivationMessages: quizData.enableMotivationMessages,
+        enableEmojiReactions: quizData.enableEmojiReactions,
+        anonymousMode: quizData.anonymousMode,
+        teamMode: quizData.teamMode,
+        teamCount: quizData.teamCount ?? null,
+        teamAssignment: quizData.teamAssignment,
+        teamNames: quizData.teamNames ?? [],
+        backgroundMusic: quizData.backgroundMusic ?? null,
+        nicknameTheme: quizData.nicknameTheme,
+        bonusTokenCount: quizData.bonusTokenCount ?? null,
+        readingPhaseEnabled: quizData.readingPhaseEnabled ?? true,
+        preset: ((quizData as Record<string, unknown>)['preset'] as QuizPreset) ?? 'PLAYFUL',
       }),
-      questions: parsed.data.quiz.questions
+      questions: quizData.questions
         .sort((a, b) => a.order - b.order)
         .map((question, index) => ({
           id: generateUuid(),
@@ -980,7 +1016,10 @@ export class QuizStoreService implements OnDestroy {
 
     this.quizDocuments.update((current) => [imported, ...current]);
     this.persistToStorage();
-    return imported;
+    return {
+      quiz: imported,
+      warnings,
+    };
   }
 
   addQuestion(quizId: string, input: AddQuizQuestionInput): QuizQuestion {

--- a/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.html
+++ b/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.html
@@ -45,7 +45,25 @@
   </div>
 
   @if (actionInfo()) {
-    <p class="quiz-list__info" role="status">{{ actionInfo() }}</p>
+    <div class="quiz-list__info" role="status">
+      <p class="quiz-list__info-text">{{ actionInfo() }}</p>
+      @if (actionInfoWarnings().length > 0) {
+        <p class="quiz-list__info-list-title">Nicht übernommen:</p>
+        <ul class="quiz-list__info-list">
+          @for (warning of actionInfoWarnings(); track $index) {
+            <li class="quiz-list__info-item">
+              <p class="quiz-list__info-item-title">{{ formatImportWarning(warning) }}</p>
+              @if (warning.questionText) {
+                <div
+                  class="quiz-list__info-question"
+                  [innerHTML]="renderImportWarningQuestion(warning.questionText)"
+                ></div>
+              }
+            </li>
+          }
+        </ul>
+      }
+    </div>
   }
   @if (actionError()) {
     <p class="quiz-list__error" role="alert">

--- a/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.scss
+++ b/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.scss
@@ -332,6 +332,43 @@
   color: var(--mat-sys-tertiary);
 }
 
+.quiz-list__info-text {
+  margin: 0;
+  white-space: pre-line;
+}
+
+.quiz-list__info-list-title {
+  margin: 0.5rem 0 0;
+  font-weight: 600;
+}
+
+.quiz-list__info-list {
+  margin: 0.35rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.quiz-list__info-item + .quiz-list__info-item {
+  margin-top: 0.75rem;
+}
+
+.quiz-list__info-item-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.quiz-list__info-question {
+  margin-top: 0.35rem;
+}
+
+.quiz-list__info-question :is(p, ul, ol, blockquote, pre) {
+  margin-top: 0.35rem;
+  margin-bottom: 0.35rem;
+}
+
+.quiz-list__info-question :is(h1, h2, h3, h4, h5, h6) {
+  margin: 0.45rem 0 0.25rem;
+}
+
 .quiz-list__error {
   display: flex;
   align-items: flex-start;

--- a/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.spec.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.spec.ts
@@ -414,8 +414,11 @@ describe('QuizListComponent', () => {
     const fixture = TestBed.createComponent(QuizListComponent);
     const component = fixture.componentInstance;
     mockStore.importQuiz.mockReturnValue({
-      id: 'caece014-f7cd-4d26-a101-bd494379f95f',
-      name: 'KI Import',
+      quiz: {
+        id: 'caece014-f7cd-4d26-a101-bd494379f95f',
+        name: 'KI Import',
+      },
+      warnings: [],
     });
 
     component.updateAiJsonInput(`Hier ist dein Quiz:
@@ -429,6 +432,82 @@ Viel Erfolg beim Import.`);
     component.importAiJson();
 
     expect(mockStore.importQuiz).toHaveBeenCalledWith({ quiz: { name: 'KI Import' } });
+    expect(component.actionError()).toBeNull();
+    expect(component.actionInfo()).toContain('KI Import');
+  });
+
+  it('importiert ueber den Datei-Import der Quiz-Sammlung und zeigt nur nicht uebernommene Fragen', async () => {
+    const fixture = TestBed.createComponent(QuizListComponent);
+    const component = fixture.componentInstance;
+    mockStore.importQuiz.mockReturnValue({
+      quiz: {
+        id: 'caece014-f7cd-4d26-a101-bd494379f95f',
+        name: 'Datei Import',
+      },
+      warnings: [
+        {
+          kind: 'skipped_question',
+          questionNumber: 1,
+          questionText: 'Schätzfrage',
+          message: 'Dieser Fragetyp wird in arsnova.eu noch nicht unterstützt.',
+        },
+        {
+          kind: 'simplified_question',
+          questionNumber: 2,
+          questionText: 'Freitext',
+          message: 'Sonderregeln für Freitext-Antworten wurden nicht übernommen.',
+        },
+      ],
+    });
+
+    const file = {
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          name: 'Click Import',
+          questionList: [
+            {
+              TYPE: 'SingleChoiceQuestion',
+              questionText: 'Eine Frage',
+              answerOptionList: [
+                { answerText: 'A', isCorrect: false },
+                { answerText: 'B', isCorrect: true },
+              ],
+            },
+          ],
+        }),
+      ),
+    } as unknown as File;
+    const input = document.createElement('input');
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: [file],
+    });
+
+    await component.onImportFileSelected({ target: input } as Event);
+    fixture.detectChanges();
+
+    expect(mockStore.importQuiz).toHaveBeenCalledWith({
+      name: 'Click Import',
+      questionList: [
+        {
+          TYPE: 'SingleChoiceQuestion',
+          questionText: 'Eine Frage',
+          answerOptionList: [
+            { answerText: 'A', isCorrect: false },
+            { answerText: 'B', isCorrect: true },
+          ],
+        },
+      ],
+    });
+    expect(component.actionInfo()).toContain('Datei Import');
+    expect(component.actionInfoWarnings()).toHaveLength(1);
+    const infoText = fixture.nativeElement.querySelector('.quiz-list__info')?.textContent as string;
+    expect(infoText).toContain('Nicht übernommen:');
+    expect(infoText).toContain(
+      'Frage 1: Dieser Fragetyp wird in arsnova.eu noch nicht unterstützt.',
+    );
+    expect(infoText).toContain('Schätzfrage');
+    expect(infoText).not.toContain('Freitext');
     expect(component.actionError()).toBeNull();
   });
 

--- a/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.ts
@@ -28,6 +28,8 @@ import { ThemePresetService } from '../../../core/theme-preset.service';
 import {
   DEMO_QUIZ_ID,
   QuizStoreService,
+  type QuizImportResult,
+  type QuizImportWarning,
   type QuizSettings,
   type QuizSummary,
 } from '../data/quiz-store.service';
@@ -132,6 +134,7 @@ export class QuizListComponent implements OnInit {
   readonly currentBrowserLabel = this.quizStore.currentBrowserLabel;
   readonly syncPeerInfos = this.quizStore.syncPeerInfos;
   readonly actionInfo = signal<string | null>(null);
+  readonly actionInfoWarnings = signal<QuizImportWarning[]>([]);
   readonly actionError = signal<string | null>(null);
   readonly activeLiveQuizParticipants = signal<Map<string, number>>(new Map());
   readonly showAiImport = signal(false);
@@ -173,6 +176,14 @@ export class QuizListComponent implements OnInit {
   }
 
   renderDescription(value: string): SafeHtml {
+    const raw = renderMarkdownWithKatex(value, {
+      imagePolicy: 'allow-relative-and-https',
+    }).html;
+    const html = absolutizeMarkdownHtmlRootAssetImgSrc(raw, resolveMotdAssetOrigin());
+    return this.sanitizer.bypassSecurityTrustHtml(html);
+  }
+
+  renderImportWarningQuestion(value: string): SafeHtml {
     const raw = renderMarkdownWithKatex(value, {
       imagePolicy: 'allow-relative-and-https',
     }).html;
@@ -299,6 +310,7 @@ export class QuizListComponent implements OnInit {
     this.showKiPromptPreview.set(false);
     this.actionError.set(null);
     this.actionInfo.set(null);
+    this.actionInfoWarnings.set([]);
   }
 
   toggleKiPromptPreview(): void {
@@ -313,12 +325,14 @@ export class QuizListComponent implements OnInit {
     this.aiJsonInput.set('');
     this.actionError.set(null);
     this.actionInfo.set(null);
+    this.actionInfoWarnings.set([]);
   }
 
   duplicateQuiz(quizId: string): void {
     this.actionError.set(null);
     try {
       const duplicate = this.quizStore.duplicateQuiz(quizId);
+      this.actionInfoWarnings.set([]);
       this.actionInfo.set($localize`„${duplicate.name}“ wurde dupliziert.`);
     } catch (error) {
       this.actionError.set(
@@ -330,6 +344,7 @@ export class QuizListComponent implements OnInit {
   deleteQuiz(quizId: string, quizName: string): void {
     this.actionError.set(null);
     if (this.isQuizLive(quizId)) {
+      this.actionInfoWarnings.set([]);
       this.actionInfo.set($localize`„${quizName}“ ist gerade live und kann nicht gelöscht werden.`);
       return;
     }
@@ -353,6 +368,7 @@ export class QuizListComponent implements OnInit {
       if (confirmed !== true) return;
       try {
         this.quizStore.deleteQuiz(quizId);
+        this.actionInfoWarnings.set([]);
         this.actionInfo.set($localize`„${quizName}“ wurde gelöscht.`);
       } catch (error) {
         this.actionError.set(
@@ -375,6 +391,7 @@ export class QuizListComponent implements OnInit {
       anchor.download = filename;
       anchor.click();
       URL.revokeObjectURL(url);
+      this.actionInfoWarnings.set([]);
       this.actionInfo.set($localize`„${quiz.quiz.name}“ wurde exportiert.`);
     } catch (error) {
       this.actionError.set(
@@ -393,7 +410,7 @@ export class QuizListComponent implements OnInit {
       const raw = await file.text();
       const parsed = JSON.parse(raw) as unknown;
       const imported = this.quizStore.importQuiz(parsed);
-      this.actionInfo.set($localize`„${imported.name}“ wurde importiert.`);
+      this.actionInfo.set(this.buildImportInfoMessage(imported));
       target.value = '';
     } catch (error) {
       const message = error instanceof Error ? error.message : $localize`Import fehlgeschlagen.`;
@@ -406,6 +423,7 @@ export class QuizListComponent implements OnInit {
     const prompt = this.buildCurrentKiPromptText();
     try {
       await navigator.clipboard.writeText(prompt);
+      this.actionInfoWarnings.set([]);
       this.actionInfo.set(
         $localize`:@@quizList.aiImport.copySuccess:Die Textvorlage ist jetzt in deiner Zwischenablage.`,
       );
@@ -523,6 +541,7 @@ export class QuizListComponent implements OnInit {
   importAiJson(): void {
     this.actionError.set(null);
     this.actionInfo.set(null);
+    this.actionInfoWarnings.set([]);
 
     const raw = this.aiJsonInput().trim();
     if (!raw) {
@@ -535,9 +554,7 @@ export class QuizListComponent implements OnInit {
     try {
       const parsed = parseAiImportPayload(raw);
       const imported = this.quizStore.importQuiz(parsed);
-      this.actionInfo.set(
-        $localize`:@@quizList.aiImport.success:„${imported.name}:quizName:“ wurde importiert.`,
-      );
+      this.actionInfo.set(this.buildImportInfoMessage(imported));
       this.aiJsonInput.set('');
       this.showAiImport.set(false);
     } catch (error) {
@@ -684,6 +701,17 @@ export class QuizListComponent implements OnInit {
     return $localize`:@@quizList.syncImportedSuccessWithTimestamp:Quiz-Sammlung erfolgreich synchronisiert. Neuester Stand vom ${formattedTimestamp}:timestamp:.`;
   }
 
+  private buildImportInfoMessage(result: QuizImportResult): string {
+    const skipped = result.warnings.filter((warning) => warning.kind === 'skipped_question');
+    this.actionInfoWarnings.set(skipped);
+    return `„${result.quiz.name}“ wurde importiert.`;
+  }
+
+  formatImportWarning(warning: QuizImportResult['warnings'][number]): string {
+    const label = warning.questionNumber ? `Frage ${warning.questionNumber}` : 'Quiz';
+    return `${label}: ${warning.message}`;
+  }
+
   private formatSyncTimestamp(value: string): string | null {
     const parsed = new Date(value);
     if (Number.isNaN(parsed.getTime())) {
@@ -725,6 +753,7 @@ export class QuizListComponent implements OnInit {
   private async startLiveSession(options: { quizId: string }): Promise<void> {
     this.actionError.set(null);
     this.actionInfo.set(null);
+    this.actionInfoWarnings.set([]);
     this.liveStartPending.set(true);
     tryRequestDocumentFullscreen(this.document);
     try {

--- a/docs/examples/quiz-import/README.md
+++ b/docs/examples/quiz-import/README.md
@@ -16,6 +16,9 @@ Sie entsprechen dem `QuizImportSchema` aus `@arsnova/shared-types`.
 - `word-cloud-responses-komplex.txt` – großer synthetischer Antwortsatz (2.800 Antworten)
 - `word-cloud-komplex.svg` – bereits gerenderte, sehr komplexe Word-Cloud aus dem Datensatz
 - `word-cloud-komplex-top20.csv` – Top-20 Woerter mit Haeufigkeiten
+- `arsnova-click-export.schema.json` – dokumentiertes Snapshot-Schema fuer `arsnova.click`-Exporte
+- `arsnova-click-maximal-export.json` – Vollbeispiel fuer alle bekannten `arsnova.click`-Fragetypen
+- `arsnova-click-compat.md` – Mapping- und Inkompatibilitaetsdoku fuer den aktuellen Importfilter
 
 Alle Quizzes enthalten realistische Fragestämme mit **Markdown** und **KaTeX** (`$...$`, `$$...$$`).
 

--- a/docs/examples/quiz-import/arsnova-click-compat.md
+++ b/docs/examples/quiz-import/arsnova-click-compat.md
@@ -1,0 +1,76 @@
+# arsnova.click Import-Kompatibilitaet
+
+Dieses Dokument haelt das aktuell ermittelte `arsnova.click`-Exportformat fest und beschreibt,
+wie `arsnova.eu` es derzeit importiert.
+
+## Referenzen
+
+- Formales Snapshot-Schema: `docs/examples/quiz-import/arsnova-click-export.schema.json`
+- Vollstaendiges Beispiel: `docs/examples/quiz-import/arsnova-click-maximal-export.json`
+- Aktueller Normalizer: `apps/frontend/src/app/features/quiz/data/quiz-import-normalizer.ts`
+
+## Wichtiger Kontext
+
+- Das `arsnova.click`-Export-JSON ist als Archiv-/Import-Snapshot dokumentiert, nicht als minimales DTO.
+- `TYPE` ist das massgebliche Feld fuer Fragetypen.
+- Mehrere Felder im Snapshot sind fuer `arsnova.eu` derzeit ohne Laufzeitwirkung und werden nur dokumentiert.
+
+## Aktuelles Mapping nach arsnova.eu
+
+| arsnova.click                   | arsnova.eu        | Status     | Bemerkung                                                            |
+| ------------------------------- | ----------------- | ---------- | -------------------------------------------------------------------- |
+| `SingleChoiceQuestion`          | `SINGLE_CHOICE`   | importiert | direktes Mapping                                                     |
+| `YesNoSingleChoiceQuestion`     | `SINGLE_CHOICE`   | importiert | Spezialisierung geht verloren                                        |
+| `TrueFalseSingleChoiceQuestion` | `SINGLE_CHOICE`   | importiert | Spezialisierung geht verloren                                        |
+| `MultipleChoiceQuestion`        | `MULTIPLE_CHOICE` | importiert | direktes Mapping                                                     |
+| `SurveyQuestion`                | `SURVEY`          | importiert | alle Antworten werden als nicht-korrekt normalisiert                 |
+| `ABCDSurveyQuestion`            | `SURVEY`          | importiert | Spezialtyp geht verloren                                             |
+| `FreeTextQuestion`              | `FREETEXT`        | importiert | Antwortschluessel aus click werden nicht in `arsnova.eu` uebernommen |
+| `RangedQuestion`                | kein Pendant      | abgelehnt  | aktuelle Fehlermeldung statt stiller Degradation                     |
+
+## Aktuell uebernommene Session-Felder
+
+| Feld im click-Snapshot                     | Ziel in arsnova.eu     | Bemerkung                      |
+| ------------------------------------------ | ---------------------- | ------------------------------ |
+| `name`                                     | `quiz.name`            | direkt                         |
+| `description`                              | `quiz.description`     | direkt                         |
+| `sessionConfig.readingConfirmationEnabled` | `readingPhaseEnabled`  | direkt                         |
+| `sessionConfig.nicks.blockIllegalNicks`    | `allowCustomNicknames` | invertiert                     |
+| `sessionConfig.nicks.memberGroups`         | `teamNames`            | bis max. 8 Teams               |
+| `sessionConfig.nicks.autoJoinToGroup`      | `teamAssignment`       | `true -> AUTO`, sonst `MANUAL` |
+
+## Dokumentierte, aber aktuell nicht uebernommene Snapshot-Felder
+
+- `origin`
+- `state`
+- `currentQuestionIndex`
+- `currentStartTimestamp`
+- `sentQuestionIndex`
+- `readingConfirmationRequested`
+- `questionCount`
+- `sessionConfig.confidenceSliderEnabled`
+- `sessionConfig.showResponseProgress`
+- `sessionConfig.theme`
+- `sessionConfig.leaderboardAlgorithm`
+- `sessionConfig.music.*`
+- `sessionConfig.nicks.maxMembersPerGroup`
+- `sessionConfig.nicks.selectedNicks`
+- `questionList[].displayAnswerText`
+- `questionList[].showOneAnswerPerRow`
+- `questionList[].multipleSelectionEnabled`
+- `questionList[].tags`
+- `questionList[].requiredForToken`
+- `FreeTextAnswerOption.configCaseSensitive`
+- `FreeTextAnswerOption.configTrimWhitespaces`
+- `FreeTextAnswerOption.configUseKeywords`
+- `FreeTextAnswerOption.configUsePunctuation`
+- `RangedQuestion.rangeMin`
+- `RangedQuestion.rangeMax`
+- `RangedQuestion.correctValue`
+
+## Offene Folgearbeiten fuer spaetere Angleichung
+
+1. Pruefen, ob `RangedQuestion` in `arsnova.eu` einen neuen Fragetyp braucht oder als `RATING`/`FREETEXT` bewusst umgedeutet werden soll.
+2. Entscheiden, ob `FreeTextQuestion`-Antwortoptionen als Auswertungshilfe, Tags oder neue Bewertungslogik erhalten bleiben muessen.
+3. Klaeren, ob `ABCDSurveyQuestion`, `YesNoSingleChoiceQuestion` und `TrueFalseSingleChoiceQuestion` als eigene UI-Varianten sichtbar bleiben sollen.
+4. Festlegen, ob Musik-, Theme- und Nickname-Presets in `arsnova.eu` ueberhaupt eine fachliche Entsprechung bekommen sollen.

--- a/docs/examples/quiz-import/arsnova-click-export.schema.json
+++ b/docs/examples/quiz-import/arsnova-click-export.schema.json
@@ -1,0 +1,464 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://arsnova.eu/schemas/arsnova-click-export.schema.json",
+  "title": "arsnova.click Quiz Export Snapshot",
+  "description": "Documented snapshot schema for arsnova.click quiz exports. This mirrors the observed archive/import JSON shape, not a minimal API DTO.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["name", "readingConfirmationRequested", "sessionConfig", "questionList"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "origin": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string",
+      "enum": ["Inactive", "Active", "Running", "Finished"]
+    },
+    "currentQuestionIndex": {
+      "type": "integer"
+    },
+    "currentStartTimestamp": {
+      "type": "integer"
+    },
+    "sentQuestionIndex": {
+      "type": "integer"
+    },
+    "readingConfirmationRequested": {
+      "type": "boolean"
+    },
+    "questionCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "sessionConfig": {
+      "$ref": "#/$defs/sessionConfig"
+    },
+    "questionList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/question"
+      }
+    }
+  },
+  "$defs": {
+    "defaultAnswerOption": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["TYPE", "answerText"],
+      "properties": {
+        "TYPE": {
+          "const": "DefaultAnswerOption"
+        },
+        "answerText": {
+          "type": "string"
+        },
+        "isCorrect": {
+          "type": "boolean"
+        }
+      }
+    },
+    "freeTextAnswerOption": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["TYPE", "answerText"],
+      "properties": {
+        "TYPE": {
+          "const": "FreeTextAnswerOption"
+        },
+        "answerText": {
+          "type": "string"
+        },
+        "configCaseSensitive": {
+          "type": "boolean"
+        },
+        "configTrimWhitespaces": {
+          "type": "boolean"
+        },
+        "configUseKeywords": {
+          "type": "boolean"
+        },
+        "configUsePunctuation": {
+          "type": "boolean"
+        }
+      }
+    },
+    "memberGroup": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name", "color"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        }
+      }
+    },
+    "musicEnabled": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "lobby": {
+          "type": "boolean"
+        },
+        "countdownRunning": {
+          "type": "boolean"
+        },
+        "countdownEnd": {
+          "type": "boolean"
+        }
+      }
+    },
+    "musicVolumeConfig": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "global": {
+          "type": "number"
+        },
+        "lobby": {
+          "type": "number"
+        },
+        "countdownRunning": {
+          "type": "number"
+        },
+        "countdownEnd": {
+          "type": "number"
+        },
+        "useGlobalVolume": {
+          "type": "boolean"
+        }
+      }
+    },
+    "musicTitleConfig": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "lobby": {
+          "type": "string"
+        },
+        "countdownRunning": {
+          "type": "string"
+        },
+        "countdownEnd": {
+          "type": "string"
+        }
+      }
+    },
+    "musicConfig": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/musicEnabled"
+        },
+        "volumeConfig": {
+          "$ref": "#/$defs/musicVolumeConfig"
+        },
+        "titleConfig": {
+          "$ref": "#/$defs/musicTitleConfig"
+        }
+      }
+    },
+    "nicksConfig": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "memberGroups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/memberGroup"
+          }
+        },
+        "maxMembersPerGroup": {
+          "type": "integer"
+        },
+        "autoJoinToGroup": {
+          "type": "boolean"
+        },
+        "selectedNicks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blockIllegalNicks": {
+          "type": "boolean"
+        }
+      }
+    },
+    "sessionConfig": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "confidenceSliderEnabled": {
+          "type": "boolean"
+        },
+        "readingConfirmationEnabled": {
+          "type": "boolean"
+        },
+        "showResponseProgress": {
+          "type": "boolean"
+        },
+        "theme": {
+          "type": "string"
+        },
+        "leaderboardAlgorithm": {
+          "type": "string",
+          "enum": ["PointBased", "TimeBased"]
+        },
+        "music": {
+          "$ref": "#/$defs/musicConfig"
+        },
+        "nicks": {
+          "$ref": "#/$defs/nicksConfig"
+        }
+      }
+    },
+    "questionBase": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["TYPE", "questionText", "answerOptionList"],
+      "properties": {
+        "TYPE": {
+          "type": "string"
+        },
+        "displayAnswerText": {
+          "type": "boolean"
+        },
+        "showOneAnswerPerRow": {
+          "type": "boolean"
+        },
+        "multipleSelectionEnabled": {
+          "type": "boolean"
+        },
+        "timer": {
+          "type": "integer"
+        },
+        "questionText": {
+          "type": "string"
+        },
+        "answerOptionList": {
+          "type": "array"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requiredForToken": {
+          "type": "boolean"
+        },
+        "difficulty": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "singleChoiceQuestion": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/questionBase"
+        },
+        {
+          "properties": {
+            "TYPE": {
+              "const": "SingleChoiceQuestion"
+            },
+            "answerOptionList": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/defaultAnswerOption"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "yesNoSingleChoiceQuestion": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/questionBase"
+        },
+        {
+          "properties": {
+            "TYPE": {
+              "const": "YesNoSingleChoiceQuestion"
+            },
+            "answerOptionList": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/defaultAnswerOption"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "trueFalseSingleChoiceQuestion": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/questionBase"
+        },
+        {
+          "properties": {
+            "TYPE": {
+              "const": "TrueFalseSingleChoiceQuestion"
+            },
+            "answerOptionList": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/defaultAnswerOption"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "multipleChoiceQuestion": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/questionBase"
+        },
+        {
+          "properties": {
+            "TYPE": {
+              "const": "MultipleChoiceQuestion"
+            },
+            "answerOptionList": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/defaultAnswerOption"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "surveyQuestion": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/questionBase"
+        },
+        {
+          "properties": {
+            "TYPE": {
+              "const": "SurveyQuestion"
+            },
+            "answerOptionList": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/defaultAnswerOption"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "abcdSurveyQuestion": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/questionBase"
+        },
+        {
+          "properties": {
+            "TYPE": {
+              "const": "ABCDSurveyQuestion"
+            },
+            "answerOptionList": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/defaultAnswerOption"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "rangedQuestion": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/questionBase"
+        },
+        {
+          "required": ["rangeMin", "rangeMax", "correctValue"],
+          "properties": {
+            "TYPE": {
+              "const": "RangedQuestion"
+            },
+            "answerOptionList": {
+              "type": "array",
+              "maxItems": 0
+            },
+            "rangeMin": {
+              "type": "number"
+            },
+            "rangeMax": {
+              "type": "number"
+            },
+            "correctValue": {
+              "type": "number"
+            }
+          }
+        }
+      ]
+    },
+    "freeTextQuestion": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/questionBase"
+        },
+        {
+          "properties": {
+            "TYPE": {
+              "const": "FreeTextQuestion"
+            },
+            "answerOptionList": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/freeTextAnswerOption"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "question": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/singleChoiceQuestion"
+        },
+        {
+          "$ref": "#/$defs/yesNoSingleChoiceQuestion"
+        },
+        {
+          "$ref": "#/$defs/trueFalseSingleChoiceQuestion"
+        },
+        {
+          "$ref": "#/$defs/multipleChoiceQuestion"
+        },
+        {
+          "$ref": "#/$defs/surveyQuestion"
+        },
+        {
+          "$ref": "#/$defs/abcdSurveyQuestion"
+        },
+        {
+          "$ref": "#/$defs/rangedQuestion"
+        },
+        {
+          "$ref": "#/$defs/freeTextQuestion"
+        }
+      ]
+    }
+  }
+}

--- a/docs/examples/quiz-import/arsnova-click-maximal-export.json
+++ b/docs/examples/quiz-import/arsnova-click-maximal-export.json
@@ -1,0 +1,254 @@
+{
+  "name": "Maximal Export Quiz",
+  "origin": "template-full",
+  "description": "Beispiel mit allen Fragetypen",
+  "state": "Inactive",
+  "currentQuestionIndex": -1,
+  "currentStartTimestamp": -1,
+  "sentQuestionIndex": 0,
+  "readingConfirmationRequested": false,
+  "questionCount": 8,
+  "sessionConfig": {
+    "confidenceSliderEnabled": true,
+    "readingConfirmationEnabled": true,
+    "showResponseProgress": true,
+    "theme": "Material",
+    "leaderboardAlgorithm": "PointBased",
+    "music": {
+      "enabled": {
+        "lobby": true,
+        "countdownRunning": true,
+        "countdownEnd": true
+      },
+      "volumeConfig": {
+        "global": 60,
+        "lobby": 60,
+        "countdownRunning": 60,
+        "countdownEnd": 60,
+        "useGlobalVolume": true
+      },
+      "titleConfig": {
+        "lobby": "Song0",
+        "countdownRunning": "Song0",
+        "countdownEnd": "Song0"
+      }
+    },
+    "nicks": {
+      "memberGroups": [
+        {
+          "name": "Gruppe A",
+          "color": "#ff0000"
+        }
+      ],
+      "maxMembersPerGroup": 10,
+      "autoJoinToGroup": false,
+      "selectedNicks": ["Ada Lovelace", "Alan Turing"],
+      "blockIllegalNicks": true
+    }
+  },
+  "questionList": [
+    {
+      "TYPE": "SingleChoiceQuestion",
+      "displayAnswerText": true,
+      "showOneAnswerPerRow": false,
+      "timer": 30,
+      "questionText": "Single Choice",
+      "answerOptionList": [
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "A",
+          "isCorrect": false
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "B",
+          "isCorrect": true
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "C",
+          "isCorrect": false
+        }
+      ],
+      "tags": ["single", "wissen"],
+      "requiredForToken": true,
+      "difficulty": 5
+    },
+    {
+      "TYPE": "YesNoSingleChoiceQuestion",
+      "displayAnswerText": true,
+      "showOneAnswerPerRow": false,
+      "timer": 20,
+      "questionText": "Ja/Nein",
+      "answerOptionList": [
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "Yes",
+          "isCorrect": true
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "No",
+          "isCorrect": false
+        }
+      ],
+      "tags": ["yesno"],
+      "requiredForToken": true,
+      "difficulty": 3
+    },
+    {
+      "TYPE": "TrueFalseSingleChoiceQuestion",
+      "displayAnswerText": true,
+      "showOneAnswerPerRow": false,
+      "timer": 20,
+      "questionText": "Wahr/Falsch",
+      "answerOptionList": [
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "True",
+          "isCorrect": false
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "False",
+          "isCorrect": true
+        }
+      ],
+      "tags": ["truefalse"],
+      "requiredForToken": true,
+      "difficulty": 3
+    },
+    {
+      "TYPE": "MultipleChoiceQuestion",
+      "displayAnswerText": true,
+      "showOneAnswerPerRow": true,
+      "timer": 45,
+      "questionText": "Multiple Choice",
+      "answerOptionList": [
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "A",
+          "isCorrect": true
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "B",
+          "isCorrect": false
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "C",
+          "isCorrect": true
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "D",
+          "isCorrect": false
+        }
+      ],
+      "tags": ["multiple"],
+      "requiredForToken": true,
+      "difficulty": 7
+    },
+    {
+      "TYPE": "SurveyQuestion",
+      "displayAnswerText": true,
+      "showOneAnswerPerRow": false,
+      "multipleSelectionEnabled": true,
+      "timer": 30,
+      "questionText": "Umfrage",
+      "answerOptionList": [
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "Option 1",
+          "isCorrect": false
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "Option 2",
+          "isCorrect": false
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "Option 3",
+          "isCorrect": false
+        }
+      ],
+      "tags": ["survey"],
+      "requiredForToken": false,
+      "difficulty": 1
+    },
+    {
+      "TYPE": "ABCDSurveyQuestion",
+      "displayAnswerText": false,
+      "showOneAnswerPerRow": false,
+      "timer": 15,
+      "questionText": "ABCD",
+      "answerOptionList": [
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "A",
+          "isCorrect": false
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "B",
+          "isCorrect": false
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "C",
+          "isCorrect": false
+        },
+        {
+          "TYPE": "DefaultAnswerOption",
+          "answerText": "D",
+          "isCorrect": false
+        }
+      ],
+      "tags": ["abcd"],
+      "requiredForToken": false,
+      "difficulty": 1
+    },
+    {
+      "TYPE": "RangedQuestion",
+      "displayAnswerText": false,
+      "timer": 60,
+      "questionText": "Schaetzfrage",
+      "answerOptionList": [],
+      "rangeMin": 0,
+      "rangeMax": 1000,
+      "correctValue": 420,
+      "tags": ["range"],
+      "requiredForToken": true,
+      "difficulty": 6
+    },
+    {
+      "TYPE": "FreeTextQuestion",
+      "displayAnswerText": true,
+      "timer": 45,
+      "questionText": "Freitext",
+      "answerOptionList": [
+        {
+          "TYPE": "FreeTextAnswerOption",
+          "answerText": "Paris",
+          "configCaseSensitive": false,
+          "configTrimWhitespaces": true,
+          "configUseKeywords": true,
+          "configUsePunctuation": false
+        },
+        {
+          "TYPE": "FreeTextAnswerOption",
+          "answerText": "paris",
+          "configCaseSensitive": false,
+          "configTrimWhitespaces": true,
+          "configUseKeywords": true,
+          "configUsePunctuation": false
+        }
+      ],
+      "tags": ["text"],
+      "requiredForToken": true,
+      "difficulty": 4
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- restore the arsnova.click quiz import normalizer and import warnings flow
- show skipped incompatible questions in the quiz list import feedback
- restore the documented arsnova.click schema and compatibility examples

## Verification
- npm run test
- npm run typecheck
- npm run build:prod