### PR TITLE
ci: harden deploy target and production smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,7 @@ jobs:
     env:
       DEPLOY_DIR: /home/deploy/arsnova.eu
       DEPLOY_BRANCH: main
+      DEPLOY_SHA: ${{ github.sha }}
 
     steps:
       - name: Validate deploy configuration
@@ -581,7 +582,7 @@ jobs:
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: 22
-          envs: DEPLOY_DIR,DEPLOY_BRANCH
+          envs: DEPLOY_DIR,DEPLOY_BRANCH,DEPLOY_SHA
           script: |
             set -e
             export DEPLOY_DIR="${DEPLOY_DIR:-/home/deploy/arsnova.eu}"
@@ -591,7 +592,7 @@ jobs:
             git checkout "$DEPLOY_BRANCH"
             git reset --hard "origin/$DEPLOY_BRANCH"
             chmod +x scripts/deploy.sh
-            ./scripts/deploy.sh
+            DEPLOY_SHA="$DEPLOY_SHA" ./scripts/deploy.sh
 
   # ─── Post-Deploy Smoke Check ───────────────────────────────────────────────
   post-deploy-smoke:
@@ -636,7 +637,7 @@ jobs:
     env:
       DEPLOY_DIR: /home/deploy/arsnova.eu
       DEPLOY_BRANCH: main
-      ROLLBACK_SHA: ${{ github.event.before }}
+      DEPLOY_SHA: ${{ github.event.before }}
 
     steps:
       - name: Validate rollback configuration
@@ -645,7 +646,7 @@ jobs:
           test -n "${{ secrets.DEPLOY_HOST }}" || (echo "Missing secret: DEPLOY_HOST" && exit 1)
           test -n "${{ secrets.DEPLOY_USER }}" || (echo "Missing secret: DEPLOY_USER" && exit 1)
           test -n "${{ secrets.DEPLOY_SSH_KEY }}" || (echo "Missing secret: DEPLOY_SSH_KEY" && exit 1)
-          test -n "${ROLLBACK_SHA}" || (echo "Missing rollback SHA" && exit 1)
+          test -n "${DEPLOY_SHA}" || (echo "Missing rollback SHA" && exit 1)
           echo "Rollback configuration looks complete."
 
       - name: Roll back via SSH
@@ -655,7 +656,7 @@ jobs:
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: 22
-          envs: DEPLOY_DIR,DEPLOY_BRANCH,ROLLBACK_SHA
+          envs: DEPLOY_DIR,DEPLOY_BRANCH,DEPLOY_SHA
           script: |
             set -e
             export DEPLOY_DIR="${DEPLOY_DIR:-/home/deploy/arsnova.eu}"
@@ -663,6 +664,5 @@ jobs:
             cd "$DEPLOY_DIR"
             git fetch origin
             git checkout "$DEPLOY_BRANCH"
-            git reset --hard "$ROLLBACK_SHA"
             chmod +x scripts/deploy.sh
-            ./scripts/deploy.sh
+            DEPLOY_SHA="$DEPLOY_SHA" ./scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,8 @@
 # =============================================================================
 # arsnova.eu – Deploy-Skript (auf dem Server oder via CI per SSH)
 # Voraussetzung: Im Repo-Verzeichnis, .env.production vorhanden.
-# Nutzung: ./scripts/deploy.sh   oder   bash scripts/deploy.sh
+# CI setzt DEPLOY_SHA auf den exakt geprüften Commit.
+# Manuell ohne DEPLOY_SHA wird der aktuelle Stand von origin/$DEPLOY_BRANCH verwendet.
 # =============================================================================
 
 set -euo pipefail
@@ -14,6 +15,7 @@ cd "$REPO_ROOT"
 COMPOSE_FILE="docker-compose.prod.yml"
 ENV_FILE=".env.production"
 DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
+DEPLOY_SHA="${DEPLOY_SHA:-}"
 HEALTH_MAX_WAIT_SECONDS="${HEALTH_MAX_WAIT_SECONDS:-180}"
 
 if [[ ! -f "$ENV_FILE" ]]; then
@@ -32,10 +34,37 @@ compose() {
   docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" "$@"
 }
 
-echo ">>> Schritt 1: Neuesten Code von GitHub holen (Branch: $DEPLOY_BRANCH) …"
-git fetch origin
-git checkout "$DEPLOY_BRANCH"
-git reset --hard "origin/$DEPLOY_BRANCH"
+echo ">>> Schritt 1: Ziel-Commit holen und exakt auschecken (Branch: $DEPLOY_BRANCH) …"
+git fetch --prune origin "$DEPLOY_BRANCH"
+
+if [[ -z "$DEPLOY_SHA" ]]; then
+  DEPLOY_SHA="$(git rev-parse FETCH_HEAD)"
+  echo ">>> Kein DEPLOY_SHA gesetzt; verwende aktuellen Remote-Stand: $DEPLOY_SHA"
+fi
+
+if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Fehler: ungültiger DEPLOY_SHA: $DEPLOY_SHA"
+  exit 1
+fi
+
+if ! git cat-file -e "${DEPLOY_SHA}^{commit}" 2>/dev/null; then
+  echo ">>> Ziel-Commit ist lokal noch nicht vorhanden; hole ihn explizit …"
+  git fetch origin "$DEPLOY_SHA"
+fi
+
+if ! git cat-file -e "${DEPLOY_SHA}^{commit}" 2>/dev/null; then
+  echo "Fehler: Ziel-Commit $DEPLOY_SHA konnte nicht gefunden werden."
+  exit 1
+fi
+
+git checkout --detach --force "$DEPLOY_SHA"
+
+checked_out_sha="$(git rev-parse HEAD)"
+if [[ "$checked_out_sha" != "$DEPLOY_SHA" ]]; then
+  echo "Fehler: Ausgecheckter Commit ($checked_out_sha) entspricht nicht DEPLOY_SHA ($DEPLOY_SHA)."
+  exit 1
+fi
+
 echo ">>> Git sync abgeschlossen ($(git log -1 --format='%h %s'))"
 
 echo ""

