### PR TITLE
fix(export): HTML-Vorschau entfernen

### DIFF
--- a/apps/frontend/src/app/core/session-results-report-print.util.spec.ts
+++ b/apps/frontend/src/app/core/session-results-report-print.util.spec.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  openSessionResultsReportPreview,
-  printSessionResultsReport,
-} from './session-results-report-print.util';
+import { printSessionResultsReport } from './session-results-report-print.util';
 
 function mockWritableWindow(): Window {
   const doc = {
@@ -27,36 +24,19 @@ describe('session-results-report-print.util', () => {
     vi.restoreAllMocks();
   });
 
-  it('schreibt Vorschau-HTML in ein schreibbares Fenster und löst opener', () => {
-    const previewWindow = mockWritableWindow();
-    const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
-
-    const opened = openSessionResultsReportPreview(
-      '<html><body><p>Bericht</p></body></html>',
-      'Titel',
-      'Drucken',
-    );
-
-    expect(opened).toBe(true);
-    expect(openSpy).toHaveBeenCalledWith('', '_blank');
-    expect(previewWindow.opener).toBeNull();
-    expect(previewWindow.document.write).toHaveBeenCalled();
-    const written = String(vi.mocked(previewWindow.document.write).mock.calls[0]?.[0] ?? '');
-    expect(written).toContain('Bericht');
-    expect(written).toContain('report-preview-toolbar');
-  });
-
   it('gibt false zurück, wenn das Popup blockiert ist', () => {
     vi.spyOn(window, 'open').mockReturnValue(null);
-    expect(openSessionResultsReportPreview('<html><body></body></html>', 'Titel')).toBe(false);
     expect(printSessionResultsReport('<html><body></body></html>', 'Titel')).toBe(false);
   });
 
-  it('öffnet den Druckdialog nach dem Schreiben', () => {
+  it('schreibt HTML und öffnet den Druckdialog', () => {
     const printWindow = mockWritableWindow();
-    vi.spyOn(window, 'open').mockReturnValue(printWindow);
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(printWindow);
 
     expect(printSessionResultsReport('<html><body><p>PDF</p></body></html>', 'Titel')).toBe(true);
+    expect(openSpy).toHaveBeenCalledWith('', '_blank');
+    expect(printWindow.opener).toBeNull();
+    expect(printWindow.document.write).toHaveBeenCalled();
     expect(printWindow.print).toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/core/session-results-report-print.util.ts
+++ b/apps/frontend/src/app/core/session-results-report-print.util.ts
@@ -1,41 +1,8 @@
-const PREVIEW_TOOLBAR_STYLES = `
-.report-preview-toolbar {
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-  padding: 0.65rem 0.85rem;
-  border-bottom: 1px solid #d8dee6;
-  background: #f6f8fb;
-  font: 13px/1.4 system-ui, sans-serif;
-}
-.report-preview-toolbar button {
-  border: 1px solid #90caf9;
-  background: #e3f2fd;
-  color: #0d47a1;
-  border-radius: 0.45rem;
-  padding: 0.35rem 0.75rem;
-  cursor: pointer;
-  font: inherit;
-}
-@media print {
-  .report-preview-toolbar { display: none !important; }
-}
-`;
-
-function injectPreviewToolbar(html: string, printLabel: string): string {
-  const toolbar = `<div class="report-preview-toolbar"><strong>Vorschau</strong><button type="button" onclick="window.print()">${printLabel}</button></div><style>${PREVIEW_TOOLBAR_STYLES}</style>`;
-  return html.replace('<body>', `<body>${toolbar}`);
-}
-
 /**
- * Opens a blank tab we can write into.
+ * Opens a blank tab we can write into for the PDF print fallback.
  * Do NOT pass `noopener` in the features string — modern Chromium then returns
- * `null` while still opening an empty tab (broken preview + false "blocked" errors).
- * Detach via `opener = null` after we have the Window reference.
+ * `null` while still opening an empty tab. Detach via `opener = null` after we
+ * have the Window reference.
  */
 function openWritableReportWindow(): Window | null {
   const reportWindow = window.open('', '_blank');
@@ -46,6 +13,10 @@ function openWritableReportWindow(): Window | null {
   return reportWindow;
 }
 
+/**
+ * Fallback when server-side Playwright PDF fails: open the report HTML and
+ * trigger the browser print dialog („Als PDF speichern“).
+ */
 export function printSessionResultsReport(html: string, documentTitle: string): boolean {
   const printWindow = openWritableReportWindow();
   if (!printWindow) {
@@ -64,21 +35,5 @@ export function printSessionResultsReport(html: string, documentTitle: string): 
   } else {
     printWindow.addEventListener('load', triggerPrint, { once: true });
   }
-  return true;
-}
-
-export function openSessionResultsReportPreview(
-  html: string,
-  documentTitle: string,
-  printLabel = 'Als PDF drucken',
-): boolean {
-  const previewWindow = openWritableReportWindow();
-  if (!previewWindow) {
-    return false;
-  }
-  previewWindow.document.open();
-  previewWindow.document.write(injectPreviewToolbar(html, printLabel));
-  previewWindow.document.close();
-  previewWindow.document.title = documentTitle;
   return true;
 }

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -1169,17 +1169,6 @@
                     <button
                       matButton="tonal"
                       type="button"
-                      (click)="previewSessionResultsReport()"
-                      [disabled]="exportExporting()"
-                      i18n-aria-label="@@sessionHost.exportPdfPreviewButtonAria"
-                      aria-label="Ergebnisbericht in Vorschau anzeigen"
-                    >
-                      <mat-icon>visibility</mat-icon>
-                      <span i18n="@@sessionHost.exportPdfPreviewButton">Vorschau</span>
-                    </button>
-                    <button
-                      matButton="tonal"
-                      type="button"
                       [matMenuTriggerFor]="sessionExportMoreMenu"
                       [disabled]="exportExporting()"
                       i18n-aria-label="@@sessionHost.exportMoreButtonAria"

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -129,10 +129,7 @@ import {
   buildSessionResultsCsvFilename,
 } from '../../../core/export-filename.util';
 import { stripMarkdownToPlainText } from '../../../core/markdown-plain-text.util';
-import {
-  printSessionResultsReport,
-  openSessionResultsReportPreview,
-} from '../../../core/session-results-report-print.util';
+import { printSessionResultsReport } from '../../../core/session-results-report-print.util';
 import { getSessionResultsReportLabels } from '../../../core/session-results-report-labels';
 import { buildSessionResultsReportHtml } from '../../../core/session-results-report.util';
 import { inlineExportImagesInHtml } from '@arsnova/session-export-report';
@@ -2404,7 +2401,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   private openHostSteeringCalloutForExportFailure(retry: () => void): void {
     this.hostSteeringCallout.set({
       title: $localize`:@@sessionHost.steeringCalloutExportTitle:Export noch nicht bereit`,
-      body: $localize`:@@sessionHost.steeringCalloutExportBody:PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.`,
+      body: $localize`:@@sessionHost.steeringCalloutExportBody:PDF- oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.`,
       retry,
     });
   }
@@ -6100,42 +6097,6 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       this.dismissHostSteeringCallout();
     } catch {
       this.openHostSteeringCalloutForExportFailure(() => void this.exportSessionResultsPdf());
-    } finally {
-      this.exportExporting.set(false);
-    }
-  }
-
-  async previewSessionResultsReport(): Promise<void> {
-    if (!this.code || this.exportExporting()) return;
-    this.exportStatus.set(null);
-    this.exportExporting.set(true);
-    try {
-      const exportData = await trpc.session.getExportData.query({
-        code: this.code.toUpperCase(),
-      });
-      const labels = getSessionResultsReportLabels();
-      const assetBaseUrl = window.location.origin;
-      let html = buildSessionResultsReportHtml(exportData, labels, {
-        localeId: this.localeId,
-        assetBaseUrl,
-        pageNumbersViaCss: true,
-      });
-      html = await inlineExportImagesInHtml(html, { fetchExternal: true, maxImageBytes: 400_000 });
-      const documentTitle = `${labels.documentTitle} — ${exportData.quizName}`;
-      const opened = openSessionResultsReportPreview(
-        html,
-        documentTitle,
-        $localize`:@@sessionHost.exportPdfPreviewPrint:Als PDF drucken`,
-      );
-      if (!opened) {
-        throw new Error('preview window blocked');
-      }
-      this.exportStatus.set(
-        $localize`:@@sessionHost.exportPdfPreviewDone:Berichtsvorschau geöffnet.`,
-      );
-      this.dismissHostSteeringCallout();
-    } catch {
-      this.openHostSteeringCalloutForExportFailure(() => void this.previewSessionResultsReport());
     } finally {
       this.exportExporting.set(false);
     }

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -11685,23 +11685,6 @@
           <context context-type="linenumber">1167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButtonAria" datatype="html">
-        <source>Ergebnisbericht in Vorschau anzeigen</source>
-        <target>Preview results report</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButton" datatype="html">
-        <source>Vorschau</source>
-        <target>Preview
-        </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1178</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <target>More export options</target>
@@ -13000,8 +12983,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
-        <target>PDF, preview or Excel export didn’t go through that time. Wait a few seconds, tap Try again — a second try usually sorts it.</target>
+        <source>PDF- oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <target>PDF or Excel export didn’t go through that time. Wait a few seconds, tap Try again — a second try usually sorts it.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>
@@ -14318,22 +14301,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6098</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewPrint" datatype="html">
-        <source>Als PDF drucken</source>
-        <target>Print as PDF</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewDone" datatype="html">
-        <source>Berichtsvorschau geöffnet.</source>
-        <target>Report preview opened.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -11629,22 +11629,6 @@
           <context context-type="linenumber">1167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButtonAria" datatype="html">
-        <source>Ergebnisbericht in Vorschau anzeigen</source>
-        <target>Vista previa del informe de resultados</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButton" datatype="html">
-        <source>Vorschau</source>
-        <target>avance</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1178</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <target>Más opciones de exportación</target>
@@ -12942,8 +12926,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
-        <target>PDF, vista previa o exportación a Excel no ha salido redonda esta vez. Espera unos segundos y pulsa « Probar otra vez » — el segundo intento suele ir bien.</target>
+        <source>PDF- oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <target>La exportación a PDF o Excel no ha salido redonda esta vez. Espera unos segundos y pulsa « Probar otra vez » — el segundo intento suele ir bien.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>
@@ -14261,22 +14245,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6098</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewPrint" datatype="html">
-        <source>Als PDF drucken</source>
-        <target>Imprimir como PDF</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewDone" datatype="html">
-        <source>Berichtsvorschau geöffnet.</source>
-        <target>Vista previa del informe abierta.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -11629,22 +11629,6 @@
           <context context-type="linenumber">1167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButtonAria" datatype="html">
-        <source>Ergebnisbericht in Vorschau anzeigen</source>
-        <target>Aperçu du rapport des résultats</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButton" datatype="html">
-        <source>Vorschau</source>
-        <target>aperçu</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1178</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <target>Plus d&apos;options d&apos;exportation</target>
@@ -12942,8 +12926,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
-        <target>PDF, aperçu ou export Excel n’est pas passé cette fois. Attends quelques secondes et appuie sur « Réessayer » — le deuxième essai fait souvent l’affaire.</target>
+        <source>PDF- oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <target>L’export PDF ou Excel n’est pas passé cette fois. Attends quelques secondes et appuie sur « Réessayer » — le deuxième essai fait souvent l’affaire.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>
@@ -14261,22 +14245,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6098</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewPrint" datatype="html">
-        <source>Als PDF drucken</source>
-        <target>Imprimer au format PDF</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewDone" datatype="html">
-        <source>Berichtsvorschau geöffnet.</source>
-        <target>Aperçu du rapport ouvert.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -11629,22 +11629,6 @@
           <context context-type="linenumber">1167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButtonAria" datatype="html">
-        <source>Ergebnisbericht in Vorschau anzeigen</source>
-        <target>Anteprima del rapporto sui risultati</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButton" datatype="html">
-        <source>Vorschau</source>
-        <target>anteprima</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1178</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <target>Altre opzioni di esportazione</target>
@@ -12942,8 +12926,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
-        <target>PDF, anteprima o export Excel non è arrivato questa volta. Aspetta qualche secondo e tocca « Riprova » — al secondo tentativo di solito va.</target>
+        <source>PDF- oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <target>L’export PDF o Excel non è arrivato questa volta. Aspetta qualche secondo e tocca « Riprova » — al secondo tentativo di solito va.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>
@@ -14261,22 +14245,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6098</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewPrint" datatype="html">
-        <source>Als PDF drucken</source>
-        <target>Stampa come PDF</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewDone" datatype="html">
-        <source>Berichtsvorschau geöffnet.</source>
-        <target>Anteprima del rapporto aperta.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -10321,20 +10321,6 @@
           <context context-type="linenumber">1167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButtonAria" datatype="html">
-        <source>Ergebnisbericht in Vorschau anzeigen</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewButton" datatype="html">
-        <source>Vorschau</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1178</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <context-group purpose="location">
@@ -11477,7 +11463,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
-        <source>PDF, Vorschau oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
+        <source>PDF- oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">2407</context>
@@ -12582,20 +12568,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6098</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewPrint" datatype="html">
-        <source>Als PDF drucken</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6128</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionHost.exportPdfPreviewDone" datatype="html">
-        <source>Berichtsvorschau geöffnet.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">

--- a/docs/diagrams/diagrams.md
+++ b/docs/diagrams/diagrams.md
@@ -676,7 +676,7 @@ sequenceDiagram
         BE-->>FE: SessionExportDTO (aggregiert, anonym)
         FE->>BE: session.getSessionExportPdf (Playwright)
         BE-->>FE: PDF base64
-        FE->>D: Ergebnisbericht (PDF), optional Vorschau/CSV unter Mehr
+        FE->>D: Ergebnisbericht (PDF), optional CSV unter Mehr
     end
     opt Quiz-Sammlung: letzter Durchlauf
         FE->>BE: getLastSessionExportPdfForQuiz (accessProof)

--- a/docs/features/session-export-pdf.md
+++ b/docs/features/session-export-pdf.md
@@ -23,8 +23,9 @@ Phase 2 ergänzt:
 ### Host-Abschlussansicht (`FINISHED`)
 
 - **Primär:** **Ergebnisbericht (PDF)** — Server-PDF via `getSessionExportPdf` (Playwright)
-- **Sekundär:** **Vorschau** — druckoptimiertes HTML im Browser (Print-Dialog → „Als PDF speichern“)
 - **Unter „Mehr“:** **Für Excel exportieren** — CSV mit tabellarischen Rohdaten (weniger Kontext als der PDF-Bericht)
+
+Fallback, falls das Server-PDF scheitert: Browser-Druckdialog über dasselbe HTML (`printSessionResultsReport`) — ohne eigene Vorschau-UI.
 
 ### Quiz-Sammlung (Quizkarte)
 
@@ -49,15 +50,15 @@ Beide Aktionen nutzen dasselbe Berechtigungsmodell wie Bonus-Codes (Besitznachwe
 
 ## Technik
 
-Pipeline: `SessionExportDTO` → `buildSessionResultsReportHtml()` → Playwright `page.pdf()`. Frontend-Vorschau und Backend-PDF teilen sich die Lib `@arsnova/session-export-report`.
+Pipeline: `SessionExportDTO` → `buildSessionResultsReportHtml()` → Playwright `page.pdf()`. Backend-PDF und Browser-Print-Fallback teilen sich die Lib `@arsnova/session-export-report`.
 
-| Schicht                                                | Ort                                                                                                                                         |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Shared Report-Builder (HTML, Charts, Print-CSS)        | `libs/session-export-report/`                                                                                                               |
-| Frontend-Labels (Angular `$localize`)                  | `apps/frontend/src/app/core/session-results-report-labels.ts`                                                                               |
-| Frontend-Export-Service (Download, Vorschau, Fallback) | `apps/frontend/src/app/core/session-results-export.service.ts`                                                                              |
-| Server-PDF (Playwright-Wrapper)                        | `apps/backend/src/lib/session-results-report-pdf.ts`                                                                                        |
-| tRPC                                                   | `session.getSessionExportPdf`, `session.getExportData`, `session.getLastSessionExportPdfForQuiz`, `session.getLastSessionExportDataForQuiz` |
+| Schicht                                            | Ort                                                                                                                                         |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shared Report-Builder (HTML, Charts, Print-CSS)    | `libs/session-export-report/`                                                                                                               |
+| Frontend-Labels (Angular `$localize`)              | `apps/frontend/src/app/core/session-results-report-labels.ts`                                                                               |
+| Frontend-Export-Service (Download, Print-Fallback) | `apps/frontend/src/app/core/session-results-export.service.ts`                                                                              |
+| Server-PDF (Playwright-Wrapper)                    | `apps/backend/src/lib/session-results-report-pdf.ts`                                                                                        |
+| tRPC                                               | `session.getSessionExportPdf`, `session.getExportData`, `session.getLastSessionExportPdfForQuiz`, `session.getLastSessionExportDataForQuiz` |
 
 Vor Tests und Backend-Build muss `@arsnova/session-export-report` gebaut sein (`npm run build:libs`).
 


### PR DESCRIPTION
## Summary
- Button **Vorschau** und `previewSessionResultsReport()` entfernt
- `openSessionResultsReportPreview` / Preview-Toolbar entfernt
- HTML-Pipeline bleibt für Server-PDF (Playwright) und stillen Print-Fallback
- Docs + i18n angepasst

## Test plan
- [ ] Abschlussansicht zeigt nur Startseite, PDF, Mehr (Excel) — kein Vorschau-Button
- [ ] PDF-Download funktioniert weiterhin
- [ ] Bei Server-PDF-Fehler öffnet sich weiterhin der Browser-Druckdialog

Made with [Cursor](https://cursor.com)