### PR TITLE
fix(shared-types): ESM-Import confidence in schemas.js

### DIFF
--- a/libs/shared-types/package.json
+++ b/libs/shared-types/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/fix-esm-imports.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit"

--- a/libs/shared-types/scripts/fix-esm-imports.mjs
+++ b/libs/shared-types/scripts/fix-esm-imports.mjs
@@ -1,0 +1,42 @@
+/**
+ * Patches relative imports in dist/*.js for Node ESM (requires explicit .js extensions).
+ * Source may use extensionless paths for Angular/Webpack workspace resolution.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist');
+
+function patchRelativeImports(source) {
+  return source.replace(
+    /(from\s+['"])(\.\.?\/[^'"]+?)(['"])/g,
+    (match, prefix, specifier, suffix) => {
+      if (specifier.endsWith('.js')) {
+        return match;
+      }
+      return `${prefix}${specifier}.js${suffix}`;
+    },
+  );
+}
+
+if (!fs.existsSync(distDir)) {
+  console.error('fix-esm-imports: dist directory missing — run tsc first');
+  process.exit(1);
+}
+
+let patchedFiles = 0;
+for (const entry of fs.readdirSync(distDir, { withFileTypes: true })) {
+  if (!entry.isFile() || !entry.name.endsWith('.js')) {
+    continue;
+  }
+  const filePath = path.join(distDir, entry.name);
+  const original = fs.readFileSync(filePath, 'utf8');
+  const patched = patchRelativeImports(original);
+  if (patched !== original) {
+    fs.writeFileSync(filePath, patched);
+    patchedFiles += 1;
+  }
+}
+
+console.log(`fix-esm-imports: patched ${patchedFiles} file(s) in dist/`);

--- a/libs/shared-types/src/schemas.ts
+++ b/libs/shared-types/src/schemas.ts
@@ -3,7 +3,7 @@ import {
   CONFIDENCE_SCALE_MAX,
   CONFIDENCE_SCALE_MIN,
   questionSupportsConfidence,
-} from './confidence';
+} from './confidence.js';
 
 // ---------------------------------------------------------------------------
 // Enums – müssen mit Prisma-Schema synchron bleiben

--- a/libs/shared-types/src/schemas.ts
+++ b/libs/shared-types/src/schemas.ts
@@ -3,7 +3,7 @@ import {
   CONFIDENCE_SCALE_MAX,
   CONFIDENCE_SCALE_MIN,
   questionSupportsConfidence,
-} from './confidence.js';
+} from './confidence';
 
 // ---------------------------------------------------------------------------
 // Enums – müssen mit Prisma-Schema synchron bleiben


### PR DESCRIPTION
## Summary
- Behebt `ERR_MODULE_NOT_FOUND` für `./confidence` beim Backend-Start im Docker-Image (Deploy nach #77).

## Test plan
- [x] `npm test` lokal grün
- [ ] CI Deploy erneut grün

Made with [Cursor](https://cursor.com)