### PR TITLE
fix(load): Story-0.7-Baselines für load:report:compare korrigieren

### DIFF
--- a/Backlog.md
+++ b/Backlog.md
@@ -129,7 +129,7 @@
 | 11   | 11.3  | Redaktionsbackend: Veröffentlichung & Quizlink                                     | 🔴   | ⬜ Offen  |
 | 11   | 11.4  | Redaktionsbackend: Passwort/Token-Schutz & accountbezogener Gesamtexport           | 🔴   | ⬜ Offen  |
 
-> **Repo-Abgleich (Codebase 2026-07-12):** Die weiterhin **offenen bzw. laufenden** Stories sind durch den Stand im Monorepo begründet: u. a. noch **kein** asynchroner Quizmodus mit teilnehmendenindividuellem Fortschritt, Feedback-Strategie und Host-/Presenter-Dashboard; Q&A-`moderatorView` ist weiterhin an Host-Authentifizierung gebunden, **kein** eigener Moderator-Token/-Rollenpfad. **Abgeschlossen** ist **0.7** (Baseline-Freigabe 2026-07-12): SLO-parametrisierte k6-Profile, Artillery-Live-/Reconnect-Profile, Classroom-Gates, schwere Vote-Hotpaths, Yjs-/Soak-Szenarien, standardisierte JSON-/JUnit-Reports und freigegebene Baseline in `scripts/load/baselines/story-0.7-2026-07-12.json`. Offen bleiben beim Kurzantwort-Ausbau **1.2ec–1.2ed**, neue Fragentypen **1.2f–1.2i**, **1.6c**/**1.6d** und **1.14a**.
+> **Repo-Abgleich (Codebase 2026-07-12):** Die weiterhin **offenen bzw. laufenden** Stories sind durch den Stand im Monorepo begründet: u. a. noch **kein** asynchroner Quizmodus mit teilnehmendenindividuellem Fortschritt, Feedback-Strategie und Host-/Presenter-Dashboard; Q&A-`moderatorView` ist weiterhin an Host-Authentifizierung gebunden, **kein** eigener Moderator-Token/-Rollenpfad. **Abgeschlossen** ist **0.7** (Baseline-Freigabe 2026-07-12): SLO-parametrisierte k6-Profile, Artillery-Live-/Reconnect-Profile, Classroom-Gates, schwere Vote-Hotpaths, Yjs-/Soak-Szenarien, standardisierte JSON-/JUnit-Reports und freigegebene Baseline in `scripts/load/baselines/manifests/story-0.7-2026-07-12.json`. Offen bleiben beim Kurzantwort-Ausbau **1.2ec–1.2ed**, neue Fragentypen **1.2f–1.2i**, **1.6c**/**1.6d** und **1.14a**.
 >
 > **Korrektur zum Repo-Abgleich:** `NUMERIC_ESTIMATE` ist als Fragentyp
 > implementiert und Story 1.2d als fertig bewertet. Offen ist seit dem lokalen
@@ -137,7 +137,7 @@
 > Ergebnisnachweis (eigene Runde 2, Toleranzband und Rundenvergleich), nicht die
 > Existenz des Fragentyps.
 >
-> **Laufzeitabgleich Story 0.7 (2026-07-12):** Der [lokale Baseline-Lauf](docs/implementation/LOCAL-BASELINE-FREIGABE-2026-07-12.md) bestätigt Artillery 500/500 Live und Reconnect, Vote-Timer-/Host-Progress-Hotpaths, Yjs-Sync und einen 30-Minuten-Soak. Story **0.7** ist damit betrieblich abgeschlossen; die Baseline liegt in `scripts/load/baselines/story-0.7-2026-07-12.json`.
+> **Laufzeitabgleich Story 0.7 (2026-07-12):** Der [lokale Baseline-Lauf](docs/implementation/LOCAL-BASELINE-FREIGABE-2026-07-12.md) bestätigt Artillery 500/500 Live und Reconnect, Vote-Timer-/Host-Progress-Hotpaths, Yjs-Sync und einen 30-Minuten-Soak. Story **0.7** ist damit betrieblich abgeschlossen; die Baseline liegt in `scripts/load/baselines/manifests/story-0.7-2026-07-12.json`.
 >
 > **Ergänzung Angebotsoption Westermann (2026-05-28):** **Epic 11** beschreibt einen **noch nicht beauftragten** Erweiterungspfad für **personalisierte Verlagszugänge und ein Redaktionsbackend**; hierzu existiert im Monorepo aktuell bewusst **kein** Produktcode.
 >
