### PR TITLE
ci: document rollback smoke gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,7 +624,8 @@ jobs:
     name: Rollback on Smoke Failure
     runs-on: ubuntu-latest
     needs: [deploy, post-deploy-smoke]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.deploy.result == 'success' && needs.post-deploy-smoke.result == 'failure' && github.event.before != '0000000000000000000000000000000000000000'
+    # Run only for real push deployments on main when the smoke test failed.
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.deploy.result == 'success' && needs.post-deploy-smoke.result == 'failure' && github.event.before != '0000000000000000000000000000000000000000' }}
     timeout-minutes: 30
     concurrency:
       group: deploy-main


### PR DESCRIPTION
## Summary\n- add a short comment to the rollback job so the trigger condition is immediately obvious\n- keep the rollback job limited to real push deployments on main with a failed smoke test\n\n## Notes\nThis is a small follow-up on the existing CI/deploy hardening branch.