### PR TITLE
fix(confidence): Prioritätenliste nur mit Fehlkonzept-Risiko

### DIFF
--- a/apps/frontend/src/app/core/session-results-report.util.spec.ts
+++ b/apps/frontend/src/app/core/session-results-report.util.spec.ts
@@ -149,6 +149,53 @@ describe('buildSessionResultsReportHtml', () => {
     expect(html).toContain('counter(page)');
   });
 
+  it('listet nur Fragen mit Fehlkonzept-Risiko in der Prioritätenliste', () => {
+    const html = buildSessionResultsReportHtml(
+      {
+        ...sampleExport,
+        confidenceSummary: {
+          ...sampleExport.confidenceSummary!,
+          priorityQuestionCount: 2,
+          includedQuestionCount: 3,
+          questions: [
+            ...sampleExport.confidenceSummary!.questions,
+            {
+              questionOrder: 3,
+              questionTextShort: 'Ohne Fehlkonzept-Risiko',
+              questionType: 'SINGLE_CHOICE',
+              responseCount: 20,
+              result: {
+                distribution: { '1': 0, '2': 2, '3': 4, '4': 8, '5': 6 },
+                crossTab: {
+                  correctHigh: 12,
+                  correctMid: 4,
+                  correctLow: 2,
+                  incorrectHigh: 0,
+                  incorrectMid: 1,
+                  incorrectLow: 1,
+                },
+                highConfidenceWrongCount: 0,
+              },
+            },
+          ],
+        },
+      },
+      getDefaultSessionResultsReportLabelsDe(),
+      { localeId: 'de' },
+    );
+
+    expect(html).toMatch(/Nachbesprechung empfohlen[^<]*2/);
+    expect(html).toContain('PI-Frage zur Französischen Revolution');
+    expect(html).toContain('Was ist 2+2?');
+    expect(html).not.toContain('Ohne Fehlkonzept-Risiko');
+
+    const prioritySection = html.slice(
+      html.indexOf('report-priority-list'),
+      html.indexOf('</ol>', html.indexOf('report-priority-list')) + 5,
+    );
+    expect(prioritySection.match(/<li>/g)?.length).toBe(2);
+  });
+
   it('rendert Feedback, Heatmap und Histogramm in Phase 2', () => {
     const html = buildSessionResultsReportHtml(
       {

--- a/apps/frontend/src/app/features/quiz/quiz-list/last-session-feedback-dialog.component.html
+++ b/apps/frontend/src/app/features/quiz/quiz-list/last-session-feedback-dialog.component.html
@@ -112,40 +112,49 @@
           {{ formatCount(confidence.responseCount) }}
         </p>
 
-        <h4 i18n="@@quizList.lastSessionAnalysisPriorities">Priorität für die Nachbesprechung</h4>
-        <ol class="last-session-feedback-dialog__confidence-list">
-          @for (question of confidence.questions.slice(0, 3); track question.questionOrder) {
-            <li>
-              <div class="last-session-feedback-dialog__confidence-question-title">
-                <strong>{{ question.questionOrder + 1 }}.</strong>
-                <div
-                  class="last-session-feedback-dialog__confidence-question-markdown markdown-body"
-                  [innerHTML]="renderQuestionMarkdown(question.questionTextShort)"
-                ></div>
-              </div>
-              <span>
-                {{ question.result.crossTab.incorrectHigh }}/{{ question.responseCount }} ·
-                {{
-                  confidencePercent(question.result.crossTab.incorrectHigh, question.responseCount)
-                }}
-                %
-                <span i18n="@@quizList.lastSessionAnalysisWrongHigh"
-                  >falsch + hohe Antwortsicherheit</span
-                >
-              </span>
-              <span>
-                {{ confidencePercent(incorrectCount(question), question.responseCount) }} %
-                <span i18n="@@quizList.lastSessionAnalysisIncorrect">insgesamt falsch</span>
-              </span>
-              @if (topWrongOption(question); as option) {
-                <span>
-                  <span i18n="@@quizList.lastSessionAnalysisTopSignal">Stärkstes Signal:</span>
-                  {{ option }}
-                </span>
+        @if (confidencePriorityQuestions(confidence.questions); as priorityQuestions) {
+          @if (priorityQuestions.length > 0) {
+            <h4 i18n="@@quizList.lastSessionAnalysisPriorities">
+              Priorität für die Nachbesprechung
+            </h4>
+            <ol class="last-session-feedback-dialog__confidence-list">
+              @for (question of priorityQuestions; track question.questionOrder) {
+                <li>
+                  <div class="last-session-feedback-dialog__confidence-question-title">
+                    <strong>{{ question.questionOrder + 1 }}.</strong>
+                    <div
+                      class="last-session-feedback-dialog__confidence-question-markdown markdown-body"
+                      [innerHTML]="renderQuestionMarkdown(question.questionTextShort)"
+                    ></div>
+                  </div>
+                  <span>
+                    {{ question.result.crossTab.incorrectHigh }}/{{ question.responseCount }} ·
+                    {{
+                      confidencePercent(
+                        question.result.crossTab.incorrectHigh,
+                        question.responseCount
+                      )
+                    }}
+                    %
+                    <span i18n="@@quizList.lastSessionAnalysisWrongHigh"
+                      >falsch + hohe Antwortsicherheit</span
+                    >
+                  </span>
+                  <span>
+                    {{ confidencePercent(incorrectCount(question), question.responseCount) }} %
+                    <span i18n="@@quizList.lastSessionAnalysisIncorrect">insgesamt falsch</span>
+                  </span>
+                  @if (topWrongOption(question); as option) {
+                    <span>
+                      <span i18n="@@quizList.lastSessionAnalysisTopSignal">Stärkstes Signal:</span>
+                      {{ option }}
+                    </span>
+                  }
+                </li>
               }
-            </li>
+            </ol>
           }
-        </ol>
+        }
 
         @if (confidence.suppressedQuestionCount > 0) {
           <p class="last-session-feedback-dialog__privacy">

--- a/apps/frontend/src/app/features/quiz/quiz-list/last-session-feedback-dialog.component.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-list/last-session-feedback-dialog.component.ts
@@ -15,6 +15,7 @@ import type {
   ConfidenceQuestionSummaryDTO,
   LastSessionAnalysisForQuizDTO,
 } from '@arsnova/shared-types';
+import { selectConfidencePriorityQuestions } from '@arsnova/shared-types';
 import { formatLocaleCount } from '../../../core/locale-number.util';
 import { trpc } from '../../../core/trpc.client';
 import { renderMarkdownWithKatex } from '../../../shared/markdown-katex.util';
@@ -105,6 +106,12 @@ export class LastSessionFeedbackDialogComponent implements OnInit {
 
   confidencePercent(count: number, total: number): number {
     return total > 0 ? Math.round((count / total) * 100) : 0;
+  }
+
+  confidencePriorityQuestions(
+    questions: ConfidenceQuestionSummaryDTO[],
+  ): ConfidenceQuestionSummaryDTO[] {
+    return selectConfidencePriorityQuestions(questions, 3);
   }
 
   incorrectCount(question: ConfidenceQuestionSummaryDTO): number {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -742,76 +742,78 @@
                       {{ formatCount(confidenceSummary.includedQuestionCount) }}
                     </p>
 
-                    @if (confidenceSummary.questions.length > 0) {
-                      <h3 i18n="@@sessionHost.finishedConfidencePriorities">
-                        Priorität für die Nachbesprechung
-                      </h3>
-                      <ol class="session-host__finished-confidence-list">
-                        @for (
-                          question of confidenceSummary.questions.slice(0, 3);
-                          track question.questionOrder
-                        ) {
-                          <li>
-                            <article class="session-host__finished-confidence-question">
-                              <header class="session-host__finished-confidence-question-title">
-                                <strong
-                                  class="session-host__finished-confidence-question-number"
-                                  aria-hidden="true"
-                                  >{{ question.questionOrder + 1 }}</strong
-                                >
-                                <div
-                                  class="session-host__finished-confidence-question-markdown markdown-body"
-                                  [innerHTML]="renderMarkdown(question.questionTextShort)"
-                                ></div>
-                              </header>
-                              <div class="session-host__finished-confidence-question-metrics">
-                                <span
-                                  class="session-host__finished-confidence-question-metric session-host__finished-confidence-question-metric--risk"
-                                >
-                                  <strong>
-                                    {{ question.result.crossTab.incorrectHigh }}/{{
-                                      question.responseCount
-                                    }}
-                                    ·
-                                    {{
-                                      finishedConfidencePercent(
-                                        question.result.crossTab.incorrectHigh,
+                    @if (
+                      finishedConfidencePriorityQuestions(confidenceSummary);
+                      as priorityQuestions
+                    ) {
+                      @if (priorityQuestions.length > 0) {
+                        <h3 i18n="@@sessionHost.finishedConfidencePriorities">
+                          Priorität für die Nachbesprechung
+                        </h3>
+                        <ol class="session-host__finished-confidence-list">
+                          @for (question of priorityQuestions; track question.questionOrder) {
+                            <li>
+                              <article class="session-host__finished-confidence-question">
+                                <header class="session-host__finished-confidence-question-title">
+                                  <strong
+                                    class="session-host__finished-confidence-question-number"
+                                    aria-hidden="true"
+                                    >{{ question.questionOrder + 1 }}</strong
+                                  >
+                                  <div
+                                    class="session-host__finished-confidence-question-markdown markdown-body"
+                                    [innerHTML]="renderMarkdown(question.questionTextShort)"
+                                  ></div>
+                                </header>
+                                <div class="session-host__finished-confidence-question-metrics">
+                                  <span
+                                    class="session-host__finished-confidence-question-metric session-host__finished-confidence-question-metric--risk"
+                                  >
+                                    <strong>
+                                      {{ question.result.crossTab.incorrectHigh }}/{{
                                         question.responseCount
-                                      )
-                                    }}
-                                    %
-                                  </strong>
-                                  <span i18n="@@sessionHost.finishedConfidenceWrongHigh"
-                                    >falsch + hohe Antwortsicherheit</span
-                                  >
-                                </span>
-                                <span class="session-host__finished-confidence-question-metric">
-                                  <strong>
-                                    {{
-                                      finishedConfidencePercent(
-                                        finishedConfidenceIncorrectCount(question),
-                                        question.responseCount
-                                      )
-                                    }}
-                                    %
-                                  </strong>
-                                  <span i18n="@@sessionHost.finishedConfidenceIncorrectOverall"
-                                    >insgesamt falsch</span
-                                  >
-                                </span>
-                              </div>
-                              @if (finishedConfidenceTopWrongOption(question); as option) {
-                                <p class="session-host__finished-confidence-signal">
-                                  <span i18n="@@sessionHost.finishedConfidenceTopSignal"
-                                    >Stärkstes Signal:</span
-                                  >
-                                  <strong>{{ option }}</strong>
-                                </p>
-                              }
-                            </article>
-                          </li>
-                        }
-                      </ol>
+                                      }}
+                                      ·
+                                      {{
+                                        finishedConfidencePercent(
+                                          question.result.crossTab.incorrectHigh,
+                                          question.responseCount
+                                        )
+                                      }}
+                                      %
+                                    </strong>
+                                    <span i18n="@@sessionHost.finishedConfidenceWrongHigh"
+                                      >falsch + hohe Antwortsicherheit</span
+                                    >
+                                  </span>
+                                  <span class="session-host__finished-confidence-question-metric">
+                                    <strong>
+                                      {{
+                                        finishedConfidencePercent(
+                                          finishedConfidenceIncorrectCount(question),
+                                          question.responseCount
+                                        )
+                                      }}
+                                      %
+                                    </strong>
+                                    <span i18n="@@sessionHost.finishedConfidenceIncorrectOverall"
+                                      >insgesamt falsch</span
+                                    >
+                                  </span>
+                                </div>
+                                @if (finishedConfidenceTopWrongOption(question); as option) {
+                                  <p class="session-host__finished-confidence-signal">
+                                    <span i18n="@@sessionHost.finishedConfidenceTopSignal"
+                                      >Stärkstes Signal:</span
+                                    >
+                                    <strong>{{ option }}</strong>
+                                  </p>
+                                }
+                              </article>
+                            </li>
+                          }
+                        </ol>
+                      }
                     }
 
                     @if (confidenceSummary.suppressedQuestionCount > 0) {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -76,6 +76,7 @@ import {
   createQuizHistoryAccessProof,
   resolveNumericEstimateToleranceMode,
   resolveNumericTolerance,
+  selectConfidencePriorityQuestions,
   CONFIDENCE_SCALE_MAX,
   CONFIDENCE_SCALE_MIN,
 } from '@arsnova/shared-types';
@@ -1686,6 +1687,12 @@ export class SessionHostComponent implements OnInit, OnDestroy {
 
   finishedConfidencePercent(count: number, total: number): number {
     return total > 0 ? Math.round((count / total) * 100) : 0;
+  }
+
+  finishedConfidencePriorityQuestions(
+    summary: SessionConfidenceSummaryDTO,
+  ): ConfidenceQuestionSummaryDTO[] {
+    return selectConfidencePriorityQuestions(summary.questions, 3);
   }
 
   finishedConfidenceIncorrectCount(question: ConfidenceQuestionSummaryDTO): number {

--- a/libs/session-export-report/src/session-results-report-layout.util.ts
+++ b/libs/session-export-report/src/session-results-report-layout.util.ts
@@ -23,10 +23,7 @@ export function renderCoverSummaryHtml(
   localeId: string,
 ): string {
   const questionCount = data.questions.length;
-  const riskCount =
-    data.confidenceSummary?.questions.filter(
-      (question) => question.result.crossTab.incorrectHigh > 0,
-    ).length ?? 0;
+  const riskCount = data.confidenceSummary?.priorityQuestionCount ?? 0;
   const feedbackAvg = data.feedbackSummary?.overallAverage;
 
   const items = [

--- a/libs/session-export-report/src/session-results-report.util.ts
+++ b/libs/session-export-report/src/session-results-report.util.ts
@@ -8,6 +8,7 @@ import type {
   SessionConfidenceSummaryDTO,
   SessionFeedbackSummary,
 } from '@arsnova/shared-types';
+import { selectConfidencePriorityQuestions } from '@arsnova/shared-types';
 import { formatLocaleCount, formatLocaleNumber } from './locale-number.util';
 import { stripMarkdownToPlainText } from './markdown-plain-text.util';
 import {
@@ -388,12 +389,7 @@ function renderConfidenceSummary(
   localeId: string,
 ): string {
   const total = summary.responseCount;
-  const priorityQuestions = [...summary.questions]
-    .sort((a, b) => {
-      const riskDiff = b.result.crossTab.incorrectHigh - a.result.crossTab.incorrectHigh;
-      return riskDiff !== 0 ? riskDiff : a.questionOrder - b.questionOrder;
-    })
-    .slice(0, 3);
+  const priorityQuestions = selectConfidencePriorityQuestions(summary.questions, 3);
 
   const metrics = `<div class="report-metrics">
     <div class="report-metric report-metric--success"><strong>${percent(summary.crossTab.correctHigh, total)} %</strong><span>${escapeHtml(labels.confidenceMastery)}</span></div>

--- a/libs/shared-types/src/confidence.test.ts
+++ b/libs/shared-types/src/confidence.test.ts
@@ -6,6 +6,7 @@ import {
   isConfidenceScaleValue,
   questionSupportsConfidence,
   resolveEffectiveAggregationRound,
+  selectConfidencePriorityQuestions,
 } from './confidence.js';
 
 describe('confidence helpers (Story 1.2i)', () => {
@@ -178,6 +179,55 @@ describe('confidence helpers (Story 1.2i)', () => {
       incorrectMid: 0,
       incorrectLow: 1,
     });
+  });
+
+  it('listet in der Prioritätenauswahl nur Fragen mit Fehlkonzept-Risiko', () => {
+    const withRisk = buildConfidenceResult({
+      votes: [
+        { confidenceValue: 5, isCorrect: false },
+        { confidenceValue: 5, isCorrect: false },
+        { confidenceValue: 5, isCorrect: false },
+        { confidenceValue: 5, isCorrect: false },
+        { confidenceValue: 5, isCorrect: true },
+      ],
+    });
+    const withoutRisk = buildConfidenceResult({
+      votes: [
+        { confidenceValue: 5, isCorrect: true },
+        { confidenceValue: 5, isCorrect: true },
+        { confidenceValue: 4, isCorrect: true },
+        { confidenceValue: 2, isCorrect: false },
+        { confidenceValue: 1, isCorrect: false },
+      ],
+    });
+    const summary = buildSessionConfidenceSummary({
+      questions: [
+        {
+          questionOrder: 0,
+          questionTextShort: 'Sicher falsch',
+          questionType: 'SINGLE_CHOICE',
+          result: withRisk,
+        },
+        {
+          questionOrder: 1,
+          questionTextShort: 'Ohne Fehlkonzept',
+          questionType: 'SINGLE_CHOICE',
+          result: withoutRisk,
+        },
+        {
+          questionOrder: 2,
+          questionTextShort: 'Auch sicher falsch',
+          questionType: 'MULTIPLE_CHOICE',
+          result: withRisk,
+        },
+      ],
+    });
+
+    expect(summary?.priorityQuestionCount).toBe(2);
+    expect(selectConfidencePriorityQuestions(summary?.questions ?? [], 3)).toEqual([
+      expect.objectContaining({ questionOrder: 0 }),
+      expect.objectContaining({ questionOrder: 2 }),
+    ]);
   });
 
   it('liefert ohne Frage oberhalb der Datenschutzschwelle keine Session-Zusammenfassung', () => {

--- a/libs/shared-types/src/confidence.ts
+++ b/libs/shared-types/src/confidence.ts
@@ -243,6 +243,19 @@ function incorrectCount(result: ConfidenceResult): number {
   );
 }
 
+export function hasConfidenceMisconceptionRisk(
+  question: Pick<ConfidenceQuestionSummary, 'result'>,
+): boolean {
+  return question.result.crossTab.incorrectHigh > 0;
+}
+
+/** Top-N Fragen mit Fehlkonzept-Risiko (bereits nach Priorität sortiert erwartet). */
+export function selectConfidencePriorityQuestions<
+  T extends Pick<ConfidenceQuestionSummary, 'result'>,
+>(questions: readonly T[], limit = 3): T[] {
+  return questions.filter(hasConfidenceMisconceptionRisk).slice(0, Math.max(0, limit));
+}
+
 export function buildSessionConfidenceSummary(
   input: BuildSessionConfidenceSummaryInput,
 ): SessionConfidenceSummary | null {
@@ -293,9 +306,7 @@ export function buildSessionConfidenceSummary(
     responseCount: confidenceResultResponseCount(aggregate),
     includedQuestionCount: questions.length,
     suppressedQuestionCount,
-    priorityQuestionCount: questions.filter(
-      (question) => question.result.crossTab.incorrectHigh > 0,
-    ).length,
+    priorityQuestionCount: questions.filter(hasConfidenceMisconceptionRisk).length,
     distribution: aggregate.distribution,
     crossTab: aggregate.crossTab,
     highConfidenceWrongCount: aggregate.highConfidenceWrongCount,


### PR DESCRIPTION
## Summary
- Bug: PDF/UI zeigten z. B. „2 Fragen mit Fehlkonzept-Risiko“, listeten aber 3 (inkl. Fragen ohne `incorrectHigh`)
- Ursache: Alert nutzte `priorityQuestionCount`, Liste nahm ungefiltert `questions.slice(0, 3)`
- Fix: gemeinsame Helper `selectConfidencePriorityQuestions` / `hasConfidenceMisconceptionRisk` in PDF, Host-Abschluss und Nachbesprechungs-Dialog

## Test plan
- [ ] Session mit 2 Risiko-Fragen + ≥1 Confidence-Frage ohne Risiko → Alert und Liste beide 2 Einträge
- [ ] PDF-Prioritätenliste enthält keine Frage mit 0× falsch+hoch

Made with [Cursor](https://cursor.com)