@@ -308,7 +308,7 @@ Eine Story gilt als **fertig**, wenn **alle** folgenden Kriterien erfüllt sind:
     - **CI:** PR/Push führt kurze Classroom-, Browser- und Lighthouse-Gates aus; Nacht/Manuell führt schwere Artillery-/Vote-, Yjs-, Freitext- und 5-Minuten-Soak-Szenarien aus.
     - **Dokumentation:** [`docs/PERFORMANCE-TESTING.md`](docs/PERFORMANCE-TESTING.md), [`LOCAL-BASELINE-FREIGABE-2026-07-12.md`](docs/implementation/LOCAL-BASELINE-FREIGABE-2026-07-12.md), [`PERFORMANCE-BASELINE-FREIGABE.md`](docs/implementation/PERFORMANCE-BASELINE-FREIGABE.md).
     - **Abgedeckt (Hotpaths):** Join, Session-Start, Quiz/Vote/Timer, Status-/Ergebnis-Fan-out, Host-Fortschritt, Q&A, Blitzlicht, Reconnect, Freitext-Live-Auswertung/Word-Cloud, Yjs-Sync sowie Kurz-/Langzeit-Laufzeitprofile.
-    - **Baseline-Freigabe (2026-07-12):** [Lokaler Nachlauf](docs/implementation/LOCAL-BASELINE-FREIGABE-2026-07-12.md) — Artillery 500/500 Live und Reconnect, Vote-Timer/Host-Progress, Yjs-Sync und 30-Minuten-Soak grün. Baseline: `scripts/load/baselines/story-0.7-2026-07-12.json`.
+    - **Baseline-Freigabe (2026-07-12):** [Lokaler Nachlauf](docs/implementation/LOCAL-BASELINE-FREIGABE-2026-07-12.md) — Artillery 500/500 Live und Reconnect, Vote-Timer/Host-Progress, Yjs-Sync und 30-Minuten-Soak grün. Baseline: `scripts/load/baselines/manifests/story-0.7-2026-07-12.json`.
     - **Akzeptanzkriterien — Erfüllungsgrad (Kurz):**
       - Setup lokal + CI: **ja** (PR-Smokes, Nachtjobs auf Runner).
       - Vollständige E2E mit Angular-FE unter Last: **teilweise** (Playwright-Referenzflows in CI; keine Browserfarm unter Massenlast).

--- a/docs/implementation/LOCAL-BASELINE-FREIGABE-2026-07-12.md
+++ b/docs/implementation/LOCAL-BASELINE-FREIGABE-2026-07-12.md
@@ -61,8 +61,37 @@ npm run load:soak:live-session
 - Gesamtlastmatrix: [LOCAL-TESTRUN-2026-07-10.md](LOCAL-TESTRUN-2026-07-10.md)
 - Freigabeprozess: [PERFORMANCE-BASELINE-FREIGABE.md](PERFORMANCE-BASELINE-FREIGABE.md)
 
