### PR TITLE
fix(docker): ESM-Postbuild nach tsc -b für shared-types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
 
       - name: TypeScript build – shared-types + backend
         if: needs.changes.outputs.docs_only != 'true'
-        run: npx tsc -b apps/backend/tsconfig.json
+        run: npx tsc -b apps/backend/tsconfig.json && node libs/shared-types/scripts/fix-esm-imports.mjs
 
       - name: TypeScript compile – frontend
         if: needs.changes.outputs.docs_only != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
 
       - name: TypeScript build – shared-types + backend
         if: needs.changes.outputs.docs_only != 'true'
-        run: npx tsc -b apps/backend/tsconfig.json && node libs/shared-types/scripts/fix-esm-imports.mjs
+        run: npx tsc -b apps/backend/tsconfig.json && node scripts/fix-esm-imports.mjs
 
       - name: TypeScript compile – frontend
         if: needs.changes.outputs.docs_only != 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,10 @@ COPY prisma/ prisma/
 # Generate Prisma client
 RUN npx prisma generate
 
-# Build shared-types + backend (tsc -b handles project references)
-RUN npx tsc -b apps/backend/tsconfig.json
+# Build shared-types + backend (tsc -b handles project references).
+# Postbuild: Node ESM in production requires explicit .js extensions in dist/.
+RUN npx tsc -b apps/backend/tsconfig.json \
+    && node libs/shared-types/scripts/fix-esm-imports.mjs
 
 # Build frontend localized (de/en) including root redirect index
 RUN npm run build:localize -w @arsnova/frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,11 @@ COPY prisma/ prisma/
 RUN npx prisma generate
 
 # Build shared-types + backend (tsc -b handles project references).
-# Postbuild: Node ESM in production requires explicit .js extensions in dist/.
+# Postbuild: Node ESM in production requires explicit .js extensions in dist/
+# for every ESM workspace emitted by tsc -b (shared-types + session-export-report).
+COPY scripts/fix-esm-imports.mjs scripts/fix-esm-imports.mjs
 RUN npx tsc -b apps/backend/tsconfig.json \
-    && node libs/shared-types/scripts/fix-esm-imports.mjs
+    && node scripts/fix-esm-imports.mjs
 
 # Build frontend localized (de/en) including root redirect index
 RUN npm run build:localize -w @arsnova/frontend

--- a/libs/session-export-report/package.json
+++ b/libs/session-export-report/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node ../../scripts/fix-esm-imports.mjs dist",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/libs/shared-types/scripts/fix-esm-imports.mjs
+++ b/libs/shared-types/scripts/fix-esm-imports.mjs
@@ -1,42 +1,15 @@
 /**
- * Patches relative imports in dist/*.js for Node ESM (requires explicit .js extensions).
- * Source may use extensionless paths for Angular/Webpack workspace resolution.
+ * Thin wrapper: package-local build still runs via `npm run build -w @arsnova/shared-types`.
+ * Canonical implementation lives in scripts/fix-esm-imports.mjs.
  */
-import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const distDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist');
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = path.resolve(packageRoot, '../..');
+const script = path.join(repoRoot, 'scripts/fix-esm-imports.mjs');
+const distDir = path.join(packageRoot, 'dist');
 
