### PR TITLE
fix(export): leere Vorschau/PDF und fehlendes CSV-Icon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,20 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 # Security-Patches des unveränderlich referenzierten Alpine-Basisimages einspielen.
-RUN apk upgrade --no-cache
+# Chromium für Server-PDF (Playwright nutzt System-Binary, kein Browser-Download).
+RUN apk upgrade --no-cache \
+    && apk add --no-cache \
+      chromium \
+      nss \
+      freetype \
+      harfbuzz \
+      ca-certificates \
+      ttf-freefont \
+      font-noto
+
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium \
+    PUBLIC_FRONTEND_URL=http://127.0.0.1:3000
 
 # Copy package manifests + npm config, install production deps only
 COPY package.json package-lock.json .npmrc ./

--- a/apps/backend/src/lib/session-export-asset-reader.ts
+++ b/apps/backend/src/lib/session-export-asset-reader.ts
@@ -6,6 +6,10 @@ function candidateAssetRoots(): string[] {
   const fromEnv = process.env.SESSION_EXPORT_ASSET_ROOT?.trim();
   const candidates = [
     fromEnv,
+    // Production Docker: lokalisiertes Angular-Build unter apps/frontend/dist/{locale}
+    join(cwd, 'apps/frontend/dist/de/assets'),
+    join(cwd, 'apps/frontend/dist/en/assets'),
+    join(cwd, 'apps/frontend/dist/assets'),
     join(cwd, 'apps/frontend/src/assets'),
     join(cwd, '../frontend/src/assets'),
     join(cwd, '../../apps/frontend/src/assets'),

--- a/apps/backend/src/lib/session-results-report-pdf.ts
+++ b/apps/backend/src/lib/session-results-report-pdf.ts
@@ -1,4 +1,5 @@
-import { chromium } from 'playwright';
+import { existsSync } from 'node:fs';
+import { chromium, type Browser, type LaunchOptions } from 'playwright';
 import type { SessionExportDTO } from '@arsnova/shared-types';
 import {
   buildSessionResultsReportHtml,
@@ -19,8 +20,31 @@ function resolveExportAssetBaseUrl(): string {
   return (
     process.env.SESSION_EXPORT_ASSET_BASE_URL?.trim() ||
     process.env.PUBLIC_FRONTEND_URL?.trim() ||
-    'http://127.0.0.1:4200'
+    `http://127.0.0.1:${process.env.PORT?.trim() || '3000'}`
   ).replace(/\/$/, '');
+}
+
+function resolveChromiumExecutablePath(): string | undefined {
+  const fromEnv =
+    process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH?.trim() || process.env.CHROMIUM_PATH?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  for (const candidate of ['/usr/bin/chromium-browser', '/usr/bin/chromium']) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function resolveChromiumLaunchOptions(): LaunchOptions {
+  return {
+    headless: true,
+    executablePath: resolveChromiumExecutablePath(),
+    // Docker/Alpine: kein Sandbox-Namespace, kleines /dev/shm
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  };
 }
 
 export async function buildSessionResultsPdf(
@@ -40,10 +64,13 @@ export async function buildSessionResultsPdf(
     fetchExternal: true,
     maxImageBytes: 400_000,
   });
-  const browser = await chromium.launch({ headless: true });
+
+  let browser: Browser | undefined;
   try {
+    browser = await chromium.launch(resolveChromiumLaunchOptions());
     const page = await browser.newPage();
-    await page.setContent(html, { waitUntil: 'networkidle' });
+    // `load` statt `networkidle`: fehlende Asset-URLs sollen den PDF-Export nicht hängen lassen.
+    await page.setContent(html, { waitUntil: 'load', timeout: 60_000 });
     return Buffer.from(
       await page.pdf(
         buildSessionResultsPlaywrightPdfOptions(labels, {
@@ -53,6 +80,6 @@ export async function buildSessionResultsPdf(
       ),
     );
   } finally {
-    await browser.close();
+    await browser?.close();
   }
 }

--- a/apps/frontend/src/app/core/session-results-report-print.util.spec.ts
+++ b/apps/frontend/src/app/core/session-results-report-print.util.spec.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  openSessionResultsReportPreview,
+  printSessionResultsReport,
+} from './session-results-report-print.util';
+
+function mockWritableWindow(): Window {
+  const doc = {
+    open: vi.fn(),
+    write: vi.fn(),
+    close: vi.fn(),
+    title: '',
+    readyState: 'complete',
+    addEventListener: vi.fn(),
+  };
+  return {
+    document: doc,
+    opener: {} as Window,
+    focus: vi.fn(),
+    print: vi.fn(),
+    addEventListener: vi.fn(),
+  } as unknown as Window;
+}
+
+describe('session-results-report-print.util', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('schreibt Vorschau-HTML in ein schreibbares Fenster und löst opener', () => {
+    const previewWindow = mockWritableWindow();
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
+
+    const opened = openSessionResultsReportPreview(
+      '<html><body><p>Bericht</p></body></html>',
+      'Titel',
+      'Drucken',
+    );
+
+    expect(opened).toBe(true);
+    expect(openSpy).toHaveBeenCalledWith('', '_blank');
+    expect(previewWindow.opener).toBeNull();
+    expect(previewWindow.document.write).toHaveBeenCalled();
+    const written = String(vi.mocked(previewWindow.document.write).mock.calls[0]?.[0] ?? '');
+    expect(written).toContain('Bericht');
+    expect(written).toContain('report-preview-toolbar');
+  });
+
+  it('gibt false zurück, wenn das Popup blockiert ist', () => {
+    vi.spyOn(window, 'open').mockReturnValue(null);
+    expect(openSessionResultsReportPreview('<html><body></body></html>', 'Titel')).toBe(false);
+    expect(printSessionResultsReport('<html><body></body></html>', 'Titel')).toBe(false);
+  });
+
+  it('öffnet den Druckdialog nach dem Schreiben', () => {
+    const printWindow = mockWritableWindow();
+    vi.spyOn(window, 'open').mockReturnValue(printWindow);
+
+    expect(printSessionResultsReport('<html><body><p>PDF</p></body></html>', 'Titel')).toBe(true);
+    expect(printWindow.print).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/core/session-results-report-print.util.ts
+++ b/apps/frontend/src/app/core/session-results-report-print.util.ts
@@ -31,8 +31,23 @@ function injectPreviewToolbar(html: string, printLabel: string): string {
   return html.replace('<body>', `<body>${toolbar}`);
 }
 
+/**
+ * Opens a blank tab we can write into.
+ * Do NOT pass `noopener` in the features string — modern Chromium then returns
+ * `null` while still opening an empty tab (broken preview + false "blocked" errors).
+ * Detach via `opener = null` after we have the Window reference.
+ */
+function openWritableReportWindow(): Window | null {
+  const reportWindow = window.open('', '_blank');
+  if (!reportWindow) {
+    return null;
+  }
+  reportWindow.opener = null;
+  return reportWindow;
+}
+
 export function printSessionResultsReport(html: string, documentTitle: string): boolean {
-  const printWindow = window.open('', '_blank', 'noopener,noreferrer');
+  const printWindow = openWritableReportWindow();
   if (!printWindow) {
     return false;
   }
@@ -57,7 +72,7 @@ export function openSessionResultsReportPreview(
   documentTitle: string,
   printLabel = 'Als PDF drucken',
 ): boolean {
-  const previewWindow = window.open('', '_blank', 'noopener,noreferrer');
+  const previewWindow = openWritableReportWindow();
   if (!previewWindow) {
     return false;
   }

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -199,7 +199,7 @@
               </div>
             </li>
             <li class="help-qa-feature">
-              <mat-icon class="help-qa-feature__icon" aria-hidden="true">grid_on</mat-icon>
+              <mat-icon class="help-qa-feature__icon" aria-hidden="true">fact_check</mat-icon>
               <div class="help-qa-feature__body">
                 <h3 i18n="@@help.confidenceHostTitle">Host-Auswertung nach Freigabe</h3>
                 <p i18n="@@help.confidenceHostBody">

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -1199,7 +1199,7 @@
                         matTooltip="Tabellarische Rohdaten für Tabellenkalkulation – weniger Details als der PDF-Bericht."
                         matTooltipPosition="left"
                       >
-                        <mat-icon aria-hidden="true">grid_on</mat-icon>
+                        <mat-icon aria-hidden="true">fact_check</mat-icon>
                         <span i18n="@@sessionHost.exportCsvExcelMenuItem"
                           >Für Excel exportieren</span
                         >

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -7735,7 +7735,7 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
   describe('Host-Steering-Callout bei Störfällen', () => {
     const steeringTitle = 'Das ist gerade nicht angekommen';
     const qaCalloutTitle = 'Mit den Fragen klappt es gerade nicht';
-    const exportCalloutTitle = 'Die Tabelle war noch nicht bereit';
+    const exportCalloutTitle = 'Export noch nicht bereit';
 
     const calloutEl = (fixture: ReturnType<typeof setup>) =>
       fixture.nativeElement.querySelector('.session-host__steering-callout') as HTMLElement | null;

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -2403,8 +2403,8 @@ export class SessionHostComponent implements OnInit, OnDestroy {
 
   private openHostSteeringCalloutForExportFailure(retry: () => void): void {
     this.hostSteeringCallout.set({
-      title: $localize`:@@sessionHost.steeringCalloutExportTitle:Die Tabelle war noch nicht bereit`,
-      body: $localize`:@@sessionHost.steeringCalloutExportBody:Die Übersicht zum Herunterladen ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.`,
+      title: $localize`:@@sessionHost.steeringCalloutExportTitle:Export noch nicht bereit`,
+      body: $localize`:@@sessionHost.steeringCalloutExportBody:PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.`,
       retry,
     });
   }

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -12992,16 +12992,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
-        <source>Die Tabelle war noch nicht bereit</source>
-        <target>Your spreadsheet wasn’t ready yet</target>
+        <source>Export noch nicht bereit</source>
+        <target>Export isn’t ready yet</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>Die Übersicht zum Herunterladen ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
-        <target>We couldn’t get your download ready that time. Wait a few seconds, tap Try again — a second try usually sorts it.</target>
+        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <target>PDF, preview or Excel export didn’t go through that time. Wait a few seconds, tap Try again — a second try usually sorts it.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -12934,16 +12934,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
-        <source>Die Tabelle war noch nicht bereit</source>
-        <target>La tabla aún no estaba lista</target>
+        <source>Export noch nicht bereit</source>
+        <target>Exportación aún no lista</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>Die Übersicht zum Herunterladen ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
-        <target>La descarga no ha salido redonda esta vez. Espera unos segundos y pulsa « Probar otra vez » — el segundo intento suele ir bien.</target>
+        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <target>PDF, vista previa o exportación a Excel no ha salido redonda esta vez. Espera unos segundos y pulsa « Probar otra vez » — el segundo intento suele ir bien.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -12934,16 +12934,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
-        <source>Die Tabelle war noch nicht bereit</source>
-        <target>Le tableau n’était pas encore prêt</target>
+        <source>Export noch nicht bereit</source>
+        <target>Export pas encore prêt</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>Die Übersicht zum Herunterladen ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
-        <target>Le fichier à télécharger n’est pas passé cette fois. Attends quelques secondes et appuie sur « Réessayer » — le deuxième essai fait souvent l’affaire.</target>
+        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <target>PDF, aperçu ou export Excel n’est pas passé cette fois. Attends quelques secondes et appuie sur « Réessayer » — le deuxième essai fait souvent l’affaire.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -12934,16 +12934,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
-        <source>Die Tabelle war noch nicht bereit</source>
-        <target>Il foglio non era ancora pronto</target>
+        <source>Export noch nicht bereit</source>
+        <target>Export non ancora pronto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>Die Übersicht zum Herunterladen ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
-        <target>Il file non è arrivato questa volta. Aspetta qualche secondo e tocca « Riprova » — al secondo tentativo di solito va.</target>
+        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <target>PDF, anteprima o export Excel non è arrivato questa volta. Aspetta qualche secondo e tocca « Riprova » — al secondo tentativo di solito va.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -11470,14 +11470,14 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
-        <source>Die Tabelle war noch nicht bereit</source>
+        <source>Export noch nicht bereit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>Die Übersicht zum Herunterladen ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       WS_PORT: "3001"
       YJS_WS_PORT: "3002"
       NODE_ENV: "production"
+      PUBLIC_FRONTEND_URL: "http://127.0.0.1:3000"
+      PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH: "/usr/bin/chromium"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- **Rote Fehlermeldung / leere Vorschau:** `window.open(..., 'noopener,noreferrer')` liefert in Chromium `null`, öffnet aber trotzdem einen leeren Tab — behoben durch schreibbares Fenster + `opener = null`
- **Leeres/fehlgeschlagenes PDF:** Playwright-Chromium fehlte im Production-Image; jetzt System-Chromium + Docker-Args, `waitUntil: 'load'`, korrektere Asset-Roots/`PUBLIC_FRONTEND_URL`
- **CSV-Icon unter „Mehr“:** `grid_on` fehlt im selbst gehosteten Material-Icons-Subset → `fact_check` (bereits in der App genutzt)
- Export-Callout-Text formatneutral (nicht nur „Tabelle/Spreadsheet“)

## Test plan
- [ ] Session mit 1 Teilnehmer beenden → Vorschau zeigt Bericht (kein leerer Tab, kein Callout)
- [ ] PDF-Download liefert befülltes PDF
- [ ] „Mehr“ → „Für Excel exportieren“ zeigt Icon
- [ ] Bei absichtlich blockiertem Popup erscheint der neue Callout-Text

Made with [Cursor](https://cursor.com)