+## Versionierte Baselines
+
+| Artefakt                   | Pfad                                                         |
+| -------------------------- | ------------------------------------------------------------ |
+| Manifest (Übersicht)       | `scripts/load/baselines/manifests/story-0.7-2026-07-12.json` |
+| Load-Reports (6 Szenarien) | `scripts/load/baselines/reports/story-0.7-2026-07-12/*.json` |
+| Regressionsbudgets         | `scripts/load/baselines/budgets/story-0.7/*.json`            |
+
+Das Manifest fasst Kennzahlen menschlich lesbar zusammen. `load:report:compare` erwartet
+pro Szenario einen standardisierten Load-Report mit Top-Level-`metrics` (siehe
+`scripts/load/lib/reporting.mjs`).
+
+## Regressionsvergleich
+
+Beim Nachlauf `REPORT_FILE` setzen, dann pro Szenario gegen die freigegebene Baseline
+vergleichen:
+
+```bash
+# Beispiel: Vote-Timer nach erneutem Lauf
+REPORT_FILE=artifacts/vote-timer-recheck.json \
+  PARTICIPANTS=600 npm run load:smoke:vote-timer-fairness
+
+npm run load:report:compare -- \
+  --current artifacts/vote-timer-recheck.json \
+  --baseline scripts/load/baselines/reports/story-0.7-2026-07-12/vote-timer-fairness-600.json \
+  --config scripts/load/baselines/budgets/story-0.7/vote-timer-fairness-600.json
+```
+
+Weitere Szenarien: Report- und Budget-Pfade stehen im Manifest unter `scenarios.*.report`
+bzw. `scenarios.*.budgets`.
+
 ## Freigabe
 
 **Story 0.7 — betrieblich freigegeben** am 2026-07-12 auf Basis der obigen Läufe.
-Regressionsvergleiche künftiger Läufe gegen diese Baseline über
-`scripts/load/baselines/story-0.7-2026-07-12.json` und `npm run load:report:compare`.

--- a/docs/implementation/PERFORMANCE-BASELINE-FREIGABE.md
+++ b/docs/implementation/PERFORMANCE-BASELINE-FREIGABE.md
@@ -112,5 +112,7 @@ Freigegeben durch den [lokalen Baseline-Lauf](LOCAL-BASELINE-FREIGABE-2026-07-12
 
 1. ✅ dokumentierter 30-Minuten-Soak lokal grün (874 Zyklen, HTTP-p95 16,7 ms)
 2. ✅ Artillery Live- und Reconnect-Welle mit 500 Teilnehmenden lokal grün
-3. ✅ Baseline in `scripts/load/baselines/story-0.7-2026-07-12.json` für
-   `load:report:compare` hinterlegt
+3. ✅ Baseline-Reports und Regressionsbudgets unter
+   `scripts/load/baselines/reports/story-0.7-2026-07-12/` und
+   `scripts/load/baselines/budgets/story-0.7/`; Übersicht im Manifest
+   `scripts/load/baselines/manifests/story-0.7-2026-07-12.json`

--- a/scripts/load/baselines/budgets/story-0.7/artillery-500-live-session.json
+++ b/scripts/load/baselines/budgets/story-0.7/artillery-500-live-session.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "description": "Regressionsbudgets für artillery-500-live-session (Story 0.7, 2026-07-12).",
+  "rules": [
+    {
+      "path": "layers.http.joinErrors",
+      "direction": "lower",
+      "maxAbsoluteRegression": 0
+    },
+    {
+      "path": "layers.http.voteErrors",
+      "direction": "lower",
+      "maxAbsoluteRegression": 0
+    },
+    {
+      "path": "layers.websocket.errors",
+      "direction": "lower",
+      "maxAbsoluteRegression": 0
+    }
+  ]
+}

--- a/scripts/load/baselines/budgets/story-0.7/artillery-500-reconnect-wave.json
+++ b/scripts/load/baselines/budgets/story-0.7/artillery-500-reconnect-wave.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "description": "Regressionsbudgets für artillery-500-reconnect-wave (Story 0.7, 2026-07-12).",
+  "rules": [
+    {
+      "path": "layers.websocket.reconnectErrors",
+      "direction": "lower",
+      "maxAbsoluteRegression": 0
+    },
+    {
+      "path": "layers.websocket.reconnectMsMax",
+      "direction": "lower",
+      "maxRelativeRegression": 0.25,
+      "maxAbsoluteRegression": 250
+    }
+  ]
+}