--- a/scripts/verify-production-serving.mjs
+++ b/scripts/verify-production-serving.mjs
@@ -15,8 +15,15 @@ const REQUEST_TIMEOUT_MS = Number(process.env.VERIFY_REQUEST_TIMEOUT_MS || '8000
 const RETRY_ATTEMPTS = Number(process.env.VERIFY_RETRY_ATTEMPTS || '8');
 const RETRY_DELAY_MS = Number(process.env.VERIFY_RETRY_DELAY_MS || '1500');
 
-function printCheck(label, ok, detail) {
-  console.log(`${label}:`, ok ? '✓' : '✗', detail ? `(${detail})` : '');
+let failedRequiredChecks = 0;
+
+function printCheck(label, ok, detail, { required = true } = {}) {
+  const marker = ok ? '✓' : required ? '✗' : 'WARN';
+  console.log(`${label}:`, marker, detail ? `(${detail})` : '');
+
+  if (!ok && required) {
+    failedRequiredChecks += 1;
+  }
 }
 
 function sleep(ms) {
@@ -103,7 +110,9 @@ async function main() {
     console.log('Root /');
     printCheck('Status 200', root.ok, String(root.status));
     printCheck('Content-Type HTML', root.contentType.includes('text/html'), root.contentType);
-    printCheck('Compression aktiv', Boolean(root.encoding), root.encoding || 'keine');
+    printCheck('Compression aktiv', Boolean(root.encoding), root.encoding || 'keine', {
+      required: false,
+    });
     printCheck(
       'Locale-Redirect-Hinweis',
       root.text.includes("location.replace('/" ) && root.text.includes('/de/'),
@@ -130,6 +139,7 @@ async function main() {
       'Theme-CSS inline',
       locale.text.includes('--mat-sys-surface-container'),
       'critical theme tokens',
+      { required: false },
     );
     console.log('');
 
@@ -149,9 +159,9 @@ async function main() {
       stats ? `${stats.serviceStatus} / ${stats.loadStatus}` : 'keine Daten',
     );
 
-    if (!root.ok || !locale.ok || !api.ok) {
-      console.log(
-        '\nHinweis: Mindestens ein Prüfschritt war nicht erfolgreich. Backend läuft und liefert dist/browser sowie /trpc korrekt aus?',
+    if (failedRequiredChecks > 0) {
+      console.error(
+        `\nFehler: ${failedRequiredChecks} verpflichtende Production-Prüfung(en) sind fehlgeschlagen.`,
       );
       process.exitCode = 1;
     }


### PR DESCRIPTION
## Summary

This PR hardens the two implementation points behind the most critical CI/CD findings:

- `scripts/deploy.sh` now deploys an explicit immutable `DEPLOY_SHA` and verifies that the checked-out commit matches it.
- Manual deployments without `DEPLOY_SHA` still fall back to the current remote branch head.
- The rollback target can therefore be deployed exactly instead of being overwritten by a later `origin/main` reset.
- `scripts/verify-production-serving.mjs` now fails on required structural/API checks instead of only logging failures.
- Compression and inline theme-token checks remain informational to avoid false rollback triggers caused by proxy or build-detail changes.

## Important remaining workflow change

The current `.github/workflows/ci.yml` still has to pass `github.sha` as `DEPLOY_SHA` to the deploy step and `github.event.before` as `DEPLOY_SHA` to rollback. Without that wiring, the hardened script falls back to the remote branch head for normal deploys.

I attempted to update the workflow in the same change, but the connected GitHub write action blocked edits to the workflow file itself. The branch therefore intentionally contains only the two repository changes that were successfully committed.

Recommended workflow wiring:

```yaml
env:
  DEPLOY_SHA: ${{ github.sha }}
```

and for rollback:

```yaml
env:
  DEPLOY_SHA: ${{ github.event.before }}
```

Both SSH actions should include `DEPLOY_SHA` in `envs` and invoke:

```sh
DEPLOY_SHA="$DEPLOY_SHA" ./scripts/deploy.sh
```

## CI optimization recommendations not yet applied

- Run the localized production build only once on Node 22; keep Node 20 as a compatibility compile/typecheck lane.
- Remove `needs: build` from lint, tests, and Docker build so they start immediately in parallel.
- Add `actionlint` to the deploy gate.
- Make manual k6 execution opt-in instead of implicit on every `workflow_dispatch`.
- Let the Trivy image build consume the existing GHA Docker cache.

This PR is a draft because the workflow wiring is still required before merge.