-function patchRelativeImports(source) {
-  return source.replace(
-    /(from\s+['"])(\.\.?\/[^'"]+?)(['"])/g,
-    (match, prefix, specifier, suffix) => {
-      if (specifier.endsWith('.js')) {
-        return match;
-      }
-      return `${prefix}${specifier}.js${suffix}`;
-    },
-  );
-}
-
-if (!fs.existsSync(distDir)) {
-  console.error('fix-esm-imports: dist directory missing — run tsc first');
-  process.exit(1);
-}
-
-let patchedFiles = 0;
-for (const entry of fs.readdirSync(distDir, { withFileTypes: true })) {
-  if (!entry.isFile() || !entry.name.endsWith('.js')) {
-    continue;
-  }
-  const filePath = path.join(distDir, entry.name);
-  const original = fs.readFileSync(filePath, 'utf8');
-  const patched = patchRelativeImports(original);
-  if (patched !== original) {
-    fs.writeFileSync(filePath, patched);
-    patchedFiles += 1;
-  }
-}
-
-console.log(`fix-esm-imports: patched ${patchedFiles} file(s) in dist/`);
+const result = spawnSync(process.execPath, [script, distDir], { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/scripts/fix-esm-imports.mjs
+++ b/scripts/fix-esm-imports.mjs
@@ -54,9 +54,7 @@ function patchDistDir(distDir) {
 }
 
 const distDirs =
-  process.argv.length > 2
-    ? process.argv.slice(2).map((arg) => path.resolve(arg))
-    : defaultDistDirs;
+  process.argv.length > 2 ? process.argv.slice(2).map((arg) => path.resolve(arg)) : defaultDistDirs;
 
 for (const distDir of distDirs) {
   patchDistDir(distDir);

--- a/scripts/fix-esm-imports.mjs
+++ b/scripts/fix-esm-imports.mjs
@@ -1,0 +1,63 @@
+/**
+ * Patches relative imports in dist/*.js for Node ESM (requires explicit .js extensions).
+ * Source may use extensionless paths for Angular/Webpack workspace resolution.
+ *
+ * Usage:
+ *   node scripts/fix-esm-imports.mjs [distDir ...]
+ * Defaults to libs/shared-types/dist and libs/session-export-report/dist.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const defaultDistDirs = [
+  path.join(repoRoot, 'libs/shared-types/dist'),
+  path.join(repoRoot, 'libs/session-export-report/dist'),
+];
+
+function patchRelativeImports(source) {
+  return source.replace(
+    /(from\s+['"])(\.\.?\/[^'"]+?)(['"])/g,
+    (match, prefix, specifier, suffix) => {
+      if (specifier.endsWith('.js')) {
+        return match;
+      }
+      return `${prefix}${specifier}.js${suffix}`;
+    },
+  );
+}
+
+function patchDistDir(distDir) {
+  if (!fs.existsSync(distDir)) {
+    console.error(`fix-esm-imports: dist directory missing: ${distDir}`);
+    process.exit(1);
+  }
+
+  let patchedFiles = 0;
+  for (const entry of fs.readdirSync(distDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.js')) {
+      continue;
+    }
+    const filePath = path.join(distDir, entry.name);
+    const original = fs.readFileSync(filePath, 'utf8');
+    const patched = patchRelativeImports(original);
+    if (patched !== original) {
+      fs.writeFileSync(filePath, patched);
+      patchedFiles += 1;
+    }
+  }
+
+  const label = path.relative(repoRoot, distDir) || distDir;
+  console.log(`fix-esm-imports: patched ${patchedFiles} file(s) in ${label}/`);
+}
+
+const distDirs =
+  process.argv.length > 2
+    ? process.argv.slice(2).map((arg) => path.resolve(arg))
+    : defaultDistDirs;
+
+for (const distDir of distDirs) {
+  patchDistDir(distDir);
+}


### PR DESCRIPTION
## Summary
- Deploy auf `main` scheiterte am Healthcheck (180s Timeout), weil das Docker-Image `tsc -b` nutzt und damit `fix-esm-imports.mjs` überspringt
- `dist/schemas.js` behält dann `from './confidence'` → Node ESM startet im Container nicht
- Postbuild-Schritt nach `tsc -b` in Dockerfile und CI ergänzt

## Test plan
- [x] Lokal: `tsc -b` + `fix-esm-imports.mjs` → Node-Import OK
- [ ] CI grün
- [ ] Deploy-Healthcheck grün nach Merge

Made with [Cursor](https://cursor.com)