--- a/scripts/load/baselines/budgets/story-0.7/host-vote-progress-200.json
+++ b/scripts/load/baselines/budgets/story-0.7/host-vote-progress-200.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "description": "Regressionsbudgets für host-vote-progress-200 (Story 0.7, 2026-07-12).",
+  "rules": [
+    {
+      "path": "voteSubmitP95Ms",
+      "direction": "lower",
+      "maxRelativeRegression": 0.2
+    }
+  ]
+}

--- a/scripts/load/baselines/budgets/story-0.7/soak-live-session-30m.json
+++ b/scripts/load/baselines/budgets/story-0.7/soak-live-session-30m.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "description": "Regressionsbudgets für soak-live-session-30m (Story 0.7, 2026-07-12).",
+  "rules": [
+    {
+      "path": "runtime.targetHttp.p95Ms",
+      "direction": "lower",
+      "maxRelativeRegression": 0.2
+    },
+    {
+      "path": "runtime.eventLoop.p99Ms",
+      "direction": "lower",
+      "maxRelativeRegression": 0.2
+    },
+    {
+      "path": "runtime.backendProcess.rssGrowthBytes",
+      "direction": "lower",
+      "maxRelativeRegression": 0.25,
+      "maxAbsoluteRegression": 67108864
+    }
+  ]
+}

--- a/scripts/load/baselines/budgets/story-0.7/vote-timer-fairness-600.json
+++ b/scripts/load/baselines/budgets/story-0.7/vote-timer-fairness-600.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "description": "Regressionsbudgets für vote-timer-fairness-600 (Story 0.7, 2026-07-12).",
+  "rules": [
+    {
+      "path": "scenarios.0.votes.p95Ms",
+      "direction": "lower",
+      "maxRelativeRegression": 0.15
+    },
+    {
+      "path": "scenarios.1.votes.p95Ms",
+      "direction": "lower",
+      "maxRelativeRegression": 0.15
+    }
+  ]
+}

--- a/scripts/load/baselines/budgets/story-0.7/yjs-sync-load.json
+++ b/scripts/load/baselines/budgets/story-0.7/yjs-sync-load.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "description": "Regressionsbudgets für yjs-sync-load (Story 0.7, 2026-07-12).",
+  "rules": [
+    {
+      "path": "initial.connect.p95Ms",
+      "direction": "lower",
+      "maxRelativeRegression": 0.2
+    },
+    {
+      "path": "reconnect.convergenceMs",
+      "direction": "lower",
+      "maxAbsoluteRegression": 10
+    }
+  ]
+}

