### PR TITLE
feat(status): implement Story 0.4a session daily record history

### DIFF
--- a/Backlog.md
+++ b/Backlog.md
@@ -4,7 +4,7 @@
 >
 > **Abhängigkeiten (Kernpfad):** Epic 0 → Epic 1 → Epic 2 → Epic 3 → Epic 4 → Epic 5 ✅
 >
-> **Nächster Fokus (Auswahl offener Stories):** u. a. **0.4a** (Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog), **0.7** (Last- & Performance-Tests), **0.8** (Komplexitätsabbau / McCabe-Refactor), **6.5**/**6.6** (Barrierefreiheit / UX-Testreihen), **1.2d–1.2i** (neue Fragentypen & Confidence), **1.6c** (Sync-Sicherheit), **8.5–8.8** (Q&A-Erweiterungen + Tempo-Livekanal) — **Epic 6** im Kern (6.1–6.4: Theme, i18n, Legal, Responsive) ist umgesetzt ✅. **Lehre:** Greenfield-Demo **1.7a** in **3×45 Min.** — [`docs/didaktik/greenfield-demo-1-7a-vorlesung.md`](docs/didaktik/greenfield-demo-1-7a-vorlesung.md).
+> **Nächster Fokus (Auswahl offener Stories):** u. a. **0.7** (Last- & Performance-Tests), **0.8** (Komplexitätsabbau / McCabe-Refactor), **6.5**/**6.6** (Barrierefreiheit / UX-Testreihen), **1.2d–1.2i** (neue Fragentypen & Confidence), **1.6c** (Sync-Sicherheit), **8.5–8.8** (Q&A-Erweiterungen + Tempo-Livekanal) — **Epic 6** im Kern (6.1–6.4: Theme, i18n, Legal, Responsive) ist umgesetzt ✅. **Lehre:** Greenfield-Demo **1.7a** in **3×45 Min.** — [`docs/didaktik/greenfield-demo-1-7a-vorlesung.md`](docs/didaktik/greenfield-demo-1-7a-vorlesung.md).
 >
 > **Weitere Parallelpfade:** Epic 9 ✅ (Admin: Inspektion, Löschen, Auszug für Behörden) · Epic 10 ✅ (MOTD / Plattform-Kommunikation — ADR-0018, `docs/features/motd.md`)
 
@@ -18,7 +18,7 @@
 | 0    | 0.2   | tRPC WebSocket-Adapter                                      | 🔴   | ✅ Fertig |
 | 0    | 0.3   | Yjs WebSocket-Provider                                      | 🟡   | ✅ Fertig |
 | 0    | 0.4   | Server-Status-Indikator                                     | 🟡   | ✅ Fertig |
-| 0    | 0.4a  | Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog    | 🟡   | ⬜ Offen  |
+| 0    | 0.4a  | Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog    | 🟡   | ✅ Fertig |
 | 0    | 0.5   | Rate-Limiting & Brute-Force-Schutz                          | 🔴   | ✅ Fertig |
 | 0    | 0.6   | CI/CD-Pipeline (GitHub Actions)                             | 🔴   | ✅ Fertig |
 | 0    | 0.7   | Last- & Performance-Tests mit E2E-Szenarien                 | 🟡   | ⬜ Offen  |
@@ -117,11 +117,11 @@
 | 10   | 10.7  | MOTD: Header-Icon, Archiv, Lazy Load, i18n-Inhalte          | 🟡   | ✅ Fertig |
 | 10   | 10.8  | MOTD: Härtung (Sanitize, A11y, Audit, Tests)                | 🟡   | ✅ Fertig |
 
-> **Repo-Abgleich (Codebase 2026-04-03):** Die **⬜-Stories** sind weiterhin durch den Stand im Monorepo begründet: u. a. kein Fragentyp numerische Schätzung und kein eigener Typ für bewertbare Kurzantwort in `QuestionTypeEnum` (`libs/shared-types`); Word Cloud weiterhin ohne ADR-0012/`d3-cloud`-Layout (vgl. `word-cloud.component`); Q&A-Sortierung nur nach Upvotes, **keine** Kontrovers-/Wilson-Berechnung im Router; noch **kein** vierter Session-Kanal für kontinuierliches Tempo-Feedback im Session-Modell; kein ausführbares **k6**-/Artillery-Lasttest-Setup (ADR-0013 dokumentarisch). **Umgesetzt** sind jetzt u. a. **2.1c** (Host-/Presenter-Härtung via Host-Token und `hostProcedure`) sowie die besitzgebundene Quiz-Historie per `accessProof` ohne eigene Story-ID. Die **✅-Einträge** wurden stichprobenartig nicht widerlegt. _Ohne eigene Story-ID:_ Rekord **max. Teilnehmende pro Session** in `health.stats` / Hilfe-Seite (`PlatformStatistic`, u. a. Migration `platform_statistic_max_participants`).
+> **Repo-Abgleich (Codebase 2026-04-03):** Die **⬜-Stories** sind weiterhin durch den Stand im Monorepo begründet: u. a. kein Fragentyp numerische Schätzung und kein eigener Typ für bewertbare Kurzantwort in `QuestionTypeEnum` (`libs/shared-types`); Word Cloud weiterhin ohne ADR-0012/`d3-cloud`-Layout (vgl. `word-cloud.component`); Q&A-Sortierung nur nach Upvotes, **keine** Kontrovers-/Wilson-Berechnung im Router; noch **kein** vierter Session-Kanal für kontinuierliches Tempo-Feedback im Session-Modell; kein ausführbares **k6**-/Artillery-Lasttest-Setup (ADR-0013 dokumentarisch). **Umgesetzt** sind jetzt u. a. **0.4a** (Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog mit `DailyStatistic`, `dailyHighscores` und Chart im Hilfe-Dialog), **2.1c** (Host-/Presenter-Härtung via Host-Token und `hostProcedure`) sowie die besitzgebundene Quiz-Historie per `accessProof` ohne eigene Story-ID. Die **✅-Einträge** wurden stichprobenartig nicht widerlegt. _Ohne eigene Story-ID:_ Rekord **max. Teilnehmende pro Session** in `health.stats` / Hilfe-Seite (`PlatformStatistic`, u. a. Migration `platform_statistic_max_participants`).
 >
 > **Legende Status:** ⬜ Offen · 🔨 In Arbeit · ✅ Fertig (DoD erfüllt) · ❌ Blockiert
 >
-> **Statistik:** 🔴 Must: 29 · 🟡 Should: 62 · 🟢 Could: 11 = **102 Stories gesamt** (**80** ✅ Fertig · **22** ⬜ Offen)
+> **Statistik:** 🔴 Must: 29 · 🟡 Should: 62 · 🟢 Could: 11 = **102 Stories gesamt** (**81** ✅ Fertig · **21** ⬜ Offen)
 
 ---
 
@@ -212,15 +212,15 @@ Eine Story gilt als **fertig**, wenn **alle** folgenden Kriterien erfüllt sind:
     - [x] ⚠️ _Abhängigkeit:_ Vor Umsetzung von Story 2.1a liefert die Query Initialwerte (`activeSessions: 0`, `totalParticipants: 0`, `completedSessions: 0`).
 - **Story 0.4a (Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog):** 🟡 Als Betreiber oder Lehrender möchte ich im Hilfe-Dialog der Betriebsstatusanzeige den Verlauf der Session-Tagesrekorde der **groessten einzelnen Session pro UTC-Tag** sehen, damit ich die Entwicklung der jeweils groessten Session der Plattform ueber die letzten 30 Tage einschaetzen kann, ohne das kompakte Footer-Widget zu ueberladen.
   - **Akzeptanzkriterien:**
-    - `health.stats` liefert zusaetzlich `dailyHighscores` fuer die letzten 30 UTC-Tage in chronologischer Reihenfolge; jeder Eintrag enthaelt `date` und `count`, wobei `count` die **maximale gleichzeitige Teilnehmendenzahl in der groessten einzelnen Session dieses UTC-Tages** ist, nicht die Summe aller Tagesnutzer.
-    - Tage ohne neuen Rekord werden in der API als `count = 0` ergaenzt, damit das Diagramm eine stabile 30-Tage-Achse hat.
-    - Das Prisma-Schema enthaelt ein Modell `DailyStatistic` mit genau einem Datensatz pro UTC-Tag; Updates erfolgen atomar per Upsert und nur dann, wenn der aktuelle Session-Stand hoeher ist als der bisherige Tageswert.
-    - Die Rekordaktualisierung bleibt beim Session-Beitritt Fire-and-Forget und darf den Join-Flow nicht verzoegern.
-    - Der Hilfe-Dialog (`ServerStatusHelpDialogComponent`) zeigt unterhalb des Allzeit-Rekords ein Line-Chart fuer den 30-Tage-Verlauf; das kompakte Footer-Widget selbst bleibt unveraendert.
-    - Die Diagramm-Bibliothek wird ausschliesslich beim Oeffnen des Dialogs lazy geladen; es wird kein Angular-Wrapper eingefuehrt.
-    - Die Aktualisierung des Verlaufs bleibt beim bestehenden 30-Sekunden-Polling; es wird kein zusaetzlicher WebSocket-Kanal nur fuer diese Statistik eingefuehrt.
-    - Neue UI-Texte, Beschriftungen und ARIA-Hinweise werden gemaess ADR-0008 in allen gepflegten App-Sprachen ergaenzt.
-    - Backend- und Frontend-Tests decken mindestens den API-Vertrag sowie die Darstellung des Hilfe-Dialogs mit und ohne Verlauf ab.
+    - [x] `health.stats` liefert zusaetzlich `dailyHighscores` fuer die letzten 30 UTC-Tage in chronologischer Reihenfolge; jeder Eintrag enthaelt `date` und `count`, wobei `count` die **maximale gleichzeitige Teilnehmendenzahl in der groessten einzelnen Session dieses UTC-Tages** ist, nicht die Summe aller Tagesnutzer.
+    - [x] Tage ohne neuen Rekord werden in der API als `count = 0` ergaenzt, damit das Diagramm eine stabile 30-Tage-Achse hat.
+    - [x] Das Prisma-Schema enthaelt ein Modell `DailyStatistic` mit genau einem Datensatz pro UTC-Tag; Updates erfolgen atomar per Upsert und nur dann, wenn der aktuelle Session-Stand hoeher ist als der bisherige Tageswert.
+    - [x] Die Rekordaktualisierung bleibt beim Session-Beitritt Fire-and-Forget und darf den Join-Flow nicht verzoegern.
+    - [x] Der Hilfe-Dialog (`ServerStatusHelpDialogComponent`) zeigt unterhalb des Allzeit-Rekords ein Line-Chart fuer den 30-Tage-Verlauf; das kompakte Footer-Widget selbst bleibt unveraendert.
+    - [x] Die Diagramm-Bibliothek wird ausschliesslich beim Oeffnen des Dialogs lazy geladen; es wird kein Angular-Wrapper eingefuehrt.
+    - [x] Die Aktualisierung des Verlaufs bleibt beim bestehenden 30-Sekunden-Polling; es wird kein zusaetzlicher WebSocket-Kanal nur fuer diese Statistik eingefuehrt.
+    - [x] Neue UI-Texte, Beschriftungen und ARIA-Hinweise werden gemaess ADR-0008 in allen gepflegten App-Sprachen ergaenzt.
+    - [x] Backend- und Frontend-Tests decken mindestens den API-Vertrag sowie die Darstellung des Hilfe-Dialogs mit und ohne Verlauf ab.
 - **Story 0.5 (Rate-Limiting & Brute-Force-Schutz):** 🔴 Als System möchte ich Missbrauch durch automatisierte Anfragen verhindern, damit die Plattform stabil und fair bleibt.
   - **Akzeptanzkriterien:**
     - [x] **Session-Code-Eingabe (Story 3.1):** Maximal 5 Fehlversuche pro IP-Adresse innerhalb von 5 Minuten. Nach Überschreitung wird eine 60-Sekunden-Sperre verhängt mit Hinweismeldung.

--- a/Backlog.md
+++ b/Backlog.md
@@ -4,7 +4,7 @@
 >
 > **Abhängigkeiten (Kernpfad):** Epic 0 → Epic 1 → Epic 2 → Epic 3 → Epic 4 → Epic 5 ✅
 >
-> **Nächster Fokus (Auswahl offener Stories):** u. a. **0.4a** (Tagesrekord-Verlauf im Server-Status-Hilfedialog), **0.7** (Last- & Performance-Tests), **0.8** (Komplexitätsabbau / McCabe-Refactor), **6.5**/**6.6** (Barrierefreiheit / UX-Testreihen), **1.2d–1.2i** (neue Fragentypen & Confidence), **1.6c** (Sync-Sicherheit), **8.5–8.8** (Q&A-Erweiterungen + Tempo-Livekanal) — **Epic 6** im Kern (6.1–6.4: Theme, i18n, Legal, Responsive) ist umgesetzt ✅. **Lehre:** Greenfield-Demo **1.7a** in **3×45 Min.** — [`docs/didaktik/greenfield-demo-1-7a-vorlesung.md`](docs/didaktik/greenfield-demo-1-7a-vorlesung.md).
+> **Nächster Fokus (Auswahl offener Stories):** u. a. **0.4a** (Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog), **0.7** (Last- & Performance-Tests), **0.8** (Komplexitätsabbau / McCabe-Refactor), **6.5**/**6.6** (Barrierefreiheit / UX-Testreihen), **1.2d–1.2i** (neue Fragentypen & Confidence), **1.6c** (Sync-Sicherheit), **8.5–8.8** (Q&A-Erweiterungen + Tempo-Livekanal) — **Epic 6** im Kern (6.1–6.4: Theme, i18n, Legal, Responsive) ist umgesetzt ✅. **Lehre:** Greenfield-Demo **1.7a** in **3×45 Min.** — [`docs/didaktik/greenfield-demo-1-7a-vorlesung.md`](docs/didaktik/greenfield-demo-1-7a-vorlesung.md).
 >
 > **Weitere Parallelpfade:** Epic 9 ✅ (Admin: Inspektion, Löschen, Auszug für Behörden) · Epic 10 ✅ (MOTD / Plattform-Kommunikation — ADR-0018, `docs/features/motd.md`)
 
@@ -18,7 +18,7 @@
 | 0    | 0.2   | tRPC WebSocket-Adapter                                      | 🔴   | ✅ Fertig |
 | 0    | 0.3   | Yjs WebSocket-Provider                                      | 🟡   | ✅ Fertig |
 | 0    | 0.4   | Server-Status-Indikator                                     | 🟡   | ✅ Fertig |
-| 0    | 0.4a  | Tagesrekord-Verlauf im Server-Status-Hilfedialog            | 🟡   | ⬜ Offen  |
+| 0    | 0.4a  | Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog    | 🟡   | ⬜ Offen  |
 | 0    | 0.5   | Rate-Limiting & Brute-Force-Schutz                          | 🔴   | ✅ Fertig |
 | 0    | 0.6   | CI/CD-Pipeline (GitHub Actions)                             | 🔴   | ✅ Fertig |
 | 0    | 0.7   | Last- & Performance-Tests mit E2E-Szenarien                 | 🟡   | ⬜ Offen  |
@@ -210,7 +210,7 @@ Eine Story gilt als **fertig**, wenn **alle** folgenden Kriterien erfüllt sind:
     - [x] Die Daten werden alle 30 Sekunden automatisch aktualisiert (Polling).
     - [x] Es werden keine personenbezogenen Daten exponiert (nur aggregierte Zahlen).
     - [x] ⚠️ _Abhängigkeit:_ Vor Umsetzung von Story 2.1a liefert die Query Initialwerte (`activeSessions: 0`, `totalParticipants: 0`, `completedSessions: 0`).
-- **Story 0.4a (Tagesrekord-Verlauf im Server-Status-Hilfedialog):** 🟡 Als Betreiber oder Lehrender möchte ich im Hilfe-Dialog der Betriebsstatusanzeige den Verlauf der Tagesrekorde der **groessten einzelnen Session pro UTC-Tag** sehen, damit ich die Entwicklung der jeweils groessten Session der Plattform ueber die letzten 30 Tage einschaetzen kann, ohne das kompakte Footer-Widget zu ueberladen.
+- **Story 0.4a (Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog):** 🟡 Als Betreiber oder Lehrender möchte ich im Hilfe-Dialog der Betriebsstatusanzeige den Verlauf der Session-Tagesrekorde der **groessten einzelnen Session pro UTC-Tag** sehen, damit ich die Entwicklung der jeweils groessten Session der Plattform ueber die letzten 30 Tage einschaetzen kann, ohne das kompakte Footer-Widget zu ueberladen.
   - **Akzeptanzkriterien:**
     - `health.stats` liefert zusaetzlich `dailyHighscores` fuer die letzten 30 UTC-Tage in chronologischer Reihenfolge; jeder Eintrag enthaelt `date` und `count`, wobei `count` die **maximale gleichzeitige Teilnehmendenzahl in der groessten einzelnen Session dieses UTC-Tages** ist, nicht die Summe aller Tagesnutzer.
     - Tage ohne neuen Rekord werden in der API als `count = 0` ergaenzt, damit das Diagramm eine stabile 30-Tage-Achse hat.

--- a/Backlog.md
+++ b/Backlog.md
@@ -210,9 +210,9 @@ Eine Story gilt als **fertig**, wenn **alle** folgenden Kriterien erfüllt sind:
     - [x] Die Daten werden alle 30 Sekunden automatisch aktualisiert (Polling).
     - [x] Es werden keine personenbezogenen Daten exponiert (nur aggregierte Zahlen).
     - [x] ⚠️ _Abhängigkeit:_ Vor Umsetzung von Story 2.1a liefert die Query Initialwerte (`activeSessions: 0`, `totalParticipants: 0`, `completedSessions: 0`).
-- **Story 0.4a (Tagesrekord-Verlauf im Server-Status-Hilfedialog):** 🟡 Als Betreiber oder Lehrender möchte ich im Hilfe-Dialog der Betriebsstatusanzeige den Verlauf der Tagesrekorde sehen, damit ich Auslastungsspitzen der Plattform ueber die letzten 30 Tage einschaetzen kann, ohne das kompakte Footer-Widget zu ueberladen.
+- **Story 0.4a (Tagesrekord-Verlauf im Server-Status-Hilfedialog):** 🟡 Als Betreiber oder Lehrender möchte ich im Hilfe-Dialog der Betriebsstatusanzeige den Verlauf der Tagesrekorde der **groessten einzelnen Session pro UTC-Tag** sehen, damit ich die Entwicklung der jeweils groessten Session der Plattform ueber die letzten 30 Tage einschaetzen kann, ohne das kompakte Footer-Widget zu ueberladen.
   - **Akzeptanzkriterien:**
