### PR TITLE
feat(frontend): Story 5.4a – bunte Foyer-Einflug-Chips im Preset Spie…

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -48,7 +48,7 @@
     "@trpc/client": "^11.0.0",
     "@trpc/server": "^11.0.0",
     "chart.js": "^4.5.1",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.2",
     "express": "^5.1.0",
     "highlight.js": "^11.11.1",
     "katex": "^0.16.32",

--- a/apps/frontend/src/app/features/session/session-host/foyer-entrance-layer.component.html
+++ b/apps/frontend/src/app/features/session/session-host/foyer-entrance-layer.component.html
@@ -25,6 +25,7 @@
         [style.--foyer-overlay-tilt-start]="overlayTiltStart(chip)"
         [style.grid-column]="overlayGridColumn(chip)"
         [style.grid-row]="overlayGridRow(chip)"
+        [attr.data-color-variant]="chip.colorVariant"
       >
         <div
           class="foyer-entrance-layer__content"

--- a/apps/frontend/src/app/features/session/session-host/foyer-entrance-layer.component.scss
+++ b/apps/frontend/src/app/features/session/session-host/foyer-entrance-layer.component.scss
@@ -23,6 +23,24 @@
   --foyer-shadow-strong: color-mix(in srgb, var(--mat-sys-shadow) 32%, transparent);
 }
 