--- a/scripts/load/baselines/manifests/story-0.7-2026-07-12.json
+++ b/scripts/load/baselines/manifests/story-0.7-2026-07-12.json
@@ -1,11 +1,15 @@
 {
   "schemaVersion": 1,
-  "description": "Freigegebene Story-0.7-Baseline vom 2026-07-12 (lokal, Commit e3285372).",
+  "kind": "baseline-manifest",
+  "description": "Freigegebene Story-0.7-Baseline vom 2026-07-12 (lokal, Commit e3285372). Menschlich lesbare Übersicht; maschineller Vergleich über die referenzierten Report- und Budget-Dateien.",
   "approvedAt": "2026-07-12T13:04:02.928Z",
   "commit": "e3285372",
   "environment": "local-dev",
+  "documentation": "docs/implementation/LOCAL-BASELINE-FREIGABE-2026-07-12.md",
   "scenarios": {
     "vote-timer-fairness-600": {
+      "report": "reports/story-0.7-2026-07-12/vote-timer-fairness-600.json",
+      "budgets": "budgets/story-0.7/vote-timer-fairness-600.json",
       "participants": 600,
       "activeVoteP95Ms": 788,
       "graceVoteP95Ms": 992,
@@ -14,11 +18,15 @@
       "rejectedOutsideGrace": 600
     },
     "host-vote-progress-200": {
+      "report": "reports/story-0.7-2026-07-12/host-vote-progress-200.json",
+      "budgets": "budgets/story-0.7/host-vote-progress-200.json",
       "participants": 200,
       "voteSubmitP95Ms": 153,
       "failedVotes": 0
     },
     "artillery-500-live-session": {
+      "report": "reports/story-0.7-2026-07-12/artillery-500-live-session.json",
+      "budgets": "budgets/story-0.7/artillery-500-live-session.json",
       "participants": 500,
       "joins": 500,
       "votes": 500,
@@ -28,18 +36,24 @@
       "wsErrors": 0
     },
     "artillery-500-reconnect-wave": {
+      "report": "reports/story-0.7-2026-07-12/artillery-500-reconnect-wave.json",
+      "budgets": "budgets/story-0.7/artillery-500-reconnect-wave.json",
       "participants": 500,
       "reconnects": 500,
       "reconnectResultsSeen": 500,
       "reconnectMsMax": 5
     },
     "yjs-sync-load": {
+      "report": "reports/story-0.7-2026-07-12/yjs-sync-load.json",
+      "budgets": "budgets/story-0.7/yjs-sync-load.json",
       "clients": 30,
       "connectP95Ms": 73,
       "reconnectP95Ms": 324,
       "reconnectConvergenceMs": 6
     },
     "soak-live-session-30m": {
+      "report": "reports/story-0.7-2026-07-12/soak-live-session-30m.json",
+      "budgets": "budgets/story-0.7/soak-live-session-30m.json",
       "durationMinutes": 30,
       "completedCycles": 874,
       "httpP95Ms": 16.68,

--- a/scripts/load/baselines/reports/story-0.7-2026-07-12/artillery-500-live-session.json
+++ b/scripts/load/baselines/reports/story-0.7-2026-07-12/artillery-500-live-session.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": 1,
+  "scenario": "artillery-500-live-session",
+  "timestamp": "2026-07-12T12:32:36.456Z",
+  "environment": {
+    "participants": 500,
+    "rampSeconds": 60,
+    "arrivalRate": 9,
+    "minJoinRatio": 0.95,
+    "minVoteRatio": 0.9,
+    "minWsRatio": 0.9
+  },
+  "metrics": {
+    "scenario": "artillery-500-live-session",
+    "participantsTarget": 500,
+    "sessionCode": "[redacted]",
+    "layers": {
+      "http": {
+        "joins": 500,
+        "joinErrors": 0,
+        "votes": 500,
+        "voteErrors": 0,
+        "qaSubmits": 100,
+        "blitzVotes": 500,
+        "infoPolls": 500,
+        "questionReads": 500
+      },
+      "websocket": {
+        "connections": 500,
+        "statusEvents": 721,
+        "errors": 0,
+        "hostSubscriptionErrors": 0,
+        "hostProgressMessages": 253,
+        "hostProgressMaxVotes": 500,
+        "hostStatusMessages": 2,
+        "hostLastStatus": "RESULTS",
+        "hostResultsSeen": true
+      }
+    },
+    "reveal": {
+      "joins": 500,
+      "votes": 500,
+      "hostVotes": 500,
+      "waitedMs": 64603,
+      "joinStable": true
+    },
+    "snapshots": {
+      "progressTotalVotes": 500,
+      "sessionStatus": "RESULTS"
+    },
+    "artilleryReportFile": "[artillery-internal]",
+    "artilleryExitCode": 0
+  },
+  "assertions": [
+    {
+      "name": "scenario",
+      "passed": true
+    }
+  ],
+  "gitCommit": "e3285372"
+}

--- a/scripts/load/baselines/reports/story-0.7-2026-07-12/artillery-500-reconnect-wave.json
+++ b/scripts/load/baselines/reports/story-0.7-2026-07-12/artillery-500-reconnect-wave.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": 1,
+  "scenario": "artillery-500-reconnect-wave",
+  "timestamp": "2026-07-12T12:33:47.821Z",
+  "environment": {
+    "participants": 500,
+    "rampSeconds": 60,
+    "arrivalRate": 9,
+    "minJoinRatio": 0.95,
+    "minReconnectRatio": 0.9,
+    "minWsRatio": 0.9,
+    "minResultsAfterReconnectRatio": 0.9
+  },
+  "metrics": {
+    "scenario": "artillery-500-reconnect-wave",
+    "participantsTarget": 500,
+    "sessionCode": "[redacted]",
+    "layers": {
+      "http": {
+        "joins": 500,
+        "joinErrors": 0
+      },
+      "websocket": {
+        "connections": 1000,
+        "statusEvents": 1500,
+        "errors": 0,
+        "reconnects": 500,
+        "reconnectErrors": 0,
+        "reconnectResultsSeen": 500,
+        "reconnectResultsMissing": 0,
+        "reconnectMsMax": 5,
+        "reconnectMsAvg": 2,
+        "hostSubscriptionErrors": 0,
+        "hostStatusMessages": 2,
+        "hostLastStatus": "RESULTS",
+        "hostResultsSeen": true
+      }
+    },
+    "reveal": {
+      "joins": 500,
+      "reconnects": 500,
+      "waitedMs": 65120,
+      "joinStable": true,
+      "reconnectStable": true
+    },
+    "snapshots": {
+      "sessionStatus": "RESULTS"
+    },
+    "limits": {
+      "reconnectMsMax": 3000,
+      "resultsWaitMs": 125000,
+      "statusAfterReconnectLimitMs": 5000
+    },
+    "artilleryReportFile": "[artillery-internal]",
+    "artilleryExitCode": 0
+  },
+  "assertions": [
+    {
+      "name": "scenario",
+      "passed": true
+    }
+  ],
+  "gitCommit": "e3285372"
+}

--- a/scripts/load/baselines/reports/story-0.7-2026-07-12/host-vote-progress-200.json
+++ b/scripts/load/baselines/reports/story-0.7-2026-07-12/host-vote-progress-200.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "scenario": "host-vote-progress-200",
+  "timestamp": "2026-07-12T12:31:22.638Z",
+  "environment": {
+    "participants": 200,
+    "voteP95LimitMs": 2000
+  },
+  "metrics": {
+    "code": "[redacted]",
+    "participants": 200,
+    "voteSpikeDurationMs": 153,
+    "voteSubmitP50Ms": 152,
+    "voteSubmitP95Ms": 153,
+    "voteSubmitMaxMs": 153,
+    "failedVotes": 0,
+    "subscriptionErrors": 0,
+    "currentQuestionMessages": 1,
+    "currentQuestionVoteBearingMessages": 0,
+    "progressMessages": 2,
+    "progressMaxTotalVotes": 200,
+    "progressSnapshotTotalVotes": 200,
+    "currentQuestionSnapshotTotalVotes": 200
+  },
+  "assertions": [
+    {
+      "name": "scenario",
+      "passed": true
+    }
+  ],
+  "gitCommit": "e3285372"
+}

