### PR TITLE
feat(frontend): sichtbare Zähler locale-aware formatieren

### DIFF
--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -4,6 +4,7 @@ import {
   Directive,
   ElementRef,
   HostListener,
+  LOCALE_ID,
   OnInit,
   OnDestroy,
   PLATFORM_ID,
@@ -33,6 +34,7 @@ import { localizePath } from './core/locale-router';
 import { HostDisplayModeService } from './core/host-display-mode.service';
 import { SeoService } from './core/seo.service';
 import { MotdHeaderStateService } from './core/motd-header-state.service';
+import { formatLocaleBadgeCount, formatLocaleCount } from './core/locale-number.util';
 
 const STORAGE_PLAYFUL_WELCOMED = 'home-playful-welcomed';
 const STORAGE_PWA_INSTALL_DISMISSED = 'pwa-install-dismissed';
@@ -134,6 +136,7 @@ export class AppComponent implements OnInit, OnDestroy {
   private readonly hostDisplayMode = inject(HostDisplayModeService);
   private readonly seo = inject(SeoService);
   readonly motdHeaderState = inject(MotdHeaderStateService);
+  private readonly localeId = inject(LOCALE_ID) as string;
   private versionSub: Subscription | null = null;
   private routerSub: Subscription | null = null;
   private presetSub: Subscription | null = null;
@@ -199,7 +202,7 @@ export class AppComponent implements OnInit, OnDestroy {
   /** Footer: Badge mit ungelesenen Archiv-Meldungen (max. „99+“), wie Toolbar-Megafon. */
   footerNewsArchiveBadgeText = computed(() => {
     const n = this.motdHeaderState.archiveUnreadCount();
-    return n > 99 ? '99+' : String(n);
+    return formatLocaleBadgeCount(n, this.localeId);
   });
 
   /** Barrierefrei: Zähler in der Link-Beschriftung bei ungelesenen Meldungen. */
@@ -211,7 +214,7 @@ export class AppComponent implements OnInit, OnDestroy {
     if (n === 1) {
       return $localize`:@@app.footer.newsArchiveAriaOne:News-Archiv öffnen, eine ungelesene Meldung`;
     }
-    return $localize`:@@app.footer.newsArchiveAriaCount:News-Archiv öffnen, ${n}:INTERPOLATION: ungelesene Meldungen`;
+    return $localize`:@@app.footer.newsArchiveAriaCount:News-Archiv öffnen, ${formatLocaleCount(n, this.localeId)}:INTERPOLATION: ungelesene Meldungen`;
   });
 
   ngOnInit(): void {

--- a/apps/frontend/src/app/core/locale-number.util.spec.ts
+++ b/apps/frontend/src/app/core/locale-number.util.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatLocaleCount,
+  formatLocaleNumber,
+  formatLocalePercent,
+  formatLocaleBadgeCount,
+} from './locale-number.util';
+
+describe('locale-number util', () => {
+  it('formatiert Ganzzahlen locale-spezifisch', () => {
+    expect(formatLocaleCount(2126, 'de')).toBe('2.126');
+    expect(formatLocaleCount(2126, 'en')).toBe('2,126');
+    expect(formatLocaleCount(98, 'de')).toBe('98');
+  });
+
+  it('faellt bei ungueltigen Werten auf 0 zurueck', () => {
+    expect(formatLocaleCount(Number.NaN, 'de')).toBe('0');
+    expect(formatLocaleCount(Number.POSITIVE_INFINITY, 'en')).toBe('0');
+  });
+
+  it('formatiert Dezimalzahlen mit konfigurierbaren Nachkommastellen', () => {
+    expect(
+      formatLocaleNumber(4.25, 'de', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
+    ).toBe('4,3');
+    expect(
+      formatLocaleNumber(4.25, 'en', { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
+    ).toBe('4.3');
+  });
+
+  it('formatiert Prozentwerte', () => {
+    expect(formatLocalePercent(33.3, 'de', 1)).toBe('33,3');
+    expect(formatLocalePercent(50, 'en', 0)).toBe('50');
+  });
+
+  it('formatiert Badge-Zaehler mit Obergrenze', () => {
+    expect(formatLocaleBadgeCount(5, 'de')).toBe('5');
+    expect(formatLocaleBadgeCount(120, 'de')).toBe('99+');
+    expect(formatLocaleBadgeCount(1_500, 'en')).toBe('99+');
+  });
+});

--- a/apps/frontend/src/app/core/locale-number.util.ts
+++ b/apps/frontend/src/app/core/locale-number.util.ts
@@ -1,0 +1,66 @@
+/**
+ * Locale-aware number formatting for user-visible counts and metrics.
+ */
+
+export interface FormatLocaleNumberOptions {
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+}
+
+function normalizeLocale(locale: string): string {
+  return (locale ?? 'de').trim() || 'de';
+}
+
+function safeFiniteNumber(value: number, fallback = 0): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+/** Ganzzahlige Zähler (Sessions, Stimmen, Teilnehmende) mit Tausendertrennzeichen. */
+export function formatLocaleCount(value: number, locale = 'de'): string {
+  return new Intl.NumberFormat(normalizeLocale(locale), {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(safeFiniteNumber(value));
+}
+
+export function formatLocaleNumber(
+  value: number,
+  locale = 'de',
+  options: FormatLocaleNumberOptions = {},
+): string {
+  const { minimumFractionDigits = 0, maximumFractionDigits = 0 } = options;
+  return new Intl.NumberFormat(normalizeLocale(locale), {
+    minimumFractionDigits,
+    maximumFractionDigits,
+  }).format(safeFiniteNumber(value));
+}
+
+/** Prozentwerte (0–100) mit optionalen Nachkommastellen. */
+export function formatLocalePercent(
+  value: number,
+  locale = 'de',
+  maximumFractionDigits = 0,
+): string {
+  const minimumFractionDigits = maximumFractionDigits > 0 ? 0 : 0;
+  return formatLocaleNumber(value, locale, {
+    minimumFractionDigits,
+    maximumFractionDigits,
+  });
+}
+
+const BADGE_COUNT_CAP = 99;
+
+/** Badge-Zähler mit Obergrenze (z. B. „99+“ / „99+“). */
+export function formatLocaleBadgeCount(
+  value: number,
+  locale = 'de',
+  cap = BADGE_COUNT_CAP,
+): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return formatLocaleCount(0, locale);
+  }
+  if (value > cap) {
+    return `${formatLocaleCount(cap, locale)}+`;
+  }
+  return formatLocaleCount(value, locale);
+}

--- a/apps/frontend/src/app/features/admin/admin-motd-panel.component.html
+++ b/apps/frontend/src/app/features/admin/admin-motd-panel.component.html
@@ -50,7 +50,7 @@
           <mat-expansion-panel-header>
             <mat-panel-title class="admin-motd__expansion-title">
               <span i18n="@@admin.motd.listTitle">Vorhandene Meldungen</span>
-              <span class="admin-motd__expander-count">({{ motds().length }})</span>
+              <span class="admin-motd__expander-count">({{ formatCount(motds().length) }})</span>
             </mat-panel-title>
           </mat-expansion-panel-header>
           <div class="admin-motd__list-panel-body">
@@ -62,18 +62,20 @@
                   @for (m of motds(); track m.id) {
                     <li>
                       <span class="admin-motd__item-meta" i18n="@@admin.motd.listItemMeta"
-                        >{{ m.status }} · v{{ m.contentVersion }} · Priorität {{ m.priority }}</span
+                        >{{ m.status }} · v{{ formatCount(m.contentVersion) }} · Priorität
+                        {{ formatCount(m.priority) }}</span
                       >
                       <span class="admin-motd__item-dates"
                         >{{ formatMotdListStartsAt(m.startsAt) }} –
                         {{ formatMotdListEndsAt(m.endsAt) }}</span
                       >
                       <span class="admin-help admin-motd__stats" i18n="@@admin.motd.statsLine">
-                        Nutzerreaktionen (Zähler): Alles klar {{ m.interaction.ackCount }}, Daumen
-                        hoch {{ m.interaction.thumbUp }}, Daumen runter
-                        {{ m.interaction.thumbDown }}, Overlay geschlossen
-                        {{ m.interaction.dismissClose }}, Wegwischen
-                        {{ m.interaction.dismissSwipe }}
+                        Nutzerreaktionen (Zähler): Alles klar
+                        {{ formatCount(m.interaction.ackCount) }}, Daumen hoch
+                        {{ formatCount(m.interaction.thumbUp) }}, Daumen runter
+                        {{ formatCount(m.interaction.thumbDown) }}, Overlay geschlossen
+                        {{ formatCount(m.interaction.dismissClose) }}, Wegwischen
+                        {{ formatCount(m.interaction.dismissSwipe) }}
                       </span>
                       <div
                         class="admin-motd__item-actions"
@@ -123,7 +125,9 @@
           <mat-expansion-panel-header>
             <mat-panel-title class="admin-motd__expansion-title">
               <span i18n="@@admin.motd.tplSectionTitle">Textvorlagen</span>
-              <span class="admin-motd__expander-count">({{ templates().length }})</span>
+              <span class="admin-motd__expander-count"
+                >({{ formatCount(templates().length) }})</span
+              >
             </mat-panel-title>
           </mat-expansion-panel-header>
           <div class="admin-motd__templates">
@@ -182,10 +186,10 @@
         @if (motdInteractionStats(); as st) {
           <div class="admin-motd__stats-block">
             <p class="admin-help admin-motd__stats-detail" i18n="@@admin.motd.statsDetail">
-              Nutzerreaktionen (Zähler): Alles klar {{ st.ackCount }}, Daumen hoch {{ st.thumbUp }},
-              Daumen runter {{ st.thumbDown }}, Overlay geschlossen {{ st.dismissClose }},
-              Wegwischen
-              {{ st.dismissSwipe }}
+              Nutzerreaktionen (Zähler): Alles klar {{ formatCount(st.ackCount) }}, Daumen hoch
+              {{ formatCount(st.thumbUp) }}, Daumen runter {{ formatCount(st.thumbDown) }}, Overlay
+              geschlossen {{ formatCount(st.dismissClose) }}, Wegwischen
+              {{ formatCount(st.dismissSwipe) }}
             </p>
             <!-- Immer sichtbar wenn Zähler angezeigt werden (kein @if(editingId): sonst fehlt der Button bei Zustands-Lücken). -->
             <div class="admin-motd__stats-reset">

--- a/apps/frontend/src/app/features/admin/admin-motd-panel.component.ts
+++ b/apps/frontend/src/app/features/admin/admin-motd-panel.component.ts
@@ -40,9 +40,10 @@ import {
   formatMotdAdminDateTimeForDisplay,
   formatMotdEndsAtForDisplay,
 } from '../../core/motd-ends-display';
-import { trpc } from '../../core/trpc.client';
+import { formatLocaleCount } from '../../core/locale-number.util';
 import { localizeKnownServerError } from '../../core/localize-known-server-message';
 import { resolveMotdAssetOrigin } from '../../core/motd-asset-origin';
+import { trpc } from '../../core/trpc.client';
 import {
   absolutizeMarkdownHtmlRootAssetImgSrc,
   renderMarkdownWithoutKatex,
@@ -166,6 +167,10 @@ export class AdminMotdPanelComponent implements OnInit {
   formatTplUpdatedAt(iso: string): string {
     const bcp = ADMIN_MOTD_DATE_LOCALE[String(this.appLocaleId)] ?? 'de-DE';
     return formatMotdAdminDateTimeForDisplay(iso, bcp);
+  }
+
+  formatCount(value: number | null | undefined): string {
+    return formatLocaleCount(value ?? 0, String(this.appLocaleId));
   }
 
   newMotd(): void {

--- a/apps/frontend/src/app/features/admin/admin.component.html
+++ b/apps/frontend/src/app/features/admin/admin.component.html
@@ -71,7 +71,7 @@
                   direkt zu den Details.
                 </p>
                 <p class="admin-help" i18n="@@admin.listCountHint">
-                  Aktuell sichtbare Sessions: {{ sessionTotal() }}
+                  Aktuell sichtbare Sessions: {{ formatCount(sessionTotal()) }}
                 </p>
 
                 <div class="admin-lookup">
@@ -142,7 +142,7 @@
                                 <span
                                   class="admin-list__chip"
                                   i18n="@@admin.liveParticipantsWithActivityChip"
-                                  >Live: {{ liveCount }} · Letzte Aktivität:
+                                  >Live: {{ formatCount(liveCount) }} · Letzte Aktivität:
                                   {{ formatDateTime(session.lastActivityAt) }}</span
                                 >
                               } @else {
@@ -189,7 +189,7 @@
                                       <strong i18n="@@admin.metaParticipantsLabel"
                                         >Teilnehmende:</strong
                                       >
-                                      {{ detail.session.participantCount }}
+                                      {{ formatCount(detail.session.participantCount) }}
                                     </p>
                                   </div>
                                   @if (detail.title) {
@@ -412,7 +412,7 @@
                       Nicht mehr benötigte Quiz-Kopien werden ebenfalls entfernt.
                     </p>
                     <p class="admin-help" i18n="@@admin.deleteAllCountHint">
-                      Aktuell erfasste Sessions: {{ sessionTotal() }}
+                      Aktuell erfasste Sessions: {{ formatCount(sessionTotal()) }}
                     </p>
                     <p class="admin-help" i18n="@@admin.deleteAllConfirmHint">
                       Zur Bestätigung gib die Sicherheitsphrase ein.

--- a/apps/frontend/src/app/features/admin/admin.component.ts
+++ b/apps/frontend/src/app/features/admin/admin.component.ts
@@ -12,6 +12,7 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatTab, MatTabGroup } from '@angular/material/tabs';
+import { formatLocaleCount } from '../../core/locale-number.util';
 import { trpc } from '../../core/trpc.client';
 import { renderMarkdownWithKatex } from '../../shared/markdown-katex.util';
 import { AdminMotdPanelComponent } from './admin-motd-panel.component';
@@ -627,6 +628,10 @@ export class AdminComponent implements OnInit {
       }
     }
     return fallback;
+  }
+
+  formatCount(value: number | null | undefined): string {
+    return formatLocaleCount(value ?? 0, String(this.locale));
   }
 
   formatDateTime(iso: string | null | undefined): string {

--- a/apps/frontend/src/app/features/feedback/feedback-host.component.html
+++ b/apps/frontend/src/app/features/feedback/feedback-host.component.html
@@ -423,11 +423,11 @@
             <dl class="feedback-host__tempo-trend-metrics">
               <div>
                 <dt i18n="@@feedback.tempoMetricActive">Online</dt>
-                <dd>{{ data.tempoTrend?.activeParticipants ?? 0 }}</dd>
+                <dd>{{ formatCount(data.tempoTrend?.activeParticipants) }}</dd>
               </div>
               <div>
                 <dt i18n="@@feedback.tempoMetricResponses">Im Barometer</dt>
-                <dd>{{ data.tempoTrend?.tempoVotes ?? data.totalVotes }}</dd>
+                <dd>{{ formatCount(data.tempoTrend?.tempoVotes ?? data.totalVotes) }}</dd>
               </div>
             </dl>
           </div>
@@ -438,7 +438,7 @@
               Jetzt zum Vergleich ein zweites Blitzlicht...
             </p>
             <p class="feedback-host__discussion-hint" i18n="@@feedback.compareRoundSummary">
-              Runde 1: {{ data.round1Total ?? 0 }} Stimmen erfasst.
+              Runde 1: {{ formatCount(data.round1Total) }} Stimmen erfasst.
             </p>
             @if (round1StarAverage(); as average) {
               <div class="feedback-host__average-strip" role="status" aria-live="polite">
@@ -575,12 +575,12 @@
                       <div class="feedback-host__bar-track">
                         <div
                           class="feedback-host__bar-fill feedback-host__bar-fill--r1"
-                          [style.width.%]="round1Percentage(entry.key)"
+                          [style.width.%]="round1PercentageValue(entry.key)"
                         ></div>
                       </div>
                       <span class="feedback-host__comparison-pct feedback-host__comparison-pct--r1"
-                        >{{ round1Count(entry.key) }} ({{
-                          round1Percentage(entry.key)
+                        >{{ formatCount(round1Count(entry.key)) }} ({{
+                          round1PercentageLabel(entry.key)
                         }}&nbsp;%)</span
                       >
                     </div>
@@ -593,12 +593,12 @@
                       <div class="feedback-host__bar-track">
                         <div
                           class="feedback-host__bar-fill feedback-host__bar-fill--r2"
-                          [style.width.%]="round2Percentage(entry.key)"
+                          [style.width.%]="round2PercentageValue(entry.key)"
                         ></div>
                       </div>
                       <span class="feedback-host__comparison-pct feedback-host__comparison-pct--r2"
-                        >{{ round2Count(entry.key) }} ({{
-                          round2Percentage(entry.key)
+                        >{{ formatCount(round2Count(entry.key)) }} ({{
+                          round2PercentageLabel(entry.key)
                         }}&nbsp;%)</span
                       >
                     </div>
@@ -610,15 +610,18 @@
               <div class="feedback-host__opinion-shift" role="status">
                 <mat-icon>swap_horiz</mat-icon>
                 <span i18n
-                  >{{ shift.changedCount }} von {{ shift.bothRoundsCount }} ({{
-                    shift.changedPercentage
+                  >{{ formatCount(shift.changedCount) }} von
+                  {{ formatCount(shift.bothRoundsCount) }} ({{
+                    formatCount(shift.changedPercentage)
                   }}&nbsp;%) änderten ihre Meinung</span
                 >
                 @if (shift.migrations && shift.migrations.length > 0) {
                   <ul class="feedback-host__migrations" role="list">
                     @for (m of shift.migrations; track m.from + m.to) {
                       <li class="feedback-host__migration-item">
-                        <span class="feedback-host__migration-count">{{ m.count }}×</span>
+                        <span class="feedback-host__migration-count"
+                          >{{ formatCount(m.count) }}×</span
+                        >
                         <span class="feedback-host__migration-from">
                           @if (displayIcon(m.from, data.type); as icon) {
                             @if (icon.kind === 'mat') {
@@ -714,7 +717,7 @@
             } @else {
               <span i18n>{data.totalVotes, plural,
                 =1 {1 Stimme}
-                other {{{ data.totalVotes }} Stimmen}
+                other {{{ formatCount(data.totalVotes) }} Stimmen}
               }</span>
             }
           </p>
@@ -753,7 +756,7 @@
                 [attr.aria-label]="
                   displayLabel(entry.key, data.type) +
                   ': ' +
-                  entry.value +
+                  formatCount(entry.value) +
                   ' (' +
                   percentage(entry.key) +
                   ' %)'
@@ -813,7 +816,7 @@
                   ></div>
                 </div>
                 <span class="feedback-host__bar-count" aria-hidden="true"
-                  >{{ entry.value }} ({{ percentage(entry.key) }} %)</span
+                  >{{ formatCount(entry.value) }} ({{ percentage(entry.key) }} %)</span
                 >
               </div>
             }

--- a/apps/frontend/src/app/features/feedback/feedback-host.component.ts
+++ b/apps/frontend/src/app/features/feedback/feedback-host.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   HostListener,
   Injector,
+  LOCALE_ID,
   NgZone,
   OnDestroy,
   OnInit,
@@ -19,6 +20,7 @@ import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { clearFeedbackHostToken, setFeedbackHostToken } from '../../core/feedback-host-token';
+import { formatLocaleCount, formatLocalePercent } from '../../core/locale-number.util';
 import { clearHostToken } from '../../core/host-session-token';
 import { trpc } from '../../core/trpc.client';
 import {
@@ -78,6 +80,7 @@ export class FeedbackHostComponent implements OnInit, OnDestroy {
   private readonly ngZone = inject(NgZone);
   private readonly snackBar = inject(MatSnackBar);
   private readonly document = inject(DOCUMENT);
+  private readonly localeId = inject(LOCALE_ID) as string;
   private readonly injector = inject(Injector);
   private subscription: Unsubscribable | null = null;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -480,22 +483,30 @@ export class FeedbackHostComponent implements OnInit, OnDestroy {
     return this.starAverage(data.distribution, data.totalVotes);
   });
 
-  round1Percentage(key: string): string {
+  round1PercentageValue(key: string): number {
     const data = this.result();
-    if (!data?.round1Distribution || !data.round1Total) return '0';
+    if (!data?.round1Distribution || !data.round1Total) return 0;
     const count = data.round1Distribution[key] ?? 0;
-    return data.round1Total > 0 ? String(Math.round((count / data.round1Total) * 100)) : '0';
+    return data.round1Total > 0 ? Math.round((count / data.round1Total) * 100) : 0;
+  }
+
+  round1PercentageLabel(key: string): string {
+    return formatLocalePercent(this.round1PercentageValue(key), this.localeId, 0);
   }
 
   round1Count(key: string): number {
     return this.result()?.round1Distribution?.[key] ?? 0;
   }
 
-  round2Percentage(key: string): string {
+  round2PercentageValue(key: string): number {
     const data = this.result();
-    if (!data || data.totalVotes === 0) return '0';
+    if (!data || data.totalVotes === 0) return 0;
     const count = data.distribution[key] ?? 0;
-    return data.totalVotes > 0 ? String(Math.round((count / data.totalVotes) * 100)) : '0';
+    return data.totalVotes > 0 ? Math.round((count / data.totalVotes) * 100) : 0;
+  }
+
+  round2PercentageLabel(key: string): string {
+    return formatLocalePercent(this.round2PercentageValue(key), this.localeId, 0);
   }
 
   round2Count(key: string): number {
@@ -516,14 +527,14 @@ export class FeedbackHostComponent implements OnInit, OnDestroy {
     if (totalVotes === 1) {
       return $localize`:@@feedback.voteCountOne:1 Stimme`;
     }
-    return $localize`:@@feedback.voteCountMany:${totalVotes}:count: Stimmen`;
+    return $localize`:@@feedback.voteCountMany:${formatLocaleCount(totalVotes, this.localeId)}:count: Stimmen`;
   }
 
   tempoParticipantCountLabel(totalVotes: number): string {
     if (totalVotes === 1) {
       return $localize`:@@feedback.tempoParticipantCountOne:1 Person im Barometer`;
     }
-    return $localize`:@@feedback.tempoParticipantCountMany:${totalVotes}:count: Teilnehmende im Barometer`;
+    return $localize`:@@feedback.tempoParticipantCountMany:${formatLocaleCount(totalVotes, this.localeId)}:count: Teilnehmende im Barometer`;
   }
 
   openTempoHelp(event?: Event): void {
@@ -707,7 +718,12 @@ export class FeedbackHostComponent implements OnInit, OnDestroy {
   readonly percentages = computed<Record<string, string>>(() => {
     const data = this.result();
     if (!data || data.totalVotes === 0) {
-      return Object.fromEntries(Object.keys(data?.distribution ?? {}).map((k) => [k, '0']));
+      return Object.fromEntries(
+        Object.keys(data?.distribution ?? {}).map((k) => [
+          k,
+          formatLocalePercent(0, this.localeId, 0),
+        ]),
+      );
     }
     const entries = Object.entries(data.distribution);
     const total = data.totalVotes;
@@ -726,7 +742,8 @@ export class FeedbackHostComponent implements OnInit, OnDestroy {
     return Object.fromEntries(
       raw.map((r) => {
         const val = r.floor / 10;
-        return [r.key, val % 1 === 0 ? String(val) : val.toFixed(1).replace('.', ',')];
+        const fractionDigits = val % 1 === 0 ? 0 : 1;
+        return [r.key, formatLocalePercent(val, this.localeId, fractionDigits)];
       }),
     );
   });
@@ -738,7 +755,11 @@ export class FeedbackHostComponent implements OnInit, OnDestroy {
   }
 
   percentage(key: string): string {
-    return this.percentages()[key] ?? '0';
+    return this.percentages()[key] ?? formatLocalePercent(0, this.localeId, 0);
+  }
+
+  formatCount(value: number | null | undefined): string {
+    return formatLocaleCount(value ?? 0, this.localeId);
   }
 
   resultsAriaLabel(type: string): string {

--- a/apps/frontend/src/app/features/home/home.component.html
+++ b/apps/frontend/src/app/features/home/home.component.html
@@ -406,7 +406,7 @@
             [routerLink]="localizedPath('/quiz')"
             class="home-cta home-cta--secondary"
             (mouseenter)="preloadQuiz()"
-            [matBadge]="quizCount()"
+            [matBadge]="quizCountBadgeText()"
             [matBadgeHidden]="quizCount() === 0"
           >
             <mat-icon class="home-cta__icon">library_books</mat-icon>

--- a/apps/frontend/src/app/features/home/home.component.ts
+++ b/apps/frontend/src/app/features/home/home.component.ts
@@ -7,6 +7,7 @@ import {
   OnInit,
   ViewChild,
   PLATFORM_ID,
+  LOCALE_ID,
   computed,
   inject,
   signal,
@@ -41,6 +42,7 @@ import {
 import { localizeCommands, localizePath } from '../../core/locale-router';
 import { navigateToHostSession } from '../../core/session-host-navigation';
 import { DEMO_QUIZ_ID, QuizStoreService } from '../quiz/data/quiz-store.service';
+import { formatLocaleCount } from '../../core/locale-number.util';
 import {
   QUICK_FEEDBACK_PRESET_CHIPS,
   QUICK_FEEDBACK_TEMPO_SPOTLIGHT,
@@ -150,6 +152,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly quizCount = computed(
     () => this.quizStore.quizzes().filter((q) => q.id !== DEMO_QUIZ_ID).length,
   );
+  readonly quizCountBadgeText = computed(() => formatLocaleCount(this.quizCount(), this.localeId));
   readonly latestHostedQuizId = computed(() => {
     const quizzes = this.quizStore.quizzes().filter((quiz) => quiz.id !== DEMO_QUIZ_ID);
     return quizzes.reduce<string | null>((latestId, quiz) => {
@@ -169,6 +172,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly sanitizer = inject(DomSanitizer);
   private readonly motdCurrent = inject(MotdCurrentService);
+  private readonly localeId = inject(LOCALE_ID) as string;
   @ViewChild('motdCloseBtn') private readonly motdCloseBtn?: ElementRef<HTMLButtonElement>;
 
   /** Aktive MOTD (Epic 10); nur Browser, nach getCurrent. */

--- a/apps/frontend/src/app/features/join/join.component.html
+++ b/apps/frontend/src/app/features/join/join.component.html
@@ -63,7 +63,7 @@
             <p class="join-card__quiz">{{ s.title }}</p>
           }
           <p class="join-card__participants">
-            <span class="join-card__participants-count">{{ s.participantCount }}</span>
+            <span class="join-card__participants-count">{{ formatCount(s.participantCount) }}</span>
             {{ s.participantCount === 1 ? participantSingular() : participantPlural() }}
             {{ inLobbyLabel() }}
           </p>

--- a/apps/frontend/src/app/features/join/join.component.ts
+++ b/apps/frontend/src/app/features/join/join.component.ts
@@ -11,6 +11,7 @@ import { trpc } from '../../core/trpc.client';
 import type { SessionInfoDTO, TeamDTO } from '@arsnova/shared-types';
 import type { NicknameTheme } from '@arsnova/shared-types';
 import { getEffectiveLocale, localeIdToSupported } from '../../core/locale-from-path';
+import { formatLocaleCount } from '../../core/locale-number.util';
 import {
   localizeKnownServerError,
   sessionNotFoundUiMessage,
@@ -264,8 +265,11 @@ export class JoinComponent implements OnInit, OnDestroy {
     $localize`:@@join.nicknameFallbackHint:Die Namensliste ist vollständig vergeben. Du kannst jetzt aus weiteren Pseudonymen wählen.`;
   /** i18n: "in der Lobby" suffix. */
   inLobbyLabel = () => $localize`in der Lobby`;
-  teamMembersLabel = (count: number) =>
-    count === 1 ? $localize`${count} Mitglied` : $localize`${count} Mitglieder`;
+  teamMembersLabel = (count: number) => {
+    const formatted = formatLocaleCount(count, this.localeId);
+    return count === 1 ? $localize`${formatted} Mitglied` : $localize`${formatted} Mitglieder`;
+  };
+  formatCount = (value: number) => formatLocaleCount(value, this.localeId);
   teamCardAriaLabel = (team: TeamDTO) =>
     $localize`${this.teamNameDisplayLabel(team.name)}, ${this.teamMembersLabel(team.memberCount)}`;
   teamNameUsesEmojiMarker = (teamName: string) => edgeEmojiMarkerPosition(teamName) !== null;

--- a/apps/frontend/src/app/features/quiz/quiz-list/last-session-feedback-dialog.component.html
+++ b/apps/frontend/src/app/features/quiz/quiz-list/last-session-feedback-dialog.component.html
@@ -72,7 +72,7 @@
           <span class="last-session-feedback-dialog__avg-stars" aria-hidden="true">★</span>
         </p>
         <p class="last-session-feedback-dialog__count">
-          {{ row.summary.totalResponses }}
+          {{ formatCount(row.summary.totalResponses) }}
           {{ row.summary.totalResponses === 1 ? feedbackRatingSingular() : feedbackRatingPlural() }}
         </p>
         @if (getFeedbackDistributionLine(row.summary.overallDistribution); as distLine) {

--- a/apps/frontend/src/app/features/quiz/quiz-list/last-session-feedback-dialog.component.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-list/last-session-feedback-dialog.component.ts
@@ -11,6 +11,7 @@ import {
 import { MatIcon } from '@angular/material/icon';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import type { LastSessionFeedbackForQuizDTO } from '@arsnova/shared-types';
+import { formatLocaleCount } from '../../../core/locale-number.util';
 import { trpc } from '../../../core/trpc.client';
 
 export interface LastSessionFeedbackDialogData {
@@ -71,9 +72,13 @@ export class LastSessionFeedbackDialogComponent implements OnInit {
     const parts: string[] = [];
     for (let star = 1; star <= 5; star++) {
       const n = dist[String(star)] ?? 0;
-      if (n > 0) parts.push(`${n}× ${star} ★`);
+      if (n > 0) parts.push(`${formatLocaleCount(n, this.localeId)}× ${star} ★`);
     }
     return parts.length > 0 ? parts.join(' · ') : null;
+  }
+
+  formatCount(value: number): string {
+    return formatLocaleCount(value, this.localeId);
   }
 
   feedbackRatingSingular(): string {

--- a/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.html
+++ b/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.html
@@ -446,7 +446,7 @@
                     class="quiz-list-item__feature-chip quiz-list-item__feature-chip--live"
                     i18n="@@quizList.chipLiveParticipants"
                   >
-                    {{ liveParticipantCount }} live dabei
+                    {{ formatCount(liveParticipantCount) }} live dabei
                   </span>
                 }
               }
@@ -456,7 +456,7 @@
                 class="quiz-list-item__badge"
                 [class.quiz-list-item__badge--empty]="quiz.questionCount === 0"
               >
-                {{ quiz.questionCount }}
+                {{ formatCount(quiz.questionCount) }}
               </span>
               @if (quiz.questionCount === 0) {
                 <span class="quiz-list-item__meta-text quiz-list-item__meta-text--warn" i18n

--- a/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.ts
@@ -3,6 +3,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   Component,
   ElementRef,
+  LOCALE_ID,
   OnInit,
   computed,
   effect,
@@ -34,6 +35,7 @@ import {
   type TeamAssignment,
 } from '@arsnova/shared-types';
 import { homePresetOptionsKeyForQuizPreset } from '../../../core/home-preset-storage';
+import { formatLocaleCount } from '../../../core/locale-number.util';
 import { ThemePresetService } from '../../../core/theme-preset.service';
 import {
   DEMO_QUIZ_ID,
@@ -104,6 +106,7 @@ const QUIZ_HISTORY_SCOPE_ID_PATTERN =
 })
 export class QuizListComponent implements OnInit {
   private readonly document = inject(DOCUMENT);
+  private readonly localeId = inject(LOCALE_ID) as string;
   private readonly quizStore = inject(QuizStoreService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
@@ -272,7 +275,11 @@ export class QuizListComponent implements OnInit {
     if (count === 0)
       return $localize`:@@quizList.syncPeerCountNone:Gerade kein anderes Gerät aktiv`;
     if (count === 1) return $localize`:@@quizList.syncPeerCountOne:Gerade 1 weiteres Gerät aktiv`;
-    return $localize`:@@quizList.syncPeerCountMany:Gerade ${count}:count: weitere Geräte aktiv`;
+    return $localize`:@@quizList.syncPeerCountMany:Gerade ${formatLocaleCount(count, this.localeId)}:count: weitere Geräte aktiv`;
+  }
+
+  formatCount(value: number): string {
+    return formatLocaleCount(value, this.localeId);
   }
 
   deviceSummary(deviceLabel: string, browserLabel: string): string {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -813,7 +813,9 @@
                                 {{ entry.totalScore | number }}
                               </td>
                               <td class="session-host__lb-col--correct">
-                                {{ entry.correctCount }}/{{ entry.totalQuestions }}
+                                {{ formatCount(entry.correctCount) }}/{{
+                                  formatCount(entry.totalQuestions)
+                                }}
                               </td>
                             </tr>
                           }
@@ -911,7 +913,7 @@
                         <span class="session-host__feedback-avg-stars" aria-hidden="true">★</span>
                       </p>
                       <p class="session-host__feedback-count">
-                        {{ fb.totalResponses }}
+                        {{ formatCount(fb.totalResponses) }}
                         {{
                           fb.totalResponses === 1
                             ? feedbackRatingSingular()
@@ -951,13 +953,13 @@
                               class="session-host__feedback-badge session-host__feedback-badge--yes"
                             >
                               <mat-icon aria-hidden="true">thumb_up</mat-icon>
-                              {{ fb.wouldRepeatYes }}
+                              {{ formatCount(fb.wouldRepeatYes) }}
                             </span>
                             <span
                               class="session-host__feedback-badge session-host__feedback-badge--no"
                             >
                               <mat-icon aria-hidden="true">thumb_down</mat-icon>
-                              {{ fb.wouldRepeatNo }}
+                              {{ formatCount(fb.wouldRepeatNo) }}
                             </span>
                           </span>
                         </div>
@@ -1079,7 +1081,7 @@
                           </span>
                           <span class="session-host__vote-progress-copy">
                             <span class="session-host__vote-progress-value"
-                              >{{ voteProgress.percentage }} %</span
+                              >{{ formatCount(voteProgress.percentage) }} %</span
                             >
                             <span class="session-host__vote-progress-meta">{{
                               voteProgressCompactLabel(
@@ -1210,7 +1212,9 @@
                               q.ratingAvg !== undefined
                             ) {
                               <div class="session-host__rating-result">
-                                <span class="session-host__rating-avg">∅ {{ q.ratingAvg }}</span>
+                                <span class="session-host__rating-avg"
+                                  >∅ {{ formatDecimal(q.ratingAvg) }}</span
+                                >
                                 <span class="session-host__rating-count">{{
                                   ratingSubmittedLabel(
                                     q.ratingCount ?? 0,
@@ -1236,7 +1240,9 @@
                                         [style.width.%]="pct"
                                       ></div>
                                     </div>
-                                    <span class="session-host__rating-bar-count">{{ count }}</span>
+                                    <span class="session-host__rating-bar-count">{{
+                                      formatCount(count)
+                                    }}</span>
                                   </div>
                                 }
                               </div>
@@ -1268,7 +1274,7 @@
                                   class="session-host__numeric-vote-count"
                                   i18n="@@sessionHost.numericVoteCount"
                                 >
-                                  {{ numericVoteCount }} Antworten eingegangen
+                                  {{ formatCount(numericVoteCount) }} Antworten eingegangen
                                 </p>
                               }
                             } @else if (effectiveStatus() === 'RESULTS') {
@@ -1423,7 +1429,7 @@
                                               bin.count === 0
                                             "
                                             [attr.aria-hidden]="bin.count === 0 ? 'true' : null"
-                                            >{{ bin.count }}</span
+                                            >{{ formatCount(bin.count) }}</span
                                           >
                                         </div>
                                       }
@@ -1505,7 +1511,7 @@
                                               bin.count === 0
                                             "
                                             [attr.aria-hidden]="bin.count === 0 ? 'true' : null"
-                                            >{{ bin.count }}</span
+                                            >{{ formatCount(bin.count) }}</span
                                           >
                                         </div>
                                       }
@@ -1624,11 +1630,12 @@
                                           class="session-host__numeric-paired"
                                           i18n="@@sessionHost.numericPairedImproved"
                                         >
-                                          Paarvergleich: {{ rc.pairedAnalysis.closerCount }} näher,
-                                          {{ rc.pairedAnalysis.fartherCount }} weiter weg,
-                                          {{ rc.pairedAnalysis.unchangedCount }} gleich ({{
-                                            rc.pairedAnalysis.pairedCount
-                                          }}
+                                          Paarvergleich:
+                                          {{ formatCount(rc.pairedAnalysis.closerCount) }} näher,
+                                          {{ formatCount(rc.pairedAnalysis.fartherCount) }} weiter
+                                          weg,
+                                          {{ formatCount(rc.pairedAnalysis.unchangedCount) }} gleich
+                                          ({{ formatCount(rc.pairedAnalysis.pairedCount) }}
                                           Paare)
                                         </p>
                                       }
@@ -1676,7 +1683,7 @@
                                                   [attr.aria-hidden]="
                                                     bin.count === 0 ? 'true' : null
                                                   "
-                                                  >{{ bin.count }}</span
+                                                  >{{ formatCount(bin.count) }}</span
                                                 >
                                               </div>
                                             }
@@ -1815,7 +1822,7 @@
                                           bin.count === 0
                                         "
                                         [attr.aria-hidden]="bin.count === 0 ? 'true' : null"
-                                        >{{ bin.count }}</span
+                                        >{{ formatCount(bin.count) }}</span
                                       >
                                     </div>
                                   }
@@ -1908,13 +1915,13 @@
                                 <span
                                   class="session-host__round-comparison-label session-host__round-comparison-label--r1"
                                   i18n="@@sessionHost.roundComparisonRound1VotesLabelOne"
-                                  >Runde 1 ({{ round1Votes }} Stimme)</span
+                                  >Runde 1 ({{ formatCount(round1Votes) }} Stimme)</span
                                 >
                               } @else {
                                 <span
                                   class="session-host__round-comparison-label session-host__round-comparison-label--r1"
                                   i18n="@@sessionHost.roundComparisonRound1VotesLabelMany"
-                                  >Runde 1 ({{ round1Votes }} Stimmen)</span
+                                  >Runde 1 ({{ formatCount(round1Votes) }} Stimmen)</span
                                 >
                               }
                               @let round2Votes = q.roundComparison.round2Total;
@@ -1922,13 +1929,13 @@
                                 <span
                                   class="session-host__round-comparison-label session-host__round-comparison-label--r2"
                                   i18n="@@sessionHost.roundComparisonRound2VotesLabelOne"
-                                  >Runde 2 ({{ round2Votes }} Stimme)</span
+                                  >Runde 2 ({{ formatCount(round2Votes) }} Stimme)</span
                                 >
                               } @else {
                                 <span
                                   class="session-host__round-comparison-label session-host__round-comparison-label--r2"
                                   i18n="@@sessionHost.roundComparisonRound2VotesLabelMany"
-                                  >Runde 2 ({{ round2Votes }} Stimmen)</span
+                                  >Runde 2 ({{ formatCount(round2Votes) }} Stimmen)</span
                                 >
                               }
                             </div>
@@ -1940,8 +1947,11 @@
                               <p class="session-host__round-comparison-correct">
                                 <mat-icon>check_circle</mat-icon>
                                 <span i18n="@@sessionHost.roundComparisonCorrectCounts"
-                                  >Richtig: {{ q.roundComparison.round1CorrectCount }} in Runde 1,
-                                  danach {{ q.roundComparison.round2CorrectCount }} in Runde 2</span
+                                  >Richtig:
+                                  {{ formatCount(q.roundComparison.round1CorrectCount) }} in Runde
+                                  1, danach
+                                  {{ formatCount(q.roundComparison.round2CorrectCount) }} in Runde
+                                  2</span
                                 >
                                 @if (
                                   q.roundComparison.round1Total > 0 &&
@@ -2062,7 +2072,7 @@
                                     @for (m of shift.migrations; track m.from + m.to) {
                                       <li class="session-host__migration-item">
                                         <span class="session-host__migration-count"
-                                          >{{ m.count }}×</span
+                                          >{{ formatCount(m.count) }}×</span
                                         >
                                         <span class="session-host__migration-from">{{
                                           m.from
@@ -2149,7 +2159,7 @@
                                       >{{ a.votePercentage }}&nbsp;%</span
                                     >
                                     <span class="session-host__vote-dist-count"
-                                      >({{ a.voteCount }})</span
+                                      >({{ formatCount(a.voteCount) }})</span
                                     >
                                   </div>
                                   <div class="session-host__vote-dist-track">
@@ -2702,7 +2712,7 @@
                         >question_answer</mat-icon
                       >
                       <span i18n="@@sessionQa.summaryTotal"
-                        >Gesamt: {{ qaForumQuestionCount() }}</span
+                        >Gesamt: {{ formatCount(qaForumQuestionCount()) }}</span
                       >
                     </span>
                     @if (qaPendingCount() > 0) {
@@ -2711,7 +2721,7 @@
                           >hourglass_top</mat-icon
                         >
                         <span i18n="@@sessionQa.summaryPending"
-                          >Warten auf Freigabe: {{ qaPendingCount() }}</span
+                          >Warten auf Freigabe: {{ formatCount(qaPendingCount()) }}</span
                         >
                       </span>
                     }
@@ -2720,7 +2730,7 @@
                         <mat-icon class="session-qa-summary__icon" aria-hidden="true"
                           >push_pin</mat-icon
                         >
-                        {{ qaPinnedCount() }}
+                        {{ formatCount(qaPinnedCount()) }}
                       </span>
                     }
                     @if (qaArchivedCount() > 0) {
@@ -2728,7 +2738,7 @@
                         <mat-icon class="session-qa-summary__icon" aria-hidden="true"
                           >archive</mat-icon
                         >
-                        {{ qaArchivedCount() }}
+                        {{ formatCount(qaArchivedCount()) }}
                       </span>
                     }
                     @if (qaDeletedCount() > 0) {
@@ -2736,7 +2746,7 @@
                         <mat-icon class="session-qa-summary__icon" aria-hidden="true"
                           >delete_outline</mat-icon
                         >
-                        {{ qaDeletedCount() }}
+                        {{ formatCount(qaDeletedCount()) }}
                       </span>
                     }
                   </div>
@@ -2796,7 +2806,7 @@
                       >arrow_upward</mat-icon
                     >
                     <span i18n="@@sessionQa.newQuestionsLabel"
-                      >{{ qaUnseenCount() }} neue Fragen</span
+                      >{{ formatCount(qaUnseenCount()) }} neue Fragen</span
                     >
                   </button>
                 }
@@ -2936,8 +2946,8 @@
                           question.negativeVoteCount !== undefined
                         ) {
                           <span class="session-qa-card__metric" i18n="@@sessionQa.voteBreakdown"
-                            >{{ question.positiveVoteCount }} positiv ·
-                            {{ question.negativeVoteCount }} negativ</span
+                            >{{ formatCount(question.positiveVoteCount) }} positiv ·
+                            {{ formatCount(question.negativeVoteCount) }} negativ</span
                           >
                         }
                         @if (qaSortMode() === 'BEST' && question.bestScore !== undefined) {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -5,6 +5,7 @@ import {
   tryExitDocumentFullscreen,
   tryRequestDocumentFullscreen,
 } from '../../../core/document-fullscreen.util';
+import { formatLocaleCount, formatLocaleNumber } from '../../../core/locale-number.util';
 import {
   Component,
   ElementRef,
@@ -1563,7 +1564,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     const parts: string[] = [];
     for (let star = 1; star <= 5; star++) {
       const n = dist[String(star)] ?? 0;
-      if (n > 0) parts.push(`${n}× ${star} ★`);
+      if (n > 0) parts.push(`${formatLocaleCount(n, this.localeId)}× ${star} ★`);
     }
     return parts.length > 0 ? parts.join(' · ') : null;
   }
@@ -2570,11 +2571,12 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     if (connectedCount === 1) {
       return $localize`:@@sessionHost.connectedParticipantCountOne:1 live verbunden`;
     }
-    return $localize`:@@sessionHost.connectedParticipantCountMany:${connectedCount}:connectedCount: live verbunden`;
+    return $localize`:@@sessionHost.connectedParticipantCountMany:${formatLocaleCount(connectedCount, this.localeId)}:connectedCount: live verbunden`;
   }
 
   teamMemberLabel(count: number): string {
-    return count === 1 ? $localize`${count} Mitglied` : $localize`${count} Mitglieder`;
+    const formatted = formatLocaleCount(count, this.localeId);
+    return count === 1 ? $localize`${formatted} Mitglied` : $localize`${formatted} Mitglieder`;
   }
 
   teamNameUsesEmojiMarker(teamName: string): boolean {
@@ -3428,44 +3430,51 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   }
 
   voteProgressCompactLabel(votes: number, participants: number): string {
-    return $localize`${votes} von ${participants}`;
+    return $localize`${formatLocaleCount(votes, this.localeId)} von ${formatLocaleCount(participants, this.localeId)}`;
   }
 
   voteProgressAria(votes: number, participants: number, percentage: number): string {
+    const formattedPercentage = formatLocaleCount(percentage, this.localeId);
     if (votes === 1) {
-      return $localize`:@@sessionHost.voteProgressAriaOne:${votes}:votes: von ${participants}:participants: Teilnehmenden hat abgestimmt. ${percentage}:percentage: Prozent erreicht.`;
+      return $localize`:@@sessionHost.voteProgressAriaOne:${formatLocaleCount(votes, this.localeId)}:votes: von ${formatLocaleCount(participants, this.localeId)}:participants: Teilnehmenden hat abgestimmt. ${formattedPercentage}:percentage: Prozent erreicht.`;
     }
-    return $localize`:@@sessionHost.voteProgressAriaMany:${votes}:votes: von ${participants}:participants: Teilnehmenden haben abgestimmt. ${percentage}:percentage: Prozent erreicht.`;
+    return $localize`:@@sessionHost.voteProgressAriaMany:${formatLocaleCount(votes, this.localeId)}:votes: von ${formatLocaleCount(participants, this.localeId)}:participants: Teilnehmenden haben abgestimmt. ${formattedPercentage}:percentage: Prozent erreicht.`;
   }
 
   /** Ergebnisansicht: „X von Y hat/haben abgestimmt“ (Plural nach Anzahl abgegebener Stimmen). */
   votesCastLabel(votes: number, participantTotal: number | null | undefined): string {
     const totalStr =
-      participantTotal !== undefined && participantTotal !== null ? String(participantTotal) : '?';
+      participantTotal !== undefined && participantTotal !== null
+        ? formatLocaleCount(participantTotal, this.localeId)
+        : '?';
+    const voteCount = formatLocaleCount(votes, this.localeId);
     if (votes === 1) {
-      return $localize`:@@sessionHost.votesCastOne:${votes}:voteCount: von ${totalStr}:participantTotal: hat abgestimmt`;
+      return $localize`:@@sessionHost.votesCastOne:${voteCount}:voteCount: von ${totalStr}:participantTotal: hat abgestimmt`;
     }
-    return $localize`:@@sessionHost.votesCastMany:${votes}:voteCount: von ${totalStr}:participantTotal: haben abgestimmt`;
+    return $localize`:@@sessionHost.votesCastMany:${voteCount}:voteCount: von ${totalStr}:participantTotal: haben abgestimmt`;
   }
 
   /** Bewertungsfrage Ergebnis: „X von Y hat/haben bewertet“. */
   ratingSubmittedLabel(count: number, participantTotal: number | null | undefined): string {
     const totalStr =
-      participantTotal !== undefined && participantTotal !== null ? String(participantTotal) : '?';
+      participantTotal !== undefined && participantTotal !== null
+        ? formatLocaleCount(participantTotal, this.localeId)
+        : '?';
+    const voteCount = formatLocaleCount(count, this.localeId);
     if (count === 1) {
-      return $localize`:@@sessionHost.ratingSubmittedOne:${count}:voteCount: von ${totalStr}:participantTotal: hat bewertet`;
+      return $localize`:@@sessionHost.ratingSubmittedOne:${voteCount}:voteCount: von ${totalStr}:participantTotal: hat bewertet`;
     }
-    return $localize`:@@sessionHost.ratingSubmittedMany:${count}:voteCount: von ${totalStr}:participantTotal: haben bewertet`;
+    return $localize`:@@sessionHost.ratingSubmittedMany:${voteCount}:voteCount: von ${totalStr}:participantTotal: haben bewertet`;
   }
 
   /** Multiple-Choice-Ergebnis: korrekt gewählte Antworten inkl. Prozent. */
   correctAllVotersLabel(correct: number, total: number): string {
     const pct = total > 0 ? Math.round((correct / total) * 100) : 0;
-    return $localize`:@@sessionHost.correctAllVoters:${correct}:correctCount: von ${total}:voteTotal: komplett richtig (${pct}:percentage:\u00a0%)`;
+    return $localize`:@@sessionHost.correctAllVoters:${formatLocaleCount(correct, this.localeId)}:correctCount: von ${formatLocaleCount(total, this.localeId)}:voteTotal: komplett richtig (${formatLocaleCount(pct, this.localeId)}:percentage:\u00a0%)`;
   }
 
   opinionShiftChangedMindLabel(changed: number, both: number, pct: number): string {
-    return $localize`:@@sessionHost.opinionShiftChangedMind:${changed}:changed: von ${both}:both: (${pct}:pct:\u00a0%) änderten ihre Meinung`;
+    return $localize`:@@sessionHost.opinionShiftChangedMind:${formatLocaleCount(changed, this.localeId)}:changed: von ${formatLocaleCount(both, this.localeId)}:both: (${formatLocaleCount(pct, this.localeId)}:pct:\u00a0%) änderten ihre Meinung`;
   }
 
   opinionShiftWrongToCorrectLabel(count: number): string {
@@ -4304,11 +4313,11 @@ export class SessionHostComponent implements OnInit, OnDestroy {
 
   qaTabMetaLabel(): string | null {
     if (this.activeChannel() !== 'qa' && this.qaUnseenCount() > 0) {
-      return $localize`:@@sessionTabs.questionsBadgeNew:${this.qaUnseenCount()}:count: neu`;
+      return $localize`:@@sessionTabs.questionsBadgeNew:${formatLocaleCount(this.qaUnseenCount(), this.localeId)}:count: neu`;
     }
 
     if (this.qaForumQuestionCount() > 0) {
-      return String(this.qaForumQuestionCount());
+      return formatLocaleCount(this.qaForumQuestionCount(), this.localeId);
     }
 
     return null;
@@ -4729,6 +4738,14 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     }
 
     return `${formatNumber((value ?? 0) * 100, this.localeId, '1.0-0')} %`;
+  }
+
+  formatCount(value: number | null | undefined): string {
+    return formatLocaleCount(value ?? 0, this.localeId);
+  }
+
+  formatDecimal(value: number | null | undefined, maximumFractionDigits = 1): string {
+    return formatLocaleNumber(value ?? 0, this.localeId, { maximumFractionDigits });
   }
 
   async setQaSortMode(mode: QaQuestionSortMode): Promise<void> {

--- a/apps/frontend/src/app/features/session/session-present/session-present.component.html
+++ b/apps/frontend/src/app/features/session/session-present/session-present.component.html
@@ -94,7 +94,7 @@
             </div>
             <div class="session-present__qa-votes">
               <mat-icon aria-hidden="true">thumb_up</mat-icon>
-              <span>{{ pinnedQuestion.upvoteCount }}</span>
+              <span>{{ formatCount(pinnedQuestion.upvoteCount) }}</span>
             </div>
           </div>
           <div
@@ -127,7 +127,7 @@
               <article class="session-present__qa-list-item" role="listitem">
                 <div class="session-present__qa-list-votes">
                   <mat-icon aria-hidden="true">thumb_up</mat-icon>
-                  <span>{{ question.upvoteCount }}</span>
+                  <span>{{ formatCount(question.upvoteCount) }}</span>
                 </div>
                 <div
                   class="session-present__qa-list-text"
@@ -176,7 +176,8 @@
                 <span class="session-present__feedback-status">{{ statusLabel }}</span>
               }
               <span class="session-present__feedback-votes">
-                {{ quickFeedback.totalVotes }}&nbsp;<span i18n="@@sessionPresent.quickFeedbackVotes"
+                {{ formatCount(quickFeedback.totalVotes) }}&nbsp;<span
+                  i18n="@@sessionPresent.quickFeedbackVotes"
                   >Stimmen</span
                 >
               </span>
@@ -221,7 +222,7 @@
                   ></div>
                 </div>
                 <span class="session-present__feedback-row-value">
-                  {{ entry.value }} ({{ quickFeedbackPercentage(entry.value) }} %)
+                  {{ formatCount(entry.value) }} ({{ quickFeedbackPercentage(entry.value) }} %)
                 </span>
               </div>
             }

--- a/apps/frontend/src/app/features/session/session-present/session-present.component.ts
+++ b/apps/frontend/src/app/features/session/session-present/session-present.component.ts
@@ -26,6 +26,7 @@ import type {
 } from '@arsnova/shared-types';
 import { recordServerTimeSample } from '../session-server-clock';
 import { localizePath } from '../../../core/locale-router';
+import { formatLocaleCount, formatLocalePercent } from '../../../core/locale-number.util';
 import {
   getEffectiveLocale,
   localeIdToSupported,
@@ -270,7 +271,7 @@ export class SessionPresentComponent implements OnInit, OnDestroy {
     if (!entry) {
       return null;
     }
-    return $localize`${entry.teamName} gewinnt mit ${entry.totalScore}:totalScore: Punkten!`;
+    return $localize`${entry.teamName} gewinnt mit ${formatLocaleCount(entry.totalScore, this.localeId)}:totalScore: Punkten!`;
   }
 
   renderMarkdown(value: string): SafeHtml {
@@ -321,9 +322,13 @@ export class SessionPresentComponent implements OnInit, OnDestroy {
   quickFeedbackPercentage(value: number): string {
     const total = this.quickFeedbackResult()?.totalVotes ?? 0;
     if (total <= 0) {
-      return '0';
+      return formatLocalePercent(0, this.localeId, 0);
     }
-    return String(Math.round((value / total) * 100));
+    return formatLocalePercent(Math.round((value / total) * 100), this.localeId, 0);
+  }
+
+  formatCount(value: number | null | undefined): string {
+    return formatLocaleCount(value ?? 0, this.localeId);
   }
 
   private async refreshSessionMeta(): Promise<void> {

--- a/apps/frontend/src/app/features/session/session-present/word-cloud.component.html
+++ b/apps/frontend/src/app/features/session/session-present/word-cloud.component.html
@@ -20,13 +20,14 @@
       <p class="word-cloud__meta-line">
         <span class="word-cloud__meta-pill">
           @if (isWordCountPartial()) {
-            {{ visibleWordCount() }} / {{ words().length }} {{ wordLabel(words().length) }}
+            {{ formatCount(visibleWordCount()) }} / {{ formatCount(words().length) }}
+            {{ wordLabel(words().length) }}
           } @else {
             {{ words().length }} {{ wordLabel(words().length) }}
           }
         </span>
         <span class="word-cloud__meta-pill"
-          >{{ responseSummary().total }} {{ itemLabel(responseSummary().total) }}</span
+          >{{ formatCount(responseSummary().total) }} {{ itemLabel(responseSummary().total) }}</span
         >
       </p>
       @if (analysisDetailLabel()) {
@@ -186,7 +187,7 @@
             >
               <span
                 >{{ showResponsesLabel(responseSummary().visible) }} ({{
-                  responseSummary().visible
+                  formatCount(responseSummary().visible)
                 }})</span
               >
               <mat-icon aria-hidden="true">{{

--- a/apps/frontend/src/app/features/session/session-present/word-cloud.component.ts
+++ b/apps/frontend/src/app/features/session/session-present/word-cloud.component.ts
@@ -27,6 +27,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 import type { CloudLayout } from 'd3-cloud';
 import type { WordCloudAnalysisEntryDTO } from '@arsnova/shared-types';
 import { getEffectiveLocale, localeIdToSupported } from '../../../core/locale-from-path';
+import { formatLocaleCount } from '../../../core/locale-number.util';
 import { tryRequestDocumentFullscreen } from '../../../core/document-fullscreen.util';
 import {
   getWordCloudChipPadding,
@@ -817,6 +818,10 @@ export class WordCloudComponent implements AfterViewInit, OnDestroy {
 
   wordLabel(count: number): string {
     return count === 1 ? this.wordLabelSingular() : this.wordLabelPlural();
+  }
+
+  formatCount(value: number): string {
+    return formatLocaleCount(value, this.localeId);
   }
 
   showResponsesLabel(count: number): string {

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
@@ -563,7 +563,9 @@
                   }}</span>
                 </div>
                 <div class="vote-team-reward__stat">
-                  <span class="vote-team-reward__stat-value">{{ ownTeam.memberCount }}</span>
+                  <span class="vote-team-reward__stat-value">{{
+                    formatCount(ownTeam.memberCount)
+                  }}</span>
                   <span class="vote-team-reward__stat-label">{{
                     vpc.voteTeamStatMembers(isPlayfulPreset())
                   }}</span>
@@ -1414,7 +1416,7 @@
                         @if (sc.streakCount >= 3) {
                           🔥
                         }
-                        {{ sc.streakCount }}er
+                        {{ formatCount(sc.streakCount) }}er
                       </span>
                       <span class="vote-scorecard__stat-label" i18n
                         >Serie (×{{ sc.streakMultiplier | number: '1.1-1' }})</span
@@ -1427,9 +1429,9 @@
                     }}</span>
                     <span class="vote-scorecard__stat-label">
                       @if (sc.rankChange > 0) {
-                        ↑ {{ sc.rankChange }}
+                        ↑ {{ formatCount(sc.rankChange) }}
                       } @else if (sc.rankChange < 0) {
-                        ↓ {{ sc.rankChange * -1 }}
+                        ↓ {{ formatCount(sc.rankChange * -1) }}
                       } @else {
                         <span i18n>Dein Rang</span>
                       }
@@ -1510,7 +1512,9 @@
                   }}</span>
                 </div>
                 <div class="vote-team-reward__stat">
-                  <span class="vote-team-reward__stat-value">{{ ownTeam.memberCount }}</span>
+                  <span class="vote-team-reward__stat-value">{{
+                    formatCount(ownTeam.memberCount)
+                  }}</span>
                   <span class="vote-team-reward__stat-label">{{
                     vpc.voteTeamStatMembers(isPlayfulPreset())
                   }}</span>
@@ -1747,7 +1751,7 @@
                         [class.session-qa-card__vote-count--positive]="question.upvoteCount > 0"
                         [class.session-qa-card__vote-count--negative]="question.upvoteCount < 0"
                       >
-                        {{ question.upvoteCount }}
+                        {{ formatCount(question.upvoteCount) }}
                       </span>
                       <button
                         type="button"
@@ -1802,7 +1806,7 @@
                         <mat-icon class="session-qa-card__score-icon" aria-hidden="true"
                           >thumb_up_off_alt</mat-icon
                         >
-                        {{ question.upvoteCount }}
+                        {{ formatCount(question.upvoteCount) }}
                       </span>
                       @if (question.isOwn) {
                         <button

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
@@ -84,6 +84,7 @@ import {
   findKindergartenNicknameEmoji,
 } from '../../join/kindergarten-nickname-icons';
 import { getEffectiveLocale } from '../../../core/locale-from-path';
+import { formatLocaleCount } from '../../../core/locale-number.util';
 import {
   areOriginalNicknamesExhausted,
   getGeneratedNicknameFallbackList,
@@ -121,8 +122,7 @@ type SessionChannelTab = 'quiz' | 'qa' | 'quickFeedback';
 type ParticipantLiveChannelTab = Extract<SessionChannelTab, 'qa' | 'quickFeedback'>;
 type QuickFeedbackPhaseKey = string | null;
 type ShortTextEvaluationResult =
-  | ReturnType<typeof evaluateShortAnswer>
-  | ReturnType<typeof evaluateNumericAnswer>;
+  ReturnType<typeof evaluateShortAnswer> | ReturnType<typeof evaluateNumericAnswer>;
 type StoredVoteResponse = {
   answerIds?: string[];
   freeText?: string;
@@ -2206,18 +2206,18 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
       if (entry.totalScore <= 0) {
         return $localize`:@@sessionVote.teamRewardMsgFinishedOwnZero:Quiz beendet – ihr habt keine Team-Punkte gesammelt.`;
       }
-      return $localize`:@@sessionVote.teamRewardMsgFinishedOther:Ihr beendet mit ${entry.totalScore}:totalScore: Punkten auf Platz ${entry.rank}:teamRank:.`;
+      return $localize`:@@sessionVote.teamRewardMsgFinishedOther:Ihr beendet mit ${formatLocaleCount(entry.totalScore, getEffectiveLocale())}:totalScore: Punkten auf Platz ${formatLocaleCount(entry.rank, getEffectiveLocale())}:teamRank:.`;
     }
     if (entry.totalScore <= 0) {
       if (!anyTeamScored) {
         return $localize`:@@sessionVote.teamRewardMsgAllZero:Mit richtigen Antworten sammelt ihr Punkte fürs Team.`;
       }
-      return $localize`:@@sessionVote.teamRewardMsgChasing:Aktuell Platz ${entry.rank}:teamRank: mit ${entry.totalScore}:totalScore: Punkten.`;
+      return $localize`:@@sessionVote.teamRewardMsgChasing:Aktuell Platz ${formatLocaleCount(entry.rank, getEffectiveLocale())}:teamRank: mit ${formatLocaleCount(entry.totalScore, getEffectiveLocale())}:totalScore: Punkten.`;
     }
     if (entry.rank === 1 && anyTeamScored) {
-      return $localize`:@@sessionVote.teamRewardMsgLeading:Mit ${entry.totalScore}:totalScore: Punkten führt ihr.`;
+      return $localize`:@@sessionVote.teamRewardMsgLeading:Mit ${formatLocaleCount(entry.totalScore, getEffectiveLocale())}:totalScore: Punkten führt ihr.`;
     }
-    return $localize`:@@sessionVote.teamRewardMsgChasing:Aktuell Platz ${entry.rank}:teamRank: mit ${entry.totalScore}:totalScore: Punkten.`;
+    return $localize`:@@sessionVote.teamRewardMsgChasing:Aktuell Platz ${formatLocaleCount(entry.rank, getEffectiveLocale())}:teamRank: mit ${formatLocaleCount(entry.totalScore, getEffectiveLocale())}:totalScore: Punkten.`;
   }
 
   teamRewardLeaderHint(): string | null {
@@ -2295,9 +2295,9 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
   teamStandingAriaLabel(entry: TeamLeaderboardEntryDTO): string {
     const teamLabel = this.teamNameDisplayLabel(entry.teamName);
     if (!this.teamScoreboardHasPoints()) {
-      return $localize`:@@sessionVote.teamStandingNoRank:${teamLabel}:teamName: mit ${this.teamMemberLabel(entry.memberCount)}:memberCountLabel: und ${entry.totalScore}:totalScore: Team-Punkten, noch ohne Rang`;
+      return $localize`:@@sessionVote.teamStandingNoRank:${teamLabel}:teamName: mit ${this.teamMemberLabel(entry.memberCount)}:memberCountLabel: und ${formatLocaleCount(entry.totalScore, getEffectiveLocale())}:totalScore: Team-Punkten, noch ohne Rang`;
     }
-    return $localize`:@@sessionVote.teamStandingWithMembers:Platz ${entry.rank}:teamRank:: ${teamLabel}:teamName: mit ${this.teamMemberLabel(entry.memberCount)}:memberCountLabel: und ${entry.totalScore}:totalScore: Punkten`;
+    return $localize`:@@sessionVote.teamStandingWithMembers:Platz ${formatLocaleCount(entry.rank, getEffectiveLocale())}:teamRank:: ${teamLabel}:teamName: mit ${this.teamMemberLabel(entry.memberCount)}:memberCountLabel: und ${formatLocaleCount(entry.totalScore, getEffectiveLocale())}:totalScore: Punkten`;
   }
 
   private teamNameDisplayLabel(teamName: string): string {
@@ -2315,7 +2315,12 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
   }
 
   teamMemberLabel(count: number): string {
-    return count === 1 ? $localize`${count} Mitglied` : $localize`${count} Mitglieder`;
+    const formatted = formatLocaleCount(count, getEffectiveLocale());
+    return count === 1 ? $localize`${formatted} Mitglied` : $localize`${formatted} Mitglieder`;
+  }
+
+  formatCount(value: number): string {
+    return formatLocaleCount(value, getEffectiveLocale());
   }
 
   teamScoreBarWidth(totalScore: number): string {

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.spec.ts
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.spec.ts
@@ -78,6 +78,7 @@ describe('ServerStatusHelpDialogComponent', () => {
     expect(text).toContain('Sessions, die gerade sichtbar weiterlaufen');
     expect(text).toContain('Mit laufendem Countdown im aktuellen Aktivitätsfenster');
     expect(text).toContain('Alle je beendeten Live-Sessions (kumulativ)');
+    expect(text).toContain('98');
     expect(text).toContain('Rekordteilnahme');
     expect(text).toContain('Session-Tagesrekorde der letzten 100 Tage');
     expect(text).toContain(

--- a/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts
+++ b/apps/frontend/src/app/shared/server-status-help-dialog/server-status-help-dialog.component.ts
@@ -20,6 +20,7 @@ import {
 } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import type { ServerStatsDTO } from '@arsnova/shared-types';
+import { formatLocaleCount, formatLocaleNumber } from '../../core/locale-number.util';
 type ChartRenderer = import('./server-status-help-dialog-chart').ServerStatusHistoryChartRenderer;
 
 const THEME_PRESET_DOM_EVENT = 'arsnova:preset-updated';
@@ -121,7 +122,7 @@ export interface ServerStatusHelpDialogData {
                     <mat-icon aria-hidden="true">play_circle</mat-icon>
                     <span i18n="@@app.footer.statusMetricActiveSessions">Aktive Sessions</span>
                   </div>
-                  <strong>{{ s.activeSessions }}</strong>
+                  <strong>{{ formatCount(s.activeSessions) }}</strong>
                   <p
                     class="status-help-dialog__metric-hint"
                     i18n="@@app.footer.statusMetricActiveSessionsHint"
@@ -134,7 +135,7 @@ export interface ServerStatusHelpDialogData {
                     <mat-icon aria-hidden="true">meeting_room</mat-icon>
                     <span i18n="@@app.footer.statusMetricOpenSessions">Offene Sessions</span>
                   </div>
-                  <strong>{{ s.openSessions }}</strong>
+                  <strong>{{ formatCount(s.openSessions) }}</strong>
                   <p
                     class="status-help-dialog__metric-hint"
                     i18n="@@app.footer.statusMetricOpenSessionsHint"
@@ -147,7 +148,7 @@ export interface ServerStatusHelpDialogData {
                     <mat-icon aria-hidden="true">group</mat-icon>
                     <span i18n="@@app.footer.statusMetricParticipants">Aktive Teilnehmende</span>
                   </div>
-                  <strong>{{ s.totalParticipants }}</strong>
+                  <strong>{{ formatCount(s.totalParticipants) }}</strong>
                   <p
                     class="status-help-dialog__metric-hint"
                     i18n="@@app.footer.statusMetricParticipantsHint"
@@ -160,14 +161,14 @@ export interface ServerStatusHelpDialogData {
                     <mat-icon aria-hidden="true">bolt</mat-icon>
                     <span i18n="@@app.footer.statusMetricBlitz">Blitz-Runden</span>
                   </div>
-                  <strong>{{ s.activeBlitzRounds }}</strong>
+                  <strong>{{ formatCount(s.activeBlitzRounds) }}</strong>
                 </article>
                 <article class="status-help-dialog__metric status-help-dialog__metric--wide">
                   <div class="status-help-dialog__metric-head">
                     <mat-icon aria-hidden="true">check_circle</mat-icon>
                     <span i18n="@@app.footer.statusMetricCompleted">Abgeschlossen</span>
                   </div>
-                  <strong>{{ s.completedSessions }}</strong>
+                  <strong>{{ formatCount(s.completedSessions) }}</strong>
                   <p
                     class="status-help-dialog__metric-hint"
                     i18n="@@app.footer.statusMetricCompletedHint"
@@ -194,7 +195,7 @@ export interface ServerStatusHelpDialogData {
                     <mat-icon aria-hidden="true">how_to_vote</mat-icon>
                     <span i18n="@@app.footer.statusMetricVotes">Abstimmungen / Minute</span>
                   </div>
-                  <strong>{{ s.votesLastMinute }}</strong>
+                  <strong>{{ formatCount(s.votesLastMinute) }}</strong>
                   <p
                     class="status-help-dialog__metric-hint"
                     i18n="@@app.footer.statusMetricVotesHint"
@@ -207,7 +208,7 @@ export interface ServerStatusHelpDialogData {
                     <mat-icon aria-hidden="true">sync_alt</mat-icon>
                     <span i18n="@@app.footer.statusMetricTransitions">Statuswechsel / Minute</span>
                   </div>
-                  <strong>{{ s.sessionTransitionsLastMinute }}</strong>
+                  <strong>{{ formatCount(s.sessionTransitionsLastMinute) }}</strong>
                   <p
                     class="status-help-dialog__metric-hint"
                     i18n="@@app.footer.statusMetricTransitionsHint"
@@ -220,7 +221,7 @@ export interface ServerStatusHelpDialogData {
                     <mat-icon aria-hidden="true">timer</mat-icon>
                     <span i18n="@@app.footer.statusMetricCountdowns">Countdown-Sessions</span>
                   </div>
-                  <strong>{{ s.activeCountdownSessions }}</strong>
+                  <strong>{{ formatCount(s.activeCountdownSessions) }}</strong>
                   <p
                     class="status-help-dialog__metric-hint"
                     i18n="@@app.footer.statusMetricCountdownsHint"
@@ -262,7 +263,7 @@ export interface ServerStatusHelpDialogData {
           </div>
           <div class="status-help-dialog__record-figure">
             <div class="status-help-dialog__record-number">
-              {{ s.maxParticipantsSingleSession }}
+              {{ formatCount(s.maxParticipantsSingleSession) }}
             </div>
             <div class="status-help-dialog__record-unit" i18n="@@help.statsUnit">Teilnehmende</div>
           </div>
@@ -446,9 +447,13 @@ export class ServerStatusHelpDialogComponent {
     if (!statistics) return null;
 
     return {
-      median: this.formatNumber(statistics.median),
-      standardDeviation: this.formatNumber(statistics.standardDeviation),
-      max: this.formatNumber(statistics.max),
+      median: formatLocaleNumber(statistics.median, this.locale, {
+        maximumFractionDigits: 0,
+      }),
+      standardDeviation: formatLocaleNumber(statistics.standardDeviation, this.locale, {
+        maximumFractionDigits: 0,
+      }),
+      max: formatLocaleCount(statistics.max, this.locale),
     };
   });
 
@@ -520,10 +525,7 @@ export class ServerStatusHelpDialogComponent {
     this.chartRenderer?.destroy();
   }
 
-  private formatNumber(value: number, maximumFractionDigits = 0): string {
-    return new Intl.NumberFormat(this.locale, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits,
-    }).format(value);
+  protected formatCount(value: number): string {
+    return formatLocaleCount(value, this.locale);
   }
 }

--- a/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.ts
+++ b/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.ts
@@ -20,6 +20,7 @@ import {
   localeIdToSupported,
   SUPPORTED_LOCALES,
 } from '../../core/locale-from-path';
+import { formatLocaleBadgeCount, formatLocaleCount } from '../../core/locale-number.util';
 import { MotdHeaderStateService } from '../../core/motd-header-state.service';
 import { MotdArchiveDialogComponent } from '../motd-archive-dialog/motd-archive-dialog.component';
 import { ThemePresetService } from '../../core/theme-preset.service';
@@ -77,7 +78,7 @@ export class TopToolbarComponent {
   /** Badge-Text (max. „99+“). */
   readonly motdArchiveBadgeText = computed(() => {
     const n = this.motdHeaderState.archiveUnreadCount();
-    return n > 99 ? '99+' : String(n);
+    return formatLocaleBadgeCount(n, this.localeId as string);
   });
 
   /** Barrierefrei: Zähler in der Beschriftung, wenn Archiv-Einträge existieren. */
@@ -89,7 +90,7 @@ export class TopToolbarComponent {
     if (n === 1) {
       return $localize`:@@motd.toolbarArchiveAriaOne:News und Archiv, eine ungelesene Meldung`;
     }
-    return $localize`:@@motd.toolbarArchiveAriaCount:News und Archiv, ${n}:INTERPOLATION: ungelesene Meldungen`;
+    return $localize`:@@motd.toolbarArchiveAriaCount:News und Archiv, ${formatLocaleCount(n, this.localeId as string)}:INTERPOLATION: ungelesene Meldungen`;
   });
 
   /** Kurzinfo beim Hover (unterscheidet ungelesene Meldungen). */
@@ -101,7 +102,7 @@ export class TopToolbarComponent {
     if (n === 1) {
       return $localize`:@@motd.toolbarArchiveTooltipUnreadOne:News und Archiv · 1 ungelesene Meldung`;
     }
-    return $localize`:@@motd.toolbarArchiveTooltipUnreadCount:News und Archiv · ${n}:INTERPOLATION: ungelesene Meldungen`;
+    return $localize`:@@motd.toolbarArchiveTooltipUnreadCount:News und Archiv · ${formatLocaleCount(n, this.localeId as string)}:INTERPOLATION: ungelesene Meldungen`;
   });
 
   /** true wenn URL-Locale ≠ de, aber nur ein Build (z. B. Dev) → Hinweis anzeigen. */


### PR DESCRIPTION
## Summary
- Zentrale Hilfsfunktionen in `core/locale-number.util.ts` für Ganzzahlen, Dezimalzahlen, Prozente und Badge-Zähler (`99+`)
- Locale-Formatierung für sichtbare Metriken in Session-UI, Status-Dialog, Feedback, Quiz-Liste, Join und Admin
- Badges (News-Archiv, Quiz-Sammlung) und Aria-Labels/Tooltips nutzen dieselbe Formatierung

## Test plan
- [x] `npm run test -w apps/frontend` (916 Tests)
- [x] Pre-commit: `typecheck` + Monorepo-Tests
- [x] `npm run build:localize -w @arsnova/frontend` (alle 5 Locales, Prerender, MOTD-Assets)
- [ ] Manuell: Status-Dialog → abgeschlossene Sessions zeigen Tausendertrennzeichen (z. B. `2.126` in DE)
- [ ] Manuell: EN-Build `/en/` → gleiche Metrik als `2,126`


Made with [Cursor](https://cursor.com)