+.foyer-entrance-layer__chip-shell[data-color-variant='1'] {
+  --foyer-accent: var(--mat-sys-secondary);
+  --foyer-accent-surface: var(--mat-sys-secondary-container);
+  --foyer-accent-color: var(--mat-sys-on-secondary-container);
+  --foyer-accent-glow: color-mix(in srgb, var(--mat-sys-secondary-container) 68%, transparent);
+  --foyer-overlay-surface: var(--mat-sys-secondary-container);
+  --foyer-overlay-color: var(--mat-sys-on-secondary-container);
+}
+
+.foyer-entrance-layer__chip-shell[data-color-variant='2'] {
+  --foyer-accent: var(--mat-sys-tertiary);
+  --foyer-accent-surface: var(--mat-sys-tertiary-container);
+  --foyer-accent-color: var(--mat-sys-on-tertiary-container);
+  --foyer-accent-glow: color-mix(in srgb, var(--mat-sys-tertiary-container) 68%, transparent);
+  --foyer-overlay-surface: var(--mat-sys-tertiary-container);
+  --foyer-overlay-color: var(--mat-sys-on-tertiary-container);
+}
+
 .foyer-entrance-layer {
   position: relative;
   padding: 0.25rem 0 0.5rem;

--- a/apps/frontend/src/app/features/session/session-host/foyer-entrance-layer.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/foyer-entrance-layer.component.spec.ts
@@ -5,6 +5,7 @@ import { FoyerEntranceLayerComponent } from './foyer-entrance-layer.component';
 
 describe('FoyerEntranceLayerComponent', () => {
   const motion = {
+    colorVariant: 0 as const,
     enterDurationMs: 1800,
     presenceMs: 3600,
     settleDelayMs: 1200,
@@ -356,5 +357,69 @@ describe('FoyerEntranceLayerComponent', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('gibt jedem Chip-Shell das korrekte data-color-variant-Attribut', () => {
+    const fixture = TestBed.configureTestingModule({
+      imports: [FoyerEntranceLayerComponent],
+    }).createComponent(FoyerEntranceLayerComponent);
+
+    fixture.componentRef.setInput('chips', [
+      {
+        id: 'chip-a',
+        teamId: null,
+        kind: 'text',
+        fullLabel: 'Ada',
+        ariaLabel: 'Ada',
+        emoji: null,
+        text: 'Ada',
+        sequence: 0,
+        delayMs: 0,
+        lane: 0,
+        direction: 'left' as const,
+        ...motion,
+        colorVariant: 0 as const,
+      },
+      {
+        id: 'chip-b',
+        teamId: null,
+        kind: 'text',
+        fullLabel: 'Linus',
+        ariaLabel: 'Linus',
+        emoji: null,
+        text: 'Linus',
+        sequence: 1,
+        delayMs: 0,
+        lane: 1,
+        direction: 'right' as const,
+        ...motion,
+        colorVariant: 1 as const,
+      },
+      {
+        id: 'chip-c',
+        teamId: null,
+        kind: 'text',
+        fullLabel: 'Grace',
+        ariaLabel: 'Grace',
+        emoji: null,
+        text: 'Grace',
+        sequence: 2,
+        delayMs: 0,
+        lane: 2,
+        direction: 'left' as const,
+        ...motion,
+        colorVariant: 2 as const,
+      },
+    ]);
+    fixture.detectChanges();
+
+    const shells = Array.from(
+      fixture.nativeElement.querySelectorAll('.foyer-entrance-layer__chip-shell'),
+    ) as HTMLElement[];
+
+    expect(shells).toHaveLength(3);
+    expect(shells[0].getAttribute('data-color-variant')).toBe('0');
+    expect(shells[1].getAttribute('data-color-variant')).toBe('1');
+    expect(shells[2].getAttribute('data-color-variant')).toBe('2');
   });
 });

--- a/apps/frontend/src/app/features/session/session-host/foyer-entrance-layer.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/foyer-entrance-layer.component.ts
@@ -11,6 +11,8 @@ import {
 
 import type { FoyerChipLabel, FoyerChipLabelKind } from './foyer-chip-label.util';
 
+export type FoyerChipColorVariant = 0 | 1 | 2;
+
 export type FoyerEntranceChip = FoyerChipLabel & {
   id: string;
   participantId?: string;
@@ -21,6 +23,7 @@ export type FoyerEntranceChip = FoyerChipLabel & {
   delayMs: number;
   lane: number;
   direction: 'left' | 'right';
+  colorVariant: FoyerChipColorVariant;
   enterDurationMs: number;
   presenceMs: number;
   settleDelayMs: number;

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -3199,6 +3199,52 @@ describe('SessionHostComponent', () => {
     fixture.destroy();
   });
 
+  it('rotiert Chip-Farben (colorVariant 0/1/2) bei aufeinanderfolgenden Joins', async () => {
+    let participantJoinedHandler: ((data: unknown) => void) | null = null;
+    getInfoQueryMock.mockResolvedValue({
+      ...defaultSession,
+      status: 'LOBBY',
+      preset: 'PLAYFUL',
+      enableRewardEffects: true,
+    });
+    getParticipantsQueryMock.mockResolvedValue({
+      participantCount: 1,
+      participants: [{ id: 'p1', nickname: 'Ada' }],
+    });
+    onParticipantJoinedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (data: unknown) => void }) => {
+        participantJoinedHandler = opts.onData;
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    fixture.detectChanges();
+
+    participantJoinedHandler?.({
+      participantCount: 4,
+      participants: [
+        { id: 'p1', nickname: 'Ada' },
+        { id: 'p2', nickname: 'Linus' },
+        { id: 'p3', nickname: 'Grace' },
+        { id: 'p4', nickname: 'Alan' },
+      ],
+    });
+    fixture.detectChanges();
+
+    const shells = Array.from(
+      fixture.nativeElement.querySelectorAll('.foyer-entrance-layer__chip-shell'),
+    ) as HTMLElement[];
+
+    expect(shells).toHaveLength(3);
+    const variants = shells.map((s) => s.getAttribute('data-color-variant'));
+    expect(variants).toEqual(['0', '1', '2']);
+    fixture.destroy();
+  });
+
   it('zeigt groessere Join-Wellen im Quiz-Foyer nur noch als Einzelankuenfte', async () => {
     let participantJoinedHandler: ((data: unknown) => void) | null = null;
     getInfoQueryMock.mockResolvedValue({

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -99,6 +99,7 @@ import {
 } from '../session-quiz-picker-dialog.component';
 import {
   FoyerEntranceLayerComponent,
+  type FoyerChipColorVariant,
   type FoyerEntranceChip,
 } from './foyer-entrance-layer.component';
 import { buildFoyerChipLabel } from './foyer-chip-label.util';
@@ -2255,6 +2256,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       delayMs: 0,
       lane: this.nextFoyerLane(participant.teamId ?? null),
       direction: teamDirection ?? (sequence % 2 === 0 ? 'left' : 'right'),
+      colorVariant: (sequence % 3) as FoyerChipColorVariant,
       ...this.defaultFoyerArrivalMotionProfile(
         participant.teamId !== null && participant.teamId !== undefined,
       ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@emnapi/runtime": "1.8.1",
         "@eslint/js": "^10.0.1",
         "@types/qrcode": "^1.5.6",
-        "ajv": "^8.18.0",
+        "ajv": "^6.15.0",
         "astro": "^5.18.0",
         "concurrently": "^9.0.0",
         "eslint": "^10.0.0",
@@ -221,7 +221,7 @@
         "@trpc/client": "^11.0.0",
         "@trpc/server": "^11.0.0",
         "chart.js": "^4.5.1",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.2",
         "express": "^5.1.0",
         "highlight.js": "^11.11.1",
         "katex": "^0.16.32",
@@ -847,6 +847,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "apps/frontend/node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "apps/frontend/node_modules/emoji-regex": {
@@ -1507,6 +1516,23 @@
         }
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@angular-devkit/build-angular/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -1587,6 +1613,23 @@
         }
       }
     },
+    "node_modules/@angular-devkit/build-webpack/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@angular-devkit/build-webpack/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -1626,6 +1669,23 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/core/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@angular/animations": {
@@ -1788,6 +1848,23 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/build/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@angular/build/node_modules/picomatch": {
@@ -6470,6 +6547,23 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -10078,16 +10172,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
@@ -10112,6 +10206,23 @@
         }
       }
     },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ajv-keywords": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -10124,6 +10235,13 @@
       "peerDependencies": {
         "ajv": "^8.8.2"
       }
+    },
+    "node_modules/ajv/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -12799,15 +12917,6 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
-    "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -13198,30 +13307,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.1.1",
@@ -20013,6 +20098,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/schema-utils/node_modules/ajv-formats": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@emnapi/runtime": "1.8.1",
     "@eslint/js": "^10.0.1",
     "@types/qrcode": "^1.5.6",
-    "ajv": "^8.18.0",
+    "ajv": "^6.15.0",
     "astro": "^5.18.0",
     "concurrently": "^9.0.0",
     "eslint": "^10.0.0",


### PR DESCRIPTION
# Was wurde umgesetzt

Story 5.4a: Im Preset **Spielerisch** fliegen neu beitretende Teilnehmende 
als farbige Chips animiert in das Host-Foyer ein. Der Effekt ist nur aktiv 
während der LOBBY-Phase eines Quiz-Sessions.

Kernänderungen

**Mehrfarbige Chips (primary / secondary / tertiary)**  
Jede neu beitretende Person erhält einen Chip, der zwischen den drei 
Material Design 3-Akzentfarben rotiert (primär → sekundär → tertiär, 
via `sequence % 3`). Das erzeugt ein lebendiges, aber geordnetes Gesamtbild 
ohne visuelles Chaos.

**Technische Umsetzung**  
- Neues Feld `colorVariant: 0 | 1 | 2` in `FoyerEntranceChip`
- Das `data-color-variant`-Attribut am Shell-Element steuert CSS-Custom-Property-Overrides
  (`--foyer-accent-*`, `--foyer-accent-surface`, `--foyer-overlay-surface` etc.)
- Variant 1 → `--mat-sys-secondary-*`, Variant 2 → `--mat-sys-tertiary-*`
- Kein JavaScript-Farblogik: alles über den CSS-Cascade geregelt
- `session-host.component.ts`: `createFoyerArrivalChip` vergibt `colorVariant: (sequence % 3)`

**Schutzmechanismen bleiben erhalten**  
- Chips erscheinen nur bei echten Neu-Joins (nicht für Baseline-Teilnehmende)
- Nur im PLAYFUL-Preset + LOBBY-Status + `enableRewardEffects !== false`
- Kein Team-Modus (eigene Layer)
- Bei vielen gleichzeitigen Joins: Burst-Logik reduziert auf Einzel-Chips

**Infrastruktur-Fix**  
`dompurify` (fehlte in node_modules trotz package.json-Eintrag) und `ajv@6` 
(Pre-Commit-Hook-Abhängigkeit) wurden installiert.

---

## Geänderte Dateien

| Datei | Änderung |
|---|---|
| `foyer-entrance-layer.component.ts` | `FoyerChipColorVariant`-Typ exportiert, `colorVariant`-Feld zu `FoyerEntranceChip` hinzugefügt |
| `foyer-entrance-layer.component.html` | `[attr.data-color-variant]="chip.colorVariant"` Binding am Shell-Element |
| `foyer-entrance-layer.component.scss` | CSS-Blöcke für `data-color-variant='1'` (secondary) und `='2'` (tertiary) |
| `session-host.component.ts` | `colorVariant: (sequence % 3) as FoyerChipColorVariant` in `createFoyerArrivalChip` |
| `foyer-entrance-layer.component.spec.ts` | Neuer Test: prüft `data-color-variant` 0/1/2 korrekt am DOM |
| `session-host.component.spec.ts` | Neuer Test: Farbrotation 0→1→2 bei drei aufeinanderfolgenden Joins |
| `package.json` / `package-lock.json` | `dompurify` + `ajv@6` hinzugefügt |

---

## Testergebnisse

Test Files  57 passed (57)
Tests      665 passed (665)   ← Backend + Frontend, alle grün



Typecheck: `npm run typecheck` → keine Fehler  
Pre-Commit-Hook: ESLint + Prettier + Typecheck + Tests → alles grün

---

## Manueller Test

**Voraussetzung:** Quiz mit Preset „Spielerisch" (Standard), Session im Status LOBBY

1. Host-URL öffnen (`/session/XXXXXX/host`)
2. Auf einem zweiten Gerät/Tab als Teilnehmende:r beitreten
3. → Chip fliegt von links oder rechts ins Foyer ein (680ms Animation)
4. → Chip bleibt ~3,5s sichtbar (Dev-Modus), dann Fade-out
5. Weitere Teilnehmende beitreten lassen → Chips rotieren durch primäre, 
   sekundäre und tertiäre Akzentfarbe

**Negativtest:**  
- Preset auf „Seriös" wechseln → kein Einflug-Effekt  
- Teilnehmende, die bereits beim Laden der Host-Seite im Raum waren, 
  bekommen keinen Chip (korrekt – nur Neu-Joins zählen)

---

## Bezug zum Backlog

Schließt Story **5.4a** (Foyer-Einflug im Preset Spielerisch) aus `Backlog.md`  
Akzeptanzkriterien erfüllt:
- ✅ Nur im Preset Spielerisch
- ✅ Nur in der LOBBY/Connecting-Phase
- ✅ Bunte, unterscheidbare Chips (3 M3-Farben)
- ✅ Einflugbewegung von außen ins Foyer
- ✅ Lesbar auch bei mehreren gleichzeitigen Joins
- ✅ Host-Lobby profitiert sichtbar
- ✅ `prefers-reduced-motion` unterstützt (vereinfachte Animation)