--- a/scripts/load/baselines/reports/story-0.7-2026-07-12/soak-live-session-30m.json
+++ b/scripts/load/baselines/reports/story-0.7-2026-07-12/soak-live-session-30m.json
@@ -1,0 +1,101 @@
+{
+  "schemaVersion": 1,
+  "scenario": "soak-live-session",
+  "timestamp": "2026-07-12T13:04:02.928Z",
+  "gitCommit": "e3285372",
+  "environment": {
+    "trpcUrl": "http://127.0.0.1:3000/trpc",
+    "wsUrl": "ws://127.0.0.1:3001",
+    "durationMinutes": 30,
+    "participants": 20,
+    "joinWaveSize": 5,
+    "joinWaveDelayMs": 250,
+    "voteConcurrency": 10,
+    "cyclePauseMs": 2000,
+    "maxCycles": 9007199254740991,
+    "reconnectEveryCycles": 0,
+    "reconnectClients": 5,
+    "reconnectTimeoutMs": 5000,
+    "metricsIntervalMs": 10000,
+    "backendPid": null,
+    "redisUrl": "[konfiguriert]",
+    "databaseUrl": "[konfiguriert]",
+    "reportFile": "scripts/load/baselines/reports/story-0.7-2026-07-12/soak-live-session-30m.json",
+    "httpP95LimitMs": 2000,
+    "eventLoopP99LimitMs": 200,
+    "memoryGrowthLimitMb": 256,
+    "validateOnly": false
+  },
+  "metrics": {
+    "durationMs": 1800131,
+    "session": {
+      "code": "VCZ6VV",
+      "completedCycles": 874
+    },
+    "runtime": {
+      "targetHttp": {
+        "samples": 20997,
+        "errors": 0,
+        "errorRatePercent": 0,
+        "p50Ms": 11.34,
+        "p95Ms": 16.68,
+        "p99Ms": 24.6,
+        "maxMs": 54.66
+      },
+      "eventLoop": {
+        "p95Ms": 22.1,
+        "p99Ms": 22.43,
+        "maxMs": 67.31
+      },
+      "backendProcess": {
+        "rssStartBytes": 134742016,
+        "rssEndBytes": 162430976,
+        "rssGrowthBytes": 27688960,
+        "peakRssBytes": 172720128
+      },
+      "redisPing": {
+        "errors": 0,
+        "p95Ms": 7.15
+      },
+      "postgresSelect1": {
+        "errors": 0,
+        "p95Ms": 7
+      }
+    },
+    "cleanup": {
+      "quickFeedbackEnded": null,
+      "sessionEnded": true,
+      "errors": []
+    }
+  },
+  "assertions": [
+    {
+      "name": "functional-errors",
+      "passed": true,
+      "actual": 0,
+      "expected": 0,
+      "measurable": true
+    },
+    {
+      "name": "target-http-p95-ms",
+      "passed": true,
+      "actual": 16.68,
+      "expected": 2000,
+      "measurable": true
+    },
+    {
+      "name": "load-generator-event-loop-p99-ms",
+      "passed": true,
+      "actual": 22.43,
+      "expected": 200,
+      "measurable": true
+    },
+    {
+      "name": "backend-rss-growth-mb",
+      "passed": true,
+      "actual": 26.41,
+      "expected": 256,
+      "measurable": true
+    }
+  ]
+}

