### PR TITLE
ci: skip stale production deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,14 +546,42 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # ─── Deploy Freshness Check (nur aktueller main-HEAD darf deployen) ──────────
+  deploy-freshness:
+    name: Deploy Freshness Check
+    runs-on: ubuntu-latest
+    needs: [lint, test, docker, typecheck, lighthouse, e2e, audit, trivy-fs, trivy-image]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true'
+    outputs:
+      should_deploy: ${{ steps.check.outputs.should_deploy }}
+
+    steps:
+      - name: Check current main head
+        id: check
+        env:
+          DEPLOY_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current_main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+
+          if [[ "$current_main_sha" != "$DEPLOY_SHA" ]]; then
+            echo "Deploy SHA $DEPLOY_SHA ist nicht mehr aktueller main-HEAD ($current_main_sha); Deploy wird übersprungen."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Deploy SHA ist aktueller main-HEAD: $DEPLOY_SHA"
+          echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+
   # ─── Deploy (nur Push auf main, nach allen Qualitäts-Gates) ───────────────────
   # Läuft nur, wenn Repository-Variable DEPLOY_ENABLED = 'true' gesetzt ist.
   # Ohne Server: Variable weglassen → Deploy wird übersprungen, CI bleibt grün.
   deploy:
     name: Deploy to Server
     runs-on: ubuntu-latest
-    needs: [lint, test, docker, typecheck, lighthouse, e2e, audit, trivy-fs, trivy-image]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true'
+    needs: deploy-freshness
+    if: needs.deploy-freshness.outputs.should_deploy == 'true'
     timeout-minutes: 30
     concurrency:
       group: deploy-main
@@ -588,9 +616,6 @@ jobs:
             export DEPLOY_DIR="${DEPLOY_DIR:-/home/deploy/arsnova.eu}"
             export DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
             cd "$DEPLOY_DIR"
-            git fetch origin
-            git checkout "$DEPLOY_BRANCH"
-            git reset --hard "origin/$DEPLOY_BRANCH"
             chmod +x scripts/deploy.sh
             DEPLOY_SHA="$DEPLOY_SHA" ./scripts/deploy.sh
 


### PR DESCRIPTION
## Summary
- add a deploy freshness gate that only allows the current main HEAD to deploy
- skip stale deploy jobs cleanly before entering the production deploy job
- remove the redundant git fetch/checkout/reset before scripts/deploy.sh

## Verification
- git diff --check
- YAML parse via Ruby
- GitHub API main-ref lookup matches origin/main
- local commit hook: typecheck, backend tests, frontend tests