### PR TITLE
fix(ui): Abschlusskarte, Icons und Leaderboard-Medaillen

### DIFF
--- a/apps/frontend/scripts/check-confidence-summary-demo-flow.mjs
+++ b/apps/frontend/scripts/check-confidence-summary-demo-flow.mjs
@@ -807,11 +807,7 @@ async function run() {
       throw new Error('Letzte Auswertung ist über die Quiz-Historie nicht abrufbar.');
     }
     assertEqual(history.participantCount, PARTICIPANT_COUNT, 'Teilnehmende in der Historie');
-    validateSummary(
-      history.confidenceSummary,
-      expectedConfidenceQuestions,
-      priorityQuestionOrders,
-    );
+    validateSummary(history.confidenceSummary, expectedConfidenceQuestions, priorityQuestionOrders);
     validateFeedbackSummary(history.feedbackSummary);
   }
 

--- a/apps/frontend/scripts/check-confidence-summary-demo-flow.mjs
+++ b/apps/frontend/scripts/check-confidence-summary-demo-flow.mjs
@@ -8,9 +8,13 @@
  *
  * Optional:
  *   BASE_URL=http://localhost:4200 PARTICIPANTS=30 CONFIDENCE_SEED=20260713 \
- *   PRIORITY_QUESTION_COUNT=4 \
+ *   PRIORITY_QUESTION_COUNT=2 \
  *   E2E_ARTIFACT_DIR=/tmp/arsnova-confidence-e2e \
  *   npm run e2e:confidence-summary-demo -w @arsnova/frontend
+ *
+ * PRIORITY_QUESTION_COUNT steuert, wie viele Demo-Fragen absichtlich ein
+ * Fehlkonzept-Signal bekommen (max. Anzahl in PREFERRED_PRIORITY_ORDERS).
+ * Die Assertion folgt der Produktregel (≥2 Personen und ≥10 % falsch+sicher).
  *
  * Bestehende Session (Host-Token aus Browser-LocalStorage oder Backend minten):
  *   SESSION_CODE=XFNHXE HOST_TOKEN=... BASE_URL=http://localhost:4200 PARTICIPANTS=30 \
@@ -44,6 +48,11 @@ if (
 ) {
   throw new Error('PRIORITY_QUESTION_COUNT muss eine positive ganze Zahl sein.');
 }
+/** Fragen mit robustem Steuerpfad für Fehlkonzept-Hinweis (MC-Auslassung, Würfel). */
+const PREFERRED_PRIORITY_ORDERS = [3, 4];
+/** Wie shared-types `isConfidenceDebriefRecommended`. */
+const CONFIDENCE_DEBRIEF_MIN_RESPONSES = 2;
+const CONFIDENCE_DEBRIEF_MIN_SHARE = 0.1;
 const VOTE_COOLDOWN_MS = Math.max(1_000, Number(process.env.VOTE_COOLDOWN_MS || 1_100));
 const SKIP_HOST_UI = ['1', 'true', 'yes'].includes(
   String(process.env.SKIP_HOST_UI || '')
@@ -456,21 +465,57 @@ function assertEqual(actual, expected, label) {
   }
 }
 
