### PR TITLE
chore(deps): @y/websocket-server von Dependabot ignorieren

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular-devkit/*'
         update-types: ['version-update:semver-major']
+      # @y/websocket-server 0.1.5 kollidiert mit @y/y (yjs 14) und Root-Override (yjs 13.6.31).
+      # exclude-patterns in groups reicht nicht — Dependabot öffnet sonst weiterhin Einzel-PRs.
+      - dependency-name: '@y/websocket-server'
     groups:
       angular:
         patterns:


### PR DESCRIPTION
## Summary
Adressiert [Codex-Review auf #64](https://github.com/kqc-real/arsnova.eu/pull/64#pullrequestreview-4682114108): `exclude-patterns` in Dependabot-Gruppen verhindert nur Gruppen-PRs, nicht Einzel-Bumps für `@y/websocket-server`.

- `ignore`-Eintrag für `@y/websocket-server` bis zur yjs-Abstimmung (`@y/y` 14 vs. Root-Override 13.6.31)
- Verhindert wiederkehrende fehlschlagende Einzel-PRs wie #58

## Test plan
- [x] YAML-Änderung
- [ ] Nach Merge: kein neuer `@y/websocket-server`-Einzel-PR vom Weekly-Job


Made with [Cursor](https://cursor.com)