### PR TITLE
chore(ci): Staging-Capacity-Job entfernen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,6 @@ on:
         required: false
         default: false
         type: boolean
-      run_staging_capacity:
-        description: 'Explizit den vollständigen Artillery-Kapazitätslauf gegen Staging ausführen'
-        required: false
-        default: false
-        type: boolean
-      staging_participants:
-        description: 'Teilnehmende für den Staging-Kapazitätslauf'
-        required: false
-        default: '500'
-        type: string
 
 permissions:
   contents: read
@@ -1088,85 +1078,6 @@ jobs:
           path: |
             ${{ runner.temp }}/artillery-reconnect-500/
             ${{ runner.temp }}/backend.log
-          if-no-files-found: ignore
-          retention-days: 30
-
-  staging-capacity:
-    name: Staging Capacity (Artillery)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && inputs.run_staging_capacity
-    timeout-minutes: 40
-    environment:
-      name: performance-staging
-    env:
-      STAGING_BASE_URL: ${{ vars.STAGING_BASE_URL }}
-      TRPC_URL: ${{ vars.STAGING_TRPC_URL }}
-      WS_URL: ${{ vars.STAGING_WS_URL }}
-      PARTICIPANTS: ${{ inputs.staging_participants || '500' }}
-      ARTILLERY_RAMP_SECONDS: ${{ inputs.artillery_ramp_seconds || '60' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-
-      - name: Setup Node.js 22
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build shared types
-        run: npm run build -w @arsnova/shared-types
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-
-      - name: Validate staging target
-        run: |
-          set -euo pipefail
-          test -n "$STAGING_BASE_URL" || (echo "Repository-Variable STAGING_BASE_URL fehlt." && exit 1)
-          test -n "$TRPC_URL" || (echo "Repository-Variable STAGING_TRPC_URL fehlt." && exit 1)
-          test -n "$WS_URL" || (echo "Repository-Variable STAGING_WS_URL fehlt." && exit 1)
-          [[ "$STAGING_BASE_URL" == https://* ]] || (echo "STAGING_BASE_URL muss HTTPS verwenden." && exit 1)
-          [[ "$TRPC_URL" == https://* ]] || (echo "STAGING_TRPC_URL muss HTTPS verwenden." && exit 1)
-          [[ "$WS_URL" == wss://* ]] || (echo "STAGING_WS_URL muss WSS verwenden." && exit 1)
-          [[ "$STAGING_BASE_URL" != https://arsnova.eu* ]] || (echo "Produktionsziel ist für staging-capacity gesperrt." && exit 1)
-          [[ "$TRPC_URL" != https://arsnova.eu/* ]] || (echo "Produktionsziel ist für staging-capacity gesperrt." && exit 1)
-
-      - name: Run full staging capacity scenarios
-        run: |
-          set -euo pipefail
-          REPORT_DIR="$RUNNER_TEMP/staging-capacity"
-          mkdir -p "$REPORT_DIR"
-          run_status=0
-          load_pid=""
-          # shellcheck disable=SC2317,SC2329
-          cleanup() {
-            if [ -n "$load_pid" ]; then
-              kill "$load_pid" 2>/dev/null || true
-            fi
-          }
-          trap cleanup EXIT
-
-          REPORT_FILE="$REPORT_DIR/live-session.json" JUNIT_FILE="$REPORT_DIR/live-session.junit.xml" npm run load:artillery:500 > "$REPORT_DIR/live-session.log" 2>&1 &
-          load_pid="$!"
-          sleep 10
-          BASE_URL="${STAGING_BASE_URL%/}/de" TRPC_URL="$TRPC_URL" npm run smoke:unified-session -w @arsnova/frontend > "$REPORT_DIR/browser-reference.log" 2>&1 || run_status=$?
-          wait "$load_pid" || run_status=$?
-          load_pid=""
-          REPORT_FILE="$REPORT_DIR/reconnect-wave.json" JUNIT_FILE="$REPORT_DIR/reconnect-wave.junit.xml" npm run load:artillery:reconnect:500 || run_status=$?
-          cp -R scripts/load/artillery/reports "$REPORT_DIR/" 2>/dev/null || true
-          exit "$run_status"
-
-      - name: Upload staging capacity reports
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: staging-capacity-reports
-          path: ${{ runner.temp }}/staging-capacity/
           if-no-files-found: ignore
           retention-days: 30
 

--- a/docs/CI-WORKFLOW.md
+++ b/docs/CI-WORKFLOW.md
@@ -240,15 +240,6 @@ Wichtig: Jobs ohne direkte Abhängigkeit laufen **parallel**.
 - **Wann?** Nur bei `schedule` oder `workflow_dispatch`.
 - **Artefakt:** `artillery-reconnect-500-reports` (Summary JSON + Artillery-Report + `backend.log`).
 
-### 4.11b staging-capacity
-
-- **Was?** Explizit freizugebender vollständiger Artillery-Lauf gegen die
-  `performance-staging`-Umgebung (Live-Session und Reconnect, standardmäßig 500 TN).
-- **Wann?** Nur manuell mit `run_staging_capacity=true`; URLs kommen aus
-  `STAGING_TRPC_URL` und `STAGING_WS_URL`. Das Produktionsziel ist in diesem Job gesperrt.
-- **Warum?** Trennt den echten Kapazitätsnachweis von verrauschten GitHub-Runner-Smokes
-  und erzwingt eine bewusste Freigabe der Zielumgebung.
-
 ### 4.12 load-test
 
 - **Was?** k6-Health-Loadtest gegen Produktion.

--- a/docs/PERFORMANCE-TESTING.md
+++ b/docs/PERFORMANCE-TESTING.md
@@ -10,14 +10,13 @@ die Live-SLOs stehen in
 - **PR/Deploy-Gate:** kurze, reproduzierbare Classroom- und Browser-Smokes in
   `classroom-smokes`, `e2e` und `lighthouse`.
 - **Nacht/Manuell:** protokollnahe Kapazität, Reconnect, Yjs, schwere Vote-Hotpaths
-  und 5-Minuten-Soak in den Artillery-Jobs und `load-test`.
-- **Staging-Kapazität:** bewusster 500-TN-Nachweis gegen eine isolierte Zielumgebung
-  per `workflow_dispatch` mit `run_staging_capacity=true`.
+  und 5-Minuten-Soak in den Artillery-Jobs (`artillery-500`, `artillery-reconnect-500`)
+  und optional `load-test`.
 - **Langzeitprofil:** 30/60-Minuten-Soak mit Prozess-, Redis- und PostgreSQL-Probes
-  lokal oder in einer dedizierten Staging-Umgebung.
+  lokal gegen `npm run dev:backend` (kein separater Staging-Server).
 
-Lasttests niemals ungeplant gegen Produktion ausführen. Der Produktions-k6-Lauf und
-der Staging-Kapazitätslauf benötigen eine explizite Workflow-Freigabe.
+Lasttests niemals ungeplant gegen Produktion ausführen. Der Produktions-k6-Lauf
+benötigt eine explizite Workflow-Freigabe (`run_production_load=true`).
 
 ## Letzter lokaler Gesamtlauf
 
@@ -41,7 +40,8 @@ Der [gezielte QA-Nachlauf vom 2026-07-11](implementation/LOCAL-QA-RECHECK-2026-0
 schließt diese technischen Befunde: Yjs konvergierte nach Reconnect in 6 ms,
 die beiden akzeptierenden 600er Vote-Pfade hielten mit p95 766 ms und 968 ms das
 1.000-ms-Gate ein, 6/6 Browser-Flows und 6/6 Lighthouse-Läufe bestanden. Als
-offener Nachweis verbleiben Staging-Langlauf und Baseline-Freigabe.
+offener Nachweis verbleiben Langzeit-Soak und Baseline-Freigabe
+(siehe [PERFORMANCE-BASELINE-FREIGABE.md](implementation/PERFORMANCE-BASELINE-FREIGABE.md)).
 
 Dieser Lauf ist ein lokaler Entwicklungsnachweis, keine freigegebene Baseline.
 Insbesondere darf die bloße Existenz eines Szenarios nicht mit einem bestandenen

--- a/docs/implementation/LOCAL-QA-RECHECK-2026-07-11.md
+++ b/docs/implementation/LOCAL-QA-RECHECK-2026-07-11.md
@@ -33,8 +33,7 @@ Frontend-Laufzeit.
   Migrationen gegen eine leere Datenbank an.
 - **GitHub-Enforcement:** Das aktive Ruleset verlangt 19 strikte Statuschecks,
   einschließlich Workflow-Lint, Format, Landing-Build und CodeQL. `production`
-  und `performance-staging` erlauben nur geschützte Branches; Admin-Bypass ist
-  deaktiviert.
+  erlaubt nur geschützte Branches; Admin-Bypass ist deaktiviert.
 
 ## Korrekturen
 
@@ -63,6 +62,8 @@ Frontend-Laufzeit.
 ## Verbleibender Betriebsnachweis
 
 Offen bleibt kein reproduzierbarer lokaler Fehler aus dem Gesamtlauf. Vor einer
-Produktionsbaseline sind weiterhin ein freigegebener 30-/60-Minuten-Langlauf in
-einer stabilen Staging-Umgebung und die versionierte Baseline-/Regressionsfreigabe
-erforderlich.
+Produktionsbaseline sind weiterhin ein freigegebener 30-/60-Minuten-Langlauf (lokal
+oder auf dem Zielserver) und die versionierte Baseline-/Regressionsfreigabe
+erforderlich. Ein separater Staging-Server ist nicht vorgesehen; Kapazitätsnachweise
+laufen über die CI-Artillery-Jobs und lokale Soak-Skripte
+(siehe [PERFORMANCE-BASELINE-FREIGABE.md](PERFORMANCE-BASELINE-FREIGABE.md)).

--- a/docs/implementation/PERFORMANCE-BASELINE-FREIGABE.md
+++ b/docs/implementation/PERFORMANCE-BASELINE-FREIGABE.md
@@ -1,9 +1,9 @@
-# Staging-Baseline und Performance-Freigabe
+# Performance-Baseline und Freigabe
 
-**Stand:** 2026-07-11
+**Stand:** 2026-07-12
 
 Dieses Dokument beschreibt den verbleibenden betrieblichen Nachweis für Story **0.7**:
-freigegebene Last-/Performance-Baselines aus einer stabilen Staging-Umgebung.
+freigegebene Last-/Performance-Baselines ohne separaten Staging-Server.
 
 Die technischen Gates (Unit, Browser, Yjs, Vote-p95, Lighthouse, CI) sind im
 [QA-Nachlauf vom 2026-07-11](LOCAL-QA-RECHECK-2026-07-11.md) lokal grün. Dieser
@@ -14,49 +14,42 @@ Langzeit- und Regressionsnachweis.
 
 ### Repository-Variablen
 
-| Variable                  | Zweck                                          | Beispiel                           |
-| ------------------------- | ---------------------------------------------- | ---------------------------------- |
-| `STAGING_BASE_URL`        | HTTPS-Frontend der Staging-Umgebung            | `https://staging.arsnova.eu`       |
-| `STAGING_TRPC_URL`        | HTTPS-tRPC-Endpunkt                            | `https://staging.arsnova.eu/trpc`  |
-| `STAGING_WS_URL`          | WSS-tRPC-WebSocket                             | `wss://staging.arsnova.eu/trpc-ws` |
-| `ARTILLERY_PARTICIPANTS`  | Standard für Nacht-/Manuell-Läufe              | `500`                              |
-| `ARTILLERY_RAMP_SECONDS`  | Ramp-up-Dauer                                  | `60`                               |
-| `PRODUCTION_LOAD_ENABLED` | Nacht-k6 gegen Produktion (`true` nur bewusst) | `false`                            |
-| `DEPLOY_ENABLED`          | Produktions-Deploy in CI                       | `true`                             |
+| Variable                  | Zweck                                          | Beispiel |
+| ------------------------- | ---------------------------------------------- | -------- |
+| `ARTILLERY_PARTICIPANTS`  | Standard für Nacht-/Manuell-Läufe              | `500`    |
+| `ARTILLERY_RAMP_SECONDS`  | Ramp-up-Dauer                                  | `60`     |
+| `PRODUCTION_LOAD_ENABLED` | Nacht-k6 gegen Produktion (`true` nur bewusst) | `false`  |
+| `DEPLOY_ENABLED`          | Produktions-Deploy in CI                       | `true`   |
 
-Die Staging-URLs dürfen **nicht** auf `https://arsnova.eu` zeigen. Der Job
-`staging-capacity` bricht in diesem Fall absichtlich ab.
+Ein separater Staging-Server ist **nicht** vorgesehen. Der frühere CI-Job
+`staging-capacity` wurde entfernt (2026-07-12).
 
 ### GitHub-Environments
 
-| Environment           | Zweck                                       |
-| --------------------- | ------------------------------------------- |
-| `performance-staging` | Manueller Kapazitätslauf `staging-capacity` |
-| `production`          | Deploy und Rollback                         |
+| Environment  | Zweck               |
+| ------------ | ------------------- |
+| `production` | Deploy und Rollback |
 
-Beide Umgebungen sollten ohne Admin-Bypass und mit Branch-Schutz konfiguriert
-sein. Details zum aktuellen Enforcement stehen im
-[QA-Nachlauf](LOCAL-QA-RECHECK-2026-07-11.md).
+## Ablauf: Kapazitätslauf (CI-Runner)
 
-## Ablauf: Staging-Kapazitätslauf
+Kapazitätsnachweise gegen PostgreSQL/Redis im GitHub-Actions-Runner:
 
-1. Staging-Stack mit gleicher Migrationskette wie Produktion betreiben
-   (`prisma migrate deploy`, kein `db push`).
-2. Repository-Variablen setzen (siehe oben).
-3. In GitHub Actions **CI → Run workflow** ausführen:
-   - `run_staging_capacity`: `true`
-   - `staging_participants`: `500` (oder Zielwert)
+1. In GitHub Actions **CI → Run workflow** ausführen (oder den täglichen Schedule abwarten).
+2. Optional anpassen:
+   - `artillery_participants`: `500`
    - `artillery_ramp_seconds`: `60`
-4. Artefakt `staging-capacity-reports` herunterladen und prüfen:
-   - Artillery Live-Session: 500/500 Joins, Votes, WS
-   - Artillery Reconnect: 500/500 Reconnects
-   - Browser-Referenzflow `smoke:unified-session` parallel grün
-5. Ergebnis im Messprotokoll festhalten
+3. Artefakte prüfen:
+   - `artillery-500-reports` — Live-Session, Vote-Smokes, Yjs, Freitext, 5-Min-Soak
+   - `artillery-reconnect-500-reports` — Reconnect-Welle
+4. Ergebnis im Messprotokoll festhalten
    ([VORLAGE-MESSPROTOKOLL-LAST.md](../praktikum/VORLAGE-MESSPROTOKOLL-LAST.md)).
+
+Details zu den Jobs: [CI-WORKFLOW.md](../CI-WORKFLOW.md) (Abschnitte `artillery-500`,
+`artillery-reconnect-500`).
 
 ## Ablauf: 30-/60-Minuten-Soak
 
-Lokal oder in Staging gegen dieselbe Zielumgebung:
+Lokal gegen dasselbe Backend-Setup wie in CI:
 
 ```bash
 npm run dev:backend
@@ -92,7 +85,7 @@ npm run load:report:compare -- \
 
 4. Freigabe dokumentieren:
    - Datum und Commit-Stand
-   - Zielumgebung (Staging/Produktion)
+   - Zielumgebung (CI-Runner / lokaler Soak / Produktion nach Deploy)
    - Teilnehmerzahl und Dauer
    - p95/p99, Fehlerrate, beobachtete Engpässe
    - Verantwortliche Freigabe
@@ -115,8 +108,9 @@ Diese Werte dienen als **lokale Referenz**, nicht als freigegebene Produktionsba
 
 Story 0.7 gilt betrieblich abgeschlossen, wenn:
 
-1. ein dokumentierter 30- oder 60-Minuten-Soak in Staging grün ist,
-2. ein Staging-Kapazitätslauf mit 500 Teilnehmenden grün ist,
+1. ein dokumentierter 30- oder 60-Minuten-Soak lokal grün ist,
+2. die CI-Artillery-Jobs (`artillery-500`, `artillery-reconnect-500`) mit 500
+   Teilnehmenden grün sind,
 3. die Baseline-Reports fachlich freigegeben und für `load:report:compare`
    nutzbar sind.
 


### PR DESCRIPTION
## Summary
- Entfernt den CI-Job `staging-capacity` und die Inputs `run_staging_capacity` / `staging_participants` (kein Staging-Server)
- Kapazitätsnachweise: `artillery-500` + `artillery-reconnect-500` (Schedule/Manuell)
- Doku: `STAGING-BASELINE-FREIGABE.md` → `PERFORMANCE-BASELINE-FREIGABE.md`, CI-WORKFLOW und PERFORMANCE-TESTING angepasst

## Test plan
- [ ] CI grün (Workflow Lint, keine toten Job-Referenzen)

Made with [Cursor](https://cursor.com)