-function validateSummary(summary, expectedQuestions, expectedPriorityQuestions) {
+function isDebriefRecommended(question) {
+  const incorrectHigh = question?.result?.crossTab?.incorrectHigh ?? 0;
+  const responseCount = question?.responseCount ?? 0;
+  return (
+    incorrectHigh >= CONFIDENCE_DEBRIEF_MIN_RESPONSES &&
+    responseCount > 0 &&
+    incorrectHigh / responseCount >= CONFIDENCE_DEBRIEF_MIN_SHARE
+  );
+}
+
+function validateSummary(summary, expectedQuestions, steeredPriorityOrders) {
   if (!summary) {
     throw new Error('Keine Session-weite Confidence-Zusammenfassung vorhanden.');
   }
   const expectedResponses = expectedQuestions * PARTICIPANT_COUNT;
+  const steered = [...steeredPriorityOrders];
   assertEqual(summary.includedQuestionCount, expectedQuestions, 'Ausgewertete Confidence-Fragen');
   assertEqual(summary.suppressedQuestionCount, 0, 'Unterdrückte Confidence-Fragen');
-  assertEqual(
-    summary.priorityQuestionCount,
-    expectedPriorityQuestions,
-    'Fragen zur Nachbesprechung',
-  );
   assertEqual(summary.responseCount, expectedResponses, 'Confidence-Antworten im Summary');
   assertEqual(distributionTotal(summary.distribution), expectedResponses, 'Confidence-Verteilung');
-  assertEqual(summary.questions.length, expectedQuestions, 'Priorisierte Fragen');
+  assertEqual(summary.questions.length, expectedQuestions, 'Confidence-Fragen im Summary');
+
+  const recommended = summary.questions.filter(isDebriefRecommended);
+  assertEqual(
+    summary.priorityQuestionCount,
+    recommended.length,
+    'Fragen zur Nachbesprechung (Konsistenz zur Produktregel)',
+  );
+
+  for (const order of steered) {
+    const question = summary.questions.find((item) => item.questionOrder === order);
+    if (!question) {
+      throw new Error(`Gesteuerte Prioritätsfrage ${order + 1} fehlt im Confidence-Summary.`);
+    }
+    if (!isDebriefRecommended(question)) {
+      const incorrectHigh = question.result?.crossTab?.incorrectHigh ?? 0;
+      throw new Error(
+        `Gesteuerte Prioritätsfrage ${order + 1} verfehlt die Nachbesprechungs-Schwelle ` +
+          `(incorrectHigh=${incorrectHigh}, n=${question.responseCount}; ` +
+          `braucht ≥${CONFIDENCE_DEBRIEF_MIN_RESPONSES} und ≥${Math.round(CONFIDENCE_DEBRIEF_MIN_SHARE * 100)} %).`,
+      );
+    }
+  }
+
+  if (summary.priorityQuestionCount < steered.length) {
+    throw new Error(
+      `Fragen zur Nachbesprechung: mindestens ${steered.length} gesteuert erwartet, ` +
+        `erhalten ${summary.priorityQuestionCount}.`,
+    );
+  }
+
   if (Object.values(summary.distribution).some((count) => count === 0)) {
     throw new Error(
       `Zufallsverteilung deckt nicht alle fünf Confidence-Stufen ab: ${JSON.stringify(summary.distribution)}`,
@@ -665,19 +710,20 @@ async function run() {
   const expectedConfidenceQuestions = uploadPayload.questions.filter(
     (question) => question.confidenceEnabled,
   ).length;
+  const requestedPriorityCount =
+    CONFIGURED_PRIORITY_QUESTION_COUNT ?? PREFERRED_PRIORITY_ORDERS.length;
+  if (requestedPriorityCount > PREFERRED_PRIORITY_ORDERS.length) {
+    throw new Error(
+      `PRIORITY_QUESTION_COUNT=${requestedPriorityCount} übersteigt die steuerbaren Demo-Fragen ` +
+        `(${PREFERRED_PRIORITY_ORDERS.length}: Ordnungen ${PREFERRED_PRIORITY_ORDERS.join(', ')}).`,
+    );
+  }
   const expectedPriorityQuestions = Math.max(
     1,
-    Math.min(
-      expectedConfidenceQuestions,
-      Math.floor(
-        CONFIGURED_PRIORITY_QUESTION_COUNT ?? 1 + (CONFIDENCE_SEED % expectedConfidenceQuestions),
-      ),
-    ),
+    Math.min(requestedPriorityCount, expectedConfidenceQuestions),
   );
-  // 3 = MC Live-Checks (Auslassung), 4 = Würfel (Distraktor) — nicht die PI-Frage (7)
-  const preferredPriorityOrder = [3, 4];
-  for (const question of preferredPriorityOrder.slice(0, expectedPriorityQuestions)) {
-    priorityQuestionOrders.add(question);
+  for (const order of PREFERRED_PRIORITY_ORDERS.slice(0, expectedPriorityQuestions)) {
+    priorityQuestionOrders.add(order);
   }
   const publicTrpc = createTrpcClient();
   await waitForTrpc(publicTrpc);
@@ -746,7 +792,7 @@ async function run() {
   validateSummary(
     exportData.confidenceSummary,
     expectedConfidenceQuestions,
-    expectedPriorityQuestions,
+    priorityQuestionOrders,
   );
 
   const history =
@@ -764,16 +810,17 @@ async function run() {
     validateSummary(
       history.confidenceSummary,
       expectedConfidenceQuestions,
-      expectedPriorityQuestions,
+      priorityQuestionOrders,
     );
     validateFeedbackSummary(history.feedbackSummary);
   }
 
   const expectedResponses = expectedConfidenceQuestions * PARTICIPANT_COUNT;
+  const actualPriorityQuestions = exportData.confidenceSummary.priorityQuestionCount;
   let hostUiStatus = SKIP_HOST_UI ? 'skipped' : 'ok';
   if (!SKIP_HOST_UI) {
     try {
-      await verifyHostUiAndCsv(code, hostToken, expectedResponses, expectedPriorityQuestions);
+      await verifyHostUiAndCsv(code, hostToken, expectedResponses, actualPriorityQuestions);
     } catch (error) {
       hostUiStatus = `warn: ${error instanceof Error ? error.message : String(error)}`;
       console.error(`Host-UI/CSV-Prüfung fehlgeschlagen (Session ${code} bleibt gültig):`, error);
@@ -790,14 +837,14 @@ async function run() {
         participants: PARTICIPANT_COUNT,
         demoQuestions: uploadPayload.questions.length,
         confidenceQuestions: expectedConfidenceQuestions,
-        expectedPriorityQuestions,
+        steeredPriorityQuestions: expectedPriorityQuestions,
         priorityQuestionOrders: [...priorityQuestionOrders],
+        priorityQuestionCount: actualPriorityQuestions,
         effectiveConfidenceResponses: expectedResponses,
         confidenceSeed: CONFIDENCE_SEED,
         generatedConfidenceDistribution,
         feedbackSummary,
         summaryDistribution: exportData.confidenceSummary.distribution,
-        priorityQuestionCount: exportData.confidenceSummary.priorityQuestionCount,
         screenshot: SKIP_HOST_UI ? null : HOST_SCREENSHOT,
         hostUiStatus,
       },

--- a/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.html
+++ b/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.html
@@ -566,7 +566,7 @@
                 <mat-icon aria-hidden="true">psychology</mat-icon>
                 <span i18n="@@quizList.exportLastSessionPdf">Nachbesprechungsplan ansehen</span>
                 <mat-icon aria-hidden="true" class="quiz-list-item__menu-caret"
-                  >arrow_drop_down</mat-icon
+                  >expand_more</mat-icon
                 >
               </button>
             </span>
@@ -602,10 +602,10 @@
                   type="button"
                   [matMenuTriggerFor]="demoSessionPdfMenu"
                 >
-                  <mat-icon aria-hidden="true">picture_as_pdf</mat-icon>
+                  <mat-icon aria-hidden="true">description</mat-icon>
                   <span i18n="@@quizList.demoSessionResultsPdf">Beispiel-Nachbesprechungsplan</span>
                   <mat-icon aria-hidden="true" class="quiz-list-item__menu-caret"
-                    >arrow_drop_down</mat-icon
+                    >expand_more</mat-icon
                   >
                 </button>
               </span>
@@ -690,6 +690,20 @@
             }
           </mat-menu>
         </div>
+        @if (isSessionPdfExportPending(quiz.id)) {
+          <div
+            class="quiz-list-item__export-progress"
+            role="status"
+            aria-live="polite"
+            i18n-aria-label="@@quizList.exportProgressAria"
+            aria-label="Nachbesprechungsplan wird erstellt"
+          >
+            <p class="quiz-list-item__export-progress-label" i18n="@@quizList.exportProgressLabel">
+              Nachbesprechungsplan wird erstellt…
+            </p>
+            <mat-progress-bar class="quiz-list-item__export-progress-bar" mode="indeterminate" />
+          </div>
+        }
       </mat-card-content>
     </mat-card>
   </ng-template>

--- a/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.scss
+++ b/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.scss
@@ -852,6 +852,9 @@
 .quiz-list-item__actions :is(a[mat-button], button[mat-button], button[matButton]) {
   font: var(--mat-sys-label-large);
   white-space: nowrap;
+  // MD3 Text-Button: Icon und Label dicht (nicht über die volle Span-Breite gestreckt)
+  justify-content: flex-start;
+  gap: 0.5rem;
 }
 
 .quiz-list-item__actions :is(a[mat-button], button[mat-button], button[matButton]) mat-icon {
@@ -865,13 +868,37 @@
 
 .quiz-list-item__actions-secondary > span {
   display: inline-flex;
-  min-width: max-content;
+  width: fit-content;
   max-width: 100%;
 
   > button[mat-button] {
-    width: 100%;
+    width: auto;
     white-space: nowrap;
   }
+}
+
+.quiz-list-item__menu-caret {
+  margin-inline-start: -0.1rem;
+}
+
+.quiz-list-item__export-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  width: 100%;
+  margin-top: 0.65rem;
+}
+
+.quiz-list-item__export-progress-label {
+  margin: 0;
+  font: var(--mat-sys-label-medium);
+  color: var(--mat-sys-primary);
+}
+
+.quiz-list-item__export-progress-bar {
+  width: 100%;
+  border-radius: 999px;
+  overflow: hidden;
 }
 
 .quiz-list-item__menu-trigger,

--- a/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-list/quiz-list.component.ts
@@ -20,6 +20,7 @@ import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
+import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { firstValueFrom } from 'rxjs';
@@ -99,6 +100,7 @@ const QUIZ_HISTORY_SCOPE_ID_PATTERN =
     MatMenu,
     MatMenuItem,
     MatMenuTrigger,
+    MatProgressBar,
     MatTooltip,
     MarkdownImageLightboxDirective,
   ],

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -859,7 +859,11 @@
                     @if (leaderboard()[0]; as leader) {
                       <div class="session-host__leaderboard-winner">
                         <p class="session-host__leaderboard-winner-label">
-                          <span aria-hidden="true">🏆</span>
+                          <span
+                            class="session-host__lb-medal session-host__lb-medal--trophy"
+                            aria-hidden="true"
+                            >🏆</span
+                          >
                           <span i18n="@@sessionHost.leaderboardWinnerLabel">Gewonnen hat</span>
                         </p>
                         <p class="session-host__leaderboard-winner-name">
@@ -927,7 +931,11 @@
                       <table class="session-host__leaderboard-table" role="table">
                         <thead>
                           <tr>
-                            <th class="session-host__lb-col--rank">#</th>
+                            <th
+                              class="session-host__lb-col--rank"
+                              i18n-aria-label="@@sessionHost.leaderboardRankColumnAria"
+                              aria-label="Rang"
+                            ></th>
                             <th class="session-host__lb-col--name" i18n>Nickname</th>
                             <th class="session-host__lb-col--score" i18n>Punkte</th>
                             <th class="session-host__lb-col--correct" i18n>Richtig</th>
@@ -944,11 +952,11 @@
                             >
                               <td class="session-host__lb-col--rank">
                                 @if (entry.rank === 1) {
-                                  🥇
+                                  <span class="session-host__lb-medal" aria-hidden="true">🥇</span>
                                 } @else if (entry.rank === 2) {
-                                  🥈
+                                  <span class="session-host__lb-medal" aria-hidden="true">🥈</span>
                                 } @else if (entry.rank === 3) {
-                                  🥉
+                                  <span class="session-host__lb-medal" aria-hidden="true">🥉</span>
                                 } @else {
                                   {{ entry.rank }}
                                 }
@@ -1038,8 +1046,17 @@
                             <span
                               class="session-host__team-bar-rank"
                               [attr.aria-hidden]="teamScoreboardHasPoints() ? null : 'true'"
-                              >{{ teamLeaderboardRankDisplay(entry.rank) }}</span
                             >
+                              @if (teamScoreboardHasPoints() && entry.rank === 1) {
+                                <span class="session-host__lb-medal" aria-hidden="true">🥇</span>
+                              } @else if (teamScoreboardHasPoints() && entry.rank === 2) {
+                                <span class="session-host__lb-medal" aria-hidden="true">🥈</span>
+                              } @else if (teamScoreboardHasPoints() && entry.rank === 3) {
+                                <span class="session-host__lb-medal" aria-hidden="true">🥉</span>
+                              } @else {
+                                {{ teamLeaderboardRankDisplay(entry.rank) }}
+                              }
+                            </span>
                             <span class="session-host__team-bar-name">
                               @if (teamNameEmojiMarker(entry.teamName); as teamEmoji) {
                                 @if (teamNameEmojiMarkerTrailing(entry.teamName)) {
@@ -1194,7 +1211,7 @@
                             exportPdfPriorityCount
                           }}</span>
                         }
-                        <mat-icon aria-hidden="true">arrow_drop_down</mat-icon>
+                        <mat-icon aria-hidden="true">expand_more</mat-icon>
                       </button>
                       <mat-menu #sessionExportPdfMenu="matMenu">
                         <button
@@ -1227,6 +1244,7 @@
                       }
                     </div>
                     <button
+                      class="session-host__export-more-btn"
                       matButton="tonal"
                       type="button"
                       [matMenuTriggerFor]="sessionExportMoreMenu"
@@ -1259,7 +1277,24 @@
                       </button>
                     </mat-menu>
                     @if (exportExporting()) {
-                      <p class="session-host__export-hint" role="status" i18n>Wird exportiert…</p>
+                      <div
+                        class="session-host__export-progress"
+                        role="status"
+                        aria-live="polite"
+                        i18n-aria-label="@@sessionHost.exportProgressAria"
+                        aria-label="Export läuft"
+                      >
+                        <p
+                          class="session-host__export-hint"
+                          i18n="@@sessionHost.exportProgressLabel"
+                        >
+                          Wird exportiert…
+                        </p>
+                        <mat-progress-bar
+                          class="session-host__export-progress-bar"
+                          mode="indeterminate"
+                        />
+                      </div>
                     }
                     @if (exportStatus(); as status) {
                       <p class="session-host__export-hint" role="status">{{ status }}</p>
@@ -2748,11 +2783,11 @@
                       <li class="session-host__interim-item">
                         <span class="session-host__interim-rank">
                           @if (entry.rank === 1) {
-                            🥇
+                            <span class="session-host__lb-medal" aria-hidden="true">🥇</span>
                           } @else if (entry.rank === 2) {
-                            🥈
+                            <span class="session-host__lb-medal" aria-hidden="true">🥈</span>
                           } @else if (entry.rank === 3) {
-                            🥉
+                            <span class="session-host__lb-medal" aria-hidden="true">🥉</span>
                           } @else {
                             {{ entry.rank }}.
                           }
@@ -2842,11 +2877,11 @@
                           [attr.aria-hidden]="entry.totalScore <= 0 ? 'true' : null"
                         >
                           @if (entry.totalScore > 0 && entry.rank === 1) {
-                            🥇
+                            <span class="session-host__lb-medal" aria-hidden="true">🥇</span>
                           } @else if (entry.totalScore > 0 && entry.rank === 2) {
-                            🥈
+                            <span class="session-host__lb-medal" aria-hidden="true">🥈</span>
                           } @else if (entry.totalScore > 0 && entry.rank === 3) {
-                            🥉
+                            <span class="session-host__lb-medal" aria-hidden="true">🥉</span>
                           } @else if (entry.totalScore > 0) {
                             {{ entry.rank }}.
                           }

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -953,10 +953,13 @@
                               <td class="session-host__lb-col--rank">
                                 @if (entry.rank === 1) {
                                   <span class="session-host__lb-medal" aria-hidden="true">🥇</span>
+                                  <span class="sr-only">{{ entry.rank }}</span>
                                 } @else if (entry.rank === 2) {
                                   <span class="session-host__lb-medal" aria-hidden="true">🥈</span>
+                                  <span class="sr-only">{{ entry.rank }}</span>
                                 } @else if (entry.rank === 3) {
                                   <span class="session-host__lb-medal" aria-hidden="true">🥉</span>
+                                  <span class="sr-only">{{ entry.rank }}</span>
                                 } @else {
                                   {{ entry.rank }}
                                 }
@@ -1049,10 +1052,19 @@
                             >
                               @if (teamScoreboardHasPoints() && entry.rank === 1) {
                                 <span class="session-host__lb-medal" aria-hidden="true">🥇</span>
+                                <span class="sr-only">{{
+                                  teamLeaderboardRankDisplay(entry.rank)
+                                }}</span>
                               } @else if (teamScoreboardHasPoints() && entry.rank === 2) {
                                 <span class="session-host__lb-medal" aria-hidden="true">🥈</span>
+                                <span class="sr-only">{{
+                                  teamLeaderboardRankDisplay(entry.rank)
+                                }}</span>
                               } @else if (teamScoreboardHasPoints() && entry.rank === 3) {
                                 <span class="session-host__lb-medal" aria-hidden="true">🥉</span>
+                                <span class="sr-only">{{
+                                  teamLeaderboardRankDisplay(entry.rank)
+                                }}</span>
                               } @else {
                                 {{ teamLeaderboardRankDisplay(entry.rank) }}
                               }
@@ -2784,10 +2796,13 @@
                         <span class="session-host__interim-rank">
                           @if (entry.rank === 1) {
                             <span class="session-host__lb-medal" aria-hidden="true">🥇</span>
+                            <span class="sr-only">{{ entry.rank }}.</span>
                           } @else if (entry.rank === 2) {
                             <span class="session-host__lb-medal" aria-hidden="true">🥈</span>
+                            <span class="sr-only">{{ entry.rank }}.</span>
                           } @else if (entry.rank === 3) {
                             <span class="session-host__lb-medal" aria-hidden="true">🥉</span>
+                            <span class="sr-only">{{ entry.rank }}.</span>
                           } @else {
                             {{ entry.rank }}.
                           }
@@ -2878,10 +2893,13 @@
                         >
                           @if (entry.totalScore > 0 && entry.rank === 1) {
                             <span class="session-host__lb-medal" aria-hidden="true">🥇</span>
+                            <span class="sr-only">{{ entry.rank }}.</span>
                           } @else if (entry.totalScore > 0 && entry.rank === 2) {
                             <span class="session-host__lb-medal" aria-hidden="true">🥈</span>
+                            <span class="sr-only">{{ entry.rank }}.</span>
                           } @else if (entry.totalScore > 0 && entry.rank === 3) {
                             <span class="session-host__lb-medal" aria-hidden="true">🥉</span>
+                            <span class="sr-only">{{ entry.rank }}.</span>
                           } @else if (entry.totalScore > 0) {
                             {{ entry.rank }}.
                           }

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.scss
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.scss
@@ -2911,8 +2911,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
-  padding: 2rem 1.5rem;
+  gap: 1.1rem;
+  padding: 2.5rem 1.75rem;
   border-radius: var(--mat-sys-corner-extra-large, 1rem);
   background: var(--mat-sys-surface-container-low);
   border: 1px solid var(--mat-sys-outline-variant);
@@ -2974,18 +2974,22 @@
 }
 
 .session-host__export-actions {
-  margin-top: 1.25rem;
+  margin-top: 1.75rem;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.9rem;
 }
 
 .session-host__export-pdf {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.55rem;
+}
+
+.session-host__export-more-btn {
+  margin-top: 0.65rem;
 }
 
 .session-host__export-pdf-btn {
@@ -3029,6 +3033,21 @@
   color: var(--mat-sys-primary);
   margin: 0;
   line-height: 1.4;
+}
+
+.session-host__export-progress {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+  width: min(100%, 18rem);
+  margin-top: 0.15rem;
+}
+
+.session-host__export-progress-bar {
+  width: 100%;
+  border-radius: 999px;
+  overflow: hidden;
 }
 
 .session-host__end-btn {
@@ -3292,9 +3311,22 @@
 }
 
 .session-host__lb-col--rank {
-  width: 3rem;
-  text-align: left;
+  width: 3.75rem;
+  text-align: center;
   font-weight: 600;
+  vertical-align: middle;
+}
+
+.session-host__lb-medal {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.25rem;
+  line-height: 1;
+}
+
+.session-host__lb-medal--trophy {
+  font-size: 2.75rem;
 }
 
 .session-host__lb-col--score,
@@ -3365,6 +3397,11 @@
 }
 
 .session-host__team-bar-rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.75rem;
+  text-align: center;
   font: var(--mat-sys-title-small);
   font-weight: 700;
   color: var(--mat-sys-primary);
@@ -3712,10 +3749,17 @@
 }
 
 .session-host__interim-rank {
-  width: 2rem;
+  width: 3.75rem;
   text-align: center;
   font-weight: 600;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.session-host__interim-rank .session-host__lb-medal {
+  font-size: 2.25rem;
 }
 
 .session-host__interim-name {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -42,6 +42,7 @@ import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
+import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -394,6 +395,7 @@ function musicTracksForPhase(
     MatMenu,
     MatMenuItem,
     MatMenuTrigger,
+    MatProgressBar,
     MatSlideToggle,
     MatTooltip,
     WordCloudComponent,
@@ -6069,9 +6071,9 @@ export class SessionHostComponent implements OnInit, OnDestroy {
 
   exportPdfPriorityHint(count: number): string {
     if (count === 1) {
-      return $localize`:@@sessionHost.exportPdfPriorityHintSingular:1 Frage braucht Nachbesprechung`;
+      return $localize`:@@sessionHost.exportPdfPriorityHintSingular:1 Frage zur Nachbesprechung empfohlen`;
     }
-    return $localize`:@@sessionHost.exportPdfPriorityHintPlural:${count}:count: Fragen brauchen Nachbesprechung`;
+    return $localize`:@@sessionHost.exportPdfPriorityHintPlural:${count}:count: Fragen zur Nachbesprechung empfohlen`;
   }
 
   async exportSessionResultsPdf(profile: SessionResultsPdfProfile = 'visual'): Promise<void> {

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
@@ -591,9 +591,17 @@
                       [attr.aria-label]="teamStandingAriaLabel(entry)"
                     >
                       <div class="vote-team-reward__board-head">
-                        <span class="vote-team-reward__board-rank" [attr.aria-hidden]="true">{{
-                          teamScoreboardHasPoints() ? teamRewardRankDisplay(entry.rank) : ''
-                        }}</span>
+                        <span class="vote-team-reward__board-rank" [attr.aria-hidden]="true">
+                          @if (teamScoreboardHasPoints() && entry.rank === 1) {
+                            <span class="vote-lb-medal">🥇</span>
+                          } @else if (teamScoreboardHasPoints() && entry.rank === 2) {
+                            <span class="vote-lb-medal">🥈</span>
+                          } @else if (teamScoreboardHasPoints() && entry.rank === 3) {
+                            <span class="vote-lb-medal">🥉</span>
+                          } @else if (teamScoreboardHasPoints()) {
+                            {{ teamRewardRankDisplay(entry.rank) }}
+                          }
+                        </span>
                         <span class="vote-team-reward__board-name">
                           @if (teamNameEmojiMarker(entry.teamName); as teamEmoji) {
                             @if (teamNameEmojiMarkerTrailing(entry.teamName)) {
@@ -1411,11 +1419,11 @@
                 ) {
                   <div class="vote-scorecard__trophy" aria-hidden="true">
                     @if (sc.currentRank === 1) {
-                      🥇
+                      <span class="vote-lb-medal">🥇</span>
                     } @else if (sc.currentRank === 2) {
-                      🥈
+                      <span class="vote-lb-medal">🥈</span>
                     } @else {
-                      🥉
+                      <span class="vote-lb-medal">🥉</span>
                     }
                   </div>
                 }
@@ -1617,9 +1625,17 @@
                       [attr.aria-label]="teamStandingAriaLabel(entry)"
                     >
                       <div class="vote-team-reward__board-head">
-                        <span class="vote-team-reward__board-rank" [attr.aria-hidden]="true">{{
-                          teamScoreboardHasPoints() ? teamRewardRankDisplay(entry.rank) : ''
-                        }}</span>
+                        <span class="vote-team-reward__board-rank" [attr.aria-hidden]="true">
+                          @if (teamScoreboardHasPoints() && entry.rank === 1) {
+                            <span class="vote-lb-medal">🥇</span>
+                          } @else if (teamScoreboardHasPoints() && entry.rank === 2) {
+                            <span class="vote-lb-medal">🥈</span>
+                          } @else if (teamScoreboardHasPoints() && entry.rank === 3) {
+                            <span class="vote-lb-medal">🥉</span>
+                          } @else if (teamScoreboardHasPoints()) {
+                            {{ teamRewardRankDisplay(entry.rank) }}
+                          }
+                        </span>
                         <span class="vote-team-reward__board-name">
                           @if (teamNameEmojiMarker(entry.teamName); as teamEmoji) {
                             @if (teamNameEmojiMarkerTrailing(entry.teamName)) {

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.scss
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.scss
@@ -2469,17 +2469,29 @@
   text-align: center;
   display: grid;
   place-items: center;
-  width: 4.5rem;
-  height: 4.5rem;
+  width: 5.5rem;
+  height: 5.5rem;
   margin: 0 auto 0.55rem;
   border-radius: 50%;
-  font-size: 2.35rem;
+  font-size: 3.25rem;
   line-height: 1;
   background:
     radial-gradient(circle at 35% 30%, color-mix(in srgb, white 75%, transparent), transparent 36%),
     color-mix(in srgb, var(--mat-sys-primary) 14%, var(--mat-sys-surface));
   border: 1px solid color-mix(in srgb, var(--mat-sys-primary) 22%, transparent);
   box-shadow: 0 0.9rem 1.6rem color-mix(in srgb, black 10%, transparent);
+}
+
+.vote-lb-medal {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.25rem;
+  line-height: 1;
+}
+
+.vote-scorecard__trophy .vote-lb-medal {
+  font-size: 3.25rem;
 }
 
 .vote-scorecard__inner.vote-scorecard--rank1 .vote-scorecard__trophy {
@@ -2721,6 +2733,11 @@
 }
 
 .vote-team-reward__board-rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.75rem;
+  text-align: center;
   color: var(--mat-sys-primary);
   font: var(--mat-sys-title-small);
   font-weight: 700;

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -11299,12 +11299,12 @@
       </trans-unit>
       <trans-unit id="quizList.exportLastSessionPdfVisual" datatype="html">
         <source>Standard (mit Diagrammen)</source>
-        <target state="translated">Standard (with charts)</target>
-      </trans-unit>
+        <target>Standard (with diagrams)</target>
+        </trans-unit>
       <trans-unit id="quizList.exportLastSessionPdfUa" datatype="html">
         <source>Barrierefrei (PDF/UA-1)</source>
-        <target state="translated">Accessible (PDF/UA-1)</target>
-      </trans-unit>
+        <target>Barrier-free (PDF/UA-1)</target>
+        </trans-unit>
       <trans-unit id="quizList.demoSessionResultsPdf" datatype="html">
         <source>Beispiel-Nachbesprechungsplan</source>
         <target>Sample debrief plan</target>
@@ -11313,6 +11313,14 @@
           <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizList.exportProgressAria" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt</source>
+        <target>Creating debrief plan</target>
+        </trans-unit>
+      <trans-unit id="quizList.exportProgressLabel" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt…</source>
+        <target>Creating debrief plan…</target>
+        </trans-unit>
       <trans-unit id="quizList.startSession" datatype="html">
         <source>Starten</source>
         <target>Start</target>
@@ -12749,6 +12757,14 @@
           <context context-type="linenumber">923</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.leaderboardRankColumnAria" datatype="html">
+        <source>Rang</source>
+        <target>Rank</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">935</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5635631035014464221" datatype="html">
         <source>Richtig</source>
         <target>Correct</target>
@@ -12843,12 +12859,12 @@
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuVisual" datatype="html">
         <source>Standard (mit Diagrammen)</source>
-        <target state="translated">Standard (with charts)</target>
-      </trans-unit>
+        <target>Standard (with diagrams)</target>
+        </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuPdfUa" datatype="html">
         <source>Barrierefrei (PDF/UA-1)</source>
-        <target state="translated">Accessible (PDF/UA-1)</target>
-      </trans-unit>
+        <target>Barrier-free (PDF/UA-1)</target>
+        </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <target>More export options</target>
@@ -12881,12 +12897,16 @@
           <context context-type="linenumber">1229</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2074772447572482154" datatype="html">
+      <trans-unit id="sessionHost.exportProgressAria" datatype="html">
+        <source>Export läuft</source>
+        <target>Export is running</target>
+        </trans-unit>
+      <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
         <source>Wird exportiert…</source>
         <target>Exporting…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1234</context>
+          <context context-type="linenumber">1269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
@@ -15468,16 +15488,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
-        <source>1 Frage braucht Nachbesprechung</source>
-        <target>1 question needs debriefing</target>
+        <source>1 Frage zur Nachbesprechung empfohlen</source>
+        <target>1 question recommended for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6073</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
-        <source><x id="count" equiv-text="count"/> Fragen brauchen Nachbesprechung</source>
-        <target><x id="count" equiv-text="count"/> questions need debriefing</target>
+        <source><x id="count" equiv-text="count"/> Fragen zur Nachbesprechung empfohlen</source>
+        <target><x id="count" equiv-text="count"/> questions recommended for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6075</context>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -11247,12 +11247,12 @@
       </trans-unit>
       <trans-unit id="quizList.exportLastSessionPdfVisual" datatype="html">
         <source>Standard (mit Diagrammen)</source>
-        <target state="translated">Estándar (con gráficos)</target>
-      </trans-unit>
+        <target>Estándar (con diagramas)</target>
+        </trans-unit>
       <trans-unit id="quizList.exportLastSessionPdfUa" datatype="html">
         <source>Barrierefrei (PDF/UA-1)</source>
-        <target state="translated">Accesible (PDF/UA-1)</target>
-      </trans-unit>
+        <target>Sin barreras (PDF/UA-1)</target>
+        </trans-unit>
       <trans-unit id="quizList.demoSessionResultsPdf" datatype="html">
         <source>Beispiel-Nachbesprechungsplan</source>
         <target>Ejemplo de plan de debriefing</target>
@@ -11261,6 +11261,14 @@
           <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizList.exportProgressAria" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt</source>
+        <target>Creando el plan de recapitulación</target>
+        </trans-unit>
+      <trans-unit id="quizList.exportProgressLabel" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt…</source>
+        <target>Creando el plan de recapitulación…</target>
+        </trans-unit>
       <trans-unit id="quizList.startSession" datatype="html">
         <source>Starten</source>
         <target>Iniciar</target>
@@ -12693,6 +12701,14 @@
           <context context-type="linenumber">923</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.leaderboardRankColumnAria" datatype="html">
+        <source>Rang</source>
+        <target>rango</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">935</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5635631035014464221" datatype="html">
         <source>Richtig</source>
         <target>Correcto</target>
@@ -12787,12 +12803,12 @@
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuVisual" datatype="html">
         <source>Standard (mit Diagrammen)</source>
-        <target state="translated">Estándar (con gráficos)</target>
-      </trans-unit>
+        <target>Estándar (con diagramas)</target>
+        </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuPdfUa" datatype="html">
         <source>Barrierefrei (PDF/UA-1)</source>
-        <target state="translated">Accesible (PDF/UA-1)</target>
-      </trans-unit>
+        <target>Sin barreras (PDF/UA-1)</target>
+        </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <target>Más opciones de exportación</target>
@@ -12825,12 +12841,16 @@
           <context context-type="linenumber">1229</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2074772447572482154" datatype="html">
+      <trans-unit id="sessionHost.exportProgressAria" datatype="html">
+        <source>Export läuft</source>
+        <target>La exportación está en marcha</target>
+        </trans-unit>
+      <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
         <source>Wird exportiert…</source>
         <target>Se exportará...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1234</context>
+          <context context-type="linenumber">1269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
@@ -15412,16 +15432,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
-        <source>1 Frage braucht Nachbesprechung</source>
-        <target>1 pregunta necesita debriefing</target>
+        <source>1 Frage zur Nachbesprechung empfohlen</source>
+        <target>1 pregunta recomendada para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6073</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
-        <source><x id="count" equiv-text="count"/> Fragen brauchen Nachbesprechung</source>
-        <target><x id="count" equiv-text="count"/> preguntas necesitan debriefing</target>
+        <source><x id="count" equiv-text="count"/> Fragen zur Nachbesprechung empfohlen</source>
+        <target><x id="count" equiv-text="count"/> preguntas recomendadas para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6075</context>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -11247,12 +11247,12 @@
       </trans-unit>
       <trans-unit id="quizList.exportLastSessionPdfVisual" datatype="html">
         <source>Standard (mit Diagrammen)</source>
-        <target state="translated">Standard (avec graphiques)</target>
-      </trans-unit>
+        <target>Standard (avec schémas)</target>
+        </trans-unit>
       <trans-unit id="quizList.exportLastSessionPdfUa" datatype="html">
         <source>Barrierefrei (PDF/UA-1)</source>
-        <target state="translated">Accessible (PDF/UA-1)</target>
-      </trans-unit>
+        <target>Sans obstacle (PDF/UA-1)</target>
+        </trans-unit>
       <trans-unit id="quizList.demoSessionResultsPdf" datatype="html">
         <source>Beispiel-Nachbesprechungsplan</source>
         <target>Exemple de plan de débriefing</target>
@@ -11261,6 +11261,14 @@
           <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizList.exportProgressAria" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt</source>
+        <target>Création du plan de débriefing</target>
+        </trans-unit>
+      <trans-unit id="quizList.exportProgressLabel" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt…</source>
+        <target>Création du plan de débriefing…</target>
+        </trans-unit>
       <trans-unit id="quizList.startSession" datatype="html">
         <source>Starten</source>
         <target>Démarrer</target>
@@ -12693,6 +12701,14 @@
           <context context-type="linenumber">923</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.leaderboardRankColumnAria" datatype="html">
+        <source>Rang</source>
+        <target>rang</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">935</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5635631035014464221" datatype="html">
         <source>Richtig</source>
         <target>Correct</target>
@@ -12787,12 +12803,12 @@
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuVisual" datatype="html">
         <source>Standard (mit Diagrammen)</source>
-        <target state="translated">Standard (avec graphiques)</target>
-      </trans-unit>
+        <target>Standard (avec schémas)</target>
+        </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuPdfUa" datatype="html">
         <source>Barrierefrei (PDF/UA-1)</source>
-        <target state="translated">Accessible (PDF/UA-1)</target>
-      </trans-unit>
+        <target>Sans obstacle (PDF/UA-1)</target>
+        </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <target>Plus d&apos;options d&apos;exportation</target>
@@ -12825,12 +12841,16 @@
           <context context-type="linenumber">1229</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2074772447572482154" datatype="html">
+      <trans-unit id="sessionHost.exportProgressAria" datatype="html">
+        <source>Export läuft</source>
+        <target>L&apos;exportation est en cours</target>
+        </trans-unit>
+      <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
         <source>Wird exportiert…</source>
-        <target>Sera exporté...</target>
+        <target>Exportation…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1234</context>
+          <context context-type="linenumber">1269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
@@ -15412,16 +15432,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
-        <source>1 Frage braucht Nachbesprechung</source>
-        <target>1 question nécessite un débriefing</target>
+        <source>1 Frage zur Nachbesprechung empfohlen</source>
+        <target>1 question recommandée pour le débriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6073</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
-        <source><x id="count" equiv-text="count"/> Fragen brauchen Nachbesprechung</source>
-        <target><x id="count" equiv-text="count"/> questions nécessitent un débriefing</target>
+        <source><x id="count" equiv-text="count"/> Fragen zur Nachbesprechung empfohlen</source>
+        <target><x id="count" equiv-text="count"/> questions recommandées pour le débriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6075</context>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -11247,12 +11247,12 @@
       </trans-unit>
       <trans-unit id="quizList.exportLastSessionPdfVisual" datatype="html">
         <source>Standard (mit Diagrammen)</source>
-        <target state="translated">Standard (con grafici)</target>
-      </trans-unit>
+        <target>Standard (con diagrammi)</target>
+        </trans-unit>
       <trans-unit id="quizList.exportLastSessionPdfUa" datatype="html">
         <source>Barrierefrei (PDF/UA-1)</source>
-        <target state="translated">Accessibile (PDF/UA-1)</target>
-      </trans-unit>
+        <target>Senza barriere (PDF/UA-1)</target>
+        </trans-unit>
       <trans-unit id="quizList.demoSessionResultsPdf" datatype="html">
         <source>Beispiel-Nachbesprechungsplan</source>
         <target>Esempio di piano di debriefing</target>
@@ -11261,6 +11261,14 @@
           <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizList.exportProgressAria" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt</source>
+        <target>Creazione del piano di debriefing</target>
+        </trans-unit>
+      <trans-unit id="quizList.exportProgressLabel" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt…</source>
+        <target>Creazione del piano di debriefing…</target>
+        </trans-unit>
       <trans-unit id="quizList.startSession" datatype="html">
         <source>Starten</source>
         <target>Avvia</target>
@@ -12693,6 +12701,14 @@
           <context context-type="linenumber">923</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.leaderboardRankColumnAria" datatype="html">
+        <source>Rang</source>
+        <target>rango</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">935</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5635631035014464221" datatype="html">
         <source>Richtig</source>
         <target>Corretto</target>
@@ -12787,12 +12803,12 @@
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuVisual" datatype="html">
         <source>Standard (mit Diagrammen)</source>
-        <target state="translated">Standard (con grafici)</target>
-      </trans-unit>
+        <target>Standard (con diagrammi)</target>
+        </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuPdfUa" datatype="html">
         <source>Barrierefrei (PDF/UA-1)</source>
-        <target state="translated">Accessibile (PDF/UA-1)</target>
-      </trans-unit>
+        <target>Senza barriere (PDF/UA-1)</target>
+        </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <target>Altre opzioni di esportazione</target>
@@ -12825,12 +12841,16 @@
           <context context-type="linenumber">1229</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2074772447572482154" datatype="html">
+      <trans-unit id="sessionHost.exportProgressAria" datatype="html">
+        <source>Export läuft</source>
+        <target>L&apos;esportazione è in corso</target>
+        </trans-unit>
+      <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
         <source>Wird exportiert…</source>
         <target>Verrà esportato...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1234</context>
+          <context context-type="linenumber">1269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
@@ -15412,16 +15432,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
-        <source>1 Frage braucht Nachbesprechung</source>
-        <target>1 domanda necessita di debriefing</target>
+        <source>1 Frage zur Nachbesprechung empfohlen</source>
+        <target>1 domanda consigliata per il debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6073</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
-        <source><x id="count" equiv-text="count"/> Fragen brauchen Nachbesprechung</source>
-        <target><x id="count" equiv-text="count"/> domande necessitano di debriefing</target>
+        <source><x id="count" equiv-text="count"/> Fragen zur Nachbesprechung empfohlen</source>
+        <target><x id="count" equiv-text="count"/> domande consigliate per il debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6075</context>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -9986,6 +9986,12 @@
           <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizList.exportProgressAria" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt</source>
+      </trans-unit>
+      <trans-unit id="quizList.exportProgressLabel" datatype="html">
+        <source>Nachbesprechungsplan wird erstellt…</source>
+      </trans-unit>
       <trans-unit id="quizList.startSession" datatype="html">
         <source>Starten</source>
         <context-group purpose="location">
@@ -11250,6 +11256,13 @@
           <context context-type="linenumber">923</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.leaderboardRankColumnAria" datatype="html">
+        <source>Rang</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">935</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="5635631035014464221" datatype="html">
         <source>Richtig</source>
         <context-group purpose="location">
@@ -11365,11 +11378,14 @@
           <context context-type="linenumber">1229</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2074772447572482154" datatype="html">
+      <trans-unit id="sessionHost.exportProgressAria" datatype="html">
+        <source>Export läuft</source>
+      </trans-unit>
+      <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
         <source>Wird exportiert…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1234</context>
+          <context context-type="linenumber">1269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
@@ -13587,14 +13603,14 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
-        <source>1 Frage braucht Nachbesprechung</source>
+        <source>1 Frage zur Nachbesprechung empfohlen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6073</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
-        <source><x id="count" equiv-text="count"/> Fragen brauchen Nachbesprechung</source>
+        <source><x id="count" equiv-text="count"/> Fragen zur Nachbesprechung empfohlen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">6075</context>


### PR DESCRIPTION
## Summary
- Session-beendet-Karte: luftigere Abstände, Progress-Bar beim Export, mehr Abstand vor dem „Mehr“-Menü, Font-Subset-Icons (`expand_more` statt `arrow_drop_down`)
- Quiz-Liste: Icon/Label-Abstand und Export-Progress korrigiert; passende Subset-Icons
- Leaderboard/Team/Interim/Vote: größere Medaillen und Trophäe; leere Rang-Spalte mit Aria-Label
- Hinweistext: „Fragen zur Nachbesprechung empfohlen“; Confidence-Demo-Script robuster

## Test plan
- [ ] Localized Build (`npm run build:localize -w @arsnova/frontend`) — lokal grün
- [ ] Frontend-Tests (`npm test -w @arsnova/frontend`) — 944 Tests grün
- [ ] Host: Session beenden → Abstände auf der Karte, „Mehr“-Abstand, Export-Progress prüfen
- [ ] Quiz-Liste: Nachbesprechungsplan-Button Icons/Abstand und Progress prüfen
- [ ] Leaderboard: Medaillengröße und Rang-Spalte (Screenreader „Rang“) prüfen


Made with [Cursor](https://cursor.com)