--- a/scripts/load/baselines/reports/story-0.7-2026-07-12/vote-timer-fairness-600.json
+++ b/scripts/load/baselines/reports/story-0.7-2026-07-12/vote-timer-fairness-600.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": 1,
+  "scenario": "vote-timer-fairness-600",
+  "timestamp": "2026-07-12T12:31:16.844Z",
+  "environment": {
+    "participants": 600,
+    "timerSeconds": 8,
+    "graceMs": 2000,
+    "voteP95LimitMs": 2000
+  },
+  "metrics": {
+    "code": "[redacted]",
+    "participants": 600,
+    "timerSeconds": 8,
+    "graceMs": 2000,
+    "withinGraceRevealOffsetMs": 100,
+    "outsideGraceRevealOffsetMs": 2300,
+    "scenarios": [
+      {
+        "name": "ACTIVE vor Timerende",
+        "mode": "active",
+        "deadlineIso": "2026-07-12T12:31:01.678Z",
+        "voteWindowStartedIso": "2026-07-12T12:30:53.686Z",
+        "votes": {
+          "accepted": 600,
+          "rejected": 0,
+          "totalDurationMs": 1175,
+          "p50Ms": 402,
+          "p95Ms": 788,
+          "maxMs": 1163,
+          "errors": {}
+        },
+        "snapshot": {
+          "totalVotes": 600,
+          "queryMs": 17
+        }
+      },
+      {
+        "name": "RESULTS innerhalb Backend-Karenz",
+        "mode": "within-grace",
+        "deadlineIso": "2026-07-12T12:31:03.406Z",
+        "voteWindowStartedIso": "2026-07-12T12:31:03.525Z",
+        "votes": {
+          "accepted": 600,
+          "rejected": 0,
+          "totalDurationMs": 1187,
+          "p50Ms": 662,
+          "p95Ms": 992,
+          "maxMs": 1172,
+          "errors": {}
+        },
+        "snapshot": {
+          "totalVotes": 600,
+          "queryMs": 13
+        }
+      },
+      {
+        "name": "RESULTS ausserhalb Backend-Karenz",
+        "mode": "outside-grace",
+        "deadlineIso": "2026-07-12T12:31:13.235Z",
+        "voteWindowStartedIso": "2026-07-12T12:31:15.562Z",
+        "votes": {
+          "accepted": 0,
+          "rejected": 600,
+          "totalDurationMs": 761,
+          "p50Ms": 535,
+          "p95Ms": 718,
+          "maxMs": 746,
+          "errors": {
+            "Die Frage ist nicht mehr aktiv.": 600
+          }
+        },
+        "snapshot": {
+          "totalVotes": 0,
+          "queryMs": 18
+        }
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "name": "scenario",
+      "passed": true
+    }
+  ],
+  "gitCommit": "e3285372"
+}

