### PR TITLE
ci: harden deploy smoke host validation and optimize workflow scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 # Deploy-Branch: Standard ist main. Optional Repository-Variable DEPLOY_BRANCH setzen (z. B. deploy).
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # ─── Dependency Review (PR) ────────────────────────────────────────────────
@@ -40,12 +40,10 @@ jobs:
       - name: Dependency review
         continue-on-error: true
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
-        with:
-          fail-on-severity: high
 
       - name: Dependency review result
         if: always()
-        run: echo "Dependency review completed (non-blocking in CI workflow)."
+        run: echo "Dependency review completed (informational, non-blocking in CI workflow)."
 
   # ─── Workflow Lint (GitHub Actions) ───────────────────────────────────────
   actionlint:
@@ -64,6 +62,7 @@ jobs:
   build:
     name: Build & Validate (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -420,7 +419,6 @@ jobs:
   load-test:
     name: k6 Load Test
     runs-on: ubuntu-latest
-    needs: build
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,7 +605,19 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Verify production serving
-        run: node scripts/verify-production-serving.mjs "https://${{ secrets.DEPLOY_HOST }}"
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          set -euo pipefail
+
+          if printf '%s' "$DEPLOY_HOST" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "DEPLOY_HOST ist eine IP-Adresse ($DEPLOY_HOST). TLS-Zertifikate enthalten i. d. R. DNS-Namen, nicht IP-SANs."
+            echo "Setze DEPLOY_HOST auf den öffentlichen DNS-Namen mit gültigem Zertifikat (z. B. arsnova.eu)."
+            exit 1
+          fi
+
+          SMOKE_URL="https://$DEPLOY_HOST"
+          node scripts/verify-production-serving.mjs "$SMOKE_URL"
 
   # ─── Rollback (wenn Post-Deploy-Smoke fehlschlägt) ───────────────────────
   rollback-on-smoke-failure:


### PR DESCRIPTION
## Summary\n- avoid canceling in-progress runs on main branch\n- skip build matrix on scheduled runs and decouple scheduled k6 load test from build\n- keep dependency review explicitly informational/non-blocking\n- fail fast in post-deploy smoke when DEPLOY_HOST is an IP (TLS SAN mismatch guard)\n\n## Why\nRecent runs showed post-deploy smoke failures caused by TLS hostname mismatch when DEPLOY_HOST points to an IP. This PR adds deterministic validation and includes CI safety/cost improvements from the review follow-up.