### PR TITLE
chore(ci): Workflow- und Run-Namen in Actions unterscheidbar machen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,15 @@
 # Deploy: Nur bei Push auf main, nach allen Tests; optional eigener Branch (s. unten).
 # =============================================================================
 
-name: CI
+name: CI · Build & Tests
+
+run-name: >-
+  CI · ${{
+    github.event_name == 'schedule' && 'Nightly' ||
+    github.event_name == 'workflow_dispatch' && 'Manual' ||
+    github.event_name == 'pull_request' && format('PR #{0}', github.event.pull_request.number) ||
+    github.ref_name
+  }}
 
 on:
   push:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,12 @@
-name: CodeQL
+name: Security · CodeQL (SAST)
+
+run-name: >-
+  SAST · ${{
+    github.event_name == 'schedule' && 'Weekly' ||
+    github.event_name == 'workflow_dispatch' && 'Manual' ||
+    github.event_name == 'pull_request' && format('PR #{0}', github.event.pull_request.number) ||
+    github.ref_name
+  }}
 
 on:
   push:


### PR DESCRIPTION
## Summary
- `ci.yml`: Workflow heißt jetzt `CI · Build & Tests`, Runs z. B. `CI · PR #62` / `CI · Nightly` / `CI · main`
- `codeql.yml`: Workflow heißt `Security · CodeQL (SAST)`, Runs z. B. `SAST · PR #62` / `SAST · Weekly`

## Test plan
- [ ] Nach Merge: neuer PR zeigt in Actions zwei klar unterscheidbare Run-Titel statt nur identischem Commit-Titel


Made with [Cursor](https://cursor.com)