--- a/scripts/load/baselines/reports/story-0.7-2026-07-12/yjs-sync-load.json
+++ b/scripts/load/baselines/reports/story-0.7-2026-07-12/yjs-sync-load.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "scenario": "yjs-sync-load",
+  "timestamp": "2026-07-12T12:33:49.891Z",
+  "environment": {
+    "yjsWsUrl": "ws://127.0.0.1:3002",
+    "room": "quiz-library-room-abbbebe5-5441-4988-a267-7dfd656f7aeb",
+    "clients": 30,
+    "updateConcurrency": 15,
+    "connectP95LimitMs": 3000,
+    "syncP95LimitMs": 5000
+  },
+  "metrics": {
+    "durationMs": 798,
+    "initial": {
+      "connect": {
+        "samples": 30,
+        "p50Ms": 69,
+        "p95Ms": 73,
+        "maxMs": 73
+      },
+      "sync": {
+        "samples": 30,
+        "p50Ms": 70,
+        "p95Ms": 73,
+        "maxMs": 73
+      },
+      "convergenceMs": 4,
+      "stateVectorSha256": "130102fe976db3e40f049ff1c93ec7441f529680d5d8566c4fa0926013dac018"
+    },
+    "reconnect": {
+      "clients": 6,
+      "connect": {
+        "samples": 6,
+        "p50Ms": 324,
+        "p95Ms": 324,
+        "maxMs": 324
+      },
+      "sync": {
+        "samples": 6,
+        "p50Ms": 325,
+        "p95Ms": 325,
+        "maxMs": 325
+      },
+      "convergenceMs": 6,
+      "stateVectorSha256": "2b1517cf64e0e32304ae076b2286f0e8d1c3b1405ee1a936735883a398296457"
+    },
+    "errorCount": 0
+  },
+  "assertions": [
+    {
+      "name": "scenario",
+      "passed": true
+    }
+  ],
+  "gitCommit": "e3285372"
+}


### PR DESCRIPTION
## Summary
- Behebt das Codex-Finding aus #55: das Aggregat-JSON war nicht mit `load:report:compare` kompatibel (fehlendes Top-Level-`metrics`).
- Versioniert 6 standardisierte Load-Reports unter `scripts/load/baselines/reports/story-0.7-2026-07-12/`.
- Hinterlegt szenariospezifische Regressionsbudgets unter `scripts/load/baselines/budgets/story-0.7/`.
- Verschiebt die menschliche Übersicht nach `scripts/load/baselines/manifests/story-0.7-2026-07-12.json` mit Verweisen auf Report- und Budget-Dateien.
- Aktualisiert Freigabe-Doku und Backlog-Verweise.

## Test plan
- [x] `npm run load:report:compare` für alle 6 Szenarien (current = baseline) grün
- [x] Pre-commit: typecheck + tests grün


Made with [Cursor](https://cursor.com)