-    - `health.stats` liefert zusaetzlich `dailyHighscores` fuer die letzten 30 UTC-Tage in chronologischer Reihenfolge; jeder Eintrag enthaelt `date` und `count`.
+    - `health.stats` liefert zusaetzlich `dailyHighscores` fuer die letzten 30 UTC-Tage in chronologischer Reihenfolge; jeder Eintrag enthaelt `date` und `count`, wobei `count` die **maximale gleichzeitige Teilnehmendenzahl in der groessten einzelnen Session dieses UTC-Tages** ist, nicht die Summe aller Tagesnutzer.
     - Tage ohne neuen Rekord werden in der API als `count = 0` ergaenzt, damit das Diagramm eine stabile 30-Tage-Achse hat.
     - Das Prisma-Schema enthaelt ein Modell `DailyStatistic` mit genau einem Datensatz pro UTC-Tag; Updates erfolgen atomar per Upsert und nur dann, wenn der aktuelle Session-Stand hoeher ist als der bisherige Tageswert.
     - Die Rekordaktualisierung bleibt beim Session-Beitritt Fire-and-Forget und darf den Join-Flow nicht verzoegern.

--- a/Backlog.md
+++ b/Backlog.md
@@ -4,7 +4,7 @@
 >
 > **Abhängigkeiten (Kernpfad):** Epic 0 → Epic 1 → Epic 2 → Epic 3 → Epic 4 → Epic 5 ✅
 >
-> **Nächster Fokus (Auswahl offener Stories):** u. a. **0.7** (Last- & Performance-Tests), **0.8** (Komplexitätsabbau / McCabe-Refactor), **6.5**/**6.6** (Barrierefreiheit / UX-Testreihen), **1.2d–1.2i** (neue Fragentypen & Confidence), **1.6c** (Sync-Sicherheit), **8.5–8.8** (Q&A-Erweiterungen + Tempo-Livekanal) — **Epic 6** im Kern (6.1–6.4: Theme, i18n, Legal, Responsive) ist umgesetzt ✅. **Lehre:** Greenfield-Demo **1.7a** in **3×45 Min.** — [`docs/didaktik/greenfield-demo-1-7a-vorlesung.md`](docs/didaktik/greenfield-demo-1-7a-vorlesung.md).
+> **Nächster Fokus (Auswahl offener Stories):** u. a. **0.4a** (Tagesrekord-Verlauf im Server-Status-Hilfedialog), **0.7** (Last- & Performance-Tests), **0.8** (Komplexitätsabbau / McCabe-Refactor), **6.5**/**6.6** (Barrierefreiheit / UX-Testreihen), **1.2d–1.2i** (neue Fragentypen & Confidence), **1.6c** (Sync-Sicherheit), **8.5–8.8** (Q&A-Erweiterungen + Tempo-Livekanal) — **Epic 6** im Kern (6.1–6.4: Theme, i18n, Legal, Responsive) ist umgesetzt ✅. **Lehre:** Greenfield-Demo **1.7a** in **3×45 Min.** — [`docs/didaktik/greenfield-demo-1-7a-vorlesung.md`](docs/didaktik/greenfield-demo-1-7a-vorlesung.md).
 >
 > **Weitere Parallelpfade:** Epic 9 ✅ (Admin: Inspektion, Löschen, Auszug für Behörden) · Epic 10 ✅ (MOTD / Plattform-Kommunikation — ADR-0018, `docs/features/motd.md`)
 
@@ -18,6 +18,7 @@
 | 0    | 0.2   | tRPC WebSocket-Adapter                                      | 🔴   | ✅ Fertig |
 | 0    | 0.3   | Yjs WebSocket-Provider                                      | 🟡   | ✅ Fertig |
 | 0    | 0.4   | Server-Status-Indikator                                     | 🟡   | ✅ Fertig |
+| 0    | 0.4a  | Tagesrekord-Verlauf im Server-Status-Hilfedialog            | 🟡   | ⬜ Offen  |
 | 0    | 0.5   | Rate-Limiting & Brute-Force-Schutz                          | 🔴   | ✅ Fertig |
 | 0    | 0.6   | CI/CD-Pipeline (GitHub Actions)                             | 🔴   | ✅ Fertig |
 | 0    | 0.7   | Last- & Performance-Tests mit E2E-Szenarien                 | 🟡   | ⬜ Offen  |
@@ -120,7 +121,7 @@
 >
 > **Legende Status:** ⬜ Offen · 🔨 In Arbeit · ✅ Fertig (DoD erfüllt) · ❌ Blockiert
 >
-> **Statistik:** 🔴 Must: 29 · 🟡 Should: 61 · 🟢 Could: 11 = **101 Stories gesamt** (**80** ✅ Fertig · **21** ⬜ Offen)
+> **Statistik:** 🔴 Must: 29 · 🟡 Should: 62 · 🟢 Could: 11 = **102 Stories gesamt** (**80** ✅ Fertig · **22** ⬜ Offen)
 
 ---
 
@@ -209,6 +210,17 @@ Eine Story gilt als **fertig**, wenn **alle** folgenden Kriterien erfüllt sind:
     - [x] Die Daten werden alle 30 Sekunden automatisch aktualisiert (Polling).
     - [x] Es werden keine personenbezogenen Daten exponiert (nur aggregierte Zahlen).
     - [x] ⚠️ _Abhängigkeit:_ Vor Umsetzung von Story 2.1a liefert die Query Initialwerte (`activeSessions: 0`, `totalParticipants: 0`, `completedSessions: 0`).
+- **Story 0.4a (Tagesrekord-Verlauf im Server-Status-Hilfedialog):** 🟡 Als Betreiber oder Lehrender möchte ich im Hilfe-Dialog der Betriebsstatusanzeige den Verlauf der Tagesrekorde sehen, damit ich Auslastungsspitzen der Plattform ueber die letzten 30 Tage einschaetzen kann, ohne das kompakte Footer-Widget zu ueberladen.
+  - **Akzeptanzkriterien:**
+    - `health.stats` liefert zusaetzlich `dailyHighscores` fuer die letzten 30 UTC-Tage in chronologischer Reihenfolge; jeder Eintrag enthaelt `date` und `count`.
+    - Tage ohne neuen Rekord werden in der API als `count = 0` ergaenzt, damit das Diagramm eine stabile 30-Tage-Achse hat.
+    - Das Prisma-Schema enthaelt ein Modell `DailyStatistic` mit genau einem Datensatz pro UTC-Tag; Updates erfolgen atomar per Upsert und nur dann, wenn der aktuelle Session-Stand hoeher ist als der bisherige Tageswert.
+    - Die Rekordaktualisierung bleibt beim Session-Beitritt Fire-and-Forget und darf den Join-Flow nicht verzoegern.
+    - Der Hilfe-Dialog (`ServerStatusHelpDialogComponent`) zeigt unterhalb des Allzeit-Rekords ein Line-Chart fuer den 30-Tage-Verlauf; das kompakte Footer-Widget selbst bleibt unveraendert.
+    - Die Diagramm-Bibliothek wird ausschliesslich beim Oeffnen des Dialogs lazy geladen; es wird kein Angular-Wrapper eingefuehrt.
+    - Die Aktualisierung des Verlaufs bleibt beim bestehenden 30-Sekunden-Polling; es wird kein zusaetzlicher WebSocket-Kanal nur fuer diese Statistik eingefuehrt.
+    - Neue UI-Texte, Beschriftungen und ARIA-Hinweise werden gemaess ADR-0008 in allen gepflegten App-Sprachen ergaenzt.
+    - Backend- und Frontend-Tests decken mindestens den API-Vertrag sowie die Darstellung des Hilfe-Dialogs mit und ohne Verlauf ab.
 - **Story 0.5 (Rate-Limiting & Brute-Force-Schutz):** 🔴 Als System möchte ich Missbrauch durch automatisierte Anfragen verhindern, damit die Plattform stabil und fair bleibt.
   - **Akzeptanzkriterien:**
     - [x] **Session-Code-Eingabe (Story 3.1):** Maximal 5 Fehlversuche pro IP-Adresse innerhalb von 5 Minuten. Nach Überschreitung wird eine 60-Sekunden-Sperre verhängt mit Hinweismeldung.

--- a/apps/backend/src/__tests__/health.test.ts
+++ b/apps/backend/src/__tests__/health.test.ts
@@ -15,13 +15,18 @@ vi.mock('../redis', () => ({
 vi.mock('../db', () => ({
   prisma: {
     session: { count: vi.fn(), findMany: vi.fn() },
+    dailyStatistic: { findMany: vi.fn() },
     platformStatistic: { findUnique: vi.fn() },
   },
 }));
 
-vi.mock('../lib/platformStatistic', () => ({
-  updateCompletedSessionsTotal: vi.fn(),
-}));
+vi.mock('../lib/platformStatistic', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/platformStatistic')>();
+  return {
+    ...actual,
+    updateCompletedSessionsTotal: vi.fn(),
+  };
+});
 
 vi.mock('../lib/presence', () => ({
   countActiveParticipantsForSessions: vi.fn(),
@@ -53,6 +58,7 @@ describe('health.check', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(prisma.session.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.dailyStatistic.findMany).mockResolvedValue([]);
     vi.mocked(countActiveParticipantsForSessions).mockResolvedValue(0);
     vi.mocked(getActiveParticipantCountsForSessions).mockResolvedValue(new Map());
     vi.mocked(readLoadSignals).mockResolvedValue({
@@ -93,6 +99,7 @@ describe('health.footerBundle', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(prisma.session.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.dailyStatistic.findMany).mockResolvedValue([]);
     vi.mocked(countActiveParticipantsForSessions).mockResolvedValue(0);
     vi.mocked(getActiveParticipantCountsForSessions).mockResolvedValue(new Map());
     vi.mocked(readLoadSignals).mockResolvedValue({
@@ -128,6 +135,7 @@ describe('health.footerBundle', () => {
     expect(result.stats.sessionTransitionsLastMinute).toBe(0);
     expect(result.stats.activeCountdownSessions).toBe(0);
     expect(result.stats.maxParticipantsSingleSession).toBe(42);
+    expect(result.stats.dailyHighscores).toHaveLength(30);
     expect(result.stats.maxParticipantsStatisticUpdatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(result.stats.serviceStatus).toBe('stable');
     expect(result.stats.loadStatus).toBe('healthy');
@@ -138,6 +146,7 @@ describe('health.stats', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(prisma.session.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.dailyStatistic.findMany).mockResolvedValue([]);
     vi.mocked(countActiveParticipantsForSessions).mockResolvedValue(0);
     vi.mocked(getActiveParticipantCountsForSessions).mockResolvedValue(new Map());
     vi.mocked(readLoadSignals).mockResolvedValue({
@@ -167,6 +176,8 @@ describe('health.stats', () => {
     expect(result.activeCountdownSessions).toBe(0);
     expect(result.completedSessions).toBe(0);
     expect(result.maxParticipantsSingleSession).toBe(0);
+    expect(result.dailyHighscores).toHaveLength(30);
+    expect(result.dailyHighscores.every((entry) => entry.count === 0)).toBe(true);
     expect(result.maxParticipantsStatisticUpdatedAt).toBeNull();
     expect(result.serviceStatus).toBe('stable');
     expect(result.loadStatus).toBe('healthy');
@@ -362,6 +373,7 @@ describe('health.stats', () => {
         'completedSessions',
         'activeBlitzRounds',
         'maxParticipantsSingleSession',
+        'dailyHighscores',
         'maxParticipantsStatisticUpdatedAt',
         'serviceStatus',
         'loadStatus',
@@ -480,6 +492,37 @@ describe('health.stats', () => {
     expect(result.openSessions).toBe(4);
     expect(result.activeSessions).toBe(2);
     expect(result.totalParticipants).toBe(14);
+  });
+
+  it('liefert die letzten 30 UTC-Tage chronologisch und füllt Lücken mit 0 auf', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-04T15:30:00.000Z'));
+    vi.mocked(prisma.session.count).mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vi.mocked(prisma.platformStatistic.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.dailyStatistic.findMany).mockResolvedValue([
+      {
+        date: new Date('2026-05-02T00:00:00.000Z'),
+        maxParticipantsSingleSession: 17,
+      },
+      {
+        date: new Date('2026-05-04T00:00:00.000Z'),
+        maxParticipantsSingleSession: 23,
+      },
+    ] as never);
+
+    try {
+      const result = await caller.stats(undefined);
+
+      expect(result.dailyHighscores).toHaveLength(30);
+      expect(result.dailyHighscores[0]).toEqual({ date: '2026-04-05', count: 0 });
+      expect(result.dailyHighscores.slice(-3)).toEqual([
+        { date: '2026-05-02', count: 17 },
+        { date: '2026-05-03', count: 0 },
+        { date: '2026-05-04', count: 23 },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/backend/src/__tests__/platformStatistic.test.ts
+++ b/apps/backend/src/__tests__/platformStatistic.test.ts
@@ -11,6 +11,7 @@ vi.mock('../db', () => ({
 }));
 
 import {
+  updateDailyMaxParticipants,
   updateCompletedSessionsTotal,
   updateMaxParticipantsSingleSession,
 } from '../lib/platformStatistic';
@@ -30,6 +31,18 @@ describe('platformStatistic', () => {
 
   it('führt Update aus bei gültiger Teilnehmerzahl', async () => {
     await updateMaxParticipantsSingleSession(12);
+    expect(prismaExecuteRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('führt kein Tagesrekord-Update aus bei ungültiger Zahl', async () => {
+    await updateDailyMaxParticipants(0);
+    await updateDailyMaxParticipants(-1);
+    await updateDailyMaxParticipants(Number.NaN);
+    expect(prismaExecuteRaw).not.toHaveBeenCalled();
+  });
+
+  it('führt Tagesrekord-Update aus bei gültiger Teilnehmerzahl', async () => {
+    await updateDailyMaxParticipants(12, new Date('2026-05-04T12:00:00.000Z'));
     expect(prismaExecuteRaw).toHaveBeenCalledTimes(1);
   });
 
@@ -60,6 +73,31 @@ describe('platformStatistic', () => {
 
     const counts = [3, 11, 7, 19, 5];
     await Promise.all(counts.map((count) => updateMaxParticipantsSingleSession(count)));
+
+    expect(prismaExecuteRaw).toHaveBeenCalledTimes(counts.length);
+    expect(persistedMax).toBe(19);
+  });
+
+  it('bleibt bei parallelen Tagesrekord-Updates auf dem Maximum', async () => {
+    let persistedMax = 0;
+    prismaExecuteRaw.mockImplementation(
+      async (_strings: TemplateStringsArray, ...values: unknown[]) => {
+        const candidate = values.find((v) => typeof v === 'number') as number | undefined;
+        const delayMs = Math.max(0, 20 - (candidate ?? 0));
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        if (typeof candidate === 'number') {
+          persistedMax = Math.max(persistedMax, candidate);
+        }
+        return 1;
+      },
+    );
+
+    const counts = [3, 11, 7, 19, 5];
+    await Promise.all(
+      counts.map((count) =>
+        updateDailyMaxParticipants(count, new Date('2026-05-04T12:00:00.000Z')),
+      ),
+    );
 
     expect(prismaExecuteRaw).toHaveBeenCalledTimes(counts.length);
     expect(persistedMax).toBe(19);

--- a/apps/backend/src/__tests__/session.join.test.ts
+++ b/apps/backend/src/__tests__/session.join.test.ts
@@ -22,6 +22,7 @@ const { prismaMock, rateLimitMocks, statsMocks, presenceMocks } = vi.hoisted(() 
   },
   statsMocks: {
     updateMaxParticipantsSingleSession: vi.fn(),
+    updateDailyMaxParticipants: vi.fn(),
   },
   presenceMocks: {
     touchParticipantPresence: vi.fn(),
@@ -40,6 +41,7 @@ vi.mock('../lib/rateLimit', () => ({
 
 vi.mock('../lib/platformStatistic', () => ({
   updateMaxParticipantsSingleSession: statsMocks.updateMaxParticipantsSingleSession,
+  updateDailyMaxParticipants: statsMocks.updateDailyMaxParticipants,
 }));
 
 vi.mock('../lib/presence', () => ({
@@ -154,5 +156,6 @@ describe('session.join', () => {
     expect(result.rejoinToken).toBe(PARTICIPANT_ID);
     expect(result.participantCount).toBe(4);
     expect(statsMocks.updateMaxParticipantsSingleSession).toHaveBeenCalledWith(4);
+    expect(statsMocks.updateDailyMaxParticipants).toHaveBeenCalledWith(4);
   });
 });

--- a/apps/backend/src/lib/platformStatistic.ts
+++ b/apps/backend/src/lib/platformStatistic.ts
@@ -2,10 +2,19 @@
  * Plattformweite Kennzahl: höchste Teilnehmerzahl in einer einzelnen Session.
  * Aktualisierung atomar per GREATEST (parallel Join-sicher).
  */
+import { randomUUID } from 'node:crypto';
 import { prisma } from '../db';
 import { logger } from './logger';
 
 export const PLATFORM_STATISTIC_ID = 'default';
+
+export function getUtcDayStart(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+export function formatUtcDate(date: Date): string {
+  return getUtcDayStart(date).toISOString().slice(0, 10);
+}
 
 /**
  * Erhöht den gespeicherten Rekord, falls `participantCount` höher ist.
@@ -34,6 +43,39 @@ export async function updateMaxParticipantsSingleSession(participantCount: numbe
       'PlatformStatistic: maxParticipantsSingleSession konnte nicht aktualisiert werden',
       e,
     );
+  }
+}
+
+/**
+ * Erhöht den gespeicherten UTC-Tagesrekord, falls `participantCount` höher ist.
+ * Fehler werden geloggt und geschluckt – Aufrufer (z. B. Join) darf nicht fehlschlagen.
+ */
+export async function updateDailyMaxParticipants(
+  participantCount: number,
+  now: Date = new Date(),
+): Promise<void> {
+  if (!Number.isFinite(participantCount) || participantCount < 1) return;
+
+  const utcDay = getUtcDayStart(now);
+
+  try {
+    await prisma.$executeRaw`
+      INSERT INTO "DailyStatistic" ("id", "date", "maxParticipantsSingleSession", "updatedAt")
+      VALUES (${randomUUID()}, ${utcDay}, ${participantCount}, NOW())
+      ON CONFLICT ("date") DO UPDATE
+      SET
+        "maxParticipantsSingleSession" = GREATEST(
+          "DailyStatistic"."maxParticipantsSingleSession",
+          EXCLUDED."maxParticipantsSingleSession"
+        ),
+        "updatedAt" = CASE
+          WHEN EXCLUDED."maxParticipantsSingleSession" > "DailyStatistic"."maxParticipantsSingleSession"
+            THEN NOW()
+          ELSE "DailyStatistic"."updatedAt"
+        END
+    `;
+  } catch (e) {
+    logger.warn('DailyStatistic: maxParticipantsSingleSession konnte nicht aktualisiert werden', e);
   }
 }
 

--- a/apps/backend/src/routers/health.ts
+++ b/apps/backend/src/routers/health.ts
@@ -12,7 +12,11 @@ import {
 import { pingRedis, getRedis } from '../redis';
 import { prisma } from '../db';
 import { logger } from '../lib/logger';
-import { updateCompletedSessionsTotal } from '../lib/platformStatistic';
+import {
+  formatUtcDate,
+  getUtcDayStart,
+  updateCompletedSessionsTotal,
+} from '../lib/platformStatistic';
 import {
   countActiveParticipantsForSessions,
   getActiveParticipantCountsForSessions,
@@ -21,6 +25,7 @@ import { readLoadSignals } from '../lib/loadSignal';
 import { readSloSignals, type SloSignals } from '../lib/sloTelemetry';
 
 const ACTIVE_SESSION_MIN_PARTICIPANTS = 5;
+const DAILY_HIGHSCORE_DAYS = 30;
 
 const SERVER_STATUS_SCORE_THRESHOLDS = {
   busy: 60,
@@ -40,6 +45,32 @@ type LoadStatusInputs = {
   sessionTransitionsLastMinute: number;
   activeCountdownSessions: number;
 };
+
+function addUtcDays(base: Date, days: number): Date {
+  const next = new Date(base);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function buildDailyHighscores(
+  rows: Array<{ date: Date; maxParticipantsSingleSession: number }>,
+  today: Date = new Date(),
+) {
+  const rangeEnd = getUtcDayStart(today);
+  const rangeStart = addUtcDays(rangeEnd, -(DAILY_HIGHSCORE_DAYS - 1));
+  const entriesByDate = new Map(
+    rows.map((row) => [formatUtcDate(row.date), Math.max(0, row.maxParticipantsSingleSession)]),
+  );
+
+  return Array.from({ length: DAILY_HIGHSCORE_DAYS }, (_, index) => {
+    const currentDate = addUtcDays(rangeStart, index);
+    const dateKey = formatUtcDate(currentDate);
+    return {
+      date: dateKey,
+      count: entriesByDate.get(dateKey) ?? 0,
+    };
+  });
+}
 
 function getLoadStatus({
   activeSessions,
@@ -156,6 +187,8 @@ async function fetchServerStats() {
   const activeSessionWhere = {
     status: { not: 'FINISHED' as const },
   };
+  const dailyHighscoreRangeEnd = getUtcDayStart(new Date());
+  const dailyHighscoreRangeStart = addUtcDays(dailyHighscoreRangeEnd, -(DAILY_HIGHSCORE_DAYS - 1));
 
   let activeBlitzRounds = 0;
   try {
@@ -226,12 +259,34 @@ async function fetchServerStats() {
         }
       }
     })();
+    const dailyHighscoreRowsPromise = prisma.dailyStatistic
+      .findMany({
+        where: {
+          date: {
+            gte: dailyHighscoreRangeStart,
+            lte: dailyHighscoreRangeEnd,
+          },
+        },
+        orderBy: { date: 'asc' },
+        select: {
+          date: true,
+          maxParticipantsSingleSession: true,
+        },
+      })
+      .catch((err) => {
+        logger.warn(
+          'health.stats: dailyHighscores konnten nicht aus PostgreSQL gelesen werden, setze leere Historie.',
+          err,
+        );
+        return [];
+      });
 
     const [
       openSessions,
       activeSessionIds,
       completedSessionsNow,
       platformRow,
+      dailyHighscoreRows,
       loadSignals,
       sloSignals,
     ] = await Promise.all([
@@ -243,6 +298,7 @@ async function fetchServerStats() {
       // Momentan in DB vorhandene FINISHED-Sessions (kann durch Purge sinken).
       prisma.session.count({ where: { status: 'FINISHED' } }),
       platformStatisticPromise,
+      dailyHighscoreRowsPromise,
       readLoadSignals(),
       readSloSignals(),
     ]);
@@ -283,6 +339,7 @@ async function fetchServerStats() {
       completedSessions: completedSessionsTotal,
       activeBlitzRounds,
       maxParticipantsSingleSession: platformRow.maxParticipantsSingleSession,
+      dailyHighscores: buildDailyHighscores(dailyHighscoreRows, dailyHighscoreRangeEnd),
       maxParticipantsStatisticUpdatedAt: platformRow.updatedAtIso,
       serviceStatus: getServiceStatus(loadStatus, sloSignals),
       loadStatus,
@@ -298,6 +355,7 @@ async function fetchServerStats() {
       completedSessions: 0,
       activeBlitzRounds: 0,
       maxParticipantsSingleSession: 0,
+      dailyHighscores: buildDailyHighscores([]),
       maxParticipantsStatisticUpdatedAt: null,
       serviceStatus: 'stable' as const,
       loadStatus: 'healthy' as const,

--- a/apps/backend/src/routers/session.ts
+++ b/apps/backend/src/routers/session.ts
@@ -84,7 +84,10 @@ import {
   questionCountsTowardsTotalQuestions,
   questionAffectsStreak,
 } from '../lib/quizScoring';
-import { updateMaxParticipantsSingleSession } from '../lib/platformStatistic';
+import {
+  updateDailyMaxParticipants,
+  updateMaxParticipantsSingleSession,
+} from '../lib/platformStatistic';
 import { getActiveParticipantIdsForSession, touchParticipantPresence } from '../lib/presence';
 import { markCountdownSessionActive, recordSessionTransitionActivity } from '../lib/loadSignal';
 import {
@@ -3100,6 +3103,7 @@ export const sessionRouter = router({
         where: { sessionId: session.id },
       });
       void updateMaxParticipantsSingleSession(newParticipantCount);
+      void updateDailyMaxParticipants(newParticipantCount);
       void touchParticipantPresence(session.id, participantId);
       const serverTime = new Date().toISOString();
       return {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -47,6 +47,7 @@
     "@arsnova/shared-types": "*",
     "@trpc/client": "^11.0.0",
     "@trpc/server": "^11.0.0",
+    "chart.js": "^4.5.1",
     "dompurify": "^3.4.0",
     "express": "^5.1.0",
     "highlight.js": "^11.11.1",

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -29,7 +29,6 @@ import { TopToolbarComponent } from './shared/top-toolbar/top-toolbar.component'
 import { trpc } from './core/trpc.client';
 import type { ServerStatsDTO } from '@arsnova/shared-types';
 import { ServerStatusWidgetComponent } from './shared/server-status-widget/server-status-widget.component';
-import { ServerStatusHelpDialogComponent } from './shared/server-status-help-dialog/server-status-help-dialog.component';
 import { localizePath } from './core/locale-router';
 import { HostDisplayModeService } from './core/host-display-mode.service';
 import { SeoService } from './core/seo.service';
@@ -547,14 +546,17 @@ export class AppComponent implements OnInit, OnDestroy {
     this.apiRetrying.set(false);
   }
 
-  openServerStatusHelp(): void {
+  async openServerStatusHelp(): Promise<void> {
+    const { ServerStatusHelpDialogComponent } =
+      await import('./shared/server-status-help-dialog/server-status-help-dialog.component');
+
     this.dialog.open(ServerStatusHelpDialogComponent, {
       panelClass: 'app-status-help-dialog-panel',
       autoFocus: false,
       data: {
-        connectionOk: this.footerConnectionOk(),
-        loading: !this.footerHealthCheckDone(),
-        stats: this.footerStats(),
+        connectionOk: this.footerConnectionOk,
+        loading: computed(() => !this.footerHealthCheckDone()),
+        stats: this.footerStats,
       },
       width: 'min(54rem, calc(100vw - 2rem))',
       maxWidth: '100vw',

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog-chart.spec.ts
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog-chart.spec.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ServerStatusHistoryChartRenderer } from './server-status-help-dialog-chart';
+
+describe('ServerStatusHistoryChartRenderer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('resolves theme token formulas to concrete chart text colors', () => {
+    const shell = document.createElement('div');
+    const canvas = document.createElement('canvas');
+    shell.appendChild(canvas);
+    document.body.appendChild(shell);
+
+    vi.spyOn(globalThis, 'getComputedStyle').mockImplementation((element: Element) => {
+      if (element === canvas) {
+        return {
+          getPropertyValue: (property: string) => {
+            switch (property) {
+              case '--app-status-chart-grid':
+                return 'rgb(120, 120, 120)';
+              case '--app-status-chart-line':
+                return 'rgb(255, 171, 243)';
+              case '--app-status-chart-point':
+                return 'rgb(255, 232, 252)';
+              case '--app-status-chart-text':
+                return 'light-dark(#1e1a1d, #e9e0e4)';
+              case '--app-status-chart-tooltip-background':
+                return 'rgb(45, 41, 44)';
+              case '--app-status-chart-tooltip-border':
+                return 'rgb(95, 88, 92)';
+              case '--app-status-chart-tooltip-body':
+              case '--app-status-chart-tooltip-title':
+                return 'rgb(233, 224, 228)';
+              default:
+                return '';
+            }
+          },
+        } as CSSStyleDeclaration;
+      }
+
+      const htmlElement = element as HTMLElement;
+      const probeToken = htmlElement.style.getPropertyValue('--app-status-chart-probe-color');
+      return {
+        getPropertyValue: () => '',
+        color:
+          probeToken === 'light-dark(#1e1a1d, #e9e0e4)' ? 'rgb(233, 224, 228)' : 'rgb(0, 0, 0)',
+        backgroundColor: htmlElement.style.backgroundColor || 'rgb(45, 41, 44)',
+      } as CSSStyleDeclaration;
+    });
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => {
+      let fillStyle = '';
+      return {
+        get fillStyle() {
+          return fillStyle;
+        },
+        set fillStyle(value: string) {
+          fillStyle = value;
+        },
+      } as unknown as CanvasRenderingContext2D;
+    });
+
+    const renderer = new ServerStatusHistoryChartRenderer() as ServerStatusHistoryChartRenderer & {
+      readChartPalette: (canvas: HTMLCanvasElement) => { text: string };
+    };
+
+    const palette = renderer.readChartPalette(canvas);
+
+    expect(palette.text).toBe('rgb(233, 224, 228)');
+  });
+
+  it('formats y-axis ticks with the active locale', () => {
+    const renderer = new ServerStatusHistoryChartRenderer() as ServerStatusHistoryChartRenderer & {
+      buildOptions: (
+        locale: string,
+        palette: {
+          grid: string;
+          line: string;
+          point: string;
+          text: string;
+          tooltipBackground: string;
+          tooltipBorder: string;
+          tooltipBody: string;
+          tooltipTitle: string;
+        },
+      ) => {
+        scales?: {
+          y?: {
+            ticks?: {
+              callback?: (value: number | string) => string;
+            };
+          };
+        };
+      };
+    };
+
+    const options = renderer.buildOptions('de-DE', {
+      grid: 'rgb(120, 120, 120)',
+      line: 'rgb(255, 171, 243)',
+      point: 'rgb(255, 232, 252)',
+      text: 'rgb(233, 224, 228)',
+      tooltipBackground: 'rgb(45, 41, 44)',
+      tooltipBorder: 'rgb(95, 88, 92)',
+      tooltipBody: 'rgb(233, 224, 228)',
+      tooltipTitle: 'rgb(233, 224, 228)',
+    });
+
+    expect(options.scales?.y?.ticks?.callback?.(1400)).toBe('1.400');
+  });
+});

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog-chart.ts
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog-chart.ts
@@ -2,6 +2,19 @@ import type { DailyHighscoreEntry } from '@arsnova/shared-types';
 
 type ChartJsModule = typeof import('chart.js');
 type ChartInstance = import('chart.js').Chart<'line', number[], string>;
+type ChartOptions = import('chart.js').ChartOptions<'line'>;
+type ChartDataset = import('chart.js').ChartDataset<'line', number[]>;
+
+type ChartPalette = {
+  grid: string;
+  line: string;
+  point: string;
+  text: string;
+  tooltipBackground: string;
+  tooltipBorder: string;
+  tooltipBody: string;
+  tooltipTitle: string;
+};
 
 export class ServerStatusHistoryChartRenderer {
   private chartModulePromise: Promise<ChartJsModule> | null = null;
@@ -45,68 +58,9 @@ export class ServerStatusHistoryChartRenderer {
         type: 'line',
         data: {
           labels,
-          datasets: [
-            {
-              data: values,
-              borderColor: palette.line,
-              backgroundColor: palette.line,
-              pointBackgroundColor: palette.point,
-              pointBorderColor: palette.point,
-              pointHoverBackgroundColor: palette.point,
-              pointHoverBorderColor: palette.point,
-              borderWidth: 2,
-              cubicInterpolationMode: 'monotone',
-              fill: false,
-              pointHitRadius: 16,
-              pointHoverRadius: 4,
-              pointRadius: 2.5,
-              tension: 0.32,
-            },
-          ],
+          datasets: [this.buildDataset(values, palette)],
         },
-        options: {
-          animation: false,
-          maintainAspectRatio: false,
-          responsive: true,
-          interaction: {
-            intersect: false,
-            mode: 'index',
-          },
-          plugins: {
-            legend: { display: false },
-            tooltip: {
-              displayColors: false,
-              callbacks: {
-                label: (tooltipItem) =>
-                  new Intl.NumberFormat(locale).format(Number(tooltipItem.parsed.y ?? 0)),
-              },
-            },
-          },
-          scales: {
-            x: {
-              grid: {
-                display: false,
-              },
-              ticks: {
-                autoSkip: true,
-                color: palette.text,
-                maxRotation: 0,
-                maxTicksLimit: 6,
-                minRotation: 0,
-              },
-            },
-            y: {
-              beginAtZero: true,
-              grid: {
-                color: palette.grid,
-              },
-              ticks: {
-                color: palette.text,
-                precision: 0,
-              },
-            },
-          },
-        },
+        options: this.buildOptions(locale, palette),
       });
       this.chartCanvas = canvas;
       return;
@@ -123,6 +77,7 @@ export class ServerStatusHistoryChartRenderer {
     dataset.pointBorderColor = palette.point;
     dataset.pointHoverBackgroundColor = palette.point;
     dataset.pointHoverBorderColor = palette.point;
+    this.chart.options = this.buildOptions(locale, palette);
     this.chart.update();
   }
 
@@ -176,18 +131,209 @@ export class ServerStatusHistoryChartRenderer {
     }).format(parsed);
   }
 
-  private readChartPalette(canvas: HTMLCanvasElement): {
-    grid: string;
-    line: string;
-    point: string;
-    text: string;
-  } {
+  private formatChartCount(value: number, locale: string): string {
+    return new Intl.NumberFormat(locale, {
+      maximumFractionDigits: 0,
+    }).format(value);
+  }
+
+  private buildDataset(values: number[], palette: ChartPalette): ChartDataset {
+    return {
+      data: values,
+      backgroundColor: palette.line,
+      borderColor: palette.line,
+      borderWidth: 2,
+      cubicInterpolationMode: 'monotone',
+      fill: false,
+      pointBackgroundColor: palette.point,
+      pointBorderColor: palette.point,
+      pointHitRadius: 16,
+      pointHoverBackgroundColor: palette.point,
+      pointHoverBorderColor: palette.point,
+      pointHoverRadius: 4,
+      pointRadius: 2.5,
+      tension: 0.32,
+    };
+  }
+
+  private buildOptions(locale: string, palette: ChartPalette): ChartOptions {
+    return {
+      animation: false,
+      locale,
+      maintainAspectRatio: false,
+      responsive: true,
+      interaction: {
+        intersect: false,
+        mode: 'index',
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: palette.tooltipBackground,
+          bodyColor: palette.tooltipBody,
+          borderColor: palette.tooltipBorder,
+          borderWidth: 1,
+          displayColors: false,
+          titleColor: palette.tooltipTitle,
+          callbacks: {
+            label: (tooltipItem) =>
+              this.formatChartCount(Number(tooltipItem.parsed.y ?? 0), locale),
+          },
+        },
+      },
+      scales: {
+        x: {
+          border: {
+            display: false,
+          },
+          grid: {
+            display: false,
+          },
+          ticks: {
+            autoSkip: true,
+            color: palette.text,
+            maxRotation: 0,
+            maxTicksLimit: 6,
+            minRotation: 0,
+          },
+        },
+        y: {
+          beginAtZero: true,
+          border: {
+            display: false,
+          },
+          grid: {
+            color: palette.grid,
+          },
+          ticks: {
+            callback: (value) => {
+              const numericValue = Number(value);
+              if (!Number.isFinite(numericValue)) {
+                return '';
+              }
+
+              return this.formatChartCount(numericValue, locale);
+            },
+            color: palette.text,
+            precision: 0,
+          },
+        },
+      },
+    };
+  }
+
+  private readChartPalette(canvas: HTMLCanvasElement): ChartPalette {
     const styles = getComputedStyle(canvas);
     return {
-      grid: styles.getPropertyValue('--mat-sys-outline-variant').trim() || '#c4c7cf',
-      line: styles.getPropertyValue('--mat-sys-primary').trim() || '#005cbb',
-      point: styles.getPropertyValue('--mat-sys-tertiary').trim() || '#7d5260',
-      text: styles.getPropertyValue('--mat-sys-on-surface-variant').trim() || '#44474e',
+      grid: this.resolveColorToken(
+        canvas,
+        styles.getPropertyValue('--app-status-chart-grid').trim() ||
+          styles.getPropertyValue('--mat-sys-outline-variant').trim(),
+        '#c4c7cf',
+      ),
+      line: this.resolveColorToken(
+        canvas,
+        styles.getPropertyValue('--app-status-chart-line').trim() ||
+          styles.getPropertyValue('--mat-sys-primary').trim(),
+        '#005cbb',
+      ),
+      point: this.resolveColorToken(
+        canvas,
+        styles.getPropertyValue('--app-status-chart-point').trim() ||
+          styles.getPropertyValue('--mat-sys-tertiary').trim(),
+        '#7d5260',
+      ),
+      text: this.resolveColorToken(
+        canvas,
+        styles.getPropertyValue('--app-status-chart-text').trim() ||
+          styles.getPropertyValue('--mat-sys-on-surface').trim(),
+        '#1c1b1f',
+      ),
+      tooltipBackground: this.resolveBackgroundToken(
+        canvas,
+        styles.getPropertyValue('--app-status-chart-tooltip-background').trim() ||
+          styles.getPropertyValue('--mat-sys-surface-container-high').trim(),
+        '#f3f0f4',
+      ),
+      tooltipBorder: this.resolveColorToken(
+        canvas,
+        styles.getPropertyValue('--app-status-chart-tooltip-border').trim() ||
+          styles.getPropertyValue('--mat-sys-outline-variant').trim(),
+        '#c4c7cf',
+      ),
+      tooltipBody: this.resolveColorToken(
+        canvas,
+        styles.getPropertyValue('--app-status-chart-tooltip-body').trim() ||
+          styles.getPropertyValue('--mat-sys-on-surface').trim(),
+        '#1c1b1f',
+      ),
+      tooltipTitle: this.resolveColorToken(
+        canvas,
+        styles.getPropertyValue('--app-status-chart-tooltip-title').trim() ||
+          styles.getPropertyValue('--mat-sys-on-surface').trim(),
+        '#1c1b1f',
+      ),
     };
+  }
+
+  private resolveColorToken(canvas: HTMLCanvasElement, token: string, fallback: string): string {
+    return this.resolveCssColor(canvas, token, fallback, 'color');
+  }
+
+  private resolveBackgroundToken(
+    canvas: HTMLCanvasElement,
+    token: string,
+    fallback: string,
+  ): string {
+    return this.resolveCssColor(canvas, token, fallback, 'backgroundColor');
+  }
+
+  private resolveCssColor(
+    canvas: HTMLCanvasElement,
+    token: string,
+    fallback: string,
+    property: 'color' | 'backgroundColor',
+  ): string {
+    if (!token) {
+      return fallback;
+    }
+
+    const host = canvas.parentElement instanceof HTMLElement ? canvas.parentElement : canvas;
+    const probe = canvas.ownerDocument.createElement('span');
+    probe.style.position = 'absolute';
+    probe.style.inlineSize = '0';
+    probe.style.blockSize = '0';
+    probe.style.overflow = 'hidden';
+    probe.style.opacity = '0';
+    probe.style.pointerEvents = 'none';
+    probe.style.setProperty('--app-status-chart-probe-color', token);
+    probe.style[property] = 'var(--app-status-chart-probe-color)';
+    host.appendChild(probe);
+
+    const probeStyles = getComputedStyle(probe);
+    const resolved =
+      property === 'backgroundColor' ? probeStyles.backgroundColor : probeStyles.color;
+    probe.remove();
+
+    return this.normalizeCanvasColor(canvas, resolved) || resolved || fallback;
+  }
+
+  private normalizeCanvasColor(canvas: HTMLCanvasElement, color: string): string | null {
+    if (!color) {
+      return null;
+    }
+
+    const normalizationCanvas = canvas.ownerDocument.createElement('canvas');
+    const context = normalizationCanvas.getContext('2d');
+    if (!context) {
+      return color;
+    }
+
+    try {
+      context.fillStyle = color;
+      return context.fillStyle || color;
+    } catch {
+      return color;
+    }
   }
 }

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog-chart.ts
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog-chart.ts
@@ -1,0 +1,193 @@
+import type { DailyHighscoreEntry } from '@arsnova/shared-types';
+
+type ChartJsModule = typeof import('chart.js');
+type ChartInstance = import('chart.js').Chart<'line', number[], string>;
+
+export class ServerStatusHistoryChartRenderer {
+  private chartModulePromise: Promise<ChartJsModule> | null = null;
+  private chart: ChartInstance | null = null;
+  private chartCanvas: HTMLCanvasElement | null = null;
+  private renderChain: Promise<void> = Promise.resolve();
+
+  async render(
+    points: DailyHighscoreEntry[],
+    canvas: HTMLCanvasElement,
+    locale: string,
+  ): Promise<void> {
+    this.renderChain = this.renderChain.then(() => this.renderNow(points, canvas, locale));
+    await this.renderChain;
+  }
+
+  private async renderNow(
+    points: DailyHighscoreEntry[],
+    canvas: HTMLCanvasElement,
+    locale: string,
+  ): Promise<void> {
+    if (!points.length) {
+      this.destroy();
+      return;
+    }
+
+    const chartJs = await this.loadChartModule();
+    const context = this.tryGetCanvasContext(canvas);
+    if (!context) return;
+
+    const labels = points.map((entry) => this.formatChartDate(entry.date, locale));
+    const values = points.map((entry) => entry.count);
+    const palette = this.readChartPalette(canvas);
+
+    if (this.chart && this.chartCanvas !== canvas) {
+      this.destroy();
+    }
+
+    if (!this.chart) {
+      this.chart = new chartJs.Chart(context, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              data: values,
+              borderColor: palette.line,
+              backgroundColor: palette.line,
+              pointBackgroundColor: palette.point,
+              pointBorderColor: palette.point,
+              pointHoverBackgroundColor: palette.point,
+              pointHoverBorderColor: palette.point,
+              borderWidth: 2,
+              cubicInterpolationMode: 'monotone',
+              fill: false,
+              pointHitRadius: 16,
+              pointHoverRadius: 4,
+              pointRadius: 2.5,
+              tension: 0.32,
+            },
+          ],
+        },
+        options: {
+          animation: false,
+          maintainAspectRatio: false,
+          responsive: true,
+          interaction: {
+            intersect: false,
+            mode: 'index',
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              displayColors: false,
+              callbacks: {
+                label: (tooltipItem) =>
+                  new Intl.NumberFormat(locale).format(Number(tooltipItem.parsed.y ?? 0)),
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: {
+                display: false,
+              },
+              ticks: {
+                autoSkip: true,
+                color: palette.text,
+                maxRotation: 0,
+                maxTicksLimit: 6,
+                minRotation: 0,
+              },
+            },
+            y: {
+              beginAtZero: true,
+              grid: {
+                color: palette.grid,
+              },
+              ticks: {
+                color: palette.text,
+                precision: 0,
+              },
+            },
+          },
+        },
+      });
+      this.chartCanvas = canvas;
+      return;
+    }
+
+    this.chart.data.labels = labels;
+    const dataset = this.chart.data.datasets[0];
+    if (!dataset) return;
+
+    dataset.data = values;
+    dataset.borderColor = palette.line;
+    dataset.backgroundColor = palette.line;
+    dataset.pointBackgroundColor = palette.point;
+    dataset.pointBorderColor = palette.point;
+    dataset.pointHoverBackgroundColor = palette.point;
+    dataset.pointHoverBorderColor = palette.point;
+    this.chart.update();
+  }
+
+  destroy(): void {
+    this.chart?.destroy();
+    this.chart = null;
+    this.chartCanvas = null;
+  }
+
+  private async loadChartModule(): Promise<ChartJsModule> {
+    if (!this.chartModulePromise) {
+      this.chartModulePromise = import('chart.js').then((chartJs) => {
+        chartJs.Chart.register(
+          chartJs.CategoryScale,
+          chartJs.Filler,
+          chartJs.LineController,
+          chartJs.LineElement,
+          chartJs.LinearScale,
+          chartJs.PointElement,
+          chartJs.Tooltip,
+        );
+        return chartJs;
+      });
+    }
+
+    return this.chartModulePromise;
+  }
+
+  private tryGetCanvasContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D | null {
+    if (typeof navigator !== 'undefined' && /\bjsdom\b/i.test(navigator.userAgent)) {
+      return null;
+    }
+
+    try {
+      return canvas.getContext('2d');
+    } catch {
+      return null;
+    }
+  }
+
+  private formatChartDate(date: string, locale: string): string {
+    const parsed = new Date(`${date}T00:00:00.000Z`);
+    if (Number.isNaN(parsed.getTime())) {
+      return date;
+    }
+
+    return new Intl.DateTimeFormat(locale, {
+      day: 'numeric',
+      month: 'short',
+      timeZone: 'UTC',
+    }).format(parsed);
+  }
+
+  private readChartPalette(canvas: HTMLCanvasElement): {
+    grid: string;
+    line: string;
+    point: string;
+    text: string;
+  } {
+    const styles = getComputedStyle(canvas);
+    return {
+      grid: styles.getPropertyValue('--mat-sys-outline-variant').trim() || '#c4c7cf',
+      line: styles.getPropertyValue('--mat-sys-primary').trim() || '#005cbb',
+      point: styles.getPropertyValue('--mat-sys-tertiary').trim() || '#7d5260',
+      text: styles.getPropertyValue('--mat-sys-on-surface-variant').trim() || '#44474e',
+    };
+  }
+}

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.scss
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.scss
@@ -41,6 +41,10 @@ mat-dialog-actions {
   background: color-mix(in srgb, var(--mat-sys-surface-container-high) 72%, var(--mat-sys-surface));
 }
 
+.status-help-dialog__panel--history {
+  background: color-mix(in srgb, var(--mat-sys-tertiary-container) 16%, var(--mat-sys-surface));
+}
+
 .status-help-dialog__panel-header {
   display: flex;
   align-items: center;
@@ -255,6 +259,18 @@ mat-dialog-actions {
   font-style: italic;
 }
 
+.status-help-dialog__history-chart-shell {
+  position: relative;
+  min-height: 12.5rem;
+  padding-top: 0.2rem;
+}
+
+.status-help-dialog__history-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .status-help-dialog__legend {
   margin: 0;
   padding: 0;
@@ -391,6 +407,10 @@ mat-dialog-actions {
   .status-help-dialog__record-number {
     font: var(--mat-sys-headline-large);
     font-weight: 700;
+  }
+
+  .status-help-dialog__history-chart-shell {
+    min-height: 11rem;
   }
 
   .status-help-dialog__record-unit {

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.scss
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.scss
@@ -260,6 +260,26 @@ mat-dialog-actions {
 }
 
 .status-help-dialog__history-chart-shell {
+  --app-status-chart-grid: color-mix(in srgb, var(--mat-sys-on-surface) 16%, transparent);
+  --app-status-chart-line: color-mix(
+    in srgb,
+    var(--mat-sys-primary) 82%,
+    var(--mat-sys-on-surface) 18%
+  );
+  --app-status-chart-point: color-mix(
+    in srgb,
+    var(--mat-sys-tertiary) 76%,
+    var(--mat-sys-on-surface) 24%
+  );
+  --app-status-chart-text: var(--mat-sys-on-surface);
+  --app-status-chart-tooltip-background: color-mix(
+    in srgb,
+    var(--mat-sys-surface-container-high) 94%,
+    var(--mat-sys-surface)
+  );
+  --app-status-chart-tooltip-border: color-mix(in srgb, var(--mat-sys-on-surface) 16%, transparent);
+  --app-status-chart-tooltip-body: var(--mat-sys-on-surface);
+  --app-status-chart-tooltip-title: var(--mat-sys-on-surface);
   position: relative;
   min-height: 12.5rem;
   padding-top: 0.2rem;

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.spec.ts
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.spec.ts
@@ -1,9 +1,25 @@
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ServerStatusHelpDialogComponent } from './server-status-help-dialog.component';
 
+function buildDailyHighscores() {
+  return Array.from({ length: 30 }, (_, index) => ({
+    date: `2026-04-${String(index + 1).padStart(2, '0')}`,
+    count: index + 1,
+  }));
+}
+
 describe('ServerStatusHelpDialogComponent', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('shows live metrics and the session attendance record when stats are available', () => {
     TestBed.configureTestingModule({
       imports: [ServerStatusHelpDialogComponent],
@@ -11,9 +27,9 @@ describe('ServerStatusHelpDialogComponent', () => {
         {
           provide: MAT_DIALOG_DATA,
           useValue: {
-            connectionOk: true,
-            loading: false,
-            stats: {
+            connectionOk: signal(true),
+            loading: signal(false),
+            stats: signal({
               openSessions: 11,
               activeSessions: 6,
               totalParticipants: 145,
@@ -23,10 +39,11 @@ describe('ServerStatusHelpDialogComponent', () => {
               completedSessions: 98,
               activeBlitzRounds: 3,
               maxParticipantsSingleSession: 412,
+              dailyHighscores: buildDailyHighscores(),
               maxParticipantsStatisticUpdatedAt: '2026-04-05T10:15:00.000Z',
               serviceStatus: 'limited',
               loadStatus: 'busy',
-            },
+            }),
           },
         },
       ],
@@ -56,7 +73,12 @@ describe('ServerStatusHelpDialogComponent', () => {
     expect(text).toContain('Mit laufendem Countdown im aktuellen Aktivitätsfenster');
     expect(text).toContain('Alle je beendeten Live-Sessions (kumulativ)');
     expect(text).toContain('Rekordteilnahme');
+    expect(text).toContain('Session-Tagesrekorde der letzten 30 Tage');
+    expect(text).toContain(
+      'Jeder Punkt zeigt den Rekord der größten einzelnen Session eines UTC-Tages.',
+    );
     expect(text).toContain('412');
+    expect((fixture.nativeElement as HTMLElement).querySelector('canvas')).not.toBeNull();
   });
 
   it('shows a loading fallback when the first live request has not finished yet', () => {
@@ -66,9 +88,9 @@ describe('ServerStatusHelpDialogComponent', () => {
         {
           provide: MAT_DIALOG_DATA,
           useValue: {
-            connectionOk: true,
-            loading: true,
-            stats: null,
+            connectionOk: signal(true),
+            loading: signal(true),
+            stats: signal(null),
           },
         },
       ],

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.spec.ts
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.spec.ts
@@ -103,4 +103,46 @@ describe('ServerStatusHelpDialogComponent', () => {
     expect(text).toContain('Live-Daten werden geladen');
     expect(text).not.toContain('Rekordteilnahme');
   });
+
+  it('rerenders the history chart when the app theme changes', () => {
+    TestBed.configureTestingModule({
+      imports: [ServerStatusHelpDialogComponent],
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            connectionOk: signal(true),
+            loading: signal(false),
+            stats: signal({
+              openSessions: 4,
+              activeSessions: 2,
+              totalParticipants: 48,
+              votesLastMinute: 7,
+              sessionTransitionsLastMinute: 3,
+              activeCountdownSessions: 1,
+              completedSessions: 12,
+              activeBlitzRounds: 0,
+              maxParticipantsSingleSession: 96,
+              dailyHighscores: buildDailyHighscores(),
+              maxParticipantsStatisticUpdatedAt: '2026-04-05T10:15:00.000Z',
+              serviceStatus: 'stable',
+              loadStatus: 'healthy',
+            }),
+          },
+        },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(ServerStatusHelpDialogComponent);
+    const component = fixture.componentInstance as ServerStatusHelpDialogComponent & {
+      syncChart: (stats: unknown, canvas: HTMLCanvasElement) => Promise<void>;
+    };
+    const syncChartSpy = vi.spyOn(component, 'syncChart').mockResolvedValue();
+
+    fixture.detectChanges();
+    expect(syncChartSpy).toHaveBeenCalledTimes(1);
+
+    globalThis.dispatchEvent(new Event('arsnova:preset-updated'));
+    expect(syncChartSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts
@@ -22,6 +22,8 @@ import { MatIcon } from '@angular/material/icon';
 import type { ServerStatsDTO } from '@arsnova/shared-types';
 type ChartRenderer = import('./server-status-help-dialog-chart').ServerStatusHistoryChartRenderer;
 
+const THEME_PRESET_DOM_EVENT = 'arsnova:preset-updated';
+
 export interface ServerStatusHelpDialogData {
   connectionOk: Signal<boolean>;
   loading: Signal<boolean>;
@@ -374,6 +376,12 @@ export class ServerStatusHelpDialogComponent {
   readonly data = inject<ServerStatusHelpDialogData>(MAT_DIALOG_DATA);
   private chartRenderer: ChartRenderer | null = null;
   private chartRendererPromise: Promise<ChartRenderer> | null = null;
+  private readonly refreshChartForThemeChange = (): void => {
+    const stats = this.effectiveStats();
+    const canvas = this.dailyHighscoresCanvas()?.nativeElement;
+    if (!stats || !canvas) return;
+    void this.syncChart(stats, canvas);
+  };
 
   readonly effectiveStats = computed<ServerStatsDTO | null>(() => {
     return this.data.stats();
@@ -404,6 +412,13 @@ export class ServerStatusHelpDialogComponent {
 
   constructor() {
     this.destroyRef.onDestroy(() => this.destroyChart());
+
+    if (typeof globalThis.addEventListener === 'function') {
+      globalThis.addEventListener(THEME_PRESET_DOM_EVENT, this.refreshChartForThemeChange);
+      this.destroyRef.onDestroy(() => {
+        globalThis.removeEventListener(THEME_PRESET_DOM_EVENT, this.refreshChartForThemeChange);
+      });
+    }
 
     effect(() => {
       const stats = this.effectiveStats();

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts
@@ -1,4 +1,15 @@
-import { Component, LOCALE_ID, computed, inject } from '@angular/core';
+import {
+  Component,
+  DestroyRef,
+  ElementRef,
+  LOCALE_ID,
+  computed,
+  effect,
+  inject,
+  untracked,
+  viewChild,
+} from '@angular/core';
+import type { Signal } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import {
   MAT_DIALOG_DATA,
@@ -9,11 +20,12 @@ import {
 } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import type { ServerStatsDTO } from '@arsnova/shared-types';
+type ChartRenderer = import('./server-status-help-dialog-chart').ServerStatusHistoryChartRenderer;
 
 export interface ServerStatusHelpDialogData {
-  connectionOk: boolean;
-  loading: boolean;
-  stats: ServerStatsDTO | null;
+  connectionOk: Signal<boolean>;
+  loading: Signal<boolean>;
+  stats: Signal<ServerStatsDTO | null>;
 }
 
 @Component({
@@ -253,9 +265,39 @@ export interface ServerStatusHelpDialogData {
             <div class="status-help-dialog__record-unit" i18n="@@help.statsUnit">Teilnehmende</div>
           </div>
         </section>
+
+        <section
+          class="status-help-dialog__panel status-help-dialog__panel--history"
+          aria-labelledby="server-status-daily-history-heading"
+        >
+          <div class="status-help-dialog__panel-header status-help-dialog__panel-header--stacked">
+            <h3
+              id="server-status-daily-history-heading"
+              class="status-help-dialog__section-title"
+              i18n="@@help.dailyHighscoresTitle"
+            >
+              Session-Tagesrekorde der letzten 30 Tage
+            </h3>
+            <p
+              class="status-help-dialog__copy status-help-dialog__copy--compact"
+              i18n="@@help.dailyHighscoresHint"
+            >
+              Jeder Punkt zeigt den Rekord der größten einzelnen Session eines UTC-Tages.
+            </p>
+          </div>
+          <div class="status-help-dialog__history-chart-shell">
+            <canvas
+              #dailyHighscoresCanvas
+              class="status-help-dialog__history-canvas"
+              role="img"
+              i18n-aria-label="@@help.dailyHighscoresChartAria"
+              aria-label="Linienchart der Session-Tagesrekorde der letzten 30 UTC-Tage"
+            ></canvas>
+          </div>
+        </section>
       } @else {
         <section class="status-help-dialog__state" aria-live="polite">
-          @if (data.loading) {
+          @if (data.loading()) {
             <p class="status-help-dialog__copy" i18n="@@app.footer.statusLoading">
               Live-Daten werden geladen…
             </p>
@@ -326,10 +368,15 @@ export interface ServerStatusHelpDialogData {
 })
 export class ServerStatusHelpDialogComponent {
   private readonly locale = inject(LOCALE_ID);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dailyHighscoresCanvas =
+    viewChild<ElementRef<HTMLCanvasElement>>('dailyHighscoresCanvas');
   readonly data = inject<ServerStatusHelpDialogData>(MAT_DIALOG_DATA);
+  private chartRenderer: ChartRenderer | null = null;
+  private chartRendererPromise: Promise<ChartRenderer> | null = null;
 
   readonly effectiveStats = computed<ServerStatsDTO | null>(() => {
-    return this.data.stats;
+    return this.data.stats();
   });
 
   readonly recordUpdatedFormatted = computed(() => {
@@ -355,8 +402,24 @@ export class ServerStatusHelpDialogComponent {
     }
   });
 
+  constructor() {
+    this.destroyRef.onDestroy(() => this.destroyChart());
+
+    effect(() => {
+      const stats = this.effectiveStats();
+      const canvas = this.dailyHighscoresCanvas()?.nativeElement;
+
+      if (!stats || !canvas) {
+        this.destroyChart();
+        return;
+      }
+
+      untracked(() => void this.syncChart(stats, canvas));
+    });
+  }
+
   statusTone(): 'healthy' | 'busy' | 'overloaded' | 'unknown' {
-    if (!this.data.connectionOk) return 'unknown';
+    if (!this.data.connectionOk()) return 'unknown';
     const stats = this.effectiveStats();
     switch (stats?.serviceStatus) {
       case 'stable':
@@ -368,5 +431,35 @@ export class ServerStatusHelpDialogComponent {
       default:
         return 'unknown';
     }
+  }
+
+  private async syncChart(stats: ServerStatsDTO, canvas: HTMLCanvasElement): Promise<void> {
+    if (!stats.dailyHighscores.length) {
+      this.destroyChart();
+      return;
+    }
+
+    const renderer = await this.getChartRenderer();
+    await renderer.render(stats.dailyHighscores, canvas, this.locale);
+  }
+
+  private async getChartRenderer(): Promise<ChartRenderer> {
+    if (this.chartRenderer) {
+      return this.chartRenderer;
+    }
+
+    if (!this.chartRendererPromise) {
+      this.chartRendererPromise = import('./server-status-help-dialog-chart').then((module) => {
+        const renderer = new module.ServerStatusHistoryChartRenderer();
+        this.chartRenderer = renderer;
+        return renderer;
+      });
+    }
+
+    return this.chartRendererPromise;
+  }
+
+  private destroyChart(): void {
+    this.chartRenderer?.destroy();
   }
 }

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -12647,6 +12647,30 @@
           <context context-type="linenumber">232,234</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.dailyHighscoresTitle" datatype="html">
+        <source> Session-Tagesrekorde der letzten 30 Tage</source>
+        <target>Session daily records for the last 30 days</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">263,267</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresHint" datatype="html">
+        <source> Jeder Punkt zeigt den Rekord der größten einzelnen Session eines UTC-Tages.</source>
+        <target>Each point shows the record for the largest single session of a UTC day.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">269,271</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresChartAria" datatype="html">
+        <source>Linienchart der Session-Tagesrekorde der letzten 30 UTC-Tage</source>
+        <target>Line chart of the session daily records for the last 30 UTC days</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">278</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.statsHint" datatype="html">
         <source> Bisher höchste Teilnehmerzahl in einer einzelnen Live-Session auf diesem Server.</source>
         <target>Highest number of participants so far in a single live session on this server.</target>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -12597,6 +12597,30 @@
           <context context-type="linenumber">235,237</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.dailyHighscoresTitle" datatype="html">
+        <source> Session-Tagesrekorde der letzten 30 Tage</source>
+        <target>Récords diarios de sesión de los últimos 30 días</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">263,267</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresHint" datatype="html">
+        <source> Jeder Punkt zeigt den Rekord der größten einzelnen Session eines UTC-Tages.</source>
+        <target>Cada punto muestra el récord de la sesión individual más grande de un día UTC.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">269,271</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresChartAria" datatype="html">
+        <source>Linienchart der Session-Tagesrekorde der letzten 30 UTC-Tage</source>
+        <target>Gráfico de líneas de los récords diarios de sesión de los últimos 30 días UTC</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">278</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.statsAsOf" datatype="html">
         <source> Zuletzt erhöht am <x id="INTERPOLATION" equiv-text="{{ dateLabel }}"/></source>
         <target>Último aumento el <x id="INTERPOLATION" equiv-text="{{ dateLabel }}"/></target>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -12597,6 +12597,30 @@
           <context context-type="linenumber">235,237</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.dailyHighscoresTitle" datatype="html">
+        <source> Session-Tagesrekorde der letzten 30 Tage</source>
+        <target>Records quotidiens de session des 30 derniers jours</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">263,267</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresHint" datatype="html">
+        <source> Jeder Punkt zeigt den Rekord der größten einzelnen Session eines UTC-Tages.</source>
+        <target>Chaque point montre le record de la plus grande session unique d&apos;une journée UTC.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">269,271</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresChartAria" datatype="html">
+        <source>Linienchart der Session-Tagesrekorde der letzten 30 UTC-Tage</source>
+        <target>Graphique linéaire des records quotidiens de session des 30 derniers jours UTC</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">278</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.statsAsOf" datatype="html">
         <source> Zuletzt erhöht am <x id="INTERPOLATION" equiv-text="{{ dateLabel }}"/></source>
         <target>Dernière augmentation le <x id="INTERPOLATION" equiv-text="{{ dateLabel }}"/></target>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -12597,6 +12597,30 @@
           <context context-type="linenumber">235,237</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.dailyHighscoresTitle" datatype="html">
+        <source> Session-Tagesrekorde der letzten 30 Tage</source>
+        <target>Record giornalieri di sessione degli ultimi 30 giorni</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">263,267</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresHint" datatype="html">
+        <source> Jeder Punkt zeigt den Rekord der größten einzelnen Session eines UTC-Tages.</source>
+        <target>Ogni punto mostra il record della singola sessione più grande di un giorno UTC.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">269,271</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresChartAria" datatype="html">
+        <source>Linienchart der Session-Tagesrekorde der letzten 30 UTC-Tage</source>
+        <target>Grafico a linee dei record giornalieri di sessione degli ultimi 30 giorni UTC</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">278</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.statsAsOf" datatype="html">
         <source> Zuletzt erhöht am <x id="INTERPOLATION" equiv-text="{{ dateLabel }}"/></source>
         <target>Ultimo aumento il <x id="INTERPOLATION" equiv-text="{{ dateLabel }}"/></target>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -11173,6 +11173,27 @@
           <context context-type="linenumber">235,237</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.dailyHighscoresTitle" datatype="html">
+        <source> Session-Tagesrekorde der letzten 30 Tage </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">263,267</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresHint" datatype="html">
+        <source> Jeder Punkt zeigt den Rekord der größten einzelnen Session eines UTC-Tages. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">269,271</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.dailyHighscoresChartAria" datatype="html">
+        <source>Linienchart der Session-Tagesrekorde der letzten 30 UTC-Tage</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts</context>
+          <context context-type="linenumber">278</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.statsAsOf" datatype="html">
         <source> Zuletzt erhöht am <x id="INTERPOLATION" equiv-text="{{ dateLabel }}"/> </source>
         <context-group purpose="location">

--- a/docs/architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md
+++ b/docs/architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD013 -->
 
-# ADR-0024: Tagesrekord-Verlauf fuer Session-Teilnehmende im Server-Status-Hilfedialog
+# ADR-0024: Session-Tagesrekord-Verlauf fuer Session-Teilnehmende im Server-Status-Hilfedialog
 
 **Status:** Proposed  
 **Datum:** 2026-05-04  
@@ -15,11 +15,11 @@ Der Server-Status in `arsnova.eu` besitzt bereits zwei etablierte Ebenen:
 
 Der aktuelle Produktstand zeigt im Hilfe-Dialog bereits den Allzeit-Rekord `maxParticipantsSingleSession` aus `PlatformStatistic`. Fuer Lehre, Betrieb und Produktbeobachtung fehlt jedoch eine historische Sicht darauf, wie sich Tageshoechstwerte ueber die letzten Wochen entwickeln.
 
-Wichtig ist die fachliche Abgrenzung: Der Tagesrekord meint **nicht** die Summe aller Teilnehmenden eines Tages ueber alle Sessions hinweg, sondern die **maximale gleichzeitige Teilnehmendenzahl in der groessten einzelnen Session des jeweiligen UTC-Tages**.
+Wichtig ist die fachliche Abgrenzung: Der Session-Tagesrekord meint **nicht** die Summe aller Teilnehmenden eines Tages ueber alle Sessions hinweg, sondern die **maximale gleichzeitige Teilnehmendenzahl in der groessten einzelnen Session des jeweiligen UTC-Tages**.
 
 Fuer die geplante Story `0.4a` entstehen dadurch mehrere gekoppelte Architekturfragen:
 
-- Wo wird der Tagesrekord gespeichert?
+- Wo wird der Session-Tagesrekord gespeichert?
 - Wie bleibt der Join-Flow trotz zusaetzlicher Statistikaktualisierung schnell?
 - Wie kommt die Historie typsicher in `health.stats`?
 - Wie wird die Visualisierung eingebaut, ohne das Footer-Widget oder das Initial-Bundle aufzublaehen?
@@ -32,7 +32,7 @@ Bestehende Leitplanken:
 
 ## Entscheidung
 
-### 1. Tagesrekorde werden persistent in PostgreSQL gespeichert
+### 1. Session-Tagesrekorde werden persistent in PostgreSQL gespeichert
 
 Es wird ein neues Prisma-Modell `DailyStatistic` eingefuehrt. Pro UTC-Tag existiert genau ein Datensatz mit dem Rekord der **groessten einzelnen Session dieses Tages**:
 
@@ -44,7 +44,7 @@ Die Speicherung erfolgt in PostgreSQL ueber Prisma, nicht nur fluechtig in Redis
 
 ### 2. Rekord-Updates bleiben Fire-and-Forget beim Session-Join
 
-Beim Session-Beitritt wird die Statistikaktualisierung weiterhin asynchron ausgeloest. Zusaetzlich zum bestehenden Allzeit-Rekord wird der Tagesrekord atomar per Upsert aktualisiert.
+Beim Session-Beitritt wird die Statistikaktualisierung weiterhin asynchron ausgeloest. Zusaetzlich zum bestehenden Allzeit-Rekord wird der Session-Tagesrekord atomar per Upsert aktualisiert.
 
 Damit gilt weiterhin:
 
@@ -98,7 +98,7 @@ Die Aktualisierung des Verlaufs erfolgt ueber das bestehende Polling von `health
 ## Alternativen (geprueft)
 
 - **Historie jedes Mal aus Session- und Participant-Daten ableiten:** verworfen, da teurer, fehleranfaelliger und semantisch unklarer fuer den Tagesrekordbegriff.
-- **Redis statt PostgreSQL fuer Tagesrekorde:** verworfen, da die Daten Neustarts ueberleben und zur bestehenden Prisma-Statistiklogik passen sollen.
+- **Redis statt PostgreSQL fuer Session-Tagesrekorde:** verworfen, da die Daten Neustarts ueberleben und zur bestehenden Prisma-Statistiklogik passen sollen.
 - **Mini-Sparkline direkt im Footer:** verworfen, da das kompakte Widget bewusst textbasiert und leichtgewichtig bleiben soll.
 - **Groessere Chart-Bibliothek oder Angular-Wrapper:** verworfen, da Bundle-Groesse und Integrations-Overhead fuer diesen Anwendungsfall unnoetig hoch waeren.
 - **WebSocket-Push fuer den Verlauf:** verworfen, da das bestehende Polling fuer diese langsame Kennzahl ausreicht.

--- a/docs/architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md
+++ b/docs/architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md
@@ -1,0 +1,114 @@
+<!-- markdownlint-disable MD013 -->
+
+# ADR-0024: Tagesrekord-Verlauf fuer Session-Teilnehmende im Server-Status-Hilfedialog
+
+**Status:** Proposed  
+**Datum:** 2026-05-04  
+**Entscheider:** Projektteam
+
+## Kontext
+
+Der Server-Status in `arsnova.eu` besitzt bereits zwei etablierte Ebenen:
+
+1. das kompakte Footer-Widget fuer die schnelle Orientierung,
+2. den Hilfe-Dialog fuer die Einordnung und Detailansicht.
+
+Der aktuelle Produktstand zeigt im Hilfe-Dialog bereits den Allzeit-Rekord `maxParticipantsSingleSession` aus `PlatformStatistic`. Fuer Lehre, Betrieb und Produktbeobachtung fehlt jedoch eine historische Sicht darauf, wie sich Tageshoechstwerte ueber die letzten Wochen entwickeln.
+
+Fuer die geplante Story `0.4a` entstehen dadurch mehrere gekoppelte Architekturfragen:
+
+- Wo wird der Tagesrekord gespeichert?
+- Wie bleibt der Join-Flow trotz zusaetzlicher Statistikaktualisierung schnell?
+- Wie kommt die Historie typsicher in `health.stats`?
+- Wie wird die Visualisierung eingebaut, ohne das Footer-Widget oder das Initial-Bundle aufzublaehen?
+
+Bestehende Leitplanken:
+
+- `health.stats` ist tRPC-basiert (ADR-0003).
+- Neue UI-Texte muessen dem i18n-Modell folgen (ADR-0008).
+- Der Hilfe-Dialog ist die vorgesehene Detailflaeche fuer Statuserklaerungen; das Footer-Widget bleibt kompakt (ADR-0021).
+
+## Entscheidung
+
+### 1. Tagesrekorde werden persistent in PostgreSQL gespeichert
+
+Es wird ein neues Prisma-Modell `DailyStatistic` eingefuehrt. Pro UTC-Tag existiert genau ein Datensatz mit:
+
+- `date`
+- `maxParticipantsSingleSession`
+- `updatedAt`
+
+Die Speicherung erfolgt in PostgreSQL ueber Prisma, nicht nur fluechtig in Redis.
+
+### 2. Rekord-Updates bleiben Fire-and-Forget beim Session-Join
+
+Beim Session-Beitritt wird die Statistikaktualisierung weiterhin asynchron ausgeloest. Zusaetzlich zum bestehenden Allzeit-Rekord wird der Tagesrekord atomar per Upsert aktualisiert.
+
+Damit gilt weiterhin:
+
+- kein blockierendes Warten im Join-Flow,
+- keine zweite synchrone Roundtrip-Abhaengigkeit fuer den Beitritt,
+- Race-Conditions werden ueber atomare Persistenzlogik reduziert.
+
+### 3. `health.stats` liefert einen 30-Tage-Verlauf als API-Vertrag
+
+`ServerStatsDTO` wird um `dailyHighscores` erweitert. Das Feld liefert die letzten 30 UTC-Tage in chronologischer Reihenfolge mit:
+
+- `date` als ISO-String,
+- `count` als Tagesrekord.
+
+Fehlende Tage werden serverseitig mit `count = 0` aufgefuellt, damit die Frontend-Darstellung eine stabile Zeitachse hat.
+
+### 4. Die Visualisierung lebt nur im Hilfe-Dialog
+
+Der Verlauf wird ausschliesslich im `ServerStatusHelpDialogComponent` angezeigt. Das kompakte Footer-Widget bekommt keinen zusaetzlichen Chart oder Sparkline.
+
+Damit bleibt die Aufmerksamkeits- und Platzhierarchie eindeutig:
+
+- Footer = schneller Statusueberblick,
+- Hilfe-Dialog = Detailansicht und historische Einordnung.
+
+### 5. Das Diagramm wird lazy geladen und ohne Angular-Wrapper gerendert
+
+Fuer die Diagrammdarstellung wird `chart.js` direkt verwendet, ohne zusaetzlichen Angular-Wrapper. Der Import erfolgt nur beim Oeffnen des Dialogs.
+
+### 6. Es bleibt beim bestehenden Polling-Modell
+
+Die Aktualisierung des Verlaufs erfolgt ueber das bestehende Polling von `health.stats`. Fuer diese Statistik wird kein eigener WebSocket-Kanal eingefuehrt.
+
+## Konsequenzen
+
+### Positiv
+
+- Der Produktvertrag bleibt konsistent mit ADR-0021: Details gehoeren in den Dialog, nicht in den Footer.
+- Die Historie ist persistent, reproduzierbar und fuer spaetere Auswertungen anschlussfaehig.
+- Der API-Vertrag bleibt typsicher und klar in `shared-types` abbildbar.
+- Die Frontend-Performance bleibt kontrollierbar, weil das Diagramm nur bei Bedarf geladen wird.
+- Das Feature eignet sich didaktisch gut als vertikaler Durchstich ueber Prisma, Backend, shared-types, Frontend und Git-Workflow.
+
+### Negativ / Risiken
+
+- Zusaetzliches Prisma-Modell plus Migration erhoehen die Pflegekosten.
+- Die serverseitige Null-Auffuellung der 30-Tage-Achse muss sauber getestet werden.
+- Diagrammcode im Dialog erhoeht die UI-Komplexitaet und benoetigt A11y- und i18n-Sorgfalt.
+- Polling bedeutet, dass der Verlauf nicht in Echtzeit pro Sekunde sichtbar ist; diese Verzoegerung ist bewusst akzeptiert.
+
+## Alternativen (geprueft)
+
+- **Historie jedes Mal aus Session- und Participant-Daten ableiten:** verworfen, da teurer, fehleranfaelliger und semantisch unklarer fuer den Tagesrekordbegriff.
+- **Redis statt PostgreSQL fuer Tagesrekorde:** verworfen, da die Daten Neustarts ueberleben und zur bestehenden Prisma-Statistiklogik passen sollen.
+- **Mini-Sparkline direkt im Footer:** verworfen, da das kompakte Widget bewusst textbasiert und leichtgewichtig bleiben soll.
+- **Groessere Chart-Bibliothek oder Angular-Wrapper:** verworfen, da Bundle-Groesse und Integrations-Overhead fuer diesen Anwendungsfall unnoetig hoch waeren.
+- **WebSocket-Push fuer den Verlauf:** verworfen, da das bestehende Polling fuer diese langsame Kennzahl ausreicht.
+
+## Umsetzungsleitplanken
+
+- Story-Bezug: `Backlog.md` Story `0.4a`.
+- Vor dem Coden sind mindestens ADR-0003, ADR-0008, ADR-0021 und dieses ADR zu lesen.
+- Die Implementierung darf das bestehende Footer-Layout nicht ausweiten.
+- Die API muss 30 Tage konsistent und chronologisch liefern.
+- Neue Labels, Ueberschriften und ARIA-Texte folgen dem vorhandenen i18n-Prozess.
+
+---
+
+**Referenzen:** [Backlog.md](../../../Backlog.md), [Server-Status-Widget](../../features/server-status-widget.md), [ADR-0003: Nutzung von tRPC](./0003-use-trpc-for-api.md), [ADR-0008: Internationalisierung](./0008-i18n-internationalization.md), [ADR-0021: Trennung von Betriebsstatus und Laststatus](./0021-separate-service-status-from-load-status-with-live-slo-telemetry.md), [HANDOUT-TAGESREKORD-KI-AGENT.md](../../praktikum/HANDOUT-TAGESREKORD-KI-AGENT.md).

--- a/docs/architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md
+++ b/docs/architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md
@@ -15,6 +15,8 @@ Der Server-Status in `arsnova.eu` besitzt bereits zwei etablierte Ebenen:
 
 Der aktuelle Produktstand zeigt im Hilfe-Dialog bereits den Allzeit-Rekord `maxParticipantsSingleSession` aus `PlatformStatistic`. Fuer Lehre, Betrieb und Produktbeobachtung fehlt jedoch eine historische Sicht darauf, wie sich Tageshoechstwerte ueber die letzten Wochen entwickeln.
 
+Wichtig ist die fachliche Abgrenzung: Der Tagesrekord meint **nicht** die Summe aller Teilnehmenden eines Tages ueber alle Sessions hinweg, sondern die **maximale gleichzeitige Teilnehmendenzahl in der groessten einzelnen Session des jeweiligen UTC-Tages**.
+
 Fuer die geplante Story `0.4a` entstehen dadurch mehrere gekoppelte Architekturfragen:
 
 - Wo wird der Tagesrekord gespeichert?
@@ -32,7 +34,7 @@ Bestehende Leitplanken:
 
 ### 1. Tagesrekorde werden persistent in PostgreSQL gespeichert
 
-Es wird ein neues Prisma-Modell `DailyStatistic` eingefuehrt. Pro UTC-Tag existiert genau ein Datensatz mit:
+Es wird ein neues Prisma-Modell `DailyStatistic` eingefuehrt. Pro UTC-Tag existiert genau ein Datensatz mit dem Rekord der **groessten einzelnen Session dieses Tages**:
 
 - `date`
 - `maxParticipantsSingleSession`
@@ -55,7 +57,7 @@ Damit gilt weiterhin:
 `ServerStatsDTO` wird um `dailyHighscores` erweitert. Das Feld liefert die letzten 30 UTC-Tage in chronologischer Reihenfolge mit:
 
 - `date` als ISO-String,
-- `count` als Tagesrekord.
+- `count` als maximale gleichzeitige Teilnehmendenzahl der groessten einzelnen Session dieses UTC-Tages.
 
 Fehlende Tage werden serverseitig mit `count = 0` aufgefuellt, damit die Frontend-Darstellung eine stabile Zeitachse hat.
 

--- a/docs/architecture/handbook.md
+++ b/docs/architecture/handbook.md
@@ -76,7 +76,7 @@ Wir dokumentieren jede signifikante Änderung an der Architektur, neue Bibliothe
 - [ADR-0017: Markdown-Editor — UI-Umfang vs. KI-Import-Paste-Feld](./decisions/0017-markdown-editor-ui-scope-and-ki-import-paste-field.md)
 - [ADR-0018: Message of the Day / Plattform-Kommunikation (MOTD)](./decisions/0018-message-of-the-day-platform-communication.md)
 - [ADR-0021: Trennung von Betriebsstatus (SLO) und Systemlast mit Live-Telemetrie](./decisions/0021-separate-service-status-from-load-status-with-live-slo-telemetry.md)
-- [ADR-0024: Tagesrekord-Verlauf fuer Session-Teilnehmende im Server-Status-Hilfedialog](./decisions/0024-daily-session-records-in-server-status-help-dialog.md)
+- [ADR-0024: Session-Tagesrekord-Verlauf fuer Session-Teilnehmende im Server-Status-Hilfedialog](./decisions/0024-daily-session-records-in-server-status-help-dialog.md)
 
 **Vertiefende Architektur-Dokumente:**
 

--- a/docs/architecture/handbook.md
+++ b/docs/architecture/handbook.md
@@ -75,6 +75,8 @@ Wir dokumentieren jede signifikante Änderung an der Architektur, neue Bibliothe
 - [ADR-0016: Markdown/KaTeX-Editor — Split-View und eigene MD3-Toolbar](./decisions/0016-markdown-katex-editor-split-view-and-md3-toolbar.md)
 - [ADR-0017: Markdown-Editor — UI-Umfang vs. KI-Import-Paste-Feld](./decisions/0017-markdown-editor-ui-scope-and-ki-import-paste-field.md)
 - [ADR-0018: Message of the Day / Plattform-Kommunikation (MOTD)](./decisions/0018-message-of-the-day-platform-communication.md)
+- [ADR-0021: Trennung von Betriebsstatus (SLO) und Systemlast mit Live-Telemetrie](./decisions/0021-separate-service-status-from-load-status-with-live-slo-telemetry.md)
+- [ADR-0024: Tagesrekord-Verlauf fuer Session-Teilnehmende im Server-Status-Hilfedialog](./decisions/0024-daily-session-records-in-server-status-help-dialog.md)
 
 **Vertiefende Architektur-Dokumente:**
 

--- a/docs/praktikum/AUFGABENBLATT-STORY-0.4A-TAGESREKORD.md
+++ b/docs/praktikum/AUFGABENBLATT-STORY-0.4A-TAGESREKORD.md
@@ -50,6 +50,7 @@ Du sollst dabei nicht nur Code erzeugen, sondern den kompletten Arbeitsfluss sic
 ## Fachliche Leitfragen
 
 - Wird der Tagesrekord persistent und atomar gespeichert?
+- Ist fachlich klar, dass `count` die **groesste einzelne Session des UTC-Tages** meint und **nicht** die Summe aller Nutzer dieses Tages?
 - Bleibt der Join-Flow Fire-and-Forget statt synchron blockierend?
 - Liefert `health.stats` wirklich 30 Tage in chronologischer Reihenfolge?
 - Werden fehlende Tage serverseitig als `0` aufgefuellt?

--- a/docs/praktikum/AUFGABENBLATT-STORY-0.4A-TAGESREKORD.md
+++ b/docs/praktikum/AUFGABENBLATT-STORY-0.4A-TAGESREKORD.md
@@ -1,0 +1,87 @@
+# Aufgabenblatt: Story 0.4a "Tagesrekord-Verlauf im Server-Status-Hilfedialog"
+
+**Zielgruppe:** Studierende im Informatikpraktikum (Software Engineering)  
+**Kontext:** Vertikaler Durchstich mit KI-Agent von Story ueber ADR bis zum Draft-PR
+
+## Auftrag
+
+Bearbeite die Story **0.4a - Tagesrekord-Verlauf im Server-Status-Hilfedialog** als vollstaendiges, reviewfaehiges Inkrement.
+
+Du sollst dabei nicht nur Code erzeugen, sondern den kompletten Arbeitsfluss sichtbar machen:
+
+- Story lesen und scharfstellen
+- ADRs als Architekturleitplanken verwenden
+- auf einem Feature-Branch arbeiten
+- validieren
+- einen nachvollziehbaren Pull Request vorbereiten
+
+## Verbindlicher Rahmen
+
+- Massgeblich sind **alle Akzeptanzkriterien** der Story in [Backlog.md](../../Backlog.md).
+- Zusaetzlich gilt die allgemeine **Definition of Done** aus [Backlog.md](../../Backlog.md).
+- Fuer dieses Feature sind mindestens diese Artefakte verpflichtend:
+  - [HANDOUT-TAGESREKORD-KI-AGENT.md](./HANDOUT-TAGESREKORD-KI-AGENT.md)
+  - [ADR-0003](../architecture/decisions/0003-use-trpc-for-api.md)
+  - [ADR-0008](../architecture/decisions/0008-i18n-internationalization.md)
+  - [ADR-0021](../architecture/decisions/0021-separate-service-status-from-load-status-with-live-slo-telemetry.md)
+  - [ADR-0024](../architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md)
+  - [server-status-widget.md](../features/server-status-widget.md)
+- Arbeite nach den Regeln in [AGENT.md](../../AGENT.md) und [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Was am Ende vorliegen muss
+
+- Ein nachvollziehbarer Umsetzungsstand fuer Story 0.4a.
+- Ein Feature-Branch mit sprechendem Namen.
+- Ein PR oder Draft-PR mit sauberer Beschreibung von Story, ADR, Scope, Validierung und Risiken.
+- Nachweise fuer die eigenen Checks: Tests, Typecheck, UI-Pruefung, Diff-Review.
+- Eine kurze Reflexion, an welchen Stellen der KI-Agent hilfreich war und wo du bewusst eingegriffen hast.
+
+## Empfohlene Arbeitsreihenfolge
+
+1. Lies zuerst Story 0.4a und markiere unklare Stellen.
+2. Lies danach die vier relevanten ADRs und notiere daraus konkrete Leitplanken.
+3. Lege einen Feature-Branch an, bevor du inhaltlich aenderst.
+4. Lasse den Agenten gezielt die betroffenen Dateien und Kontrollpfade recherchieren.
+5. Erstelle vor der Implementierung einen knappen Plan fuer Datenbank, Backend, shared-types und Frontend.
+6. Implementiere in kleinen Schritten und validiere nach jedem sinnvollen Schnitt.
+7. Lies den Diff selbst, bevor du einen PR erstellst.
+8. Erstelle erst dann einen Draft-PR mit sauberer Beschreibung und offenen Risiken.
+
+## Fachliche Leitfragen
+
+- Wird der Tagesrekord persistent und atomar gespeichert?
+- Bleibt der Join-Flow Fire-and-Forget statt synchron blockierend?
+- Liefert `health.stats` wirklich 30 Tage in chronologischer Reihenfolge?
+- Werden fehlende Tage serverseitig als `0` aufgefuellt?
+- Bleibt das Footer-Widget kompakt, waehrend nur der Hilfe-Dialog den Verlauf zeigt?
+- Wird das Diagramm lazy geladen und ohne Angular-Wrapper eingebunden?
+- Sind neue Texte, Labels und ARIA-Hinweise i18n-konform umgesetzt?
+
+## Mindestnachweise fuer die Abgabe
+
+- Screenshot oder kurze Demo des Hilfe-Dialogs mit Verlauf.
+- Liste der geaenderten Dateien mit einem Satz Zweck pro Datei.
+- Ausgefuehrte Validierungsschritte mit Ergebnis.
+- Link oder Text des PR-Beschreibungstemplates.
+- Kurze Notiz: Welche Agentenprompts waren brauchbar, welche mussten korrigiert werden?
+
+## Pull-Request-Mindestinhalt
+
+Der PR-Text soll mindestens diese Punkte enthalten:
+
+- Story: `0.4a`
+- ADR: `0024`
+- Scope: betroffene Schichten und Hauptdateien
+- Validierung: Tests, Typecheck, manuelle Checks
+- Risiken: z. B. Polling-Verhalten, Bundle-Groesse, A11y des Charts
+
+## Relevante Unterlagen
+
+- [Backlog.md](../../Backlog.md)
+- [HANDOUT-TAGESREKORD-KI-AGENT.md](./HANDOUT-TAGESREKORD-KI-AGENT.md)
+- [PR-REVIEW-CHECKLISTE-STORY-0.4A.md](./PR-REVIEW-CHECKLISTE-STORY-0.4A.md)
+- [PRAKTIKUM.md](./PRAKTIKUM.md)
+- [STUDENT-STORY-REIHENFOLGE.md](./STUDENT-STORY-REIHENFOLGE.md)
+- [docs/TESTING.md](../TESTING.md)
+
+_Stand: 2026-05-04_

--- a/docs/praktikum/AUFGABENBLATT-STORY-0.4A-TAGESREKORD.md
+++ b/docs/praktikum/AUFGABENBLATT-STORY-0.4A-TAGESREKORD.md
@@ -1,11 +1,11 @@
-# Aufgabenblatt: Story 0.4a "Tagesrekord-Verlauf im Server-Status-Hilfedialog"
+# Aufgabenblatt: Story 0.4a "Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog"
 
 **Zielgruppe:** Studierende im Informatikpraktikum (Software Engineering)  
 **Kontext:** Vertikaler Durchstich mit KI-Agent von Story ueber ADR bis zum Draft-PR
 
 ## Auftrag
 
-Bearbeite die Story **0.4a - Tagesrekord-Verlauf im Server-Status-Hilfedialog** als vollstaendiges, reviewfaehiges Inkrement.
+Bearbeite die Story **0.4a - Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog** als vollstaendiges, reviewfaehiges Inkrement.
 
 Du sollst dabei nicht nur Code erzeugen, sondern den kompletten Arbeitsfluss sichtbar machen:
 
@@ -49,7 +49,7 @@ Du sollst dabei nicht nur Code erzeugen, sondern den kompletten Arbeitsfluss sic
 
 ## Fachliche Leitfragen
 
-- Wird der Tagesrekord persistent und atomar gespeichert?
+- Wird der Session-Tagesrekord persistent und atomar gespeichert?
 - Ist fachlich klar, dass `count` die **groesste einzelne Session des UTC-Tages** meint und **nicht** die Summe aller Nutzer dieses Tages?
 - Bleibt der Join-Flow Fire-and-Forget statt synchron blockierend?
 - Liefert `health.stats` wirklich 30 Tage in chronologischer Reihenfolge?

--- a/docs/praktikum/HANDOUT-TAGESREKORD-KI-AGENT.md
+++ b/docs/praktikum/HANDOUT-TAGESREKORD-KI-AGENT.md
@@ -1,0 +1,281 @@
+# Handout: Implementierung des "Tages-Teilnehmerrekords" in arsnova.eu mit einem KI-Agenten
+
+**Zielgruppe:** Studierende im Informatikpraktikum (Software Engineering)
+**Thema:** Architektur, Tech Stack und der proaktive Einsatz von KI-Agenten in bestehenden Codebasen.
+
+---
+
+## 1. Einleitung & Zielsetzung
+
+In dieser Fallstudie betrachten wir die Erweiterung der Open-Source-Plattform **arsnova.eu**. Die Plattform wird für interaktive Vorlesungen (Audience Response System) genutzt.
+
+**Das Feature:** Die bestehende Betriebsstatusanzeige (Footer-Widget) soll um einen **täglichen Highscore** der Teilnehmenden pro Session erweitert werden. Diese "Ganglinie" (Line-Chart) soll im Hilfe-Dialog des Widgets visualisiert werden.
+
+**Das Lernziel:** Ihr werdet verstehen, welche Architekturschichten von diesem Feature berührt werden, wie man Performance-Fallen vermeidet und – besonders wichtig – wie man einen autonomen KI-Agenten (wie das Gemini CLI) strukturiert einsetzt, um solche Features in einer fremden, komplexen Codebasis zu konzipieren und umzusetzen.
+
+### 1.1. Die Pflichtartefakte vor dem ersten Prompt
+
+Dieses Handout ist bewusst **kein** reines Coding-Tutorial. Im Praktikum sollt ihr lernen, dass agentisches Software Engineering mit **Artefakten** beginnt, nicht mit blindem Code-Generieren. Fuer dieses Feature muessen vor dem ersten Prompt mindestens diese Dateien offen sein:
+
+- **Produktvertrag:** `Backlog.md`, **Story 0.4a** "Tagesrekord-Verlauf im Server-Status-Hilfedialog"
+- **Bestehender Feature-Kontext:** `docs/features/server-status-widget.md`
+- **API-Kontext:** `docs/architecture/decisions/0003-use-trpc-for-api.md`
+- **i18n-Kontext:** `docs/architecture/decisions/0008-i18n-internationalization.md`
+- **Status-/Dialog-Kontext:** `docs/architecture/decisions/0021-separate-service-status-from-load-status-with-live-slo-telemetry.md`
+- **Neue Architekturentscheidung fuer dieses Feature:** `docs/architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md`
+- **Agenten- und Repo-Kontext:** `AGENT.md` und `.cursorrules`
+
+**Didaktischer Kern:** Das Backlog sagt **was** geliefert werden soll. Das ADR sagt **warum** und unter welchen Leitplanken. Der Branch und der Pull Request machen sichtbar, **wie** im Team daraus ein geprueftes Inkrement wird.
+
+**Begleitmaterial fuer die Lehre:**
+
+- [Aufgabenblatt Story 0.4a](./AUFGABENBLATT-STORY-0.4A-TAGESREKORD.md)
+- [PR-Review-Checkliste Story 0.4a](./PR-REVIEW-CHECKLISTE-STORY-0.4A.md)
+
+---
+
+## 2. Architektur & Tech Stack (arsnova.eu)
+
+Die Plattform nutzt einen modernen Full-Stack. Für unser Feature müssen wir fast alle Schichten berühren (vertikaler Durchstich):
+
+### 2.1. Persistenzschicht (PostgreSQL & Prisma ORM)
+
+- **Status Quo:** Der Allzeit-Rekord liegt in der Tabelle `PlatformStatistic`.
+- **Erweiterung:** Eine neue Tabelle `DailyStatistic` mit den Spalten `date` (als Unique Constraint) und `maxParticipantsSingleSession`.
+- **Konzept:** Nutzung von **Upsert** (Update or Insert) Operationen in SQL/Prisma, um Race-Conditions bei gleichzeitigen Zugriffen (viele Studierende treten gleichzeitig bei) zu verhindern. Diese Persistenzentscheidung wird fuer das Praktikum bewusst in **ADR-0024** festgehalten.
+
+**Datenbankschema (ER-Diagramm):**
+
+```mermaid
+erDiagram
+    PlatformStatistic {
+        String id PK
+        Int maxParticipantsSingleSession
+        Int completedSessionsTotal
+        DateTime updatedAt
+    }
+    DailyStatistic {
+        String id PK
+        DateTime date UK "Unique Constraint auf Tagesebene"
+        Int maxParticipantsSingleSession
+        DateTime updatedAt
+    }
+```
+
+### 2.2. Backend & API (Node.js & tRPC)
+
+- **Status Quo:** Bei jedem Beitritt (`apps/backend/src/routers/session.ts`) wird synchron der Teilnehmer gezählt und _asynchron_ (`void updateMaxParticipantsSingleSession(...)`) der Rekord geprüft.
+- **Erweiterung:** Das Backend muss zusätzlich prüfen, ob der Tagesrekord gebrochen wurde.
+- **API (`health.stats`):** Die Datenabfrage erfolgt über tRPC. Das `ServerStatsDTO` (Data Transfer Object) wird um ein Array `dailyHighscores` erweitert, welches die Werte der letzten 30 Tage liefert. Damit bewegen wir uns direkt im Rahmen von **ADR-0003**.
+- **Architektur-Fokus (Echtzeit vs. Polling):** arsnova.eu ist ein Echtzeitsystem. Das Speichern des Rekords darf den Beitritt nicht verzögern (Daher: `void` = Fire-and-Forget). Die Aktualisierung der Anzeige bei allen Clients erfolgt bewusst _nicht_ über teure WebSockets, sondern über ressourcenschonendes HTTP-Polling (alle 30 Sekunden). Das passt zur bestehenden Trennung von kompaktem Footer und Detaildialog aus **ADR-0021**.
+
+**Ablauf beim Session-Beitritt (Sequenzdiagramm):**
+
+```mermaid
+sequenceDiagram
+    actor S as Studierender (Client)
+    participant API as Backend (tRPC)
+    participant DB as Prisma (PostgreSQL)
+
+    S->>API: joinSession(sessionId)
+    activate API
+    API->>DB: COUNT Teilnehmende der Session
+    DB-->>API: result (z.B. 42)
+
+    Note over API,DB: Fire-and-Forget (kein blockierendes Warten)
+    API-)DB: upsert PlatformStatistic (Allzeit-Rekord)
+    API-)DB: upsert DailyStatistic (Tages-Rekord)
+
+    API-->>S: Session-Daten (Erfolg)
+    deactivate API
+```
+
+### 2.3. Frontend (Angular & Chart.js)
+
+- **Erweiterung:** Im `ServerStatusHelpDialogComponent` wird ein Chart eingefügt.
+- **Performance-Fokus:** Chart-Bibliotheken sind oft sehr groß (300-800 KB). Um das Time-to-Interactive der App nicht zu ruinieren, treffen wir zwei Entscheidungen:
+  1. **Minimalismus:** Wir nutzen das kleine `chart.js` (ca. 68 KB) komplett ohne Angular-Wrapper, um Overhead zu sparen.
+  2. **Lazy Loading:** Das Chart wird über Angulars `@defer`-Direktive asynchron erst dann geladen, wenn der Dialog tatsächlich geöffnet wird.
+- **UI-Governance:** Neue Beschriftungen, Diagramm-Titel und ARIA-Hinweise muessen den Regeln aus **ADR-0008** folgen.
+
+**Zeitliches Verhalten & Performance (Sequenzdiagramm / Lazy Loading):**
+
+```mermaid
+sequenceDiagram
+    actor U as User
+    participant W as StatusWidget (Footer)
+    participant API as Backend (health.stats)
+    participant C as Chart.js (Modul)
+
+    Note over W,API: Initialisierung und ressourcenschonendes Polling
+    W->>API: GET stats (inkl. dailyHighscores)
+    API-->>W: stats (Allzeit + 30 Tage Historie)
+
+    loop Alle 30 Sekunden
+        W->>API: GET stats (Aktualisierung)
+        API-->>W: update
+    end
+
+    Note over U,C: Dialog-Öffnung triggert Lazy Loading
+    U->>W: Klick auf "Hilfe / Info"
+    W->>C: import('chart.js') (asynchron via HTTP)
+    C-->>W: Chunk geladen (ca. 68 KB)
+    W->>C: render(dailyHighscores)
+```
+
+---
+
+## 3. Der Workflow mit dem KI-Agenten
+
+Ein KI-Agent ist kein einfacher Chatbot. Er hat Zugriff auf das Dateisystem, kann Shell-Befehle (wie `grep` oder `git`) ausführen und Dateien lesen/schreiben. Entscheidend ist aber: Er muss in einen **sauberen Teamprozess** eingebettet werden. Fuer dieses Praktikum ist daher nicht nur der Code wichtig, sondern die komplette Kette **Backlog -> ADR -> Branch -> Commits -> Pull Request**.
+
+### Phase 0: Onboarding & Pflichtkontext
+
+Bevor der KI-Agent überhaupt involviert wird, muss er ein klares und detailliertes Gesamtbild des Repositories erkunden.
+
+- **Aktion:** Man fordert den Agenten explizit auf, sich an den echten Repo-Artefakten zu orientieren, z. B. durch den Prompt: _"Lies `AGENT.md`, `.cursorrules`, `Backlog.md` Story 0.4a, `docs/features/server-status-widget.md`, ADR-0003, ADR-0008, ADR-0021 und ADR-0024. Fasse mir erst die Leitplanken zusammen, bevor du Implementierungsschritte vorschlaegst."_
+- **Nutzen:** Der Agent lernt nicht nur Coding-Regeln, sondern auch den Produktvertrag und die Architekturgrenzen kennen.
+
+### Phase 1: Problem im Backlog schärfen
+
+Anstatt direkt nach Code zu fragen, wird zuerst die Story gelesen und auf Unklarheiten abgeklopft.
+
+- **Aktion:** Der Nutzer arbeitet gegen **Story 0.4a** im `Backlog.md`.
+- **KI-Arbeit:** Der Agent vergleicht Story, bestehende Doku und Code. Er benennt offene Produktfragen, zum Beispiel: _Werden fehlende Tage als `0` aufgefuellt? Bleibt das Footer-Widget unveraendert?_
+- **Didaktischer Punkt:** Gute Agentenarbeit beginnt mit **Anforderungsanalyse**, nicht mit Dateierzeugung.
+
+### Phase 2: Architekturentscheidung mit ADRs absichern
+
+Wenn ein Feature neue Persistenz, neue API-Felder oder neue Frontend-Muster mit sich bringt, reicht das Backlog allein nicht.
+
+- **Aktion:** Relevante bestehende ADRs werden gelesen, und fuer die neue Entscheidung wird **ADR-0024** angelegt oder verfeinert.
+- **Didaktischer Punkt:** Das Backlog beschreibt den **Soll-Zustand**. Das ADR dokumentiert die **Begruendung** und die verworfenen Alternativen.
+
+### Phase 3: Feature-Branch anlegen
+
+Erst jetzt beginnt die eigentliche Umsetzungsvorbereitung im Repository.
+
+- **Aktion:** Es wird **nicht** direkt auf `main` gearbeitet, sondern auf einem sprechenden Feature-Branch, zum Beispiel:
+
+```bash
+git switch -c feature/0.4a-daily-session-record-history
+```
+
+- **Didaktischer Punkt:** Der Branch ist keine Formalie, sondern der geschuetzte Raum fuer Experiment, Review und Rueckfrage.
+
+### Phase 4: Kontextaufbau (Research)
+
+Nun darf der Agent recherchieren, aber gezielt entlang der Story und der ADRs.
+
+- **Aktion:** Der Nutzer äußert einen konkreten Wunsch: _"Erweitere die Betriebsstatusanzeige gemaess Story 0.4a."_
+- **KI-Arbeit:** Der Agent nutzt Suchwerkzeuge (`grep_search`), um Relevanz zu finden. Er untersucht, wo `maxParticipantsSingleSession`, `health.stats` und der `ServerStatusHelpDialogComponent` bereits verarbeitet werden.
+
+### Phase 5: Strategie & Architekturdiskussion (Plan Mode)
+
+Bevor Code geschrieben wird, wird diskutiert. Der Agent wird in den **Planungsmodus** versetzt.
+
+- **KI-Vorschlag:** Der Agent schlägt vor, eine mächtige Bibliothek (ECharts) für das Diagramm zu nutzen.
+- **Menschliches Eingreifen (Der Dozent/Entwickler):** Als Entwickler hinterfragen wir: _"Wie groß ist ECharts? Was ist mit der Performance? Passt das ueberhaupt zum Hilfe-Dialog statt zum Footer?"_
+- **KI-Korrektur:** Der Agent analysiert die Bundle-Größen und schlägt Alternativen (Chart.js) sowie Architektur-Patterns (Lazy Loading, Null-Auffuellung der 30-Tage-Achse, Polling statt WebSocket) vor.
+
+### Phase 6: Ausführung & Validierung
+
+Der Agent arbeitet nun autonom die Liste aus dem Plan ab (Datenbank -> Backend -> shared-types -> Frontend), aber immer mit kurzen Validierungsschleifen.
+
+- **Validierung:** Nutzung von CLI-Tools (`vitest`, Typecheck, Linting, ggf. Bundle-Pruefung), Testen der App im Browser, Diff-Kontrolle.
+- **Didaktischer Punkt:** Ein Agent ist kein Autoritaetsersatz. Gruene Checks sind der erste Filter, menschliches Review der zweite.
+
+### Phase 7: Pull Request als sozialer Prüfpunkt
+
+Der Pull Request ist der Moment, in dem aus privater Agentenarbeit ein **teamfaehiger Vorschlag** wird.
+
+- **Aktion:** Der Branch wird mit einer klaren PR beschrieben, zum Beispiel:
+
+```text
+Titel: feat(status): add daily session record history
+
+- Story: 0.4a
+- ADR: 0024
+- Scope: DailyStatistic, health.stats, ServerStatusHelpDialog
+- Validierung: Typecheck, Vitest, manuelle UI-Pruefung
+- Risiken: Bundle-Groesse, Polling-Verhalten, A11y des Charts
+```
+
+- **Didaktischer Punkt:** Im Pull Request prueft das Team nicht nur _ob_ der Code funktioniert, sondern auch _ob_ Story, ADR, Tests und Begruendung zusammenpassen.
+
+### Phase 8: Der Implementierungsplan
+
+Der Agent formuliert einen verbindlichen Plan. Der Entwickler behält die volle Kontrolle und genehmigt diesen erst, wenn er logisch einwandfrei ist.
+
+_(Der von uns akzeptierte Plan für dieses Feature befindet sich in Sektion 4)._
+
+---
+
+## 4. Der akzeptierte Implementierungsplan
+
+Dieser Plan wurde durch die Diskussion in Phase 2 vom KI-Agenten erstellt und vom Entwickler (Dozent) freigegeben. Anhand dieses Plans wird das Feature nun strukturiert umgesetzt.
+
+### 4.1. Objective
+
+Erweiterung der Betriebsstatusanzeige um einen täglichen Highscore der Teilnehmer/innen pro Session. Diese "Ganglinie" der Tagesrekorde soll im "Allzeit-Rekord"-Panel des Server Status Help Dialogs als hochwertiges Line-Chart ("vom Feinsten") angezeigt werden. Um die Frontend-Performance nicht zu beeinträchtigen, wird `chart.js` (als leichtgewichtige Bibliothek) genutzt und lazy geladen (ohne den schweren Wrapper `ng2-charts`).
+
+### 4.2. Key Files & Context
+
+- **Produktvertrag:** `Backlog.md` (Story 0.4a)
+- **Feature-Doku:** `docs/features/server-status-widget.md`
+- **ADR-Kontext:** `docs/architecture/decisions/0021-separate-service-status-from-load-status-with-live-slo-telemetry.md`, `docs/architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md`
+- **Datenbank:** `prisma/schema.prisma`
+- **Backend-Logik:** `apps/backend/src/lib/platformStatistic.ts`, `apps/backend/src/routers/session.ts`, `apps/backend/src/routers/health.ts`
+- **API-Schema:** `libs/shared-types/src/schemas.ts`
+- **Frontend-Dialog:** `apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts` (und `.scss`)
+- **Package:** `apps/frontend/package.json`
+
+### 4.3. Implementation Steps
+
+#### 4.3.1. Datenbank (Prisma)
+
+- Eine neue Tabelle `DailyStatistic` zu `prisma/schema.prisma` hinzufügen:
+  ```prisma
+  model DailyStatistic {
+    id                           String   @id @default(uuid()) @db.Uuid
+    date                         DateTime @unique @db.Date
+    maxParticipantsSingleSession Int      @default(0)
+    updatedAt                    DateTime @updatedAt
+  }
+  ```
+- Migration ausführen (`npx prisma migrate dev --name add_daily_statistic`).
+
+#### 4.3.2. Backend-Logik & API
+
+- **`platformStatistic.ts`:** Eine Funktion `updateDailyMaxParticipants(count: number)` hinzufügen, die via Prisma "Upsert" den Rekord für das heutige Datum (`UTC`) aktualisiert.
+- **Session Join (`session.ts`):** Den bestehenden Aufruf asynchron erweitern, dass er auch die Tages-Statistik bedient (`void updateDailyMaxParticipants(newParticipantCount)`).
+- **`schemas.ts`:** Das `ServerStatsDTOSchema` um `dailyHighscores` erweitern:
+  ```typescript
+  dailyHighscores: z.array(
+    z.object({
+      date: z.string(),
+      count: z.number(),
+    }),
+  ).optional();
+  ```
+- **`health.ts`:** In der Route `health.stats` die Datensätze der letzten 30 Tage aus der Tabelle `DailyStatistic` auslesen und dem `ServerStatsDTO` hinzufügen.
+
+#### 4.3.3. Frontend (Chart.js)
+
+- **Abhängigkeiten:** `npm install chart.js` in `apps/frontend`.
+- **Lazy Loading:** `chart.js` wird streng asynchron geladen. Wir verwenden keine Angular-Wrapper. Das HTML-Canvas-Element wird in einem `@defer`-Block platziert.
+- **UX & Design ("vom Feinsten"):**
+  - **Type:** `line`, **Styling:** Weiche Kurven (`tension: 0.4`), gefüllter Bereich (`fill: true`), minimale Achsen (keine Grid-Linien).
+  - **Tooltips:** Aktivieren für Datum und Rekord-Anzahl.
+  - **Responsiveness:** `maintainAspectRatio: false` in einem flexiblen Container.
+- **Template Anpassung:** Das Chart im Template unterhalb des "Allzeit-Rekord"-Wertes platzieren, inklusive Überschrift "Verlauf (Letzte 30 Tage)".
+
+#### 4.3.4. i18n
+
+- Hinzufügen der nötigen Strings zu den `.xlf` Dateien.
+
+## 5. Fazit
+
+Die Arbeit mit KI-Agenten erfordert **Systemverständnis**. Die KI nimmt uns die mechanische Schreibarbeit ab, aber **ihr als Software Engineers** steuert die Initialisierung (Context) und trefft die finalen Architektur- und Performanceentscheidungen.
+
+Gerade fuer das Praktikum gilt deshalb: Ein gutes Feature beginnt nicht beim ersten Code-Snippet, sondern bei der Kette **Story -> ADR -> Branch -> Validierung -> Pull Request**. Erst wenn diese Kette sauber ist, wird aus agentischer Unterstuetzung echtes Software Engineering.

--- a/docs/praktikum/HANDOUT-TAGESREKORD-KI-AGENT.md
+++ b/docs/praktikum/HANDOUT-TAGESREKORD-KI-AGENT.md
@@ -9,7 +9,7 @@
 
 In dieser Fallstudie betrachten wir die Erweiterung der Open-Source-Plattform **arsnova.eu**. Die Plattform wird für interaktive Vorlesungen (Audience Response System) genutzt.
 
-**Das Feature:** Die bestehende Betriebsstatusanzeige (Footer-Widget) soll um einen **täglichen Highscore** der Teilnehmenden pro Session erweitert werden. Diese "Ganglinie" (Line-Chart) soll im Hilfe-Dialog des Widgets visualisiert werden.
+**Das Feature:** Die bestehende Betriebsstatusanzeige (Footer-Widget) soll um einen **taeglichen Highscore** der Teilnehmenden pro Session erweitert werden. Gemeint ist dabei immer die **groesste einzelne Session eines UTC-Tages**, **nicht** die Summe aller Nutzer dieses Tages. Diese "Ganglinie" (Line-Chart) soll im Hilfe-Dialog des Widgets visualisiert werden.
 
 **Das Lernziel:** Ihr werdet verstehen, welche Architekturschichten von diesem Feature berührt werden, wie man Performance-Fallen vermeidet und – besonders wichtig – wie man einen autonomen KI-Agenten (wie das Gemini CLI) strukturiert einsetzt, um solche Features in einer fremden, komplexen Codebasis zu konzipieren und umzusetzen.
 
@@ -66,7 +66,7 @@ erDiagram
 
 - **Status Quo:** Bei jedem Beitritt (`apps/backend/src/routers/session.ts`) wird synchron der Teilnehmer gezählt und _asynchron_ (`void updateMaxParticipantsSingleSession(...)`) der Rekord geprüft.
 - **Erweiterung:** Das Backend muss zusätzlich prüfen, ob der Tagesrekord gebrochen wurde.
-- **API (`health.stats`):** Die Datenabfrage erfolgt über tRPC. Das `ServerStatsDTO` (Data Transfer Object) wird um ein Array `dailyHighscores` erweitert, welches die Werte der letzten 30 Tage liefert. Damit bewegen wir uns direkt im Rahmen von **ADR-0003**.
+- **API (`health.stats`):** Die Datenabfrage erfolgt über tRPC. Das `ServerStatsDTO` (Data Transfer Object) wird um ein Array `dailyHighscores` erweitert, welches die Werte der letzten 30 Tage liefert. Jeder Wert steht fuer die **groesste einzelne Session des jeweiligen UTC-Tages**, nicht fuer eine Tagesgesamtsumme. Damit bewegen wir uns direkt im Rahmen von **ADR-0003**.
 - **Architektur-Fokus (Echtzeit vs. Polling):** arsnova.eu ist ein Echtzeitsystem. Das Speichern des Rekords darf den Beitritt nicht verzögern (Daher: `void` = Fire-and-Forget). Die Aktualisierung der Anzeige bei allen Clients erfolgt bewusst _nicht_ über teure WebSockets, sondern über ressourcenschonendes HTTP-Polling (alle 30 Sekunden). Das passt zur bestehenden Trennung von kompaktem Footer und Detaildialog aus **ADR-0021**.
 
 **Ablauf beim Session-Beitritt (Sequenzdiagramm):**
@@ -217,7 +217,7 @@ Dieser Plan wurde durch die Diskussion in Phase 2 vom KI-Agenten erstellt und vo
 
 ### 4.1. Objective
 
-Erweiterung der Betriebsstatusanzeige um einen täglichen Highscore der Teilnehmer/innen pro Session. Diese "Ganglinie" der Tagesrekorde soll im "Allzeit-Rekord"-Panel des Server Status Help Dialogs als hochwertiges Line-Chart ("vom Feinsten") angezeigt werden. Um die Frontend-Performance nicht zu beeinträchtigen, wird `chart.js` (als leichtgewichtige Bibliothek) genutzt und lazy geladen (ohne den schweren Wrapper `ng2-charts`).
+Erweiterung der Betriebsstatusanzeige um einen taeglichen Highscore der Teilnehmer/innen pro Session. Gemeint ist jeweils die **groesste einzelne Session eines UTC-Tages**, nicht die Summe aller Nutzer dieses Tages. Diese "Ganglinie" der Tagesrekorde soll im "Allzeit-Rekord"-Panel des Server Status Help Dialogs als hochwertiges Line-Chart ("vom Feinsten") angezeigt werden. Um die Frontend-Performance nicht zu beeintraechtigen, wird `chart.js` (als leichtgewichtige Bibliothek) genutzt und lazy geladen (ohne den schweren Wrapper `ng2-charts`).
 
 ### 4.2. Key Files & Context
 

--- a/docs/praktikum/HANDOUT-TAGESREKORD-KI-AGENT.md
+++ b/docs/praktikum/HANDOUT-TAGESREKORD-KI-AGENT.md
@@ -9,7 +9,7 @@
 
 In dieser Fallstudie betrachten wir die Erweiterung der Open-Source-Plattform **arsnova.eu**. Die Plattform wird für interaktive Vorlesungen (Audience Response System) genutzt.
 
-**Das Feature:** Die bestehende Betriebsstatusanzeige (Footer-Widget) soll um einen **taeglichen Highscore** der Teilnehmenden pro Session erweitert werden. Gemeint ist dabei immer die **groesste einzelne Session eines UTC-Tages**, **nicht** die Summe aller Nutzer dieses Tages. Diese "Ganglinie" (Line-Chart) soll im Hilfe-Dialog des Widgets visualisiert werden.
+**Das Feature:** Die bestehende Betriebsstatusanzeige (Footer-Widget) soll um einen **Session-Tagesrekord** der Teilnehmenden pro Session erweitert werden. Gemeint ist dabei immer die **groesste einzelne Session eines UTC-Tages**, **nicht** die Summe aller Nutzer dieses Tages. Diese "Ganglinie" (Line-Chart) soll im Hilfe-Dialog des Widgets visualisiert werden.
 
 **Das Lernziel:** Ihr werdet verstehen, welche Architekturschichten von diesem Feature berührt werden, wie man Performance-Fallen vermeidet und – besonders wichtig – wie man einen autonomen KI-Agenten (wie das Gemini CLI) strukturiert einsetzt, um solche Features in einer fremden, komplexen Codebasis zu konzipieren und umzusetzen.
 
@@ -17,7 +17,7 @@ In dieser Fallstudie betrachten wir die Erweiterung der Open-Source-Plattform **
 
 Dieses Handout ist bewusst **kein** reines Coding-Tutorial. Im Praktikum sollt ihr lernen, dass agentisches Software Engineering mit **Artefakten** beginnt, nicht mit blindem Code-Generieren. Fuer dieses Feature muessen vor dem ersten Prompt mindestens diese Dateien offen sein:
 
-- **Produktvertrag:** `Backlog.md`, **Story 0.4a** "Tagesrekord-Verlauf im Server-Status-Hilfedialog"
+- **Produktvertrag:** `Backlog.md`, **Story 0.4a** "Session-Tagesrekord-Verlauf im Server-Status-Hilfedialog"
 - **Bestehender Feature-Kontext:** `docs/features/server-status-widget.md`
 - **API-Kontext:** `docs/architecture/decisions/0003-use-trpc-for-api.md`
 - **i18n-Kontext:** `docs/architecture/decisions/0008-i18n-internationalization.md`
@@ -65,7 +65,7 @@ erDiagram
 ### 2.2. Backend & API (Node.js & tRPC)
 
 - **Status Quo:** Bei jedem Beitritt (`apps/backend/src/routers/session.ts`) wird synchron der Teilnehmer gezählt und _asynchron_ (`void updateMaxParticipantsSingleSession(...)`) der Rekord geprüft.
-- **Erweiterung:** Das Backend muss zusätzlich prüfen, ob der Tagesrekord gebrochen wurde.
+- **Erweiterung:** Das Backend muss zusätzlich prüfen, ob der Session-Tagesrekord gebrochen wurde.
 - **API (`health.stats`):** Die Datenabfrage erfolgt über tRPC. Das `ServerStatsDTO` (Data Transfer Object) wird um ein Array `dailyHighscores` erweitert, welches die Werte der letzten 30 Tage liefert. Jeder Wert steht fuer die **groesste einzelne Session des jeweiligen UTC-Tages**, nicht fuer eine Tagesgesamtsumme. Damit bewegen wir uns direkt im Rahmen von **ADR-0003**.
 - **Architektur-Fokus (Echtzeit vs. Polling):** arsnova.eu ist ein Echtzeitsystem. Das Speichern des Rekords darf den Beitritt nicht verzögern (Daher: `void` = Fire-and-Forget). Die Aktualisierung der Anzeige bei allen Clients erfolgt bewusst _nicht_ über teure WebSockets, sondern über ressourcenschonendes HTTP-Polling (alle 30 Sekunden). Das passt zur bestehenden Trennung von kompaktem Footer und Detaildialog aus **ADR-0021**.
 
@@ -217,7 +217,7 @@ Dieser Plan wurde durch die Diskussion in Phase 2 vom KI-Agenten erstellt und vo
 
 ### 4.1. Objective
 
-Erweiterung der Betriebsstatusanzeige um einen taeglichen Highscore der Teilnehmer/innen pro Session. Gemeint ist jeweils die **groesste einzelne Session eines UTC-Tages**, nicht die Summe aller Nutzer dieses Tages. Diese "Ganglinie" der Tagesrekorde soll im "Allzeit-Rekord"-Panel des Server Status Help Dialogs als hochwertiges Line-Chart ("vom Feinsten") angezeigt werden. Um die Frontend-Performance nicht zu beeintraechtigen, wird `chart.js` (als leichtgewichtige Bibliothek) genutzt und lazy geladen (ohne den schweren Wrapper `ng2-charts`).
+Erweiterung der Betriebsstatusanzeige um einen Session-Tagesrekord der Teilnehmer/innen pro Session. Gemeint ist jeweils die **groesste einzelne Session eines UTC-Tages**, nicht die Summe aller Nutzer dieses Tages. Diese "Ganglinie" der Session-Tagesrekorde soll im "Allzeit-Rekord"-Panel des Server Status Help Dialogs als hochwertiges Line-Chart ("vom Feinsten") angezeigt werden. Um die Frontend-Performance nicht zu beeintraechtigen, wird `chart.js` (als leichtgewichtige Bibliothek) genutzt und lazy geladen (ohne den schweren Wrapper `ng2-charts`).
 
 ### 4.2. Key Files & Context
 

--- a/docs/praktikum/PR-REVIEW-CHECKLISTE-STORY-0.4A.md
+++ b/docs/praktikum/PR-REVIEW-CHECKLISTE-STORY-0.4A.md
@@ -19,6 +19,7 @@
 
 - [ ] Das Prisma-Modell `DailyStatistic` hat genau einen Datensatz pro UTC-Tag.
 - [ ] Die Tagesrekord-Aktualisierung erfolgt atomar und nur bei hoeherem Wert.
+- [ ] `count` meint die **maximale gleichzeitige Teilnehmendenzahl in der groessten einzelnen Session des UTC-Tages**, nicht die Summe aller Tagesnutzer.
 - [ ] Der Join-Flow bleibt Fire-and-Forget und fuehrt keine neue blockierende Wartezeit ein.
 - [ ] `health.stats` liefert `dailyHighscores` fuer 30 Tage in chronologischer Reihenfolge.
 - [ ] Fehlende Tage werden serverseitig sinnvoll aufgefuellt statt dem Frontend zu ueberlassen.

--- a/docs/praktikum/PR-REVIEW-CHECKLISTE-STORY-0.4A.md
+++ b/docs/praktikum/PR-REVIEW-CHECKLISTE-STORY-0.4A.md
@@ -1,4 +1,4 @@
-# PR-Review-Checkliste: Story 0.4a "Tagesrekord-Verlauf"
+# PR-Review-Checkliste: Story 0.4a "Session-Tagesrekord-Verlauf"
 
 **Zweck:** Diese Checkliste hilft dabei, einen Pull Request zur Story **0.4a** fachlich, architektonisch und technisch zu reviewen.
 
@@ -18,7 +18,7 @@
 ## 3. Datenmodell & Backend
 
 - [ ] Das Prisma-Modell `DailyStatistic` hat genau einen Datensatz pro UTC-Tag.
-- [ ] Die Tagesrekord-Aktualisierung erfolgt atomar und nur bei hoeherem Wert.
+- [ ] Die Session-Tagesrekord-Aktualisierung erfolgt atomar und nur bei hoeherem Wert.
 - [ ] `count` meint die **maximale gleichzeitige Teilnehmendenzahl in der groessten einzelnen Session des UTC-Tages**, nicht die Summe aller Tagesnutzer.
 - [ ] Der Join-Flow bleibt Fire-and-Forget und fuehrt keine neue blockierende Wartezeit ein.
 - [ ] `health.stats` liefert `dailyHighscores` fuer 30 Tage in chronologischer Reihenfolge.

--- a/docs/praktikum/PR-REVIEW-CHECKLISTE-STORY-0.4A.md
+++ b/docs/praktikum/PR-REVIEW-CHECKLISTE-STORY-0.4A.md
@@ -1,0 +1,63 @@
+# PR-Review-Checkliste: Story 0.4a "Tagesrekord-Verlauf"
+
+**Zweck:** Diese Checkliste hilft dabei, einen Pull Request zur Story **0.4a** fachlich, architektonisch und technisch zu reviewen.
+
+## 1. Produktvertrag
+
+- [ ] Der PR verweist explizit auf **Story 0.4a** in [Backlog.md](../../Backlog.md).
+- [ ] Die Umsetzung deckt die Akzeptanzkriterien vollstaendig ab und fuehrt kein anderes Feature unter derselben Story mit.
+- [ ] Das kompakte Footer-Widget bleibt unveraendert; der Verlauf erscheint nur im Hilfe-Dialog.
+
+## 2. Architektur & ADRs
+
+- [ ] Der PR verweist auf [ADR-0024](../architecture/decisions/0024-daily-session-records-in-server-status-help-dialog.md).
+- [ ] Die API-Erweiterung bleibt tRPC- und shared-types-konform im Sinne von [ADR-0003](../architecture/decisions/0003-use-trpc-for-api.md).
+- [ ] Die Trennung zwischen kompaktem Status-Widget und Detaildialog bleibt konsistent zu [ADR-0021](../architecture/decisions/0021-separate-service-status-from-load-status-with-live-slo-telemetry.md).
+- [ ] Neue UI-Texte und Labels folgen [ADR-0008](../architecture/decisions/0008-i18n-internationalization.md).
+
+## 3. Datenmodell & Backend
+
+- [ ] Das Prisma-Modell `DailyStatistic` hat genau einen Datensatz pro UTC-Tag.
+- [ ] Die Tagesrekord-Aktualisierung erfolgt atomar und nur bei hoeherem Wert.
+- [ ] Der Join-Flow bleibt Fire-and-Forget und fuehrt keine neue blockierende Wartezeit ein.
+- [ ] `health.stats` liefert `dailyHighscores` fuer 30 Tage in chronologischer Reihenfolge.
+- [ ] Fehlende Tage werden serverseitig sinnvoll aufgefuellt statt dem Frontend zu ueberlassen.
+
+## 4. Frontend & Performance
+
+- [ ] Das Diagramm wird nur im `ServerStatusHelpDialogComponent` gerendert.
+- [ ] `chart.js` wird lazy geladen.
+- [ ] Es wird kein schwerer Angular-Wrapper eingefuehrt.
+- [ ] Die Darstellung funktioniert auch mit leerer oder teilweiser Historie.
+- [ ] Das Diagramm verschlechtert nicht sichtbar die Startseiten-Performance.
+
+## 5. i18n & A11y
+
+- [ ] Neue sichtbare Texte sind in den gepflegten App-Sprachen nachgezogen.
+- [ ] Diagramm-Ueberschrift, Hilfetexte und relevante ARIA-Hinweise sind vorhanden.
+- [ ] Der Dialog bleibt per Tastatur bedienbar und der Chart-Bereich erzeugt keine offensichtliche Accessibility-Regression.
+
+## 6. Tests & Validierung
+
+- [ ] Backend-Tests pruefen mindestens den API-Vertrag fuer `dailyHighscores`.
+- [ ] Frontend-Tests pruefen mindestens Darstellung mit und ohne Verlaufsdaten.
+- [ ] Die im PR genannten Checks wurden wirklich ausgefuehrt und sind nachvollziehbar.
+- [ ] Diff und Testnamen passen inhaltlich zur Story, nicht zu einem groesseren Seiteneffekt.
+
+## 7. Git & PR-Hygiene
+
+- [ ] Branch-Name ist sprechend und storynah.
+- [ ] Der PR-Titel benennt Scope und Aenderungsart klar.
+- [ ] Die PR-Beschreibung nennt Story, ADR, Validierung und Risiken.
+- [ ] Der PR enthaelt keine themenfremden Dateien oder Altlasten.
+
+## 8. Review-Fragen
+
+Wenn bei einem Punkt Unsicherheit besteht, sollten diese Fragen vor dem Merge geklaert sein:
+
+- Sollte die Null-Auffuellung der 30-Tage-Achse im Backend oder im Frontend liegen?
+- Reicht Polling fuer diese Kennzahl weiterhin aus, oder wurde versehentlich ein staerkeres Echtzeitmodell eingebaut?
+- Sind die Chart-Optionen robust genug fuer mobile und kleine Dialogbreiten?
+- Sind Namensgebung und Story/ADR-Verweise so klar, dass spaetere Teams die Entscheidung nachvollziehen koennen?
+
+_Stand: 2026-05-04_

--- a/libs/shared-types/src/schemas.ts
+++ b/libs/shared-types/src/schemas.ts
@@ -977,6 +977,14 @@ export const HealthCheckResponseSchema = z.object({
 
 export type HealthCheckResponse = z.infer<typeof HealthCheckResponseSchema>;
 
+export const DailyHighscoreEntrySchema = z.object({
+  /** UTC-Tag als ISO-8601 Datum (`YYYY-MM-DD`). */
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  /** Tagesrekord der größten einzelnen Session dieses UTC-Tags. */
+  count: z.number().int().min(0),
+});
+export type DailyHighscoreEntry = z.infer<typeof DailyHighscoreEntrySchema>;
+
 /** DTO: Server-Auslastung für die Startseite (Story 0.4) */
 export const ServerStatsDTOSchema = z.object({
   /** Alle noch nicht beendeten Sessions. */
@@ -996,6 +1004,8 @@ export const ServerStatsDTOSchema = z.object({
   activeBlitzRounds: z.number(),
   /** Höchste je in einer Session registrierte Teilnehmerzahl (Joins, plattformweit). */
   maxParticipantsSingleSession: z.number().int().min(0),
+  /** Verlauf der Session-Tagesrekorde der letzten 30 UTC-Tage in chronologischer Reihenfolge. */
+  dailyHighscores: z.array(DailyHighscoreEntrySchema).length(30),
   /** ISO-8601: Serverzeitpunkt, als sich der Rekord zuletzt erhöhte (`PlatformStatistic.updatedAt`), sonst null — nicht Session-Start/-Ende. */
   maxParticipantsStatisticUpdatedAt: z.string().datetime().nullable(),
   /** Betriebsstatus (SLO-nah) für den Footer. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,6 +220,7 @@
         "@arsnova/shared-types": "*",
         "@trpc/client": "^11.0.0",
         "@trpc/server": "^11.0.0",
+        "chart.js": "^4.5.1",
         "dompurify": "^3.4.0",
         "express": "^5.1.0",
         "highlight.js": "^11.11.1",
@@ -6286,6 +6287,12 @@
         "tslib": "2"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -11724,6 +11731,18 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chevrotain": {
       "version": "10.5.0",

--- a/prisma/migrations/20260504144000_add_daily_statistic/migration.sql
+++ b/prisma/migrations/20260504144000_add_daily_statistic/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "DailyStatistic" (
+    "id" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "maxParticipantsSingleSession" INTEGER NOT NULL DEFAULT 0,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DailyStatistic_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DailyStatistic_date_key" ON "DailyStatistic"("date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,6 +147,14 @@ model PlatformStatistic {
   updatedAt                   DateTime @updatedAt
 }
 
+// Pro UTC-Tag genau ein Rekord für die größte einzelne Session (Story 0.4a)
+model DailyStatistic {
+  id                           String   @id @default(uuid())
+  date                         DateTime @unique @db.Date
+  maxParticipantsSingleSession Int      @default(0)
+  updatedAt                    DateTime @updatedAt
+}
+
 // Ein Team in einer Live-Session (Story 7.1)
 model Team {
   id           String        @id @default(uuid())


### PR DESCRIPTION
## Purpose

This PR now delivers Story 0.4a end to end. It implements the Session-Tagesrekord history for the last 30 UTC days in the server-status help dialog and keeps the accompanying practicum artifacts in the same branch so students can follow the full path from story and ADR to implementation, validation, and review.

## Related issue

- Feature tracking issue: #20

## What This PR Adds

- Backlog Story `0.4a`, ADR `0024`, practicum handout, assignment sheet, and review checklist
- shared-types contract extension with `dailyHighscores` for `ServerStatsDTO`
- Prisma model and migration for `DailyStatistic`
- backend UTC-day record persistence with atomic upsert semantics
- fire-and-forget daily record updates on session join
- `health.stats` support for 30 chronological UTC days with server-side zero fill
- frontend history chart in `ServerStatusHelpDialogComponent`, lazy loaded with direct `chart.js`
- chart dark-mode palette fixes and locale-aware y-axis formatting
- i18n additions for the maintained app locales
- backend and frontend test coverage for API, dialog rendering, theme refresh, and locale formatting

## Review Focus

- Does the implementation match the intended semantics: the largest single session of each UTC day, not a daily user sum?
- Does the API always return exactly 30 chronological UTC days with gaps filled by `0`?
- Does the chart stay confined to the help dialog while the compact footer widget remains unchanged?
- Are lazy loading, dark-mode contrast, and German number formatting robust enough for production use?
- Do the practicum artifacts still align with the final runtime implementation and review workflow?

## Explicitly Out Of Scope

- no redesign of the compact footer widget
- no additional WebSocket channel for this statistic
- no Angular chart wrapper
- no broader analytics or reporting beyond the 30-day history in the help dialog

## Story / ADR

- Story: `0.4a`
- ADR: `0024`

## Validation

- `npm run typecheck`
- `npm test`
- `npm run test -w @arsnova/frontend -- src/app/shared/server-status-help-dialog/server-status-help-dialog-chart.spec.ts src/app/shared/server-status-help-dialog/server-status-help-dialog.component.spec.ts`
- manual browser smoke check of the help dialog on localhost
- verified dark-mode chart contrast
- verified German y-axis number formatting (`1.400`, `1.200`, `1.000`)
