### PR TITLE
A11y: Persönliche Frist, Punktvorschau und Session-Semantik absichern

### DIFF
--- a/apps/backend/src/__tests__/session.current-question-host.test.ts
+++ b/apps/backend/src/__tests__/session.current-question-host.test.ts
@@ -10,7 +10,7 @@ const { prismaMock, hostAuthMocks } = vi.hoisted(() => ({
       count: vi.fn(),
     },
     participant: {
-      count: vi.fn(),
+      groupBy: vi.fn(),
     },
   },
   hostAuthMocks: {
@@ -51,7 +51,7 @@ describe('session.getCurrentQuestionForHost (Story 2.3)', () => {
     resetVoteAggregationCachesForTests();
     prismaMock.vote.findMany.mockResolvedValue([]);
     prismaMock.vote.count.mockResolvedValue(0);
-    prismaMock.participant.count.mockResolvedValue(0);
+    prismaMock.participant.groupBy.mockResolvedValue([]);
   });
 
   it('liefert aktuelle Frage mit Antwortoptionen und isCorrect', async () => {
@@ -349,18 +349,26 @@ describe('session.getCurrentQuestionForHost (Story 2.3)', () => {
       status: 'ACTIVE',
       currentQuestion: 0,
       currentRound: 1,
+      activeQuestionStartedAt: new Date(),
       quiz: {
+        defaultTimer: 30,
+        timerScaleByDifficulty: true,
         questions: [
           {
             id: questionId,
             order: 0,
             type: 'NUMERIC_ESTIMATE',
+            timer: null,
+            difficulty: 'MEDIUM',
             answers: [],
           },
         ],
       },
     });
-    prismaMock.participant.count.mockResolvedValueOnce(2);
+    prismaMock.participant.groupBy.mockResolvedValueOnce([
+      { timerAccommodation: 'EXTENDED', _count: { _all: 1 } },
+      { timerAccommodation: 'OFF', _count: { _all: 1 } },
+    ]);
 
     const result = await caller.getHostVoteProgress({ code: CODE });
 
@@ -368,8 +376,10 @@ describe('session.getCurrentQuestionForHost (Story 2.3)', () => {
       questionId,
       round: 1,
       pendingTimerAccommodationCount: 2,
+      blockingTimerAccommodationCount: 1,
     });
-    expect(prismaMock.participant.count).toHaveBeenCalledWith({
+    expect(prismaMock.participant.groupBy).toHaveBeenCalledWith({
+      by: ['timerAccommodation'],
       where: {
         sessionId: '6a8edced-5f8f-4cfa-9176-454fac9570ad',
         timerAccommodation: { in: ['EXTENDED', 'OFF'] },
@@ -380,6 +390,7 @@ describe('session.getCurrentQuestionForHost (Story 2.3)', () => {
           },
         },
       },
+      _count: { _all: true },
     });
   });
 

--- a/apps/backend/src/__tests__/session.participants.test.ts
+++ b/apps/backend/src/__tests__/session.participants.test.ts
@@ -9,6 +9,8 @@ const { prismaMock, hostAuthMocks, presenceMocks } = vi.hoisted(() => ({
       findFirst: vi.fn(),
       update: vi.fn(),
     },
+    $executeRaw: vi.fn(),
+    $transaction: vi.fn(),
   },
   hostAuthMocks: {
     extractHostTokenMock: vi.fn(),
@@ -62,6 +64,10 @@ describe('session participant access (Story 2.2)', () => {
     hostAuthMocks.extractHostTokenMock.mockReturnValue('host-token-123');
     hostAuthMocks.extractHostTokenFromConnectionParamsMock.mockReturnValue(null);
     hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
+    prismaMock.$executeRaw.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
   });
 
   it('liefert Teilnehmerliste und -anzahl für gültigen Code nur für Hosts', async () => {

--- a/apps/backend/src/__tests__/session.steering.test.ts
+++ b/apps/backend/src/__tests__/session.steering.test.ts
@@ -7,6 +7,9 @@ const { prismaMock, hostAuthMocks, readingReadyMocks, platformStatisticMocks, lo
         findUnique: vi.fn(),
         update: vi.fn(),
       },
+      participant: {
+        groupBy: vi.fn(),
+      },
     },
     hostAuthMocks: {
       extractHostTokenMock: vi.fn(),
@@ -366,6 +369,9 @@ describe('session.revealAnswers (Story 2.3)', () => {
 describe('session.revealResults (Story 2.3)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hostAuthMocks.extractHostTokenMock.mockReturnValue('host-token-123');
+    hostAuthMocks.extractHostTokenFromConnectionParamsMock.mockReturnValue(null);
+    hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
   });
 
   it('wechselt von ACTIVE zu RESULTS', async () => {
@@ -385,6 +391,117 @@ describe('session.revealResults (Story 2.3)', () => {
 
     expect(result.status).toBe('RESULTS');
     expect(result.currentQuestion).toBe(0);
+    expect(prismaMock.session.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: SESSION_ID },
+        data: expect.objectContaining({ status: 'RESULTS' }),
+      }),
+    );
+  });
+
+  it('wartet mit Ergebnissen bis garantierte Zusatzzeit beendet ist', async () => {
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: SESSION_ID,
+      status: 'ACTIVE',
+      currentQuestion: 0,
+      currentRound: 1,
+      activeQuestionStartedAt: new Date(),
+      quiz: {
+        defaultTimer: 30,
+        timerScaleByDifficulty: true,
+        questions: [
+          {
+            id: '11111111-1111-4111-8111-111111111111',
+            type: 'SINGLE_CHOICE',
+            timer: null,
+            difficulty: 'MEDIUM',
+            numericTwoRounds: false,
+          },
+        ],
+      },
+    });
+    prismaMock.participant.groupBy.mockResolvedValue([
+      { timerAccommodation: 'EXTENDED', _count: { _all: 1 } },
+    ]);
+
+    await expect(caller.revealResults({ code: CODE })).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Eine Person nutzt noch ihre garantierte Zusatzzeit.',
+    });
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+  });
+
+  it('lehnt Force-Close ab solange der Raum-Countdown läuft', async () => {
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: SESSION_ID,
+      status: 'ACTIVE',
+      currentQuestion: 0,
+      currentRound: 1,
+      activeQuestionStartedAt: new Date(),
+      quiz: {
+        defaultTimer: 30,
+        timerScaleByDifficulty: true,
+        questions: [
+          {
+            id: '11111111-1111-4111-8111-111111111111',
+            type: 'SINGLE_CHOICE',
+            timer: null,
+            difficulty: 'MEDIUM',
+            numericTwoRounds: false,
+          },
+        ],
+      },
+    });
+    prismaMock.participant.groupBy.mockResolvedValue([
+      { timerAccommodation: 'EXTENDED', _count: { _all: 1 } },
+    ]);
+
+    await expect(
+      caller.revealResults({ code: CODE, forceClosePersonalTimers: true }),
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message:
+        'Persönliche Fristen dürfen erst nach Ablauf des Raum-Countdowns vorzeitig beendet werden.',
+    });
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+  });
+
+  it('erlaubt Force-Close nach Ablauf des Raum-Countdowns trotz offener 10×-Fenster', async () => {
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: SESSION_ID,
+      status: 'ACTIVE',
+      currentQuestion: 0,
+      currentRound: 1,
+      activeQuestionStartedAt: new Date(Date.now() - 31_000),
+      quiz: {
+        defaultTimer: 30,
+        timerScaleByDifficulty: true,
+        questions: [
+          {
+            id: '11111111-1111-4111-8111-111111111111',
+            type: 'SINGLE_CHOICE',
+            timer: 30,
+            difficulty: 'MEDIUM',
+            numericTwoRounds: false,
+          },
+        ],
+      },
+    });
+    prismaMock.participant.groupBy.mockResolvedValue([
+      { timerAccommodation: 'EXTENDED', _count: { _all: 2 } },
+    ]);
+    prismaMock.session.update.mockResolvedValue({
+      id: SESSION_ID,
+      status: 'RESULTS',
+      currentQuestion: 0,
+    });
+
+    const result = await caller.revealResults({
+      code: CODE,
+      forceClosePersonalTimers: true,
+    });
+
+    expect(result.status).toBe('RESULTS');
     expect(prismaMock.session.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: SESSION_ID },

--- a/apps/backend/src/__tests__/session.steering.test.ts
+++ b/apps/backend/src/__tests__/session.steering.test.ts
@@ -9,7 +9,10 @@ const { prismaMock, hostAuthMocks, readingReadyMocks, platformStatisticMocks, lo
       },
       participant: {
         groupBy: vi.fn(),
+        update: vi.fn(),
       },
+      $executeRaw: vi.fn(),
+      $transaction: vi.fn(),
     },
     hostAuthMocks: {
       extractHostTokenMock: vi.fn(),
@@ -372,6 +375,10 @@ describe('session.revealResults (Story 2.3)', () => {
     hostAuthMocks.extractHostTokenMock.mockReturnValue('host-token-123');
     hostAuthMocks.extractHostTokenFromConnectionParamsMock.mockReturnValue(null);
     hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
+    prismaMock.$executeRaw.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
   });
 
   it('wechselt von ACTIVE zu RESULTS', async () => {

--- a/apps/backend/src/routers/session.ts
+++ b/apps/backend/src/routers/session.ts
@@ -3708,7 +3708,8 @@ type TimerDbClient = Pick<typeof prisma, 'participant'> & {
 };
 
 async function lockSessionRow(db: TimerDbClient, sessionId: string): Promise<void> {
-  await db.$executeRaw`SELECT 1 FROM "Session" WHERE id = ${sessionId}::uuid FOR UPDATE`;
+  // Session.id ist textuell (UUID-String); kein `::uuid`-Cast, sonst text = uuid.
+  await db.$executeRaw`SELECT 1 FROM "Session" WHERE id = ${sessionId} FOR UPDATE`;
 }
 
 async function getTimerAccommodationProgress(

--- a/apps/backend/src/routers/session.ts
+++ b/apps/backend/src/routers/session.ts
@@ -13,6 +13,7 @@ import {
   CreateSessionOutputSchema,
   GetCurrentQuestionForStudentInputSchema,
   GetSessionInfoInputSchema,
+  HostSteeringWithTimerOverrideInputSchema,
   NextQuestionInputSchema,
   GetLiveFreetextInputSchema,
   GetActiveQuizIdsInputSchema,
@@ -144,6 +145,7 @@ import {
   touchParticipantPresence,
 } from '../lib/presence';
 import { markCountdownSessionActive, recordSessionTransitionActivity } from '../lib/loadSignal';
+import { logger } from '../lib/logger';
 import { awaitJoinAdmissionSlot } from '../lib/joinAdmission';
 import {
   clearReadingReady,
@@ -3692,6 +3694,108 @@ async function fetchHostCurrentQuestion(
   return envelope.payload;
 }
 
+type TimerAccommodationProgressInput = {
+  sessionId: string;
+  questionId: string;
+  round: number;
+  activeQuestionStartedAt: Date | null;
+  baseTimerSeconds: number | null;
+};
+
+async function getTimerAccommodationProgress(
+  input: TimerAccommodationProgressInput,
+): Promise<{ pendingCount: number; blockingCount: number }> {
+  if (
+    input.round !== 1 ||
+    !input.activeQuestionStartedAt ||
+    !input.baseTimerSeconds ||
+    input.baseTimerSeconds <= 0
+  ) {
+    return { pendingCount: 0, blockingCount: 0 };
+  }
+
+  const groups = await prisma.participant.groupBy({
+    by: ['timerAccommodation'],
+    where: {
+      sessionId: input.sessionId,
+      timerAccommodation: { in: ['EXTENDED', 'OFF'] },
+      votes: {
+        none: {
+          questionId: input.questionId,
+          round: input.round,
+        },
+      },
+    },
+    _count: { _all: true },
+  });
+  const counts = new Map(groups.map((group) => [group.timerAccommodation, group._count._all]));
+  const extendedCount = counts.get('EXTENDED') ?? 0;
+  const untimedCount = counts.get('OFF') ?? 0;
+  const extendedTimerSeconds = resolvePersonalTimerSeconds(input.baseTimerSeconds, 'EXTENDED');
+  const extendedDeadline =
+    extendedTimerSeconds && extendedTimerSeconds > 0
+      ? input.activeQuestionStartedAt.getTime() + extendedTimerSeconds * 1000
+      : 0;
+  const blockingCount = Date.now() <= extendedDeadline + 2000 ? extendedCount : 0;
+
+  return {
+    pendingCount: blockingCount + untimedCount,
+    blockingCount,
+  };
+}
+
+function isRoomCountdownElapsed(input: TimerAccommodationProgressInput): boolean {
+  if (!input.activeQuestionStartedAt || !input.baseTimerSeconds || input.baseTimerSeconds <= 0) {
+    return true;
+  }
+  const roomDeadlineMs = input.activeQuestionStartedAt.getTime() + input.baseTimerSeconds * 1000;
+  return Date.now() >= roomDeadlineMs;
+}
+
+/**
+ * Persönliche 10×-Fenster blockieren Host-Freigabe, bis sie enden —
+ * außer der Host forciert nach Ablauf des Raum-Countdowns (Anti-Sabotage).
+ */
+async function assertPersonalTimerGate(
+  input: TimerAccommodationProgressInput,
+  options: {
+    forceClosePersonalTimers?: boolean;
+    action: 'revealResults' | 'startDiscussion';
+  },
+): Promise<void> {
+  const progress = await getTimerAccommodationProgress(input);
+  if (progress.blockingCount <= 0) {
+    return;
+  }
+
+  if (options.forceClosePersonalTimers) {
+    if (!isRoomCountdownElapsed(input)) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message:
+          'Persönliche Fristen dürfen erst nach Ablauf des Raum-Countdowns vorzeitig beendet werden.',
+      });
+    }
+    logger.info('session.host_force_close_personal_timers', {
+      sessionId: input.sessionId,
+      questionId: input.questionId,
+      round: input.round,
+      action: options.action,
+      blockingCount: progress.blockingCount,
+      pendingCount: progress.pendingCount,
+    });
+    return;
+  }
+
+  throw new TRPCError({
+    code: 'PRECONDITION_FAILED',
+    message:
+      progress.blockingCount === 1
+        ? 'Eine Person nutzt noch ihre garantierte Zusatzzeit.'
+        : `${progress.blockingCount} Personen nutzen noch ihre garantierte Zusatzzeit.`,
+  });
+}
+
 async function fetchHostVoteProgress(code: string): Promise<HostVoteProgressDTO | null> {
   const normalizedCode = code.toUpperCase();
   const session = await prisma.session.findUnique({
@@ -3702,14 +3806,19 @@ async function fetchHostVoteProgress(code: string): Promise<HostVoteProgressDTO 
       status: true,
       currentQuestion: true,
       currentRound: true,
+      activeQuestionStartedAt: true,
       quiz: {
         select: {
+          defaultTimer: true,
+          timerScaleByDifficulty: true,
           questions: {
             orderBy: { order: 'asc' },
             select: {
               id: true,
               order: true,
               type: true,
+              timer: true,
+              difficulty: true,
               shortTextEvaluationKind: true,
               shortTextMaxLength: true,
               shortTextCaseSensitive: true,
@@ -3747,23 +3856,32 @@ async function fetchHostVoteProgress(code: string): Promise<HostVoteProgressDTO 
 
   const round = session.currentRound ?? 1;
   const questionType = question.type as QuestionType;
-  const pendingTimerAccommodationCount = await prisma.participant.count({
-    where: {
-      sessionId: session.id,
-      timerAccommodation: { in: ['EXTENDED', 'OFF'] },
-      votes: {
-        none: {
-          questionId: question.id,
-          round,
-        },
-      },
-    },
+  const baseTimerSeconds =
+    round === 2
+      ? null
+      : resolveEffectiveQuestionTimer(
+          question.timer,
+          session.quiz.defaultTimer,
+          question.difficulty as Difficulty,
+          session.quiz.timerScaleByDifficulty,
+        );
+  const timerAccommodationProgress = await getTimerAccommodationProgress({
+    sessionId: session.id,
+    questionId: question.id,
+    round,
+    activeQuestionStartedAt: session.activeQuestionStartedAt,
+    baseTimerSeconds,
   });
   const base = {
     questionId: question.id,
     questionOrder: question.order,
     round,
-    ...(pendingTimerAccommodationCount > 0 ? { pendingTimerAccommodationCount } : {}),
+    ...(timerAccommodationProgress.pendingCount > 0
+      ? { pendingTimerAccommodationCount: timerAccommodationProgress.pendingCount }
+      : {}),
+    ...(timerAccommodationProgress.blockingCount > 0
+      ? { blockingTimerAccommodationCount: timerAccommodationProgress.blockingCount }
+      : {}),
   };
 
   if (questionType === 'SINGLE_CHOICE' || questionType === 'MULTIPLE_CHOICE') {
@@ -5209,7 +5327,7 @@ export const sessionRouter = router({
 
   /** Ergebnis anzeigen (Story 2.3). Nur bei ACTIVE. */
   revealResults: hostProcedure
-    .input(GetSessionInfoInputSchema)
+    .input(HostSteeringWithTimerOverrideInputSchema)
     .output(SessionStatusUpdateSchema)
     .mutation(async ({ input }) => {
       const code = input.code.toUpperCase();
@@ -5220,11 +5338,20 @@ export const sessionRouter = router({
           status: true,
           currentQuestion: true,
           currentRound: true,
+          activeQuestionStartedAt: true,
           quiz: {
             select: {
+              defaultTimer: true,
+              timerScaleByDifficulty: true,
               questions: {
                 orderBy: { order: 'asc' },
-                select: { type: true, numericTwoRounds: true },
+                select: {
+                  id: true,
+                  type: true,
+                  timer: true,
+                  difficulty: true,
+                  numericTwoRounds: true,
+                },
               },
             },
           },
@@ -5238,6 +5365,31 @@ export const sessionRouter = router({
           code: 'BAD_REQUEST',
           message: 'Ergebnis anzeigen nur im Status ACTIVE.',
         });
+      }
+      const question =
+        session.currentQuestion !== null && session.currentQuestion !== undefined
+          ? (session.quiz?.questions[session.currentQuestion] ?? null)
+          : null;
+      if (question && session.quiz) {
+        const baseTimerSeconds = resolveEffectiveQuestionTimer(
+          question.timer,
+          session.quiz.defaultTimer,
+          question.difficulty as Difficulty,
+          session.quiz.timerScaleByDifficulty,
+        );
+        await assertPersonalTimerGate(
+          {
+            sessionId: session.id,
+            questionId: question.id,
+            round: session.currentRound,
+            activeQuestionStartedAt: session.activeQuestionStartedAt,
+            baseTimerSeconds,
+          },
+          {
+            forceClosePersonalTimers: input.forceClosePersonalTimers,
+            action: 'revealResults',
+          },
+        );
       }
       await prisma.session.update({
         where: { id: session.id },
@@ -5254,7 +5406,7 @@ export const sessionRouter = router({
 
   /** Diskussionsphase starten (Story 2.7 Peer Instruction). Nur bei ACTIVE (Runde 1). */
   startDiscussion: hostProcedure
-    .input(GetSessionInfoInputSchema)
+    .input(HostSteeringWithTimerOverrideInputSchema)
     .output(SessionStatusUpdateSchema)
     .mutation(async ({ input }) => {
       const code = input.code.toUpperCase();
@@ -5265,11 +5417,20 @@ export const sessionRouter = router({
           status: true,
           currentQuestion: true,
           currentRound: true,
+          activeQuestionStartedAt: true,
           quiz: {
             select: {
+              defaultTimer: true,
+              timerScaleByDifficulty: true,
               questions: {
                 orderBy: { order: 'asc' },
-                select: { type: true, numericTwoRounds: true },
+                select: {
+                  id: true,
+                  type: true,
+                  timer: true,
+                  difficulty: true,
+                  numericTwoRounds: true,
+                },
               },
             },
           },
@@ -5296,6 +5457,27 @@ export const sessionRouter = router({
           code: 'BAD_REQUEST',
           message: 'Diese Frage ist nicht für eine zweite Runde konfiguriert.',
         });
+      }
+      if (question && session.quiz) {
+        const baseTimerSeconds = resolveEffectiveQuestionTimer(
+          question.timer,
+          session.quiz.defaultTimer,
+          question.difficulty as Difficulty,
+          session.quiz.timerScaleByDifficulty,
+        );
+        await assertPersonalTimerGate(
+          {
+            sessionId: session.id,
+            questionId: question.id,
+            round: session.currentRound,
+            activeQuestionStartedAt: session.activeQuestionStartedAt,
+            baseTimerSeconds,
+          },
+          {
+            forceClosePersonalTimers: input.forceClosePersonalTimers,
+            action: 'startDiscussion',
+          },
+        );
       }
       await prisma.session.update({
         where: { id: session.id },

--- a/apps/backend/src/routers/session.ts
+++ b/apps/backend/src/routers/session.ts
@@ -3702,8 +3702,18 @@ type TimerAccommodationProgressInput = {
   baseTimerSeconds: number | null;
 };
 
+type TimerDbClient = Pick<typeof prisma, 'participant'> & {
+  $executeRaw: typeof prisma.$executeRaw;
+  session: Pick<typeof prisma.session, 'update' | 'findUnique'>;
+};
+
+async function lockSessionRow(db: TimerDbClient, sessionId: string): Promise<void> {
+  await db.$executeRaw`SELECT 1 FROM "Session" WHERE id = ${sessionId}::uuid FOR UPDATE`;
+}
+
 async function getTimerAccommodationProgress(
   input: TimerAccommodationProgressInput,
+  db: TimerDbClient = prisma,
 ): Promise<{ pendingCount: number; blockingCount: number }> {
   if (
     input.round !== 1 ||
@@ -3714,7 +3724,7 @@ async function getTimerAccommodationProgress(
     return { pendingCount: 0, blockingCount: 0 };
   }
 
-  const groups = await prisma.participant.groupBy({
+  const groups = await db.participant.groupBy({
     by: ['timerAccommodation'],
     where: {
       sessionId: input.sessionId,
@@ -3762,8 +3772,9 @@ async function assertPersonalTimerGate(
     forceClosePersonalTimers?: boolean;
     action: 'revealResults' | 'startDiscussion';
   },
+  db: TimerDbClient = prisma,
 ): Promise<void> {
-  const progress = await getTimerAccommodationProgress(input);
+  const progress = await getTimerAccommodationProgress(input, db);
   if (progress.blockingCount <= 0) {
     return;
   }
@@ -4779,9 +4790,12 @@ export const sessionRouter = router({
         });
       }
 
-      await prisma.participant.update({
-        where: { id: participant.id },
-        data: { timerAccommodation: accommodation },
+      await prisma.$transaction(async (tx) => {
+        await lockSessionRow(tx, participant.sessionId);
+        await tx.participant.update({
+          where: { id: participant.id },
+          data: { timerAccommodation: accommodation },
+        });
       });
       void touchParticipantPresence(participant.sessionId, participant.id);
       // Persönliche Felder liegen außerhalb des gemeinsamen ACTIVE-Caches.
@@ -5377,24 +5391,43 @@ export const sessionRouter = router({
           question.difficulty as Difficulty,
           session.quiz.timerScaleByDifficulty,
         );
-        await assertPersonalTimerGate(
-          {
-            sessionId: session.id,
-            questionId: question.id,
-            round: session.currentRound,
-            activeQuestionStartedAt: session.activeQuestionStartedAt,
-            baseTimerSeconds,
-          },
-          {
-            forceClosePersonalTimers: input.forceClosePersonalTimers,
-            action: 'revealResults',
-          },
-        );
+        await prisma.$transaction(async (tx) => {
+          await lockSessionRow(tx, session.id);
+          const locked = await tx.session.findUnique({
+            where: { id: session.id },
+            select: { status: true },
+          });
+          if (!locked || locked.status !== 'ACTIVE') {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Ergebnis anzeigen nur im Status ACTIVE.',
+            });
+          }
+          await assertPersonalTimerGate(
+            {
+              sessionId: session.id,
+              questionId: question.id,
+              round: session.currentRound,
+              activeQuestionStartedAt: session.activeQuestionStartedAt,
+              baseTimerSeconds,
+            },
+            {
+              forceClosePersonalTimers: input.forceClosePersonalTimers,
+              action: 'revealResults',
+            },
+            tx,
+          );
+          await tx.session.update({
+            where: { id: session.id },
+            data: { status: 'RESULTS', statusChangedAt: new Date() },
+          });
+        });
+      } else {
+        await prisma.session.update({
+          where: { id: session.id },
+          data: { status: 'RESULTS', statusChangedAt: new Date() },
+        });
       }
-      await prisma.session.update({
-        where: { id: session.id },
-        data: { status: 'RESULTS', statusChangedAt: new Date() },
-      });
       invalidateSessionStatusCachesForCode(code);
       void recordSessionTransitionActivity();
       return {
@@ -5465,24 +5498,43 @@ export const sessionRouter = router({
           question.difficulty as Difficulty,
           session.quiz.timerScaleByDifficulty,
         );
-        await assertPersonalTimerGate(
-          {
-            sessionId: session.id,
-            questionId: question.id,
-            round: session.currentRound,
-            activeQuestionStartedAt: session.activeQuestionStartedAt,
-            baseTimerSeconds,
-          },
-          {
-            forceClosePersonalTimers: input.forceClosePersonalTimers,
-            action: 'startDiscussion',
-          },
-        );
+        await prisma.$transaction(async (tx) => {
+          await lockSessionRow(tx, session.id);
+          const locked = await tx.session.findUnique({
+            where: { id: session.id },
+            select: { status: true, currentRound: true },
+          });
+          if (!locked || locked.status !== 'ACTIVE' || locked.currentRound !== 1) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Diskussionsphase nur aus Status ACTIVE.',
+            });
+          }
+          await assertPersonalTimerGate(
+            {
+              sessionId: session.id,
+              questionId: question.id,
+              round: session.currentRound,
+              activeQuestionStartedAt: session.activeQuestionStartedAt,
+              baseTimerSeconds,
+            },
+            {
+              forceClosePersonalTimers: input.forceClosePersonalTimers,
+              action: 'startDiscussion',
+            },
+            tx,
+          );
+          await tx.session.update({
+            where: { id: session.id },
+            data: { status: 'DISCUSSION', statusChangedAt: new Date() },
+          });
+        });
+      } else {
+        await prisma.session.update({
+          where: { id: session.id },
+          data: { status: 'DISCUSSION', statusChangedAt: new Date() },
+        });
       }
-      await prisma.session.update({
-        where: { id: session.id },
-        data: { status: 'DISCUSSION', statusChangedAt: new Date() },
-      });
       invalidateSessionStatusCachesForCode(code);
       void recordSessionTransitionActivity();
       return {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -468,7 +468,7 @@
           <div class="session-lobby">
             @if (sessionHeading(); as heading) {
               <section class="session-lobby__hero-card">
-                <p class="session-lobby__hero-title">{{ heading }}</p>
+                <h1 class="session-lobby__hero-title">{{ heading }}</h1>
                 @if (activeChannel() === 'quiz' && session()?.quizMotifImageUrl; as motifUrl) {
                   <div class="session-lobby__quiz-motif-wrap">
                     <img
@@ -640,23 +640,6 @@
                   </li>
                 }
               </ul>
-            }
-            @if (!sessionHeading()) {
-              <div class="session-lobby__actions">
-                <button
-                  mat-flat-button
-                  color="primary"
-                  type="button"
-                  [disabled]="controlPending() || quizStartQuestionPending()"
-                  (click)="onLobbyStartSessionClick()"
-                >
-                  @if (isQaSession()) {
-                    <span i18n="@@sessionHost.startQa">Fragerunde starten</span>
-                  } @else {
-                    <span i18n>Erste Frage starten</span>
-                  }
-                </button>
-              </div>
             }
           </div>
         } @else {
@@ -1439,17 +1422,17 @@
                           class="session-host__timer-a11y-note"
                           i18n="@@sessionHost.timerAccommodationNote"
                         >
-                          Teilnehmende können ihre persönliche Zeit bei Bedarf verlängern oder
+                          Teilnehmende können ihre persönliche Frist bei Bedarf verlängern oder
                           abschalten.
                         </p>
                       }
                     </mat-card-subtitle>
-                    <mat-card-title class="session-host__question-title">
+                    <h1 mat-card-title class="session-host__question-title">
                       <span
                         class="session-host__question-title-inner markdown-body"
                         [innerHTML]="renderMarkdown(q.text)"
                       ></span>
-                    </mat-card-title>
+                    </h1>
                     <div
                       class="session-host__question-meta"
                       i18n-aria-label="@@session.questionMetadataAria"
@@ -3537,9 +3520,16 @@
           hasCurrentQuizQuestionForHost()
         ) {
           @if (pendingTimerAccommodationCount(); as pendingCount) {
-            <p class="session-host__timer-accommodation-warning" role="status" aria-live="polite">
+            <p
+              id="session-host-timer-accommodation-status"
+              class="session-host__timer-accommodation-warning"
+              role="status"
+              aria-live="polite"
+            >
               <mat-icon aria-hidden="true">schedule</mat-icon>
-              <span>{{ pendingTimerAccommodationLabel(pendingCount) }}</span>
+              <span>{{
+                pendingTimerAccommodationLabel(pendingCount, blockingTimerAccommodationCount())
+              }}</span>
             </p>
           }
           @if (shouldShowPeerInstructionSuggestion(displayedCurrentQuestionForHost())) {
@@ -3548,7 +3538,12 @@
               color="primary"
               type="button"
               class="session-host__exit-anchor-button session-host__exit-anchor-button--primary"
-              [disabled]="controlPending()"
+              [disabled]="controlPending() || personalTimerBlocksReveal()"
+              [attr.aria-describedby]="
+                pendingTimerAccommodationCount() > 0
+                  ? 'session-host-timer-accommodation-status'
+                  : null
+              "
               (click)="startDiscussion()"
               i18n-aria-label="@@sessionHost.startDiscussionPhaseAria"
               aria-label="Diskussionsphase starten – Austausch vor zweiter Abstimmung"
@@ -3560,12 +3555,21 @@
               matButton="tonal"
               type="button"
               class="session-host__exit-anchor-button"
-              [disabled]="controlPending()"
+              [disabled]="controlPending() || personalTimerBlocksReveal()"
+              [attr.aria-describedby]="
+                pendingTimerAccommodationCount() > 0
+                  ? 'session-host-timer-accommodation-status'
+                  : null
+              "
               (click)="revealResults()"
             >
-              <span i18n="@@sessionHost.revealResultsDespiteSuggestion"
-                >Ergebnis trotzdem zeigen</span
-              >
+              @if (canForceClosePersonalTimers()) {
+                <span i18n="@@sessionHost.revealResultsForceClose">Trotzdem freigeben</span>
+              } @else {
+                <span i18n="@@sessionHost.revealResultsDespiteSuggestion"
+                  >Ergebnis trotzdem zeigen</span
+                >
+              }
             </button>
           } @else {
             <button
@@ -3573,11 +3577,19 @@
               color="primary"
               type="button"
               class="session-host__exit-anchor-button session-host__exit-anchor-button--primary"
-              [disabled]="controlPending()"
+              [disabled]="controlPending() || personalTimerBlocksReveal()"
+              [attr.aria-describedby]="
+                pendingTimerAccommodationCount() > 0
+                  ? 'session-host-timer-accommodation-status'
+                  : null
+              "
               (click)="revealResults()"
-              i18n="@@sessionHost.revealResultsAnchor"
             >
-              Ergebnis zeigen
+              @if (canForceClosePersonalTimers()) {
+                <span i18n="@@sessionHost.revealResultsForceClose">Trotzdem freigeben</span>
+              } @else {
+                <span i18n="@@sessionHost.revealResultsAnchor">Ergebnis zeigen</span>
+              }
             </button>
           }
         }

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -571,6 +571,9 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     const text = fixture.nativeElement.textContent ?? '';
     expect(text).toContain('ABC123');
     expect(text).toContain('Erste Frage starten');
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('h1.session-lobby__hero-title'),
+    ).toBeTruthy();
     fixture.destroy();
   });
 
@@ -3199,6 +3202,8 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     ) as HTMLElement | null;
 
     expect(questionText?.classList.contains('markdown-body')).toBe(true);
+    expect(questionText?.closest('h1.session-host__question-title')).toBeTruthy();
+    expect(questionText?.closest('[role="heading"][aria-level="1"]')).toBeNull();
     expect(answerText?.classList.contains('markdown-body')).toBe(true);
     fixture.destroy();
   });
@@ -3924,15 +3929,98 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
       round: 1,
       totalVotes: 0,
       pendingTimerAccommodationCount: 1,
+      blockingTimerAccommodationCount: 1,
     });
     fixture.detectChanges();
-    expect(
-      (fixture.nativeElement as HTMLElement).querySelector(
-        '.session-host__timer-accommodation-warning',
-      )?.textContent,
-    ).toContain(
-      'Eine Person mit Zeitanpassung antwortet noch. „Ergebnis zeigen“ beendet ihre Eingabe.',
+    const timerWarning = (fixture.nativeElement as HTMLElement).querySelector(
+      '.session-host__timer-accommodation-warning',
     );
+    expect(timerWarning?.textContent).toContain(
+      'Eine Person nutzt noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.',
+    );
+    const resultButton = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).find((button) => (button.textContent ?? '').includes('Ergebnis zeigen'));
+    expect(resultButton?.disabled).toBe(true);
+    expect(resultButton?.getAttribute('aria-describedby')).toBe(
+      'session-host-timer-accommodation-status',
+    );
+    fixture.destroy();
+  });
+
+  it('bietet nach Raum-Countdown Trotzdem-freigeben mit Bestaetigung an', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'ACTIVE' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'ACTIVE', currentQuestion: 0 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'bbbbbbbb-2222-4222-8222-222222222222',
+      order: 0,
+      totalQuestions: 3,
+      text: 'Welche Antwort ist richtig?',
+      type: 'SINGLE_CHOICE',
+      currentRound: 1,
+      timer: 30,
+      activeAt: null,
+      answers: [
+        { id: 'aaaaaaaa-1111-4111-8111-111111111111', text: 'A', isCorrect: false },
+        { id: 'bbbbbbbb-2222-4222-8222-222222222222', text: 'B', isCorrect: true },
+      ],
+      voteDistribution: [
+        {
+          id: 'aaaaaaaa-1111-4111-8111-111111111111',
+          text: 'A',
+          isCorrect: false,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+        {
+          id: 'bbbbbbbb-2222-4222-8222-222222222222',
+          text: 'B',
+          isCorrect: true,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+      ],
+      totalVotes: 0,
+      correctVoterCount: 0,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.componentInstance.hostVoteProgress.set({
+      questionId: 'bbbbbbbb-2222-4222-8222-222222222222',
+      questionOrder: 0,
+      round: 1,
+      totalVotes: 0,
+      pendingTimerAccommodationCount: 1,
+      blockingTimerAccommodationCount: 1,
+    });
+    fixture.componentInstance.countdownEnded.set(true);
+    fixture.detectChanges();
+
+    const timerWarning = (fixture.nativeElement as HTMLElement).querySelector(
+      '.session-host__timer-accommodation-warning',
+    );
+    expect(timerWarning?.textContent).toContain('Trotzdem freigeben');
+    const resultButton = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ).find((button) => (button.textContent ?? '').includes('Trotzdem freigeben'));
+    expect(resultButton?.disabled).toBe(false);
+
+    dialogOpenMock.mockClear();
+    dialogOpenMock.mockReturnValueOnce({ afterClosed: () => of(true) });
+    revealResultsMutateMock.mockClear();
+    await fixture.componentInstance.revealResults();
+    expect(dialogOpenMock).toHaveBeenCalled();
+    expect(revealResultsMutateMock).toHaveBeenCalledWith({
+      code: 'ABC123',
+      forceClosePersonalTimers: true,
+    });
     fixture.destroy();
   });
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -886,7 +886,9 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       );
     }
 
-    return session.quizName ?? null;
+    return (
+      session.quizName?.trim() || $localize`:@@sessionHost.lobbyQuizHeadingFallback:Quiz-Session`
+    );
   });
   readonly qaHeading = computed(
     () =>
@@ -1241,6 +1243,22 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       ? (progress.pendingTimerAccommodationCount ?? 0)
       : 0;
   });
+  readonly blockingTimerAccommodationCount = computed(() => {
+    if (this.effectiveStatus() !== 'ACTIVE') return 0;
+    const question = this.displayedCurrentQuestionForHost();
+    const progress = this.hostVoteProgress();
+    return this.hostVoteProgressMatchesQuestion(progress, question)
+      ? (progress.blockingTimerAccommodationCount ?? 0)
+      : 0;
+  });
+  /** Persönliche 10×-Fenster blockieren Freigabe, bis Raum-Countdown endet. */
+  readonly personalTimerBlocksReveal = computed(
+    () => this.blockingTimerAccommodationCount() > 0 && !this.countdownEnded(),
+  );
+  /** Nach Raum-Countdown: Host darf persönliche Fenster mit Bestätigung schließen. */
+  readonly canForceClosePersonalTimers = computed(
+    () => this.blockingTimerAccommodationCount() > 0 && this.countdownEnded(),
+  );
   readonly readingReadyStatus = computed(() => this.participantsPayload()?.readingReady ?? null);
   readonly allConnectedParticipantsReady = computed(
     () =>
@@ -3717,6 +3735,8 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       left.round === right.round &&
       left.totalVotes === right.totalVotes &&
       (left.pendingTimerAccommodationCount ?? 0) === (right.pendingTimerAccommodationCount ?? 0) &&
+      (left.blockingTimerAccommodationCount ?? 0) ===
+        (right.blockingTimerAccommodationCount ?? 0) &&
       (left.correctVoterCount ?? null) === (right.correctVoterCount ?? null) &&
       (left.incorrectVoterCount ?? null) === (right.incorrectVoterCount ?? null) &&
       JSON.stringify(left.peerInstructionSuggestion ?? null) ===
@@ -3751,11 +3771,22 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     return $localize`${formatLocaleCount(votes, this.localeId)} von ${formatLocaleCount(participants, this.localeId)}`;
   }
 
-  pendingTimerAccommodationLabel(count: number): string {
-    if (count === 1) {
-      return $localize`:@@sessionHost.timerAccommodationPendingOne:Eine Person mit Zeitanpassung antwortet noch. „Ergebnis zeigen“ beendet ihre Eingabe.`;
+  pendingTimerAccommodationLabel(count: number, blockingCount: number): string {
+    const roomCountdownEnded = this.countdownEnded();
+    if (blockingCount === 1) {
+      return roomCountdownEnded
+        ? $localize`:@@sessionHost.timerAccommodationBlockingOneForce:Eine Person nutzt noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihr persönliches Fenster.`
+        : $localize`:@@sessionHost.timerAccommodationBlockingOne:Eine Person nutzt noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.`;
     }
-    return $localize`:@@sessionHost.timerAccommodationPendingMany:${formatLocaleCount(count, this.localeId)}:count: Personen mit Zeitanpassung antworten noch. „Ergebnis zeigen“ beendet ihre Eingabe.`;
+    if (blockingCount > 1) {
+      return roomCountdownEnded
+        ? $localize`:@@sessionHost.timerAccommodationBlockingManyForce:${formatLocaleCount(blockingCount, this.localeId)}:count: Personen nutzen noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihre persönlichen Fenster.`
+        : $localize`:@@sessionHost.timerAccommodationBlockingMany:${formatLocaleCount(blockingCount, this.localeId)}:count: Personen nutzen noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.`;
+    }
+    if (count === 1) {
+      return $localize`:@@sessionHost.timerAccommodationPendingOne:Eine Person antwortet ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.`;
+    }
+    return $localize`:@@sessionHost.timerAccommodationPendingMany:${formatLocaleCount(count, this.localeId)}:count: Personen antworten ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.`;
   }
 
   voteProgressAria(votes: number, participants: number, percentage: number): string {
@@ -5822,13 +5853,20 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   }
 
   async revealResults(): Promise<void> {
-    if (this.controlPending() || !this.code) return;
+    if (this.controlPending() || !this.code || this.personalTimerBlocksReveal()) return;
+    const forceClosePersonalTimers = this.canForceClosePersonalTimers();
+    if (forceClosePersonalTimers && !(await this.confirmForceClosePersonalTimers('reveal'))) {
+      return;
+    }
     this.controlPending.set(true);
     try {
       this.clearEmojiNewBadge();
       this.stopCountdown();
       this.countdownSeconds.set(null);
-      const result = await trpc.session.revealResults.mutate({ code: this.code.toUpperCase() });
+      const result = await trpc.session.revealResults.mutate({
+        code: this.code.toUpperCase(),
+        ...(forceClosePersonalTimers ? { forceClosePersonalTimers: true } : {}),
+      });
       this.statusUpdate.set(result);
       this.dismissHostSteeringCallout();
       this.controlPending.set(false);
@@ -5843,13 +5881,20 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   }
 
   async startDiscussion(): Promise<void> {
-    if (this.controlPending() || !this.code) return;
+    if (this.controlPending() || !this.code || this.personalTimerBlocksReveal()) return;
+    const forceClosePersonalTimers = this.canForceClosePersonalTimers();
+    if (forceClosePersonalTimers && !(await this.confirmForceClosePersonalTimers('discussion'))) {
+      return;
+    }
     this.controlPending.set(true);
     try {
       this.clearEmojiNewBadge();
       this.stopCountdown();
       this.countdownSeconds.set(null);
-      const result = await trpc.session.startDiscussion.mutate({ code: this.code.toUpperCase() });
+      const result = await trpc.session.startDiscussion.mutate({
+        code: this.code.toUpperCase(),
+        ...(forceClosePersonalTimers ? { forceClosePersonalTimers: true } : {}),
+      });
       this.statusUpdate.set(result);
       this.dismissHostSteeringCallout();
       this.controlPending.set(false);
@@ -5859,6 +5904,36 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     } finally {
       this.controlPending.set(false);
     }
+  }
+
+  private async confirmForceClosePersonalTimers(intent: 'reveal' | 'discussion'): Promise<boolean> {
+    const blockingCount = this.blockingTimerAccommodationCount();
+    const consequences =
+      blockingCount === 1
+        ? [
+            $localize`:@@sessionHost.forceClosePersonalTimersConsequenceOne:Die offene persönliche 10×-Frist dieser Person endet sofort.`,
+            $localize`:@@sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput:Danach ist keine weitere Antwort mehr möglich.`,
+          ]
+        : [
+            $localize`:@@sessionHost.forceClosePersonalTimersConsequenceMany:${formatLocaleCount(blockingCount, this.localeId)}:count: offene persönliche 10×-Fristen enden sofort.`,
+            $localize`:@@sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput:Danach ist keine weitere Antwort mehr möglich.`,
+          ];
+    const dialogRef = this.dialog.open(ConfirmLeaveDialogComponent, {
+      data: {
+        title: $localize`:@@sessionHost.forceClosePersonalTimersTitle:Persönliche Fristen beenden?`,
+        message:
+          intent === 'discussion'
+            ? $localize`:@@sessionHost.forceClosePersonalTimersMessageDiscussion:Du startest die Diskussionsphase, obwohl noch persönliche Timer laufen.`
+            : $localize`:@@sessionHost.forceClosePersonalTimersMessageReveal:Du zeigst das Ergebnis, obwohl noch persönliche Timer laufen.`,
+        consequences,
+        confirmLabel: $localize`:@@sessionHost.forceClosePersonalTimersConfirm:Trotzdem freigeben`,
+        cancelLabel: $localize`:@@sessionHost.forceClosePersonalTimersCancel:Weiter warten`,
+      } satisfies ConfirmLeaveDialogData,
+      width: 'min(26rem, calc(100vw - 1.5rem))',
+      maxWidth: '100vw',
+      autoFocus: 'dialog',
+    });
+    return (await firstValueFrom(dialogRef.afterClosed())) === true;
   }
 
   async startSecondRound(): Promise<void> {

--- a/apps/frontend/src/app/features/session/session-present/word-cloud.component.html
+++ b/apps/frontend/src/app/features/session/session-present/word-cloud.component.html
@@ -7,7 +7,7 @@
     @if (eyebrow()) {
       <p class="word-cloud__eyebrow">{{ eyebrow() }}</p>
     }
-    <mat-card-title>{{ title() }}</mat-card-title>
+    <h2 mat-card-title>{{ title() }}</h2>
     @if (description()) {
       <mat-card-subtitle class="word-cloud__description">{{ description() }}</mat-card-subtitle>
     }

--- a/apps/frontend/src/app/features/session/session-present/word-cloud.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-present/word-cloud.component.spec.ts
@@ -77,6 +77,9 @@ describe('WordCloudComponent', () => {
     );
 
     expect(ranking).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('h2[mat-card-title]')?.textContent).toContain(
+      'Wortwolke',
+    );
     expect(entries[0]).toContain('motivation: Nennungen: 3');
     expect(entries).toHaveLength(fixture.componentInstance.words().length);
   });

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
@@ -1,3 +1,90 @@
+<ng-template #timerAccommodationPanel>
+  <section
+    class="vote-timer-a11y"
+    data-testid="vote-timer-accommodation"
+    aria-labelledby="vote-timer-a11y-heading"
+  >
+    <header class="vote-timer-a11y__header">
+      <mat-icon class="vote-timer-a11y__icon" aria-hidden="true">schedule</mat-icon>
+      <div>
+        <h2
+          id="vote-timer-a11y-heading"
+          class="vote-timer-a11y__title"
+          i18n="@@sessionVote.timerAccommodation.legend"
+        >
+          Zeit anpassen
+        </h2>
+        <p class="vote-timer-a11y__supporting" i18n="@@sessionVote.timerAccommodation.help">
+          Vor der Frage wählen · 10× Zeit = zehnfacher Raum-Countdown
+        </p>
+      </div>
+    </header>
+    <p class="vote-timer-a11y__points">{{ timerAccommodationPointsHint() }}</p>
+    <details class="vote-timer-a11y__scoring" data-testid="vote-scoring-info">
+      <summary class="vote-timer-a11y__scoring-summary">
+        <mat-icon aria-hidden="true">info</mat-icon>
+        <span i18n="@@sessionVote.scoringInfo.summary">So werden Punkte berechnet</span>
+      </summary>
+      <div class="vote-timer-a11y__scoring-body">
+        <p i18n="@@sessionVote.scoringInfo.intro">So setzt sich deine Punktezahl zusammen:</p>
+        <ol class="vote-timer-a11y__scoring-list">
+          <li i18n="@@sessionVote.scoringInfo.base">
+            Basis: Bis zu 1000 Punkte für eine richtige Antwort.
+          </li>
+          <li i18n="@@sessionVote.scoringInfo.difficulty">
+            Schwierigkeit: Leicht ×1, Mittel ×2, Schwer ×3.
+          </li>
+          <li i18n="@@sessionVote.scoringInfo.time">
+            Zeit: Je früher du beim gemeinsamen Raum-Countdown richtig antwortest, desto höher der
+            Zeitanteil. Nach Ablauf bleiben noch 10 % davon. Deine persönliche Frist ändert nur, wie
+            lange du antworten darfst – nicht diese Zeitwertung.
+          </li>
+          <li i18n="@@sessionVote.scoringInfo.streak">
+            Serie: Mehrere richtige Antworten hintereinander geben Bonus – 1× ×1,0 · 2× ×1,1 · 3×
+            ×1,2 · 4× ×1,3 · ab 5× ×1,5. Eine falsche bewertbare Antwort setzt die Serie zurück.
+            Umfragen und unbewerteter Freitext unterbrechen sie nicht.
+          </li>
+          <li i18n="@@sessionVote.scoringInfo.preview">
+            Die Live-Punktvorschau zeigt den aktuellen Stand ohne Serien-Bonus.
+          </li>
+        </ol>
+      </div>
+    </details>
+    <mat-button-toggle-group
+      class="vote-timer-a11y__options"
+      [value]="timerAccommodation()"
+      [disabled]="timerAccommodationSaving()"
+      [attr.aria-label]="timerAccommodationGroupAriaLabel()"
+      (change)="setTimerAccommodation($any($event.value))"
+    >
+      @for (mode of timerAccommodationModes; track mode) {
+        <mat-button-toggle class="vote-timer-a11y__option" [value]="mode">
+          {{ timerAccommodationOptionLabel(mode) }}
+        </mat-button-toggle>
+      }
+    </mat-button-toggle-group>
+    @if (timerAccommodation() === 'OFF') {
+      <p
+        class="vote-timer-a11y__status"
+        role="status"
+        aria-live="polite"
+        i18n="@@sessionVote.timerAccommodation.offStatus"
+      >
+        Keine persönliche Frist · Punkte weiter nach dem Raum-Timer
+      </p>
+    } @else if (timerAccommodation() === 'EXTENDED') {
+      <p
+        class="vote-timer-a11y__status"
+        role="status"
+        aria-live="polite"
+        i18n="@@sessionVote.timerAccommodation.extendedStatus"
+      >
+        10× Zeit aktiv · Das Ergebnis wartet auf dich
+      </p>
+    }
+  </section>
+</ng-template>
+
 @if (showSessionEndGate()) {
   <div
     id="vote-top"
@@ -296,7 +383,7 @@
       </div>
     }
 
-    @if ((countdownSeconds() !== null && isActive()) || liveScorePreviewPoints() !== null) {
+    @if ((countdownSeconds() !== null && isActive()) || liveScorePreviewAvailable()) {
       <div
         class="vote-countdown-floating"
         [class.vote-countdown-floating--with-tabs]="showChannelTabs()"
@@ -312,13 +399,34 @@
           </span>
         }
         @if (liveScorePreviewPoints() !== null) {
-          <p class="vote-score-preview" data-testid="vote-score-preview">
+          <div class="vote-score-preview" data-testid="vote-score-preview">
             <span class="vote-score-preview__label">{{ liveScorePreviewCaption() }}</span>
             <strong class="vote-score-preview__value">
               <span>{{ liveScorePreviewFormattedPoints() }}</span>
               <span i18n="@@sessionVote.scorePreview.pointsUnit">Punkte</span>
             </strong>
-          </p>
+            <button
+              mat-button
+              type="button"
+              class="vote-score-preview__toggle"
+              [attr.aria-pressed]="true"
+              (click)="setLiveScorePreviewVisible(false)"
+              i18n="@@sessionVote.scorePreview.hide"
+            >
+              Ausblenden
+            </button>
+          </div>
+        } @else if (liveScorePreviewAvailable()) {
+          <button
+            mat-button
+            type="button"
+            class="vote-score-preview-toggle"
+            [attr.aria-pressed]="false"
+            (click)="setLiveScorePreviewVisible(true)"
+            i18n="@@sessionVote.scorePreview.show"
+          >
+            Live-Punkte anzeigen
+          </button>
         }
       </div>
     }
@@ -471,6 +579,9 @@
               <p class="vote-lobby__hint">{{ vpc.voteLobbyHintQuiz(isPlayfulPreset()) }}</p>
             }
           </div>
+          @if (showLobbyTimerAccommodationControls()) {
+            <ng-container [ngTemplateOutlet]="timerAccommodationPanel" />
+          }
         </div>
       } @else if (isActive() && isStandaloneQaSession()) {
         <div class="vote-lobby vote-lobby--active">
@@ -817,15 +928,19 @@
         </div>
       } @else if (isQuestionOpen()) {
         @if (currentQuestion(); as q) {
-          <div class="vote-question" id="vote-question-anchor">
-            <p class="vote-question__label">
+          <section
+            class="vote-question"
+            id="vote-question-anchor"
+            aria-labelledby="vote-question-heading"
+          >
+            <h1 class="vote-question__label" id="vote-question-heading">
               <span>{{ vpc.voteQuestionLabel(isPlayfulPreset(), q.order + 1) }}</span>
               @if ($any(q).totalQuestions != null && q.order + 1 === $any(q).totalQuestions) {
                 <span class="vote-question__last-badge">{{
                   vpc.voteLastQuestionBadge(isPlayfulPreset())
                 }}</span>
               }
-            </p>
+            </h1>
             <div
               class="vote-question__meta"
               i18n-aria-label="@@session.questionMetadataAria"
@@ -875,19 +990,23 @@
                 </button>
               }
             </div>
-          </div>
+          </section>
         }
       } @else if (isDiscussion()) {
         @if (currentQuestion(); as q) {
-          <div class="vote-question" id="vote-question-anchor">
-            <p class="vote-question__label">
+          <section
+            class="vote-question"
+            id="vote-question-anchor"
+            aria-labelledby="vote-question-heading"
+          >
+            <h1 class="vote-question__label" id="vote-question-heading">
               <span>{{ vpc.voteQuestionLabel(isPlayfulPreset(), q.order + 1) }}</span>
               @if ($any(q).totalQuestions != null && q.order + 1 === $any(q).totalQuestions) {
                 <span class="vote-question__last-badge">{{
                   vpc.voteLastQuestionBadge(isPlayfulPreset())
                 }}</span>
               }
-            </p>
+            </h1>
             <div
               class="vote-question__meta"
               i18n-aria-label="@@session.questionMetadataAria"
@@ -909,7 +1028,7 @@
               class="vote-question__text markdown-body"
               [innerHTML]="renderQuestionMarkdown(q.text)"
             ></div>
-          </div>
+          </section>
           <div class="vote-discussion" role="status" aria-live="polite">
             <div class="vote-discussion__icon-ring">
               <mat-icon class="vote-discussion__icon">groups</mat-icon>
@@ -924,9 +1043,10 @@
           @if (isResults()) {
             <div id="vote-result-anchor"></div>
           }
-          <div
+          <section
             class="vote-question"
             id="vote-question-anchor"
+            aria-labelledby="vote-question-heading"
             [class.vote-question--round2]="currentRound() === 2"
           >
             @if (currentRound() === 2 && isActive() && !voteSent()) {
@@ -935,7 +1055,7 @@
               </p>
             }
             <div class="vote-question__header">
-              <p class="vote-question__label">
+              <h1 class="vote-question__label" id="vote-question-heading">
                 <span>{{ vpc.voteQuestionLabel(isPlayfulPreset(), q.order + 1) }}</span>
                 @if ($any(q).totalQuestions != null && q.order + 1 === $any(q).totalQuestions) {
                   <span class="vote-question__last-badge">{{
@@ -947,7 +1067,7 @@
                     vpc.voteRoundBadge(isPlayfulPreset())
                   }}</span>
                 }
-              </p>
+              </h1>
               @if (allHaveVoted() && isActive()) {
                 <span class="vote-all-voted" role="status">
                   <mat-icon>how_to_vote</mat-icon>
@@ -976,7 +1096,7 @@
               class="vote-question__text markdown-body"
               [innerHTML]="renderQuestionMarkdown(q.text)"
             ></div>
-          </div>
+          </section>
 
           @if (isActive() && questionHasMedia(q.text) && !voteSent()) {
             <div class="vote-media-hint" role="note">
@@ -995,65 +1115,7 @@
           }
 
           @if (showTimerAccommodationControls()) {
-            <section
-              class="vote-timer-a11y"
-              data-testid="vote-timer-accommodation"
-              aria-labelledby="vote-timer-a11y-heading"
-            >
-              <header class="vote-timer-a11y__header">
-                <mat-icon class="vote-timer-a11y__icon" aria-hidden="true">schedule</mat-icon>
-                <div>
-                  <h3
-                    id="vote-timer-a11y-heading"
-                    class="vote-timer-a11y__title"
-                    i18n="@@sessionVote.timerAccommodation.legend"
-                  >
-                    Zeit anpassen
-                  </h3>
-                  <p
-                    class="vote-timer-a11y__supporting"
-                    i18n="@@sessionVote.timerAccommodation.help"
-                  >
-                    Nur für dich · Der Quizablauf bleibt unverändert
-                  </p>
-                </div>
-              </header>
-              <p class="vote-timer-a11y__points" i18n="@@sessionVote.timerAccommodation.points">
-                Punkte richten sich nach dem gemeinsamen Countdown
-              </p>
-              <mat-button-toggle-group
-                class="vote-timer-a11y__options"
-                [value]="timerAccommodation()"
-                [disabled]="timerAccommodationSaving()"
-                [attr.aria-label]="timerAccommodationGroupAriaLabel()"
-                (change)="setTimerAccommodation($any($event.value))"
-              >
-                @for (mode of timerAccommodationModes; track mode) {
-                  <mat-button-toggle class="vote-timer-a11y__option" [value]="mode">
-                    {{ timerAccommodationOptionLabel(mode) }}
-                  </mat-button-toggle>
-                }
-              </mat-button-toggle-group>
-              @if (timerAccommodation() === 'OFF') {
-                <p
-                  class="vote-timer-a11y__status"
-                  role="status"
-                  aria-live="polite"
-                  i18n="@@sessionVote.timerAccommodation.offStatus"
-                >
-                  Ohne Timer aktiv · Abgabe möglich, solange die Frage offen ist
-                </p>
-              } @else if (timerAccommodation() === 'EXTENDED') {
-                <p
-                  class="vote-timer-a11y__status"
-                  role="status"
-                  aria-live="polite"
-                  i18n="@@sessionVote.timerAccommodation.extendedStatus"
-                >
-                  10× Zeit aktiv
-                </p>
-              }
-            </section>
+            <ng-container [ngTemplateOutlet]="timerAccommodationPanel" />
           }
 
           @if (voteError()) {

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.scss
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.scss
@@ -2948,6 +2948,25 @@
   white-space: nowrap;
 }
 
+.vote-score-preview__toggle,
+.vote-score-preview-toggle {
+  pointer-events: auto;
+  min-height: 32px;
+  padding-inline: 0.5rem;
+  font: var(--mat-sys-label-medium);
+}
+
+.vote-score-preview__toggle {
+  justify-self: end;
+  margin: 0.15rem -0.35rem -0.3rem 0;
+}
+
+.vote-score-preview-toggle {
+  border-radius: var(--mat-sys-corner-full);
+  background: var(--mat-sys-surface-container-high);
+  color: var(--mat-sys-primary);
+}
+
 .vote-timer-a11y {
   margin: 0.75rem 0 1rem;
   padding: 1rem;
@@ -2955,12 +2974,14 @@
   border-radius: var(--mat-sys-corner-large, 12px);
   background: var(--mat-sys-surface-container-low);
   min-width: 0;
+  text-align: start;
 }
 
 .vote-timer-a11y__header {
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
+  text-align: start;
 }
 
 .vote-timer-a11y__icon {
@@ -2984,12 +3005,84 @@
 }
 
 .vote-timer-a11y__points {
-  margin: 0.75rem 0;
+  margin: 0.75rem 0 0.5rem;
   padding: 0.5rem 0.75rem;
   border-radius: var(--mat-sys-corner-small, 4px);
   background: var(--mat-sys-secondary-container);
   color: var(--mat-sys-on-secondary-container);
   font: var(--mat-sys-label-large);
+}
+
+.vote-timer-a11y__scoring {
+  margin: 0 0 0.75rem;
+  border-radius: var(--mat-sys-corner-small, 4px);
+  border: 1px solid var(--mat-sys-outline-variant);
+  background: var(--mat-sys-surface-container-low);
+  text-align: start;
+}
+
+.vote-timer-a11y__scoring-summary {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.4rem;
+  min-height: 44px;
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  list-style: none;
+  font: var(--mat-sys-label-large);
+  color: var(--mat-sys-on-surface);
+  text-align: start;
+}
+
+.vote-timer-a11y__scoring-summary::-webkit-details-marker {
+  display: none;
+}
+
+.vote-timer-a11y__scoring-summary mat-icon {
+  flex: 0 0 auto;
+  width: 1.25rem;
+  height: 1.25rem;
+  font-size: 1.25rem;
+  color: var(--mat-sys-primary);
+}
+
+.vote-timer-a11y__scoring-summary:focus-visible {
+  outline: 2px solid var(--mat-sys-primary);
+  outline-offset: 2px;
+  border-radius: var(--mat-sys-corner-small, 4px);
+}
+
+.vote-timer-a11y__scoring-body {
+  padding: 0 0.75rem 0.75rem;
+  border-top: 1px solid var(--mat-sys-outline-variant);
+  text-align: start;
+}
+
+.vote-timer-a11y__scoring-body p {
+  margin: 0.65rem 0 0.4rem;
+  font: var(--mat-sys-body-small);
+  line-height: 1.45;
+  color: var(--mat-sys-on-surface-variant);
+  text-align: start;
+}
+
+.vote-timer-a11y__scoring-list {
+  margin: 0;
+  padding-inline-start: 1.15rem;
+  font: var(--mat-sys-body-small);
+  line-height: 1.45;
+  color: var(--mat-sys-on-surface);
+  text-align: start;
+  list-style-position: outside;
+}
+
+.vote-timer-a11y__scoring-list li {
+  text-align: start;
+}
+
+.vote-timer-a11y__scoring-list li + li {
+  margin-top: 0.4rem;
 }
 
 .vote-timer-a11y__options {

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.spec.ts
@@ -139,6 +139,8 @@ async function findNumericEstimateInput(
 describe('SessionVoteComponent', { timeout: 30_000 }, () => {
   afterEach(() => {
     vi.useRealTimers();
+    localStorage.removeItem('arsnova-live-score-preview');
+    localStorage.removeItem('arsnova-timer-accommodation');
   });
 
   it('liefert phasenabhängige Einsprung-Anker mit korrekten Fallbacks', () => {
@@ -220,7 +222,11 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
       teamName: 'Rot',
       timerAccommodation: 'DEFAULT',
     });
-    setTimerAccommodationMutateMock.mockResolvedValue({ timerAccommodation: 'EXTENDED' });
+    setTimerAccommodationMutateMock.mockImplementation(
+      async (input: { accommodation: 'DEFAULT' | 'EXTENDED' | 'OFF' }) => ({
+        timerAccommodation: input.accommodation,
+      }),
+    );
     getTeamsQueryMock.mockResolvedValue({ teams: [], teamCount: 0 });
     getTeamLeaderboardQueryMock.mockResolvedValue([
       {
@@ -381,14 +387,25 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
       '[data-testid="vote-timer-accommodation"]',
     ) as HTMLElement | null;
     expect(timerCard).toBeTruthy();
-    expect(timerCard?.querySelector('h3')?.textContent).toContain('Zeit anpassen');
+    expect(timerCard?.querySelector('h2')?.textContent).toContain('Zeit anpassen');
     expect(timerCard?.querySelector('mat-button-toggle-group')).toBeTruthy();
     expect(host.textContent).toContain('Zeit anpassen');
-    expect(host.textContent).toContain('Quizablauf bleibt unverändert');
-    expect(host.textContent).toContain('Punkte richten sich nach dem gemeinsamen Countdown');
-    expect(host.textContent).toContain('Standard');
+    expect(host.textContent).toContain('10× Zeit = zehnfacher Raum-Countdown');
+    expect(host.textContent).toContain('Punkte folgen dem gemeinsamen Countdown');
+    expect(host.textContent).toContain('So werden Punkte berechnet');
+    expect(host.textContent).not.toContain('danach nur Mindestpunkte');
+    const scoringInfo = host.querySelector(
+      '[data-testid="vote-scoring-info"]',
+    ) as HTMLDetailsElement | null;
+    expect(scoringInfo).toBeTruthy();
+    scoringInfo!.open = true;
+    fixture.detectChanges();
+    expect(scoringInfo!.textContent).toContain('Leicht ×1, Mittel ×2, Schwer ×3');
+    expect(scoringInfo!.textContent).toContain('ab 5× ×1,5');
+    expect(scoringInfo!.textContent).toContain('ohne Serien-Bonus');
+    expect(host.textContent).toContain('Ohne Frist');
     expect(host.textContent).toContain('10× Zeit');
-    expect(host.textContent).toContain('Ohne Timer');
+    expect(host.textContent).toContain('Standard');
 
     await component.setTimerAccommodation('EXTENDED');
     fixture.detectChanges();
@@ -399,8 +416,40 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
       accommodation: 'EXTENDED',
     });
     expect(component.timerAccommodation()).toBe('EXTENDED');
-    expect(host.textContent).toContain('10× Zeit aktiv');
+    expect(host.textContent).toContain(
+      'Früh abgeben lohnt sich · nach dem Countdown nur Mindestpunkte',
+    );
+    expect(host.textContent).toContain('10× Zeit aktiv · Das Ergebnis wartet auf dich');
     expect(localStorage.getItem('arsnova-timer-accommodation')).toBe('EXTENDED');
+
+    await component.setTimerAccommodation('OFF');
+    fixture.detectChanges();
+    expect(host.textContent).toContain(
+      'Keine persönliche Frist · Punkte weiter nach dem Raum-Timer',
+    );
+    expect(host.textContent).toContain(
+      'Früh abgeben lohnt sich · nach dem Countdown nur Mindestpunkte',
+    );
+    fixture.destroy();
+  });
+
+  it('bietet die Zeitanpassung bereits in der Quiz-Lobby an', () => {
+    const fixture = TestBed.createComponent(SessionVoteComponent);
+    const component = fixture.componentInstance;
+    component.status.set('LOBBY');
+    component.participantId.set('11111111-1111-4111-8111-111111111111');
+    component.sessionSettings.set({ type: 'QUIZ' });
+    fixture.detectChanges();
+
+    expect(component.showLobbyTimerAccommodationControls()).toBe(true);
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector(
+        '[data-testid="vote-timer-accommodation"]',
+      ),
+    ).toBeTruthy();
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain(
+      'Vor der Frage wählen · 10× Zeit = zehnfacher Raum-Countdown',
+    );
     fixture.destroy();
   });
 
@@ -478,6 +527,105 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
         ?.querySelector('.vote-score-preview__value')
         ?.textContent?.replace(/\s+/g, ''),
     ).toContain('200Punkte');
+    expect(floatingPreview?.getAttribute('aria-live')).toBeNull();
+    expect(floatingPreview?.getAttribute('role')).not.toBe('status');
+    component.setLiveScorePreviewVisible(false);
+    fixture.detectChanges();
+    expect(component.showLiveScorePreview()).toBe(false);
+    expect(component.liveScorePreviewPoints()).toBeNull();
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('.vote-score-preview-toggle')
+        ?.textContent,
+    ).toContain('Live-Punkte anzeigen');
+    expect(localStorage.getItem('arsnova-live-score-preview')).toBe('false');
+    fixture.destroy();
+  });
+
+  it('stellt die ausgeblendete Punktvorschau aus localStorage wieder her', async () => {
+    localStorage.setItem('arsnova-live-score-preview', 'false');
+    getInfoQueryMock.mockResolvedValue({
+      id: 'session-1',
+      code: 'ABC123',
+      type: 'QUIZ',
+      status: 'ACTIVE',
+      serverTime: MOCK_SERVER_TIME,
+      quizName: 'Demo Quiz',
+      title: null,
+      channels: {
+        quiz: { enabled: true },
+        qa: { enabled: false, open: false, title: null, moderationMode: false },
+        quickFeedback: { enabled: false, open: false },
+      },
+      participantCount: 1,
+      teamMode: false,
+      anonymousMode: false,
+      nicknameTheme: 'HIGH_SCHOOL',
+    });
+    currentQuestionQueryMock.mockResolvedValue({
+      id: 'score-preview-restore',
+      text: 'Frage',
+      type: 'SINGLE_CHOICE',
+      difficulty: 'MEDIUM',
+      order: 0,
+      totalQuestions: 1,
+      answers: [
+        { id: 'a1', text: 'A' },
+        { id: 'a2', text: 'B' },
+      ],
+      activeAt: MOCK_SERVER_TIME,
+      timer: 60,
+      sessionTimer: 60,
+      timerAccommodation: 'DEFAULT',
+      currentRound: 1,
+      totalVotes: 0,
+      participantCount: 1,
+    });
+
+    const fixture = TestBed.createComponent(SessionVoteComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance;
+    expect(component.liveScorePreviewVisible()).toBe(false);
+
+    component.status.set('ACTIVE');
+    component.currentRound.set(1);
+    component.voteSent.set(false);
+    component.voteClosed.set(false);
+    component.sessionTimerSeconds.set(60);
+    component.scorePreviewElapsedSeconds.set(0);
+    component.currentQuestion.set({
+      id: 'score-preview-restore',
+      text: 'Frage',
+      type: 'SINGLE_CHOICE',
+      difficulty: 'MEDIUM',
+      order: 0,
+      totalQuestions: 1,
+      answers: [
+        { id: 'a1', text: 'A' },
+        { id: 'a2', text: 'B' },
+      ],
+      activeAt: MOCK_SERVER_TIME,
+      timer: 60,
+      sessionTimer: 60,
+      timerAccommodation: 'DEFAULT',
+      currentRound: 1,
+      totalVotes: 0,
+      participantCount: 1,
+    });
+    fixture.detectChanges();
+
+    expect(component.liveScorePreviewAvailable()).toBe(true);
+    expect(component.liveScorePreviewPoints()).toBeNull();
+    expect(
+      (fixture.nativeElement as HTMLElement)
+        .querySelector('.vote-score-preview-toggle')
+        ?.getAttribute('aria-pressed'),
+    ).toBe('false');
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('[data-testid="vote-score-preview"]'),
+    ).toBeNull();
     fixture.destroy();
   });
 
@@ -3962,6 +4110,11 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
     ) as HTMLElement | null;
 
     expect(questionText?.classList.contains('markdown-body')).toBe(true);
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector(
+        'section.vote-question[aria-labelledby="vote-question-heading"] h1',
+      )?.textContent,
+    ).toContain('Frage 1');
     expect(answerText?.classList.contains('markdown-body')).toBe(true);
     fixture.destroy();
   });

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
@@ -14,7 +14,7 @@ import {
   afterNextRender,
   untracked,
 } from '@angular/core';
-import { DecimalPipe, formatNumber } from '@angular/common';
+import { DecimalPipe, NgTemplateOutlet, formatNumber } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
 import { MatButton } from '@angular/material/button';
@@ -114,6 +114,7 @@ const PARTICIPANT_STORAGE_KEY = 'arsnova-participant';
 const NICKNAME_STORAGE_KEY = 'arsnova-nickname';
 /** Geräteweite Präferenz für persönliche Timer-Anpassung (WCAG 2.2.1). */
 const TIMER_ACCOMMODATION_STORAGE_KEY = 'arsnova-timer-accommodation';
+const LIVE_SCORE_PREVIEW_STORAGE_KEY = 'arsnova-live-score-preview';
 const TIMER_ACCOMMODATION_MODES = [
   'DEFAULT',
   'EXTENDED',
@@ -387,6 +388,7 @@ export function getNumericEstimateMotivation(input: {
     MatProgressSpinner,
     CountdownFingersComponent,
     DecimalPipe,
+    NgTemplateOutlet,
     FeedbackVoteComponent,
     MarkdownImageLightboxDirective,
     AnswerOptionBadgeComponent,
@@ -475,6 +477,7 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
   readonly sessionTimerSeconds = signal<number | null>(null);
   /** Ganzzahlige Sekunden seit Fragenstart für die lokale Punktvorschau (1-Hz). */
   readonly scorePreviewElapsedSeconds = signal(0);
+  readonly liveScorePreviewVisible = signal(true);
   readonly timerAccommodationSaving = signal(false);
   readonly timerAccommodationModes = TIMER_ACCOMMODATION_MODES;
   private questionActiveAtMs: number | null = null;
@@ -1170,8 +1173,12 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
     return typeof sessionTimer === 'number' && sessionTimer > 0;
   });
 
-  /** Lokale Punktvorschau ohne Netzwerklast; nur bei bewerteten, getimten Fragen. */
-  readonly showLiveScorePreview = computed(() => {
+  readonly showLobbyTimerAccommodationControls = computed(
+    () => this.isLobby() && !this.isStandaloneQaSession() && !!this.participantId(),
+  );
+
+  /** Verfügbarkeit der rein lokalen Punktvorschau; verursacht keine Netzwerkanfrage. */
+  readonly liveScorePreviewAvailable = computed(() => {
     if (!this.isActive() || this.voteSent() || this.voteClosed() || this.currentRound() === 2) {
       return false;
     }
@@ -1181,6 +1188,9 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
     const sessionTimer = this.sessionTimerSeconds();
     return typeof sessionTimer === 'number' && sessionTimer > 0;
   });
+  readonly showLiveScorePreview = computed(
+    () => this.liveScorePreviewAvailable() && this.liveScorePreviewVisible(),
+  );
 
   readonly liveScorePreviewPoints = computed(() => {
     if (!this.showLiveScorePreview()) {
@@ -2493,10 +2503,17 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
       case 'EXTENDED':
         return $localize`:@@sessionVote.timerAccommodation.extended:10× Zeit`;
       case 'OFF':
-        return $localize`:@@sessionVote.timerAccommodation.off:Ohne Timer`;
+        return $localize`:@@sessionVote.timerAccommodation.off:Ohne Frist`;
       default:
         return $localize`:@@sessionVote.timerAccommodation.default:Standard`;
     }
+  }
+
+  timerAccommodationPointsHint(): string {
+    if (this.timerAccommodation() === 'DEFAULT') {
+      return $localize`:@@sessionVote.timerAccommodation.pointsDefault:Punkte folgen dem gemeinsamen Countdown`;
+    }
+    return $localize`:@@sessionVote.timerAccommodation.pointsOvertime:Früh abgeben lohnt sich · nach dem Countdown nur Mindestpunkte`;
   }
 
   liveScorePreviewCaption(): string {
@@ -2506,6 +2523,14 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
     return this.liveScorePreviewUsesUpperBound()
       ? $localize`:@@sessionVote.scorePreview.upToNow:Volle Wertung jetzt`
       : $localize`:@@sessionVote.scorePreview.correctNow:Richtige Antwort jetzt`;
+  }
+
+  setLiveScorePreviewVisible(visible: boolean): void {
+    this.liveScorePreviewVisible.set(visible);
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(LIVE_SCORE_PREVIEW_STORAGE_KEY, visible ? 'true' : 'false');
+    }
+    this.syncScorePreviewTicker();
   }
 
   async setTimerAccommodation(mode: TimerAccommodation): Promise<void> {
@@ -2743,6 +2768,9 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
     if (typeof localStorage !== 'undefined') {
       this.participantId.set(localStorage.getItem(`${PARTICIPANT_STORAGE_KEY}-${this.code}`) ?? '');
       this.playerNickname.set(localStorage.getItem(`${NICKNAME_STORAGE_KEY}-${this.code}`) ?? null);
+      this.liveScorePreviewVisible.set(
+        localStorage.getItem(LIVE_SCORE_PREVIEW_STORAGE_KEY) !== 'false',
+      );
     }
     if (confirmedTeam) {
       this.participantTeam.set({

--- a/apps/frontend/src/app/features/session/session.component.html
+++ b/apps/frontend/src/app/features/session/session.component.html
@@ -6,10 +6,10 @@
   } @else if (error()) {
     <mat-card class="session-page__error-card">
       <mat-card-header>
-        <mat-card-title>
+        <h1 mat-card-title>
           <mat-icon class="session-page__error-icon">error</mat-icon>
           <span i18n>Fehler</span>
-        </mat-card-title>
+        </h1>
       </mat-card-header>
       <mat-card-content>
         <p class="session-page__error-text" role="alert">{{ error() }}</p>

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -4234,7 +4234,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4646</context>
+          <context context-type="linenumber">4662</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -4242,11 +4242,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2074,2076</context>
+          <context context-type="linenumber">2136,2138</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2199</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackHostTitle" datatype="html">
@@ -4286,7 +4286,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3609</context>
+          <context context-type="linenumber">3635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -4730,7 +4730,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1880</context>
+          <context context-type="linenumber">1888</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -4742,7 +4742,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1885</context>
+          <context context-type="linenumber">1893</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -4766,7 +4766,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -4778,7 +4778,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -4934,7 +4934,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackVoteTitle" datatype="html">
@@ -5094,7 +5094,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2082,2085</context>
+          <context context-type="linenumber">2144,2147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.voteMissing" datatype="html">
@@ -6927,11 +6927,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4958</context>
+          <context context-type="linenumber">4974</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2268</context>
+          <context context-type="linenumber">2278</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3532753318619772032" datatype="html">
@@ -6943,11 +6943,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4960</context>
+          <context context-type="linenumber">4976</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2270</context>
+          <context context-type="linenumber">2280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="74432774947660496" datatype="html">
@@ -6959,11 +6959,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="276214048875673948" datatype="html">
@@ -6975,11 +6975,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5356551916626450286" datatype="html">
@@ -6991,11 +6991,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3903113005127984737" datatype="html">
@@ -7007,11 +7007,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeRemoveSession" datatype="html">
@@ -7263,7 +7263,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7271,7 +7271,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6658206425619028413" datatype="html">
@@ -7283,7 +7283,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7291,7 +7291,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5683915683305860193" datatype="html">
@@ -7379,15 +7379,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2911</context>
+          <context context-type="linenumber">2919</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2449</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2458</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/preset-toast/preset-toast.component.ts</context>
@@ -9798,11 +9798,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4629</context>
+          <context context-type="linenumber">4645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.medium" datatype="html">
@@ -9818,11 +9818,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4631</context>
+          <context context-type="linenumber">4647</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1787</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.hard" datatype="html">
@@ -9838,11 +9838,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4633</context>
+          <context context-type="linenumber">4649</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1779</context>
+          <context context-type="linenumber">1789</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeExactLabel" datatype="html">
@@ -11011,11 +11011,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1348</context>
+          <context context-type="linenumber">1410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1612</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesExportCsv" datatype="html">
@@ -12527,7 +12527,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3027</context>
+          <context context-type="linenumber">3031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -12539,7 +12539,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3030</context>
+          <context context-type="linenumber">3034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -12551,7 +12551,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3035</context>
+          <context context-type="linenumber">3039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -12563,7 +12563,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3225</context>
+          <context context-type="linenumber">3229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -12575,7 +12575,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3229</context>
+          <context context-type="linenumber">3233</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -12587,7 +12587,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3232</context>
+          <context context-type="linenumber">3236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -12599,7 +12599,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3235</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -12755,7 +12755,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2735</context>
+          <context context-type="linenumber">2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -12783,7 +12783,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2998</context>
+          <context context-type="linenumber">3002</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -12987,7 +12987,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2968</context>
+          <context context-type="linenumber">2972</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -13191,8 +13191,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
-        <source> Teilnehmende können ihre persönliche Zeit bei Bedarf verlängern oder abschalten.</source>
-        <target>Participants can extend or switch off their personal time if necessary.</target>
+        <source> Teilnehmende können ihre persönliche Frist bei Bedarf verlängern oder abschalten.</source>
+        <target>Participants can extend or turn off their personal deadline if needed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">1441,1444</context>
@@ -13203,19 +13203,19 @@
         <target>Question metadata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1456</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">832</context>
+          <context context-type="linenumber">947</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">894</context>
+          <context context-type="linenumber">1013</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">961</context>
+          <context context-type="linenumber">1081</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4209613400308596118" datatype="html">
@@ -13223,7 +13223,7 @@
         <target>Reading phase</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1481</context>
+          <context context-type="linenumber">1485</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
@@ -13231,7 +13231,7 @@
         <target>Answers will follow shortly.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1482,1484</context>
+          <context context-type="linenumber">1486,1488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
@@ -13239,7 +13239,7 @@
         <target>Rating scale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1540</context>
+          <context context-type="linenumber">1544</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
@@ -13247,7 +13247,7 @@
         <target>Rating distribution</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1568</context>
+          <context context-type="linenumber">1572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
@@ -13255,7 +13255,7 @@
         <target>Waiting for estimates…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1607,1609</context>
+          <context context-type="linenumber">1611,1613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
@@ -13263,7 +13263,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ q.totalVotes }}"/> answers received</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615,1617</context>
+          <context context-type="linenumber">1619,1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
@@ -13271,11 +13271,11 @@
         <target>Statistics summary</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1627</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2060</context>
+          <context context-type="linenumber">2064</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
@@ -13283,7 +13283,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1632</context>
+          <context context-type="linenumber">1636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
@@ -13291,11 +13291,11 @@
         <target>Accepted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1654</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2080</context>
+          <context context-type="linenumber">2084</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
@@ -13303,7 +13303,7 @@
         <target>Round comparison</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
@@ -13311,7 +13311,7 @@
         <target>shift</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1685</context>
+          <context context-type="linenumber">1689</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
@@ -13319,7 +13319,7 @@
         <target>Round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1706</context>
+          <context context-type="linenumber">1710</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
@@ -13327,7 +13327,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1711</context>
+          <context context-type="linenumber">1715</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
@@ -13335,11 +13335,11 @@
         <target>Show statistical details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1898</context>
+          <context context-type="linenumber">1902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2197</context>
+          <context context-type="linenumber">2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
@@ -13347,7 +13347,7 @@
         <target>Round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1912,1914</context>
+          <context context-type="linenumber">1916,1918</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
@@ -13355,7 +13355,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1940,1942</context>
+          <context context-type="linenumber">1944,1946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
@@ -13363,7 +13363,7 @@
         <target>Paired Δ: <x id="INTERPOLATION" equiv-text="{{ rc.pairedAnalysis.closerCount }}"/> closer, <x id="INTERPOLATION_1" equiv-text="{{ rc.pairedAnalysis.fartherCount }}"/> farther, <x id="INTERPOLATION_2" equiv-text="{{ rc.pairedAnalysis.unchangedCount }}"/> unchanged (<x id="INTERPOLATION_3" equiv-text="{{ rc.pairedAnalysis.pairedCount }}"/> pairs)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1971,1979</context>
+          <context context-type="linenumber">1975,1983</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
@@ -13371,7 +13371,7 @@
         <target>Δx distribution</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1989</context>
+          <context context-type="linenumber">1993</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
@@ -13379,7 +13379,7 @@
         <target>smaller is closer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2103</context>
+          <context context-type="linenumber">2107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
@@ -13387,7 +13387,7 @@
         <target>Results round</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2210,2212</context>
+          <context context-type="linenumber">2214,2216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
@@ -13395,7 +13395,7 @@
         <target>No estimates received.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2237,2239</context>
+          <context context-type="linenumber">2241,2243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
@@ -13403,7 +13403,7 @@
         <target>Before/after comparison Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
@@ -13411,7 +13411,7 @@
         <target>Round 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> vote)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
@@ -13419,7 +13419,7 @@
         <target>Round 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> votes)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2263</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
@@ -13427,7 +13427,7 @@
         <target>Round 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> vote)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2271</context>
+          <context context-type="linenumber">2275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
@@ -13435,7 +13435,7 @@
         <target>Round 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> votes)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
@@ -13443,7 +13443,7 @@
         <target>Correct: <x id="INTERPOLATION" equiv-text="{{ q.roundComparison.round1CorrectCount }}"/> in round 1, then <x id="INTERPOLATION_1" equiv-text="{{ q.roundComparison.round2CorrectCount }}"/> in round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2289,2293</context>
+          <context context-type="linenumber">2293,2297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
@@ -13451,7 +13451,7 @@
         <target>Peer instruction recommended</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2536,2538</context>
+          <context context-type="linenumber">2540,2542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
@@ -13459,7 +13459,7 @@
         <target>35–70% fully correct—second round fits.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2543,2545</context>
+          <context context-type="linenumber">2547,2549</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
@@ -13467,7 +13467,7 @@
         <target>Round 1 still hidden until you continue.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2550,2552</context>
+          <context context-type="linenumber">2554,2556</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
@@ -13475,7 +13475,7 @@
         <target>Start discussion or show results.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2557,2559</context>
+          <context context-type="linenumber">2561,2563</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
@@ -13483,7 +13483,7 @@
         <target>Self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2615,2617</context>
+          <context context-type="linenumber">2619,2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
@@ -13491,7 +13491,7 @@
         <target> Right or wrong—and how confident? Especially important: wrong despite high answer confidence. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2621,2624</context>
+          <context context-type="linenumber">2625,2628</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
@@ -13499,7 +13499,7 @@
         <target>Correctness and self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2645</context>
+          <context context-type="linenumber">2649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
@@ -13507,7 +13507,7 @@
         <target> Often wrong with high answer confidence </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2699,2701</context>
+          <context context-type="linenumber">2703,2705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
@@ -13515,7 +13515,7 @@
         <target>Updating question …</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2744,2746</context>
+          <context context-type="linenumber">2748,2750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
@@ -13523,7 +13523,7 @@
         <target>No question is live yet—tap “Next question” to begin.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2748,2750</context>
+          <context context-type="linenumber">2752,2754</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -13531,7 +13531,7 @@
         <target>Live reactions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2768</context>
+          <context context-type="linenumber">2772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
@@ -13539,7 +13539,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2774</context>
+          <context context-type="linenumber">2778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
@@ -13547,7 +13547,7 @@
         <target>new</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2782</context>
+          <context context-type="linenumber">2786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
@@ -13555,7 +13555,7 @@
         <target>No reactions yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2805</context>
+          <context context-type="linenumber">2809</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
@@ -13564,7 +13564,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2818</context>
+          <context context-type="linenumber">2822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
@@ -13572,7 +13572,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ entry.totalScore | number }}"/> pts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2885</context>
+          <context context-type="linenumber">2889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
@@ -13580,7 +13580,7 @@
         <target>Tie: response time counts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
@@ -13588,7 +13588,7 @@
         <target>Team standings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2912</context>
+          <context context-type="linenumber">2916</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
@@ -13596,7 +13596,7 @@
         <target>pts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2959</context>
+          <context context-type="linenumber">2963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
@@ -13604,7 +13604,7 @@
         <target>Switch quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2988</context>
+          <context context-type="linenumber">2992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
@@ -13612,7 +13612,7 @@
         <target>Edit Q&amp;A title</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3091</context>
+          <context context-type="linenumber">3095</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
@@ -13620,7 +13620,7 @@
         <target>Q&amp;A title</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3104</context>
+          <context context-type="linenumber">3108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
@@ -13628,7 +13628,7 @@
         <target>Ask something about this session...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3115</context>
+          <context context-type="linenumber">3119</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
@@ -13640,15 +13640,24 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1038</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
+        <source>Quiz-Session</source>
+        <target>Quiz session</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">889</context>
+        </context-group>
+      </trans-unit>
+
       <trans-unit id="sessionHost.qaTitleConfirmAria" datatype="html">
         <source>Titel speichern</source>
         <target>Save title</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3127</context>
+          <context context-type="linenumber">3131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
@@ -13656,7 +13665,7 @@
         <target>Cancel editing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3138</context>
+          <context context-type="linenumber">3142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
@@ -13664,7 +13673,7 @@
         <target>Pre-moderation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3157,3159</context>
+          <context context-type="linenumber">3161,3163</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
@@ -13672,7 +13681,7 @@
         <target>Pre-moderation is on. New questions wait for your approval.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3161,3163</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
@@ -13680,7 +13689,7 @@
         <target>No questions yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3170,3172</context>
+          <context context-type="linenumber">3174,3176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
@@ -13688,7 +13697,7 @@
         <target>Total: <x id="INTERPOLATION" equiv-text="qaQuestions().length"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3182,3183</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
@@ -13696,7 +13705,7 @@
         <target>Waiting for approval: <x id="INTERPOLATION" equiv-text="qaPendingCount()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3191,3192</context>
+          <context context-type="linenumber">3195,3196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
@@ -13704,7 +13713,7 @@
         <target>Show all questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3244</context>
+          <context context-type="linenumber">3248</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
@@ -13712,7 +13721,7 @@
         <target>Show all</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3247</context>
+          <context context-type="linenumber">3251</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
@@ -13720,7 +13729,7 @@
         <target>Show pinned questions only</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3255</context>
+          <context context-type="linenumber">3259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
@@ -13728,7 +13737,7 @@
         <target>Pinned only</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3258</context>
+          <context context-type="linenumber">3262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
@@ -13736,7 +13745,7 @@
         <target>Show new questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3270</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
@@ -13744,7 +13753,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ qaUnseenCount() }}"/> new questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3276</context>
+          <context context-type="linenumber">3280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
@@ -13752,7 +13761,7 @@
         <target>Export questions as CSV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3308</context>
+          <context context-type="linenumber">3312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
@@ -13760,7 +13769,7 @@
         <target>Export questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3311</context>
+          <context context-type="linenumber">3315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
@@ -13768,7 +13777,7 @@
         <target>Exporting…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3319,3321</context>
+          <context context-type="linenumber">3323,3325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
@@ -13776,7 +13785,7 @@
         <target>Controversial</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3388</context>
+          <context context-type="linenumber">3392</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
@@ -13784,7 +13793,7 @@
         <target><x id="INTERPOLATION" equiv-text="question.positiveVoteCount"/> positive · <x id="INTERPOLATION_1" equiv-text="question.negativeVoteCount"/> negative</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3416,3417</context>
+          <context context-type="linenumber">3420,3421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
@@ -13792,7 +13801,7 @@
         <target>Reliable approval <x id="INTERPOLATION" equiv-text="formatQaPercent(question.bestScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3424,3425</context>
+          <context context-type="linenumber">3428,3429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
@@ -13800,7 +13809,7 @@
         <target>Split reactions <x id="INTERPOLATION" equiv-text="formatQaPercent(question.controversyScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3434,3436</context>
+          <context context-type="linenumber">3438,3440</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
@@ -13808,7 +13817,7 @@
         <target>Pinned-only view active – no pinned questions yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3477,3479</context>
+          <context context-type="linenumber">3481,3483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
@@ -13816,7 +13825,7 @@
         <target>Reveal answer options</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3530</context>
+          <context context-type="linenumber">3534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
@@ -13824,7 +13833,7 @@
         <target>Start discussion phase—talk it over before round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3554</context>
+          <context context-type="linenumber">3570</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
@@ -13832,7 +13841,7 @@
         <target>Discussion phase</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3557</context>
+          <context context-type="linenumber">3573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
@@ -13840,15 +13849,87 @@
         <target>Show result anyway</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3591</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <target>Release anyway</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">3588</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
-        <source> Ergebnis zeigen</source>
+        <source>Ergebnis zeigen</source>
         <target>Show results</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3579,3581</context>
+          <context context-type="linenumber">3612</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
+        <source>Persönliche Fristen beenden?</source>
+        <target>End personal deadlines?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5926</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
+        <source>Du zeigst das Ergebnis, obwohl noch persönliche Timer laufen.</source>
+        <target>You are showing the result while personal timers are still running.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5930</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
+        <source>Du startest die Diskussionsphase, obwohl noch persönliche Timer laufen.</source>
+        <target>You are starting the discussion phase while personal timers are still running.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5929</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
+        <source>Die offene persönliche 10×-Frist dieser Person endet sofort.</source>
+        <target>This person’s open personal 10× deadline ends immediately.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> offene persönliche 10×-Fristen enden sofort.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> open personal 10× deadlines end immediately.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5921</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
+        <source>Danach ist keine weitere Antwort mehr möglich.</source>
+        <target>No further answers will be possible afterwards.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5918</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <target>Release anyway</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5932</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
+        <source>Weiter warten</source>
+        <target>Keep waiting</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5933</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
@@ -13856,7 +13937,7 @@
         <target>Next question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3595,3597</context>
+          <context context-type="linenumber">3621,3623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
@@ -13864,7 +13945,7 @@
         <target>On to the next question without a second vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3618</context>
+          <context context-type="linenumber">3644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
@@ -13872,7 +13953,7 @@
         <target>On to the next question without a second vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
@@ -13880,7 +13961,7 @@
         <target>Shows the previous question again with its result and correct answer (without a new vote).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3638</context>
+          <context context-type="linenumber">3664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
@@ -13888,7 +13969,7 @@
         <target>Show previous result again</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3640,3642</context>
+          <context context-type="linenumber">3666,3668</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
@@ -13896,7 +13977,7 @@
         <target>End session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650,3652</context>
+          <context context-type="linenumber">3676,3678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -13904,7 +13985,7 @@
         <target>Host view for lobby and control.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3658</context>
+          <context context-type="linenumber">3684</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
@@ -14232,7 +14313,7 @@
         <target>1 answer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1526</context>
+          <context context-type="linenumber">1534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
@@ -14240,7 +14321,7 @@
         <target><x id="count" equiv-text="count"/> answers</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1527</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
@@ -14248,7 +14329,7 @@
         <target>Low · <x id="label" equiv-text="q.confidenceLabelLow"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1618</context>
+          <context context-type="linenumber">1626</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
@@ -14256,7 +14337,7 @@
         <target>Low (1–2)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1619</context>
+          <context context-type="linenumber">1627</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
@@ -14264,7 +14345,7 @@
         <target>Medium (3)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1623</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
@@ -14272,7 +14353,7 @@
         <target>High · <x id="label" equiv-text="q.confidenceLabelHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1663</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
@@ -14280,7 +14361,7 @@
         <target>High (4–5)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1656</context>
+          <context context-type="linenumber">1664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
@@ -14288,7 +14369,7 @@
         <target>Correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
@@ -14296,7 +14377,7 @@
         <target>Incorrect</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1677</context>
+          <context context-type="linenumber">1685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
@@ -14304,7 +14385,7 @@
         <target><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1769</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
@@ -14312,7 +14393,7 @@
         <target>1 confident wrong answer – possible misconception</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1774</context>
+          <context context-type="linenumber">1782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
@@ -14320,7 +14401,7 @@
         <target><x id="count" equiv-text="count"/> confident wrong answers – possible misconceptions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
@@ -14328,7 +14409,7 @@
         <target>Correct+high <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · Wrong+high <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1786</context>
+          <context context-type="linenumber">1794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
@@ -14336,7 +14417,7 @@
         <target>2 (Peer Instruction)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
@@ -14344,7 +14425,7 @@
         <target>Round 1: <x id="r1" equiv-text="round1Count"/> votes · Aggregated: Round 2 with <x id="r2" equiv-text="round2Count"/> votes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1824</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
@@ -14352,7 +14433,7 @@
         <target>Aggregation Round 2 (Peer Instruction)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1826</context>
+          <context context-type="linenumber">1834</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
@@ -14360,7 +14441,7 @@
         <target>Aggregation round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1837</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
@@ -14368,7 +14449,7 @@
         <target>That didn’t quite go through</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2427</context>
+          <context context-type="linenumber">2435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
@@ -14376,7 +14457,7 @@
         <target>No worries — this happens sometimes (a quick blip or flaky Wi‑Fi). Give it a couple of seconds, then tap Try again — that usually does the trick.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2428</context>
+          <context context-type="linenumber">2436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
@@ -14384,7 +14465,7 @@
         <target>Your Q&amp;A board isn’t playing along right now</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2435</context>
+          <context context-type="linenumber">2443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
@@ -14392,7 +14473,7 @@
         <target>Nothing’s broken — it just didn’t work that once. Take a breath, wait 2–3 seconds, tap Try again, and it’ll usually snap back.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2436</context>
+          <context context-type="linenumber">2444</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
@@ -14400,7 +14481,7 @@
         <target>Export isn’t ready yet</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2443</context>
+          <context context-type="linenumber">2451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
@@ -14408,7 +14489,7 @@
         <target>PDF or Excel export didn’t go through that time. Wait a few seconds, tap Try again — a second try usually sorts it.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
@@ -14416,7 +14497,7 @@
         <target>Participants and the presentation view are redirected to the home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2578</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
@@ -14424,7 +14505,7 @@
         <target>The session ends for everyone; it is not possible to continue with the same code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2579</context>
+          <context context-type="linenumber">2587</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
@@ -14432,7 +14513,7 @@
         <target><x id="participantCount" equiv-text="participants"/> Participants are still in the session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2583</context>
+          <context context-type="linenumber">2591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
@@ -14440,7 +14521,7 @@
         <target>You already have results. After ending, you can export them or review feedback in the finished view.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2596</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
@@ -14448,7 +14529,7 @@
         <target>There are no usable results yet. After ending, you will be taken directly to the home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2592</context>
+          <context context-type="linenumber">2600</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
@@ -14456,7 +14537,7 @@
         <target>For bonus codes: Advise participants to copy their personal code now (clipboard) before they leave the page - otherwise they can easily lose it.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2597</context>
+          <context context-type="linenumber">2605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
@@ -14464,7 +14545,7 @@
         <target>Leave session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
@@ -14472,7 +14553,7 @@
         <target>Your session is still active.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
@@ -14480,7 +14561,7 @@
         <target>Leave anyway</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2606</context>
+          <context context-type="linenumber">2614</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
@@ -14488,7 +14569,7 @@
         <target>Back to session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2607</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
@@ -14496,7 +14577,7 @@
         <target>Stop preview</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2795</context>
+          <context context-type="linenumber">2803</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
@@ -14504,7 +14585,7 @@
         <target>Preview track (max. 12 seconds)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2796</context>
+          <context context-type="linenumber">2804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
@@ -14512,7 +14593,7 @@
         <target>Sound on</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2808</context>
+          <context context-type="linenumber">2816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
@@ -14520,7 +14601,7 @@
         <target>Sound off</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2809</context>
+          <context context-type="linenumber">2817</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
@@ -14528,7 +14609,7 @@
         <target>Participant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2866</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
@@ -14536,7 +14617,7 @@
         <target>Participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2870</context>
+          <context context-type="linenumber">2878</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
@@ -14544,7 +14625,7 @@
         <target>1 live participant connected</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2887</context>
+          <context context-type="linenumber">2895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
@@ -14552,7 +14633,7 @@
         <target><x id="connectedCount" equiv-text="connectedCount"/> live participants connected</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2889</context>
+          <context context-type="linenumber">2897</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
@@ -14560,7 +14641,7 @@
         <target>No one is in this team yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2923</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
@@ -14568,7 +14649,7 @@
         <target>Rating</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3729</context>
+          <context context-type="linenumber">3739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
@@ -14576,7 +14657,7 @@
         <target>Ratings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3733</context>
+          <context context-type="linenumber">3743</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
@@ -14584,11 +14665,11 @@
         <target>Results are in.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3738</context>
+          <context context-type="linenumber">3748</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3745</context>
+          <context context-type="linenumber">3755</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
@@ -14596,11 +14677,11 @@
         <target>Time&apos;s up.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3739</context>
+          <context context-type="linenumber">3749</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3746</context>
+          <context context-type="linenumber">3756</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
@@ -14608,7 +14689,7 @@
         <target>Waiting for ratings…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3740</context>
+          <context context-type="linenumber">3750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
@@ -14616,7 +14697,7 @@
         <target>Waiting for answers…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3747</context>
+          <context context-type="linenumber">3757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
@@ -14624,23 +14705,55 @@
         <target><x id="PH" equiv-text="votes"/> of <x id="PH_1" equiv-text="participants"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3761</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <target>One person is still using their 10× time. Wait for the room countdown or until the 10× time ends.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3769</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihr persönliches Fenster.</source>
+        <target>One person is still using their 10× time. “Release anyway” ends their personal window.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3768</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> people are still using their 10× time. Wait for the room countdown or until the 10× time ends.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3774</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihre persönlichen Fenster.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> people are still using their 10× time. “Release anyway” ends their personal windows.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
-        <source>Eine Person mit Zeitanpassung antwortet noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
-        <target>One person with extra time is still answering. “Show result” ends their response window.</target>
+        <source>Eine Person antwortet ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <target>One person is answering without a personal deadline. “Show results” ends their input.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
-        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen mit Zeitanpassung antworten noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
-        <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> people with extra time are still answering. “Show result” ends their response window.</target>
+        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen antworten ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> people are answering without a personal deadline. “Show results” ends their input.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3758</context>
+          <context context-type="linenumber">3774</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
@@ -14648,7 +14761,7 @@
         <target><x id="votes" equiv-text="votes"/> of <x id="participants" equiv-text="participants"/> participants voted. <x id="percentage" equiv-text="percentage"/> percent reached.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3764</context>
+          <context context-type="linenumber">3780</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
@@ -14656,7 +14769,7 @@
         <target><x id="votes" equiv-text="votes"/> of <x id="participants" equiv-text="participants"/> participants have voted. <x id="percentage" equiv-text="percentage"/> percent reached.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3766</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
@@ -14664,7 +14777,7 @@
         <target><x id="voteCount"/> out of <x id="participantTotal"/> has voted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
@@ -14672,7 +14785,7 @@
         <target><x id="voteCount"/> out of <x id="participantTotal"/> have voted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3779</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
@@ -14680,7 +14793,7 @@
         <target><x id="voteCount"/> out of <x id="participantTotal"/> has rated</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3790</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
@@ -14688,7 +14801,7 @@
         <target><x id="voteCount"/> out of <x id="participantTotal"/> have rated</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3792</context>
+          <context context-type="linenumber">3808</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
@@ -14696,7 +14809,7 @@
         <target><x id="correctCount"/> out of <x id="voteTotal"/> fully correct answers (<x id="percentage"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3798</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
@@ -14704,7 +14817,7 @@
         <target><x id="changed"/> out of <x id="both"/> (<x id="pct"/>%) changed their mind</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3802</context>
+          <context context-type="linenumber">3818</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
@@ -14712,7 +14825,7 @@
         <target>↑ <x id="count"/> wrong → correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3806</context>
+          <context context-type="linenumber">3822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
@@ -14720,7 +14833,7 @@
         <target>↓ <x id="count"/> correct → wrong</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3810</context>
+          <context context-type="linenumber">3826</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
@@ -14728,7 +14841,7 @@
         <target>Average <x id="avg"/> out of 5 stars</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3816</context>
+          <context context-type="linenumber">3832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
@@ -14736,7 +14849,7 @@
         <target><x id="PH" equiv-text="total"/> reaction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
@@ -14744,7 +14857,7 @@
         <target><x id="PH" equiv-text="total"/> reactions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
@@ -14752,7 +14865,7 @@
         <target>Lobby – participants can join</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3873</context>
+          <context context-type="linenumber">3889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
@@ -14760,7 +14873,7 @@
         <target>Q&amp;A is getting ready</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3874</context>
+          <context context-type="linenumber">3890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
@@ -14768,15 +14881,15 @@
         <target>Q&amp;A is live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3875</context>
+          <context context-type="linenumber">3891</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3877</context>
+          <context context-type="linenumber">3893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3878</context>
+          <context context-type="linenumber">3894</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
@@ -14784,7 +14897,7 @@
         <target>Paused</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3876</context>
+          <context context-type="linenumber">3892</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
@@ -14792,7 +14905,7 @@
         <target>Q&amp;A ended</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3879</context>
+          <context context-type="linenumber">3895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
@@ -14800,7 +14913,7 @@
         <target>Voting ended – waiting for results</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3884</context>
+          <context context-type="linenumber">3900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
@@ -14808,7 +14921,7 @@
         <target>Lobby – participants can join</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3887</context>
+          <context context-type="linenumber">3903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
@@ -14816,7 +14929,7 @@
         <target>Reading phase – answers are locked</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3888</context>
+          <context context-type="linenumber">3904</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
@@ -14824,7 +14937,7 @@
         <target>Voting is live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3889</context>
+          <context context-type="linenumber">3905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
@@ -14832,7 +14945,7 @@
         <target>Paused</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3890</context>
+          <context context-type="linenumber">3906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
@@ -14840,7 +14953,7 @@
         <target>Showing results</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3891</context>
+          <context context-type="linenumber">3907</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
@@ -14848,7 +14961,7 @@
         <target>Discussion – exchange before second round</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3892</context>
+          <context context-type="linenumber">3908</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
@@ -14856,7 +14969,7 @@
         <target>Session ended</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3893</context>
+          <context context-type="linenumber">3909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
@@ -14864,7 +14977,7 @@
         <target><x id="readyCount" equiv-text="readyCount"/> of <x id="connectedCount" equiv-text="connectedCount"/> ready</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3904</context>
+          <context context-type="linenumber">3920</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
@@ -14872,7 +14985,7 @@
         <target><x id="PH" equiv-text="readyCount"/> of <x id="PH_1" equiv-text="connectedCount"/> connected participants ready · <x id="PH_2" equiv-text="totalParticipantCount"/> total</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3906</context>
+          <context context-type="linenumber">3922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
@@ -14880,7 +14993,7 @@
         <target>All participants are ready – answer options can be revealed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3911</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
@@ -14888,7 +15001,7 @@
         <target>All connected participants are ready – answer options can be revealed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3913</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
@@ -14896,7 +15009,7 @@
         <target>1 second remaining</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3944</context>
+          <context context-type="linenumber">3960</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
@@ -14904,7 +15017,7 @@
         <target><x id="seconds" equiv-text="seconds"/> seconds remaining</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3945</context>
+          <context context-type="linenumber">3961</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -14918,7 +15031,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4069,4072</context>
+          <context context-type="linenumber">4085,4088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -14932,7 +15045,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4114,4117</context>
+          <context context-type="linenumber">4130,4133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -14946,7 +15059,7 @@
       )"/> to <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4119,4122</context>
+          <context context-type="linenumber">4135,4138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -14960,7 +15073,7 @@
     )"/> to <x id="right" equiv-text="this.formatNumericHostValue(band.right, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4124,4127</context>
+          <context context-type="linenumber">4140,4143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
@@ -14968,7 +15081,7 @@
         <target>Median <x id="median" equiv-text="formatNumber(stats.median, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4242</context>
+          <context context-type="linenumber">4258</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
@@ -14976,7 +15089,7 @@
         <target>Estimates</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4275</context>
+          <context context-type="linenumber">4291</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
@@ -14984,7 +15097,7 @@
         <target>valid answers</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4277</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
@@ -14992,7 +15105,7 @@
         <target>Mean</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4283</context>
+          <context context-type="linenumber">4299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
@@ -15000,7 +15113,7 @@
         <target>Average of all estimates</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4285</context>
+          <context context-type="linenumber">4301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
@@ -15008,7 +15121,7 @@
         <target>Median</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4291</context>
+          <context context-type="linenumber">4307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
@@ -15016,7 +15129,7 @@
         <target>Middle sorted value</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4293</context>
+          <context context-type="linenumber">4309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
@@ -15024,7 +15137,7 @@
         <target>Spread</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4299</context>
+          <context context-type="linenumber">4315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
@@ -15032,7 +15145,7 @@
         <target>Standard deviation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4301</context>
+          <context context-type="linenumber">4317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
@@ -15040,7 +15153,7 @@
         <target>Middle 50%</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4307</context>
+          <context context-type="linenumber">4323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -15055,7 +15168,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4312,4315</context>
+          <context context-type="linenumber">4328,4331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
@@ -15063,7 +15176,7 @@
         <target>Range</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
@@ -15071,7 +15184,7 @@
         <target>smallest to largest estimate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4326</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
@@ -15079,7 +15192,7 @@
         <target>In range</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4332</context>
+          <context context-type="linenumber">4348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -15095,7 +15208,7 @@
         )"/>% accepted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4338,4342</context>
+          <context context-type="linenumber">4354,4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
@@ -15103,7 +15216,7 @@
         <target>Avg. distance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4348</context>
+          <context context-type="linenumber">4364</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
@@ -15111,7 +15224,7 @@
         <target>to reference</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4350</context>
+          <context context-type="linenumber">4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
@@ -15119,7 +15232,7 @@
         <target>Median</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4358</context>
+          <context context-type="linenumber">4374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
@@ -15127,7 +15240,7 @@
         <target>Mean</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4361</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
@@ -15135,7 +15248,7 @@
         <target>Estimates</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4363</context>
+          <context context-type="linenumber">4379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -15151,7 +15264,7 @@
     )"/> % in the accepted range</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394,4398</context>
+          <context context-type="linenumber">4410,4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
@@ -15159,7 +15272,7 @@
         <target>Average distance to reference</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4412</context>
+          <context context-type="linenumber">4428</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
@@ -15167,7 +15280,7 @@
         <target>closer to the reference value</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4426</context>
+          <context context-type="linenumber">4442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
@@ -15175,7 +15288,7 @@
         <target>Median change</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4443</context>
+          <context context-type="linenumber">4459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
@@ -15183,7 +15296,7 @@
         <target>Mean change</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4444</context>
+          <context context-type="linenumber">4460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -15198,7 +15311,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4455,4458</context>
+          <context context-type="linenumber">4471,4474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -15213,7 +15326,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4464,4467</context>
+          <context context-type="linenumber">4480,4483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -15229,7 +15342,7 @@
         )"/> percentage points</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4476,4480</context>
+          <context context-type="linenumber">4492,4496</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -15253,7 +15366,7 @@
           )"/> comparable estimates have improved.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4496,4504</context>
+          <context context-type="linenumber">4512,4520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -15277,7 +15390,7 @@
           )"/> comparable estimates are further away.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4516</context>
+          <context context-type="linenumber">4524,4532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
@@ -15285,7 +15398,7 @@
         <target>Round 2 is mixed: closer and more distant estimates are balanced in the pair comparison.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520</context>
+          <context context-type="linenumber">4536</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -15299,7 +15412,7 @@
           )"/> in round 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4532,4535</context>
+          <context context-type="linenumber">4548,4551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -15313,7 +15426,7 @@
           )"/> larger in round 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4539,4542</context>
+          <context context-type="linenumber">4555,4558</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -15329,7 +15442,7 @@
         )"/> percentage points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4554,4558</context>
+          <context context-type="linenumber">4570,4574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -15353,7 +15466,7 @@
         )"/> estimates are within the tolerance band.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4573,4581</context>
+          <context context-type="linenumber">4589,4597</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -15367,7 +15480,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4586,4589</context>
+          <context context-type="linenumber">4602,4605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -15381,7 +15494,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4593,4596</context>
+          <context context-type="linenumber">4609,4612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
@@ -15389,11 +15502,11 @@
         <target>Quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4642</context>
+          <context context-type="linenumber">4658</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2195</context>
+          <context context-type="linenumber">2205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.questions" datatype="html">
@@ -15401,11 +15514,11 @@
         <target>Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4644</context>
+          <context context-type="linenumber">4660</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2197</context>
+          <context context-type="linenumber">2207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.questionsBadgeNew" datatype="html">
@@ -15413,11 +15526,11 @@
         <target><x id="count" equiv-text="this.qaUnseenCount()"/> new</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4652</context>
+          <context context-type="linenumber">4668</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4669</context>
+          <context context-type="linenumber">4685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelInactive" datatype="html">
@@ -15425,7 +15538,7 @@
         <target>Off</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4769</context>
+          <context context-type="linenumber">4785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelClosed" datatype="html">
@@ -15433,11 +15546,11 @@
         <target>Closed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4788</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2205</context>
+          <context context-type="linenumber">2215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7367446920402175749" datatype="html">
@@ -15445,11 +15558,11 @@
         <target>Question from <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">615</context>
+          <context context-type="linenumber">618</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8913852475666331247" datatype="html">
@@ -15457,11 +15570,11 @@
         <target>Question from the audience</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5574706582681662956" datatype="html">
@@ -15469,15 +15582,15 @@
         <target>Deselect <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4835</context>
+          <context context-type="linenumber">4851</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">580</context>
+          <context context-type="linenumber">583</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">626</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2964749761557345284" datatype="html">
@@ -15485,15 +15598,15 @@
         <target>Highlight all questions from <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4836</context>
+          <context context-type="linenumber">4852</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">581</context>
+          <context context-type="linenumber">584</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">627</context>
+          <context context-type="linenumber">630</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPinned" datatype="html">
@@ -15501,11 +15614,11 @@
         <target>Being answered</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4881</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusActive" datatype="html">
@@ -15513,11 +15626,11 @@
         <target>Open</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4867</context>
+          <context context-type="linenumber">4883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2251</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPending" datatype="html">
@@ -15525,11 +15638,11 @@
         <target>Waiting for approval</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4869</context>
+          <context context-type="linenumber">4885</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2253</context>
+          <context context-type="linenumber">2263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusArchived" datatype="html">
@@ -15537,11 +15650,11 @@
         <target>Answered</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4871</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2255</context>
+          <context context-type="linenumber">2265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusDeleted" datatype="html">
@@ -15549,11 +15662,11 @@
         <target>Removed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4873</context>
+          <context context-type="linenumber">4889</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionApprove" datatype="html">
@@ -15561,7 +15674,7 @@
         <target>Approve</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4974</context>
+          <context context-type="linenumber">4990</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
@@ -15569,7 +15682,7 @@
         <target>Highlight</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4976</context>
+          <context context-type="linenumber">4992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
@@ -15577,7 +15690,7 @@
         <target>Remove highlight</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4978</context>
+          <context context-type="linenumber">4994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
@@ -15585,7 +15698,7 @@
         <target>Archive</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4980</context>
+          <context context-type="linenumber">4996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
@@ -15593,7 +15706,7 @@
         <target>Remove permanently</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4983</context>
+          <context context-type="linenumber">4999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
@@ -15601,7 +15714,7 @@
         <target>Delete</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4984</context>
+          <context context-type="linenumber">5000</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
@@ -15609,7 +15722,7 @@
         <target>Close channel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5328</context>
+          <context context-type="linenumber">5344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
@@ -15617,7 +15730,7 @@
         <target>Reopen channel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5329</context>
+          <context context-type="linenumber">5345</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
@@ -15625,7 +15738,7 @@
         <target>Pre-moderation enabled.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5743</context>
+          <context context-type="linenumber">5759</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
@@ -15633,7 +15746,7 @@
         <target>Pre-moderation disabled.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5744</context>
+          <context context-type="linenumber">5760</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
@@ -15641,7 +15754,7 @@
         <target>Question approved.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5777</context>
+          <context context-type="linenumber">5793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
@@ -15649,7 +15762,7 @@
         <target>Question highlighted.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5779</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
@@ -15657,7 +15770,7 @@
         <target>Question archived.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5781</context>
+          <context context-type="linenumber">5797</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
@@ -15665,7 +15778,7 @@
         <target>Question removed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5782</context>
+          <context context-type="linenumber">5798</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
@@ -15673,7 +15786,7 @@
         <target>Question no.;Question text;Type;Participants;Aggregation round;Avg. points;Self-assessment n;Solid;Misconception risk;Fragile;Detected gap;Undecided;Most common incorrect high-confidence answer;Details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5995</context>
+          <context context-type="linenumber">6011</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
@@ -15681,7 +15794,7 @@
         <target>Learning status and self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6049</context>
+          <context context-type="linenumber">6065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
@@ -15689,7 +15802,7 @@
         <target>Valid answers;Evaluated questions;Not aggregated (&lt;5 responses with self-assessment);Solid;Misconception risk;Fragile;Identified knowledge gap;Undecided</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6052</context>
+          <context context-type="linenumber">6068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
@@ -15697,7 +15810,7 @@
         <target>Team leaderboard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6073</context>
+          <context context-type="linenumber">6089</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
@@ -15705,7 +15818,7 @@
         <target>Rank;Team;Color;Members;Team points;Avg. points per member</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6075</context>
+          <context context-type="linenumber">6091</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
@@ -15713,7 +15826,7 @@
         <target>Bonus codes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6093</context>
+          <context context-type="linenumber">6109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
@@ -15721,7 +15834,7 @@
         <target>Rank;Nickname;Code;Points;Generated at</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6095</context>
+          <context context-type="linenumber">6111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
@@ -15729,7 +15842,7 @@
         <target>Result CSV exported.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6103</context>
+          <context context-type="linenumber">6119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
@@ -15737,7 +15850,7 @@
         <target>View debrief plan as PDF – 1 question for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6115</context>
+          <context context-type="linenumber">6131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
@@ -15745,7 +15858,7 @@
         <target>View debrief plan as PDF – <x id="count" equiv-text="count"/> questions for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6118</context>
+          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
@@ -15753,7 +15866,7 @@
         <target>View debrief plan as PDF</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6120</context>
+          <context context-type="linenumber">6136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
@@ -15761,7 +15874,7 @@
         <target>1 question recommended for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6125</context>
+          <context context-type="linenumber">6141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
@@ -15769,7 +15882,7 @@
         <target><x id="count" equiv-text="count"/> questions recommended for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6127</context>
+          <context context-type="linenumber">6143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
@@ -15777,7 +15890,7 @@
         <target>PDF is created (<x id="PH" equiv-text="exportData.questions.length"/> questions)…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6139</context>
+          <context context-type="linenumber">6155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
@@ -15785,7 +15898,7 @@
         <target>Results PDF downloaded.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6145</context>
+          <context context-type="linenumber">6161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
@@ -15793,7 +15906,7 @@
         <target>Result PDF opened for saving.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
@@ -15801,7 +15914,7 @@
         <target>No.;Question ID;Status;Question;Score;Positive votes;Negative votes;Total votes;Wilson score;Controversy score;Controversial;Created at</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6173</context>
+          <context context-type="linenumber">6189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
@@ -15809,7 +15922,7 @@
         <target>Q&amp;A CSV exported.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6196</context>
+          <context context-type="linenumber">6212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
@@ -15817,11 +15930,11 @@
         <target>Question <x id="questionNumber" equiv-text="data.questionOrder + 1"/>: <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6359</context>
+          <context context-type="linenumber">6375</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6367</context>
+          <context context-type="linenumber">6383</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15837,7 +15950,7 @@
         <target>Live free-text is being updated.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6362</context>
+          <context context-type="linenumber">6378</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15849,7 +15962,7 @@
         <target>Current question is not a free-text question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6370</context>
+          <context context-type="linenumber">6386</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15861,7 +15974,7 @@
         <target>No active question yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6373</context>
+          <context context-type="linenumber">6389</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15873,7 +15986,7 @@
         <target>Could not load live free-text data.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6377</context>
+          <context context-type="linenumber">6393</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -17632,12 +17745,100 @@
           <context context-type="linenumber">576</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
+        <source> Zeit anpassen</source>
+        <target>Adjust time</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">14,16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
+        <source> Vor der Frage wählen · 10× Zeit = zehnfacher Raum-Countdown</source>
+        <target>Choose before the question · 10× time = ten times the room countdown</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.summary" datatype="html">
+        <source>So werden Punkte berechnet</source>
+        <target>How points are calculated</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.intro" datatype="html">
+        <source> So setzt sich deine Punktezahl zusammen: </source>
+        <target>This is how your score is put together:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">29,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.base" datatype="html">
+        <source> Basis: Bis zu 1000 Punkte für eine richtige Antwort. </source>
+        <target>Base: Up to 1000 points for a correct answer.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">33,35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.difficulty" datatype="html">
+        <source> Schwierigkeit: Leicht ×1, Mittel ×2, Schwer ×3. </source>
+        <target>Difficulty: Easy ×1, Medium ×2, Hard ×3.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">36,38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.time" datatype="html">
+        <source> Zeit: Je früher du beim gemeinsamen Raum-Countdown richtig antwortest, desto höher der Zeitanteil. Nach Ablauf bleiben noch 10 % davon. Deine persönliche Frist ändert nur, wie lange du antworten darfst – nicht diese Zeitwertung. </source>
+        <target>Time: The earlier you answer correctly during the shared room countdown, the higher your time share. After it ends, 10% of that share remains. Your personal deadline only changes how long you may answer — not this time scoring.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">39,43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.streak" datatype="html">
+        <source> Serie: Mehrere richtige Antworten hintereinander geben Bonus – 1× ×1,0 · 2× ×1,1 · 3× ×1,2 · 4× ×1,3 · ab 5× ×1,5. Eine falsche bewertbare Antwort setzt die Serie zurück. Umfragen und unbewerteter Freitext unterbrechen sie nicht. </source>
+        <target>Streak: Several correct answers in a row give a bonus – 1× ×1.0 · 2× ×1.1 · 3× ×1.2 · 4× ×1.3 · from 5× ×1.5. A wrong scored answer resets the streak. Surveys and unscored free text do not interrupt it.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">44,48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.preview" datatype="html">
+        <source> Die Live-Punktvorschau zeigt den aktuellen Stand ohne Serien-Bonus. </source>
+        <target>The live points preview shows the current value without the streak bonus.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">49,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
+        <source> Keine persönliche Frist · Punkte weiter nach dem Raum-Timer</source>
+        <target>No personal deadline · Points still follow the room timer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">74,76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
+        <source> 10× Zeit aktiv · Das Ergebnis wartet auf dich</source>
+        <target>10× time active · Results will wait for you</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">83,85</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionVote.sessionEndGateTitle" datatype="html">
         <source> Session beendet</source>
         <target>Session ended</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">21,23</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.bonusGateLead" datatype="html">
@@ -17645,7 +17846,7 @@
         <target>You have received a bonus code. Now copy it to the clipboard (e.g. for an email to the event management) before going to the home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">28,31</context>
+          <context context-type="linenumber">117,120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionEndFeedbackLead" datatype="html">
@@ -17653,7 +17854,7 @@
         <target>The session is over. If you like, rate it briefly - then you can go to the home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">44,47</context>
+          <context context-type="linenumber">133,136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionActionsAria" datatype="html">
@@ -17661,7 +17862,7 @@
         <target>Session actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.voteAria" datatype="html">
@@ -17669,7 +17870,7 @@
         <target>Choose live area</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">232</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.pointsUnit" datatype="html">
@@ -17677,7 +17878,23 @@
         <target>points</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">319</context>
+          <context context-type="linenumber">408</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.hide" datatype="html">
+        <source> Ausblenden</source>
+        <target>Hide</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">416,418</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.show" datatype="html">
+        <source> Live-Punkte anzeigen</source>
+        <target>View live points</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">427,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.mediaAnswerHint" datatype="html">
@@ -17685,47 +17902,7 @@
         <target>The picture is for viewing only. Select your answer below.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">985</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
-        <source> Zeit anpassen</source>
-        <target>Adjust time</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1010,1012</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
-        <source> Nur für dich · Der Quizablauf bleibt unverändert</source>
-        <target>Only for you · The quiz flow stays unchanged</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1016,1018</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.points" datatype="html">
-        <source> Punkte richten sich nach dem gemeinsamen Countdown</source>
-        <target>Points are based on the shared countdown</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1021,1023</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
-        <source> Ohne Timer aktiv · Abgabe möglich, solange die Frage offen ist</source>
-        <target>No timer · Submit while the question is open</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1043,1045</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
-        <source> 10× Zeit aktiv</source>
-        <target>10× time active</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericLabel" datatype="html">
@@ -17733,7 +17910,7 @@
         <target>Your estimate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1262,1264</context>
+          <context context-type="linenumber">1324,1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericPlaceholder" datatype="html">
@@ -17741,7 +17918,7 @@
         <target>Enter a number…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1284</context>
+          <context context-type="linenumber">1346</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultPrefix" datatype="html">
@@ -17749,7 +17926,7 @@
         <target>Your answer:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1933013871016789910" datatype="html">
@@ -17757,11 +17934,11 @@
         <target>Total</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1351</context>
+          <context context-type="linenumber">1413</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1717</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHeading" datatype="html">
@@ -17769,7 +17946,7 @@
         <target>How sure are you about this answer?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1404,1406</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHint" datatype="html">
@@ -17777,7 +17954,7 @@
         <target>Relates to the answer you just chose.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1411,1413</context>
+          <context context-type="linenumber">1473,1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultPrefix" datatype="html">
@@ -17785,7 +17962,7 @@
         <target>Your self-assessment:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceSentPrefix" datatype="html">
@@ -17793,7 +17970,7 @@
         <target>Self-assessment:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1480</context>
+          <context context-type="linenumber">1542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8052936664226936966" datatype="html">
@@ -17801,7 +17978,7 @@
         <target>Streak (×<x id="INTERPOLATION" equiv-text="{{ sc.streakMultiplier | number:&apos;1.1-1&apos; }}"/>)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1635</context>
+          <context context-type="linenumber">1697</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4068334453877547924" datatype="html">
@@ -17809,7 +17986,7 @@
         <target>Your rank</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1649</context>
+          <context context-type="linenumber">1711</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedNotice" datatype="html">
@@ -17817,7 +17994,7 @@
         <target>The Q&amp;A channel has been closed by the instructor. Questions and votes are currently disabled.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1865,1868</context>
+          <context context-type="linenumber">1927,1930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaIdentityHint" datatype="html">
@@ -17825,7 +18002,7 @@
         <target>You ask as</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnAria" datatype="html">
@@ -17833,7 +18010,7 @@
         <target>Delete question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2039</context>
+          <context context-type="linenumber">2101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedHint" datatype="html">
@@ -17841,7 +18018,7 @@
         <target>Existing content is hidden from participants until the instructor reopens the channel.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2058,2061</context>
+          <context context-type="linenumber">2120,2123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackClosedTitle" datatype="html">
@@ -17849,7 +18026,7 @@
         <target>Quick feedback closed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2077,2079</context>
+          <context context-type="linenumber">2139,2141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedActionsAria" datatype="html">
@@ -17857,7 +18034,7 @@
         <target>Final actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2109</context>
+          <context context-type="linenumber">2171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.quizActionsAria" datatype="html">
@@ -17865,7 +18042,7 @@
         <target>Quiz actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2147</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaActionsAria" datatype="html">
@@ -17873,7 +18050,7 @@
         <target>Q&amp;A actions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2166</context>
+          <context context-type="linenumber">2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2427920593873911865" datatype="html">
@@ -17881,7 +18058,7 @@
         <target>Perfect! 🎯</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3996850202378161277" datatype="html">
@@ -17889,7 +18066,7 @@
         <target>Correct! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1090604167231677526" datatype="html">
@@ -17897,7 +18074,7 @@
         <target>Bullseye! ⭐</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3502096474885920612" datatype="html">
@@ -17905,7 +18082,7 @@
         <target>Nice! 🔥</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7691272538064479056" datatype="html">
@@ -17913,7 +18090,7 @@
         <target>Exactly right! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7790447949587239556" datatype="html">
@@ -17921,7 +18098,7 @@
         <target>You&apos;re on a roll! 🎸</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">175</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4185659153521425300" datatype="html">
@@ -17930,7 +18107,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">175</context>
+          <context context-type="linenumber">176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS1" datatype="html">
@@ -17938,7 +18115,7 @@
         <target>Correct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS2" datatype="html">
@@ -17946,7 +18123,7 @@
         <target>Correctly.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">179</context>
+          <context context-type="linenumber">180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS3" datatype="html">
@@ -17954,7 +18131,7 @@
         <target>Answer is correct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3211338642099056060" datatype="html">
@@ -17962,7 +18139,7 @@
         <target>Close one! 🤏</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1731892131220774983" datatype="html">
@@ -17970,7 +18147,7 @@
         <target>Next time! 💡</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9186185663967902020" datatype="html">
@@ -17978,7 +18155,7 @@
         <target>Keep going! 🔄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3551623243824977572" datatype="html">
@@ -17986,7 +18163,7 @@
         <target>You&apos;ll get there! 📈</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5506746370181957809" datatype="html">
@@ -17994,7 +18171,7 @@
         <target>Don’t give up! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS1" datatype="html">
@@ -18002,7 +18179,7 @@
         <target>Not right.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS2" datatype="html">
@@ -18010,7 +18187,7 @@
         <target>Unfortunately wrong.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS3" datatype="html">
@@ -18018,7 +18195,7 @@
         <target>Try again on the next question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3145164147131753937" datatype="html">
@@ -18026,7 +18203,7 @@
         <target>Answer saved! ✓</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">195</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3110097502695814008" datatype="html">
@@ -18034,7 +18211,7 @@
         <target>Thanks for your answer! 📝</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4856001851461935545" datatype="html">
@@ -18042,7 +18219,7 @@
         <target>Keep it up! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS1" datatype="html">
@@ -18050,7 +18227,7 @@
         <target>Answer saved.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">200</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS2" datatype="html">
@@ -18058,7 +18235,7 @@
         <target>Thanks—we got your answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6032822770375401279" datatype="html">
@@ -18066,7 +18243,7 @@
         <target>So close—next round! ⏱️</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">204</context>
+          <context context-type="linenumber">205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3646778948280182955" datatype="html">
@@ -18074,7 +18251,7 @@
         <target>Time was tight—you&apos;ve got this! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">205</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5015240621073925218" datatype="html">
@@ -18082,7 +18259,7 @@
         <target>You&apos;ll get it next time! 🔄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="850308549833737974" datatype="html">
@@ -18090,7 +18267,7 @@
         <target>Keep your head up — the next one starts soon! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3277616416884173208" datatype="html">
@@ -18098,7 +18275,7 @@
         <target>Tick-tock—next chance soon! ⏰</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS1" datatype="html">
@@ -18106,7 +18283,7 @@
         <target>Time&apos;s up.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS2" datatype="html">
@@ -18114,7 +18291,7 @@
         <target>Time&apos;s up—wait for the next question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">212</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS3" datatype="html">
@@ -18122,7 +18299,7 @@
         <target>Too late to vote—another chance is coming.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">213</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakPlayful" datatype="html">
@@ -18130,7 +18307,7 @@
         <target>On fire! 🔥 <x id="c" equiv-text="sc.streakCount"/> in a row!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">302</context>
+          <context context-type="linenumber">303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakSerious" datatype="html">
@@ -18138,7 +18315,7 @@
         <target><x id="c" equiv-text="sc.streakCount"/> correct answers in a row.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">303</context>
+          <context context-type="linenumber">304</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Playful" datatype="html">
@@ -18146,7 +18323,7 @@
         <target>Moved up 1 place! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">308</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Serious" datatype="html">
@@ -18154,7 +18331,7 @@
         <target>Moved up 1 rank.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">310</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNPlayful" datatype="html">
@@ -18162,7 +18339,7 @@
         <target>Moved up <x id="n" equiv-text="sc.rankChange"/> places! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">312</context>
+          <context context-type="linenumber">313</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNSerious" datatype="html">
@@ -18170,7 +18347,7 @@
         <target>Moved up <x id="n" equiv-text="sc.rankChange"/> places.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">313</context>
+          <context context-type="linenumber">314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakPlayful" datatype="html">
@@ -18178,7 +18355,7 @@
         <target>Streak broken! Next round! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">320</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakSerious" datatype="html">
@@ -18186,7 +18363,7 @@
         <target>Streak ended—the next question counts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">321</context>
+          <context context-type="linenumber">322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopPlayful" datatype="html">
@@ -18194,7 +18371,7 @@
         <target>Chin up—you&apos;re still doing great! 🏅</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopSerious" datatype="html">
@@ -18202,7 +18379,7 @@
         <target>You&apos;re still near the top of the leaderboard.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">327</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChasePlayful" datatype="html">
@@ -18210,7 +18387,7 @@
         <target>Keep going—every question is a fresh shot! 🌟</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChaseSerious" datatype="html">
@@ -18218,7 +18395,7 @@
         <target>Keep at it—the next question means new points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">331</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivEvaluated" datatype="html">
@@ -18226,7 +18403,7 @@
         <target>Response evaluated.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">352</context>
+          <context context-type="linenumber">353</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivOutOfBand" datatype="html">
@@ -18234,7 +18411,7 @@
         <target>Outside the tolerance band.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">356</context>
+          <context context-type="linenumber">357</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivExact" datatype="html">
@@ -18242,7 +18419,7 @@
         <target>Bullseye: exactly on the reference value.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">361</context>
+          <context context-type="linenumber">362</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivInBand" datatype="html">
@@ -18250,11 +18427,11 @@
         <target>Within the accepted range.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">367</context>
+          <context context-type="linenumber">368</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">376</context>
+          <context context-type="linenumber">377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivVeryClose" datatype="html">
@@ -18262,7 +18439,7 @@
         <target>Very close to the reference value.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">373</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixPlayful" datatype="html">
@@ -18270,7 +18447,7 @@
         <target>Perfect!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixSerious" datatype="html">
@@ -18278,7 +18455,7 @@
         <target>You are now in</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixPlayful" datatype="html">
@@ -18286,7 +18463,7 @@
         <target>is already waiting for you.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">547</context>
+          <context context-type="linenumber">550</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixSerious" datatype="html">
@@ -18294,7 +18471,7 @@
         <target>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">548</context>
+          <context context-type="linenumber">551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3932968695937052509" datatype="html">
@@ -18302,7 +18479,7 @@
         <target>You ask as <x id="PH" equiv-text="nick"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3719653345310622722" datatype="html">
@@ -18310,11 +18487,11 @@
         <target>Your animal icon</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">577</context>
+          <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.playerTeamBadgeAria" datatype="html">
@@ -18322,7 +18499,7 @@
         <target><x id="nickname" equiv-text="nick"/>, <x id="teamName" equiv-text="teamLabel"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">589</context>
+          <context context-type="linenumber">592</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5952222840612966712" datatype="html">
@@ -18330,7 +18507,7 @@
         <target>Your question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.autoJoinFailed" datatype="html">
@@ -18338,7 +18515,7 @@
         <target>Participation could not be prepared.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextTooLong" datatype="html">
@@ -18346,7 +18523,7 @@
         <target>Maximum <x id="maxLength" equiv-text="maxLength"/> characters allowed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1325</context>
+          <context context-type="linenumber">1335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericInvalid" datatype="html">
@@ -18354,11 +18531,11 @@
         <target>Short answer must be entered as a number in a supported format.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1333</context>
+          <context context-type="linenumber">1343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1471</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultInvalid" datatype="html">
@@ -18366,7 +18543,7 @@
         <target>Invalid numeric format</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1437</context>
+          <context context-type="linenumber">1447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultFull" datatype="html">
@@ -18374,7 +18551,7 @@
         <target>Full credit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1442</context>
+          <context context-type="linenumber">1452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultAccepted" datatype="html">
@@ -18382,7 +18559,7 @@
         <target>Accepted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1443</context>
+          <context context-type="linenumber">1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultPartial" datatype="html">
@@ -18390,7 +18567,7 @@
         <target>Partially graded (<x id="points" equiv-text="result.points"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1457</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultRejected" datatype="html">
@@ -18398,7 +18575,7 @@
         <target>Not accepted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1450</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericNoMatch" datatype="html">
@@ -18406,7 +18583,7 @@
         <target>No reference answer fell within the configured numeric tolerance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultMatchedSolution" datatype="html">
@@ -18414,11 +18591,11 @@
         <target>Matched to the model answer “<x id="matchedModelAnswer" equiv-text="result.matchedModelAnswer"/>”.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1469</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1485</context>
+          <context context-type="linenumber">1495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonNoMatch" datatype="html">
@@ -18426,11 +18603,11 @@
         <target>No model answer fell within the configured tolerance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1477</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1501</context>
+          <context context-type="linenumber">1511</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonHamming" datatype="html">
@@ -18438,7 +18615,7 @@
         <target>A small same-length typo was still within tolerance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1495</context>
+          <context context-type="linenumber">1505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonDamerau" datatype="html">
@@ -18446,7 +18623,7 @@
         <target>A letter transposition was still within tolerance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1497</context>
+          <context context-type="linenumber">1507</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonLevenshtein" datatype="html">
@@ -18454,7 +18631,7 @@
         <target>A missing or extra character was still within tolerance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1499</context>
+          <context context-type="linenumber">1509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingRequired" datatype="html">
@@ -18462,7 +18639,7 @@
         <target>The numeric value matched, but the required unit was missing.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1509</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalentRejected" datatype="html">
@@ -18470,7 +18647,7 @@
         <target>The numeric value matched after conversion, but only the configured unit is accepted.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonWrongFamily" datatype="html">
@@ -18478,7 +18655,7 @@
         <target>The numeric value matched, but the unit belongs to a different quantity family.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1513</context>
+          <context context-type="linenumber">1523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonUnsupportedUnit" datatype="html">
@@ -18486,7 +18663,7 @@
         <target>The numeric value matched, but the submitted unit is outside the supported unit set.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1515</context>
+          <context context-type="linenumber">1525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonPartial" datatype="html">
@@ -18494,7 +18671,7 @@
         <target>The numeric value matched, but the unit prevented full credit.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1517</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalent" datatype="html">
@@ -18502,7 +18679,7 @@
         <target>The numeric value and equivalent unit were converted correctly.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingOptional" datatype="html">
@@ -18510,7 +18687,7 @@
         <target>The numeric value matched; the unit was optional in this question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1525</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonTolerance" datatype="html">
@@ -18518,7 +18695,7 @@
         <target>The numeric value fell within the configured tolerance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1528</context>
+          <context context-type="linenumber">1538</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonExact" datatype="html">
@@ -18526,7 +18703,7 @@
         <target>The numeric value and unit exactly match a model answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1531</context>
+          <context context-type="linenumber">1541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeInteger" datatype="html">
@@ -18534,7 +18711,7 @@
         <target>Integer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1865</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeDecimal" datatype="html">
@@ -18542,7 +18719,7 @@
         <target>Decimal number</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1856</context>
+          <context context-type="linenumber">1866</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatInteger" datatype="html">
@@ -18550,7 +18727,7 @@
         <target>Enter a whole number without decimal places.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1861</context>
+          <context context-type="linenumber">1871</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimalPlaces" datatype="html">
@@ -18558,7 +18735,7 @@
         <target>Use a comma or decimal point, up to <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> decimal places.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1865</context>
+          <context context-type="linenumber">1875</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimal" datatype="html">
@@ -18566,7 +18743,7 @@
         <target>Use a comma or decimal point.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1867</context>
+          <context context-type="linenumber">1877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeBoth" datatype="html">
@@ -18578,7 +18755,7 @@
       )"/> to <x id="max" equiv-text="this.formatNumericResultValue(max)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1874,1876</context>
+          <context context-type="linenumber">1884,1886</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMin" datatype="html">
@@ -18590,7 +18767,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1879,1881</context>
+          <context context-type="linenumber">1889,1891</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMax" datatype="html">
@@ -18602,7 +18779,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1884,1886</context>
+          <context context-type="linenumber">1894,1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultInBand" datatype="html">
@@ -18610,7 +18787,7 @@
         <target>In the tolerance band</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultOutOfBand" datatype="html">
@@ -18618,7 +18795,7 @@
         <target>Outside the tolerance band</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2030</context>
+          <context context-type="linenumber">2040</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultReference" datatype="html">
@@ -18630,7 +18807,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2036,2038</context>
+          <context context-type="linenumber">2046,2048</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedSingle" datatype="html">
@@ -18642,7 +18819,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2049,2051</context>
+          <context context-type="linenumber">2059,2061</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedRange" datatype="html">
@@ -18654,7 +18831,7 @@
       )"/> to <x id="right" equiv-text="this.formatNumericResultValue(acceptedRight)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2053,2055</context>
+          <context context-type="linenumber">2063,2065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultToleranceBand" datatype="html">
@@ -18666,7 +18843,7 @@
     )"/> to <x id="right" equiv-text="this.formatNumericResultValue(band.right)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2057,2059</context>
+          <context context-type="linenumber">2067,2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultExact" datatype="html">
@@ -18674,7 +18851,7 @@
         <target>Exactly at the reference value</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2068</context>
+          <context context-type="linenumber">2078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultDistance" datatype="html">
@@ -18686,7 +18863,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2070,2072</context>
+          <context context-type="linenumber">2080,2082</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultImproved" datatype="html">
@@ -18698,7 +18875,7 @@
       )"/> closer to the reference value than in round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2109,2111</context>
+          <context context-type="linenumber">2119,2121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultWorse" datatype="html">
@@ -18710,7 +18887,7 @@
       )"/> further away from the reference value than in round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2114,2116</context>
+          <context context-type="linenumber">2124,2126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultUnchanged" datatype="html">
@@ -18718,7 +18895,7 @@
         <target>Just as close to the reference value as in round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2118</context>
+          <context context-type="linenumber">2128</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericRequired" datatype="html">
@@ -18726,7 +18903,7 @@
         <target>Please enter a number.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2139</context>
+          <context context-type="linenumber">2149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericIntegerRequired" datatype="html">
@@ -18734,7 +18911,7 @@
         <target>Please enter an integer in the supported format.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2143</context>
+          <context context-type="linenumber">2153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericDecimalPlacesExceeded" datatype="html">
@@ -18742,7 +18919,7 @@
         <target>Maximum <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> decimal places allowed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2152</context>
+          <context context-type="linenumber">2162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInvalid" datatype="html">
@@ -18750,7 +18927,7 @@
         <target>Please enter a valid number in the supported format.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2154</context>
+          <context context-type="linenumber">2164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericBelowMin" datatype="html">
@@ -18758,7 +18935,7 @@
         <target>Please enter a value of at least <x id="min" equiv-text="min"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2160</context>
+          <context context-type="linenumber">2170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericAboveMax" datatype="html">
@@ -18766,7 +18943,7 @@
         <target>Please enter a value of at most <x id="max" equiv-text="max"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2163</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinalScore" datatype="html">
@@ -18774,7 +18951,7 @@
         <target>Final score</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2311</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleWinFin" datatype="html">
@@ -18782,7 +18959,7 @@
         <target>Your team wins!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2316</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinishedOther" datatype="html">
@@ -18790,7 +18967,7 @@
         <target>Finished</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasingZero" datatype="html">
@@ -18798,7 +18975,7 @@
         <target>Push now—you can still catch up!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2321</context>
+          <context context-type="linenumber">2331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleAllZero" datatype="html">
@@ -18806,7 +18983,7 @@
         <target>Show what you&apos;ve got!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2322</context>
+          <context context-type="linenumber">2332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleLeading" datatype="html">
@@ -18814,7 +18991,7 @@
         <target>You&apos;re in the lead</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2325</context>
+          <context context-type="linenumber">2335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasing" datatype="html">
@@ -18822,7 +18999,7 @@
         <target>Keep going</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2327</context>
+          <context context-type="linenumber">2337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgWinFin" datatype="html">
@@ -18830,7 +19007,7 @@
         <target>You won together: 1st place is yours.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2345</context>
+          <context context-type="linenumber">2355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedAllZero" datatype="html">
@@ -18838,7 +19015,7 @@
         <target>The quiz is over — no team scored any team points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOwnZero" datatype="html">
@@ -18846,7 +19023,7 @@
         <target>The quiz is over — your team didn&apos;t score any team points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2351</context>
+          <context context-type="linenumber">2361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOther" datatype="html">
@@ -18854,7 +19031,7 @@
         <target>You finished with <x id="totalScore" equiv-text="entry.totalScore"/> points, ranked #<x id="teamRank" equiv-text="entry.rank"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2353</context>
+          <context context-type="linenumber">2363</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgAllZero" datatype="html">
@@ -18862,7 +19039,7 @@
         <target>Correct answers earn points for your team.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2357</context>
+          <context context-type="linenumber">2367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgChasing" datatype="html">
@@ -18870,11 +19047,11 @@
         <target>Currently ranked #<x id="teamRank" equiv-text="entry.rank"/> with <x id="totalScore" equiv-text="entry.totalScore"/> points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2359</context>
+          <context context-type="linenumber">2369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgLeading" datatype="html">
@@ -18882,7 +19059,7 @@
         <target>You lead with <x id="totalScore" equiv-text="entry.totalScore"/> points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2362</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulLoading" datatype="html">
@@ -18890,7 +19067,7 @@
         <target>Loading your result…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2406</context>
+          <context context-type="linenumber">2416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulNeutral" datatype="html">
@@ -18898,7 +19075,7 @@
         <target>That&apos;s a wrap — thanks for playing!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2411</context>
+          <context context-type="linenumber">2421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingNoRank" datatype="html">
@@ -18906,7 +19083,7 @@
         <target><x id="teamName" equiv-text="entry.teamName"/> with <x id="memberCountLabel" equiv-text="this.teamMemberLabel(entry.memberCount)"/> and <x id="totalScore" equiv-text="entry.totalScore"/> team points — no ranking yet</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2442</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingWithMembers" datatype="html">
@@ -18914,7 +19091,7 @@
         <target>#<x id="teamRank"/>: <x id="teamName"/> with <x id="memberCountLabel"/> and <x id="totalScore"/> points</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2602080285199874401" datatype="html">
@@ -18922,7 +19099,7 @@
         <target><x id="PH" equiv-text="stars"/> out of 5 stars</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2477</context>
+          <context context-type="linenumber">2487</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaOne" datatype="html">
@@ -18930,7 +19107,7 @@
         <target>1 second remaining</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2483</context>
+          <context context-type="linenumber">2493</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaMany" datatype="html">
@@ -18938,7 +19115,7 @@
         <target><x id="seconds" equiv-text="seconds"/> seconds remaining</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2484</context>
+          <context context-type="linenumber">2494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.groupAria" datatype="html">
@@ -18946,7 +19123,7 @@
         <target>Personal time</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2488</context>
+          <context context-type="linenumber">2498</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.extended" datatype="html">
@@ -18954,15 +19131,15 @@
         <target>10× time</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2494</context>
+          <context context-type="linenumber">2504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.off" datatype="html">
-        <source>Ohne Timer</source>
-        <target>No timer</target>
+        <source>Ohne Frist</source>
+        <target>No deadline</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2496</context>
+          <context context-type="linenumber">2506</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.default" datatype="html">
@@ -18970,7 +19147,23 @@
         <target>Default</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2498</context>
+          <context context-type="linenumber">2508</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsDefault" datatype="html">
+        <source>Punkte folgen dem gemeinsamen Countdown</source>
+        <target>Points follow the shared countdown</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2514</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsOvertime" datatype="html">
+        <source>Früh abgeben lohnt sich · nach dem Countdown nur Mindestpunkte</source>
+        <target>Submitting early pays off · after the countdown only the minimum</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.overtimeCorrect" datatype="html">
@@ -18978,7 +19171,7 @@
         <target>Extra time · correct answer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2504</context>
+          <context context-type="linenumber">2521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.upToNow" datatype="html">
@@ -18986,7 +19179,7 @@
         <target>Full score now</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2507</context>
+          <context context-type="linenumber">2524</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.correctNow" datatype="html">
@@ -18994,7 +19187,7 @@
         <target>Correct answer now</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2508</context>
+          <context context-type="linenumber">2525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.error" datatype="html">
@@ -19002,7 +19195,7 @@
         <target>Time adjustment could not be saved.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2536</context>
+          <context context-type="linenumber">2561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeUpvoteAria" datatype="html">
@@ -19010,7 +19203,7 @@
         <target>Remove upvote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2547</context>
+          <context context-type="linenumber">2572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addUpvoteAria" datatype="html">
@@ -19018,7 +19211,7 @@
         <target>Upvote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2548</context>
+          <context context-type="linenumber">2573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeDownvoteAria" datatype="html">
@@ -19026,7 +19219,7 @@
         <target>Remove downvote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2552</context>
+          <context context-type="linenumber">2577</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addDownvoteAria" datatype="html">
@@ -19034,7 +19227,7 @@
         <target>Downvote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2553</context>
+          <context context-type="linenumber">2578</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5043949766391435553" datatype="html">
@@ -19042,7 +19235,7 @@
         <target>Rating from <x id="PH" equiv-text="this.ratingLabelMin()"/> to <x id="PH_1" equiv-text="this.ratingLabelMax()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2557</context>
+          <context context-type="linenumber">2582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2721187191897749624" datatype="html">
@@ -19050,7 +19243,7 @@
         <target>Rating <x id="PH" equiv-text="value"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2561</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLabels" datatype="html">
@@ -19058,7 +19251,7 @@
         <target>Self-assessment from 1 to 5, low: <x id="low" equiv-text="low"/>, high: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLow" datatype="html">
@@ -19066,7 +19259,7 @@
         <target>Self-assessment from 1 to 5, low: <x id="low" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2591</context>
+          <context context-type="linenumber">2616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithHigh" datatype="html">
@@ -19074,7 +19267,7 @@
         <target>Self-assessment from 1 to 5, high: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2594</context>
+          <context context-type="linenumber">2619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAria" datatype="html">
@@ -19082,7 +19275,7 @@
         <target>Self-assessment from 1 to 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2596</context>
+          <context context-type="linenumber">2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceValueAria" datatype="html">
@@ -19090,7 +19283,7 @@
         <target>Self-assessment <x id="value" equiv-text="value"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2600</context>
+          <context context-type="linenumber">2625</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithLowLabel" datatype="html">
@@ -19098,7 +19291,7 @@
         <target><x id="value" equiv-text="value"/> – <x id="label" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2611</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithHighLabel" datatype="html">
@@ -19106,7 +19299,7 @@
         <target><x id="value" equiv-text="value"/> – <x id="label" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2614</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="974858114847169012" datatype="html">
@@ -19114,7 +19307,7 @@
         <target>React with <x id="PH" equiv-text="emoji"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2634</context>
+          <context context-type="linenumber">2659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteLoadError" datatype="html">
@@ -19122,7 +19315,7 @@
         <target>Couldn&apos;t load questions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3519</context>
+          <context context-type="linenumber">3547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitSuccess" datatype="html">
@@ -19130,7 +19323,7 @@
         <target>Question sent.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3562</context>
+          <context context-type="linenumber">3590</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitError" datatype="html">
@@ -19138,19 +19331,19 @@
         <target>Couldn&apos;t send the question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3568</context>
+          <context context-type="linenumber">3596</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3588</context>
+          <context context-type="linenumber">3616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3617</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3625</context>
+          <context context-type="linenumber">3653</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.upvoteError" datatype="html">
@@ -19158,7 +19351,7 @@
         <target>Couldn&apos;t save your vote.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3666</context>
+          <context context-type="linenumber">3694</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnError" datatype="html">
@@ -19166,7 +19359,7 @@
         <target>Couldn&apos;t delete the question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3694</context>
+          <context context-type="linenumber">3722</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwnMany" datatype="html">
@@ -19174,7 +19367,7 @@
         <target>The host removed your questions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3750</context>
+          <context context-type="linenumber">3778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwn" datatype="html">
@@ -19182,7 +19375,7 @@
         <target>The host removed your question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOthersMany" datatype="html">
@@ -19190,7 +19383,7 @@
         <target>Several questions were removed by the host.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3755</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOther" datatype="html">
@@ -19198,7 +19391,7 @@
         <target>A question was removed by the host.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.readingReadyError" datatype="html">
@@ -19206,7 +19399,7 @@
         <target>Could not confirm readiness.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4017</context>
+          <context context-type="linenumber">4045</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceRequired" datatype="html">
@@ -19214,7 +19407,7 @@
         <target>Give your self-assessment before submitting.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4188</context>
+          <context context-type="linenumber">4216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9175670018185396326" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -4232,7 +4232,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4646</context>
+          <context context-type="linenumber">4662</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -4240,11 +4240,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2074,2076</context>
+          <context context-type="linenumber">2136,2138</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2199</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackHostTitle" datatype="html">
@@ -4284,7 +4284,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3609</context>
+          <context context-type="linenumber">3635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -4726,7 +4726,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1880</context>
+          <context context-type="linenumber">1888</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -4738,7 +4738,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1885</context>
+          <context context-type="linenumber">1893</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -4762,7 +4762,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -4774,7 +4774,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -4930,7 +4930,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackVoteTitle" datatype="html">
@@ -5090,7 +5090,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2082,2085</context>
+          <context context-type="linenumber">2144,2147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.voteMissing" datatype="html">
@@ -6922,11 +6922,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4958</context>
+          <context context-type="linenumber">4974</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2268</context>
+          <context context-type="linenumber">2278</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3532753318619772032" datatype="html">
@@ -6938,11 +6938,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4960</context>
+          <context context-type="linenumber">4976</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2270</context>
+          <context context-type="linenumber">2280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="74432774947660496" datatype="html">
@@ -6954,11 +6954,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="276214048875673948" datatype="html">
@@ -6970,11 +6970,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5356551916626450286" datatype="html">
@@ -6986,11 +6986,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3903113005127984737" datatype="html">
@@ -7002,11 +7002,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeRemoveSession" datatype="html">
@@ -7258,7 +7258,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7266,7 +7266,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6658206425619028413" datatype="html">
@@ -7278,7 +7278,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7286,7 +7286,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5683915683305860193" datatype="html">
@@ -7374,15 +7374,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2911</context>
+          <context context-type="linenumber">2919</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2449</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2458</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/preset-toast/preset-toast.component.ts</context>
@@ -9746,11 +9746,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4629</context>
+          <context context-type="linenumber">4645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.medium" datatype="html">
@@ -9766,11 +9766,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4631</context>
+          <context context-type="linenumber">4647</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1787</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.hard" datatype="html">
@@ -9786,11 +9786,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4633</context>
+          <context context-type="linenumber">4649</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1779</context>
+          <context context-type="linenumber">1789</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeExactLabel" datatype="html">
@@ -10958,11 +10958,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1348</context>
+          <context context-type="linenumber">1410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1612</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesExportCsv" datatype="html">
@@ -12470,7 +12470,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3027</context>
+          <context context-type="linenumber">3031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -12482,7 +12482,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3030</context>
+          <context context-type="linenumber">3034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -12494,7 +12494,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3035</context>
+          <context context-type="linenumber">3039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -12506,7 +12506,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3225</context>
+          <context context-type="linenumber">3229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -12518,7 +12518,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3229</context>
+          <context context-type="linenumber">3233</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -12530,7 +12530,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3232</context>
+          <context context-type="linenumber">3236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -12542,7 +12542,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3235</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -12698,7 +12698,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2735</context>
+          <context context-type="linenumber">2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -12726,7 +12726,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2998</context>
+          <context context-type="linenumber">3002</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -12930,7 +12930,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2968</context>
+          <context context-type="linenumber">2972</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -13134,8 +13134,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
-        <source> Teilnehmende können ihre persönliche Zeit bei Bedarf verlängern oder abschalten.</source>
-        <target>Los participantes pueden ampliar o interrumpir su tiempo personal si es necesario.</target>
+        <source> Teilnehmende können ihre persönliche Frist bei Bedarf verlängern oder abschalten.</source>
+        <target>Los participantes pueden ampliar o desactivar su plazo personal si es necesario.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">1441,1444</context>
@@ -13146,19 +13146,19 @@
         <target>Metadatos de la pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1456</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">832</context>
+          <context context-type="linenumber">947</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">894</context>
+          <context context-type="linenumber">1013</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">961</context>
+          <context context-type="linenumber">1081</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4209613400308596118" datatype="html">
@@ -13166,7 +13166,7 @@
         <target>Fase de lectura</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1481</context>
+          <context context-type="linenumber">1485</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
@@ -13174,7 +13174,7 @@
         <target>Las respuestas llegarán enseguida.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1482,1484</context>
+          <context context-type="linenumber">1486,1488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
@@ -13182,7 +13182,7 @@
         <target>Escala de valoración</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1540</context>
+          <context context-type="linenumber">1544</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
@@ -13190,7 +13190,7 @@
         <target>Distribución de las valoraciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1568</context>
+          <context context-type="linenumber">1572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
@@ -13198,7 +13198,7 @@
         <target>Esperando estimaciones…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1607,1609</context>
+          <context context-type="linenumber">1611,1613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
@@ -13206,7 +13206,7 @@
         <target><x id="INTERPOLATION"/> respuestas recibidas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615,1617</context>
+          <context context-type="linenumber">1619,1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
@@ -13214,11 +13214,11 @@
         <target>Resumen de estadísticas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1627</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2060</context>
+          <context context-type="linenumber">2064</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
@@ -13226,7 +13226,7 @@
         <target>Ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1632</context>
+          <context context-type="linenumber">1636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
@@ -13234,11 +13234,11 @@
         <target>Aceptada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1654</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2080</context>
+          <context context-type="linenumber">2084</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
@@ -13246,7 +13246,7 @@
         <target>Comparación redonda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
@@ -13254,7 +13254,7 @@
         <target>cambio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1685</context>
+          <context context-type="linenumber">1689</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
@@ -13262,7 +13262,7 @@
         <target>Ronda 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1706</context>
+          <context context-type="linenumber">1710</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
@@ -13270,7 +13270,7 @@
         <target>Ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1711</context>
+          <context context-type="linenumber">1715</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
@@ -13278,11 +13278,11 @@
         <target>Mostrar detalles estadísticos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1898</context>
+          <context context-type="linenumber">1902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2197</context>
+          <context context-type="linenumber">2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
@@ -13290,7 +13290,7 @@
         <target>Ronda 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1912,1914</context>
+          <context context-type="linenumber">1916,1918</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
@@ -13298,7 +13298,7 @@
         <target>Ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1940,1942</context>
+          <context context-type="linenumber">1944,1946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
@@ -13306,7 +13306,7 @@
         <target>Δ por pares: <x id="INTERPOLATION"/> más cerca, <x id="INTERPOLATION_1"/> más lejos, <x id="INTERPOLATION_2"/> sin cambios (<x id="INTERPOLATION_3"/> pares)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1971,1979</context>
+          <context context-type="linenumber">1975,1983</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
@@ -13314,7 +13314,7 @@
         <target>Distribución Δx</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1989</context>
+          <context context-type="linenumber">1993</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
@@ -13322,7 +13322,7 @@
         <target>más pequeño está más cerca</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2103</context>
+          <context context-type="linenumber">2107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
@@ -13330,7 +13330,7 @@
         <target>Ronda de resultados</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2210,2212</context>
+          <context context-type="linenumber">2214,2216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
@@ -13338,7 +13338,7 @@
         <target>No se han recibido estimaciones.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2237,2239</context>
+          <context context-type="linenumber">2241,2243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
@@ -13346,7 +13346,7 @@
         <target>Comparación antes y después de la votación Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
@@ -13354,7 +13354,7 @@
         <target>Ronda 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> voto)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
@@ -13362,7 +13362,7 @@
         <target>Ronda 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> votos)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2263</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
@@ -13370,7 +13370,7 @@
         <target>Ronda 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> voto)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2271</context>
+          <context context-type="linenumber">2275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
@@ -13378,7 +13378,7 @@
         <target>Ronda 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> votos)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
@@ -13386,7 +13386,7 @@
         <target>Correctas: <x id="INTERPOLATION" equiv-text="{{ q.roundComparison.round1CorrectCount }}"/> en la ronda 1, después <x id="INTERPOLATION_1" equiv-text="{{ q.roundComparison.round2CorrectCount }}"/> en la ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2289,2293</context>
+          <context context-type="linenumber">2293,2297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
@@ -13394,7 +13394,7 @@
         <target>Se recomienda Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2536,2538</context>
+          <context context-type="linenumber">2540,2542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
@@ -13402,7 +13402,7 @@
         <target>35–70 % totalmente correctos: 2.ª ronda encaja.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2543,2545</context>
+          <context context-type="linenumber">2547,2549</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
@@ -13410,7 +13410,7 @@
         <target>1.ª ronda sigue oculta hasta que decidas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2550,2552</context>
+          <context context-type="linenumber">2554,2556</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
@@ -13418,7 +13418,7 @@
         <target>Iniciar discusión o mostrar resultado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2557,2559</context>
+          <context context-type="linenumber">2561,2563</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
@@ -13426,7 +13426,7 @@
         <target>Autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2615,2617</context>
+          <context context-type="linenumber">2619,2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
@@ -13434,7 +13434,7 @@
         <target> ¿Correcto o incorrecto — y con qué seguridad? Especialmente importante: incorrecto pese a alta seguridad de respuesta. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2621,2624</context>
+          <context context-type="linenumber">2625,2628</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
@@ -13442,7 +13442,7 @@
         <target>Corrección y autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2645</context>
+          <context context-type="linenumber">2649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
@@ -13450,7 +13450,7 @@
         <target> A menudo incorrecto con alta seguridad de respuesta </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2699,2701</context>
+          <context context-type="linenumber">2703,2705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
@@ -13458,7 +13458,7 @@
         <target>Actualizando la pregunta …</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2744,2746</context>
+          <context context-type="linenumber">2748,2750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
@@ -13466,7 +13466,7 @@
         <target>Ninguna pregunta activa. Comience con &quot;Siguiente pregunta&quot;.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2748,2750</context>
+          <context context-type="linenumber">2752,2754</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -13474,7 +13474,7 @@
         <target>Reacciones de las personas participantes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2768</context>
+          <context context-type="linenumber">2772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
@@ -13482,7 +13482,7 @@
         <target>Ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2774</context>
+          <context context-type="linenumber">2778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
@@ -13490,7 +13490,7 @@
         <target>nuevo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2782</context>
+          <context context-type="linenumber">2786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
@@ -13498,7 +13498,7 @@
         <target>Aún no hay reacciones.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2805</context>
+          <context context-type="linenumber">2809</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
@@ -13506,7 +13506,7 @@
         <target>5 mejores</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2818</context>
+          <context context-type="linenumber">2822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
@@ -13514,7 +13514,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ entry.totalScore | number }}"/> puntos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2885</context>
+          <context context-type="linenumber">2889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
@@ -13522,7 +13522,7 @@
         <target>Empate: cuenta el tiempo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
@@ -13530,7 +13530,7 @@
         <target>Puntuación por equipos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2912</context>
+          <context context-type="linenumber">2916</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
@@ -13538,7 +13538,7 @@
         <target>puntos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2959</context>
+          <context context-type="linenumber">2963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
@@ -13546,7 +13546,7 @@
         <target>Cambiar cuestionario</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2988</context>
+          <context context-type="linenumber">2992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
@@ -13554,7 +13554,7 @@
         <target>Editar título de Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3091</context>
+          <context context-type="linenumber">3095</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
@@ -13562,7 +13562,7 @@
         <target>Título de Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3104</context>
+          <context context-type="linenumber">3108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
@@ -13570,7 +13570,7 @@
         <target>Preguntas sobre el evento...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3115</context>
+          <context context-type="linenumber">3119</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
@@ -13582,15 +13582,24 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1038</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
+        <source>Quiz-Session</source>
+        <target>Sesión de cuestionario</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">889</context>
+        </context-group>
+      </trans-unit>
+
       <trans-unit id="sessionHost.qaTitleConfirmAria" datatype="html">
         <source>Titel speichern</source>
         <target>Guardar título</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3127</context>
+          <context context-type="linenumber">3131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
@@ -13598,7 +13607,7 @@
         <target>Cancelar edición</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3138</context>
+          <context context-type="linenumber">3142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
@@ -13606,7 +13615,7 @@
         <target>Pre-moderación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3157,3159</context>
+          <context context-type="linenumber">3161,3163</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
@@ -13614,7 +13623,7 @@
         <target>La moderación previa está activa. Las nuevas preguntas esperan primero tu aprobación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3161,3163</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
@@ -13622,7 +13631,7 @@
         <target>Aún no hay preguntas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3170,3172</context>
+          <context context-type="linenumber">3174,3176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
@@ -13630,7 +13639,7 @@
         <target>Total: <x id="INTERPOLATION" equiv-text="qaQuestions().length"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3182,3183</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
@@ -13638,7 +13647,7 @@
         <target>Esperando aprobación: <x id="INTERPOLATION" equiv-text="qaPendingCount()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3191,3192</context>
+          <context context-type="linenumber">3195,3196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
@@ -13646,7 +13655,7 @@
         <target>Mostrar todas las preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3244</context>
+          <context context-type="linenumber">3248</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
@@ -13654,7 +13663,7 @@
         <target>Mostrar todas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3247</context>
+          <context context-type="linenumber">3251</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
@@ -13662,7 +13671,7 @@
         <target>Mostrar solo preguntas fijadas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3255</context>
+          <context context-type="linenumber">3259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
@@ -13670,7 +13679,7 @@
         <target>Solo fijadas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3258</context>
+          <context context-type="linenumber">3262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
@@ -13678,7 +13687,7 @@
         <target>Mostrar nuevas preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3270</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
@@ -13686,7 +13695,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ qaUnseenCount() }}"/> preguntas nuevas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3276</context>
+          <context context-type="linenumber">3280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
@@ -13694,7 +13703,7 @@
         <target>Exportar preguntas como CSV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3308</context>
+          <context context-type="linenumber">3312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
@@ -13702,7 +13711,7 @@
         <target>Exportar preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3311</context>
+          <context context-type="linenumber">3315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
@@ -13710,7 +13719,7 @@
         <target>Exportando…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3319,3321</context>
+          <context context-type="linenumber">3323,3325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
@@ -13718,7 +13727,7 @@
         <target>Polémica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3388</context>
+          <context context-type="linenumber">3392</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
@@ -13726,7 +13735,7 @@
         <target><x id="INTERPOLATION" equiv-text="question.positiveVoteCount"/> positivas · <x id="INTERPOLATION_1" equiv-text="question.negativeVoteCount"/> negativas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3416,3417</context>
+          <context context-type="linenumber">3420,3421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
@@ -13734,7 +13743,7 @@
         <target>Aprobación fiable <x id="INTERPOLATION" equiv-text="formatQaPercent(question.bestScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3424,3425</context>
+          <context context-type="linenumber">3428,3429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
@@ -13742,7 +13751,7 @@
         <target>Reacciones divididas <x id="INTERPOLATION" equiv-text="formatQaPercent(question.controversyScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3434,3436</context>
+          <context context-type="linenumber">3438,3440</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
@@ -13750,7 +13759,7 @@
         <target>Vista de fijadas activa – todavía no hay preguntas fijadas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3477,3479</context>
+          <context context-type="linenumber">3481,3483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
@@ -13758,7 +13767,7 @@
         <target>Mostrar opciones de respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3530</context>
+          <context context-type="linenumber">3534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
@@ -13766,7 +13775,7 @@
         <target>Iniciar fase de discusión: intercambio antes de la segunda votación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3554</context>
+          <context context-type="linenumber">3570</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
@@ -13774,7 +13783,7 @@
         <target>Fase de discusión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3557</context>
+          <context context-type="linenumber">3573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
@@ -13782,15 +13791,87 @@
         <target>Mostrar el resultado de todos modos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3591</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <target>Publicar de todos modos</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">3588</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
-        <source> Ergebnis zeigen</source>
+        <source>Ergebnis zeigen</source>
         <target>Mostrar resultado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3579,3581</context>
+          <context context-type="linenumber">3612</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
+        <source>Persönliche Fristen beenden?</source>
+        <target>¿Terminar los plazos personales?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5926</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
+        <source>Du zeigst das Ergebnis, obwohl noch persönliche Timer laufen.</source>
+        <target>Muestras el resultado aunque aún hay temporizadores personales en curso.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5930</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
+        <source>Du startest die Diskussionsphase, obwohl noch persönliche Timer laufen.</source>
+        <target>Inicias la fase de discusión aunque aún hay temporizadores personales en curso.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5929</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
+        <source>Die offene persönliche 10×-Frist dieser Person endet sofort.</source>
+        <target>El plazo personal ×10 abierto de esta persona termina de inmediato.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> offene persönliche 10×-Fristen enden sofort.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> plazos personales ×10 abiertos terminan de inmediato.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5921</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
+        <source>Danach ist keine weitere Antwort mehr möglich.</source>
+        <target>Después ya no será posible responder.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5918</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <target>Publicar de todos modos</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5932</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
+        <source>Weiter warten</source>
+        <target>Seguir esperando</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5933</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
@@ -13798,7 +13879,7 @@
         <target>Siguiente pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3595,3597</context>
+          <context context-type="linenumber">3621,3623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
@@ -13806,7 +13887,7 @@
         <target>A la siguiente pregunta sin segunda votación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3618</context>
+          <context context-type="linenumber">3644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
@@ -13814,7 +13895,7 @@
         <target>A la siguiente pregunta sin segunda votación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
@@ -13822,7 +13903,7 @@
         <target>Vuelve a mostrar la pregunta anterior con su resultado y la respuesta correcta (sin nueva votación).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3638</context>
+          <context context-type="linenumber">3664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
@@ -13830,7 +13911,7 @@
         <target>Mostrar de nuevo el resultado anterior</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3640,3642</context>
+          <context context-type="linenumber">3666,3668</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
@@ -13838,7 +13919,7 @@
         <target>Terminar sesión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650,3652</context>
+          <context context-type="linenumber">3676,3678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -13846,7 +13927,7 @@
         <target>Vista de host para lobby y control.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3658</context>
+          <context context-type="linenumber">3684</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
@@ -14174,7 +14255,7 @@
         <target>1 respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1526</context>
+          <context context-type="linenumber">1534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
@@ -14182,7 +14263,7 @@
         <target><x id="count" equiv-text="count"/> respuestas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1527</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
@@ -14190,7 +14271,7 @@
         <target>Bajo · <x id="label" equiv-text="q.confidenceLabelLow"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1618</context>
+          <context context-type="linenumber">1626</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
@@ -14198,7 +14279,7 @@
         <target>Bajo (1–2)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1619</context>
+          <context context-type="linenumber">1627</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
@@ -14206,7 +14287,7 @@
         <target>Medio (3)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1623</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
@@ -14214,7 +14295,7 @@
         <target>Alto · <x id="label" equiv-text="q.confidenceLabelHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1663</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
@@ -14222,7 +14303,7 @@
         <target>Alto (4–5)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1656</context>
+          <context context-type="linenumber">1664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
@@ -14230,7 +14311,7 @@
         <target>Correcto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
@@ -14238,7 +14319,7 @@
         <target>Incorrecto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1677</context>
+          <context context-type="linenumber">1685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
@@ -14246,7 +14327,7 @@
         <target><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1769</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
@@ -14254,7 +14335,7 @@
         <target>1 respuesta incorrecta y segura: posible error</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1774</context>
+          <context context-type="linenumber">1782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
@@ -14262,7 +14343,7 @@
         <target><x id="count" equiv-text="count"/> respuestas incorrectas seguras: posibles conceptos erróneos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
@@ -14270,7 +14351,7 @@
         <target>Correcto+alto <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · Incorrecto+alto <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1786</context>
+          <context context-type="linenumber">1794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
@@ -14278,7 +14359,7 @@
         <target>2 (Instrucción entre pares)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
@@ -14286,7 +14367,7 @@
         <target>Ronda 1: <x id="r1" equiv-text="round1Count"/> votos · Agregado: Ronda 2 con <x id="r2" equiv-text="round2Count"/> votos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1824</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
@@ -14294,7 +14375,7 @@
         <target>Ronda de agregación 2 (instrucción entre pares)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1826</context>
+          <context context-type="linenumber">1834</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
@@ -14302,7 +14383,7 @@
         <target>Ronda de agregación 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1837</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
@@ -14310,7 +14391,7 @@
         <target>Esta vez no ha llegado del todo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2427</context>
+          <context context-type="linenumber">2435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
@@ -14318,7 +14399,7 @@
         <target>Sin dramas, pasa (un tirón o un Wi‑Fi caprichoso). Espera unos segundos y pulsa « Probar otra vez » — casi siempre basta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2428</context>
+          <context context-type="linenumber">2436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
@@ -14326,7 +14407,7 @@
         <target>Con las preguntas va un poco a trompicones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2435</context>
+          <context context-type="linenumber">2443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
@@ -14334,7 +14415,7 @@
         <target>No está roto; solo no ha cuadrado esta vez. Espera unos segundos y pulsa « Probar otra vez » — a veces enseguida vuelve.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2436</context>
+          <context context-type="linenumber">2444</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
@@ -14342,7 +14423,7 @@
         <target>Exportación aún no lista</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2443</context>
+          <context context-type="linenumber">2451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
@@ -14350,7 +14431,7 @@
         <target>La exportación a PDF o Excel no ha salido redonda esta vez. Espera unos segundos y pulsa « Probar otra vez » — el segundo intento suele ir bien.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
@@ -14358,7 +14439,7 @@
         <target>Los participantes y la vista de presentación son redirigidos a la página de inicio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2578</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
@@ -14366,7 +14447,7 @@
         <target>La sesión termina para todos; No es posible continuar con el mismo código.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2579</context>
+          <context context-type="linenumber">2587</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
@@ -14374,7 +14455,7 @@
         <target><x id="participantCount" equiv-text="participants"/> Los participantes todavía están en la sesión.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2583</context>
+          <context context-type="linenumber">2591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
@@ -14382,7 +14463,7 @@
         <target>Ya tienes resultados. Después de finalizar, puedes exportarlos o revisar el feedback en la vista final.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2596</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
@@ -14390,7 +14471,7 @@
         <target>Todavía no hay resultados aprovechables. Después de finalizar, irás directamente a la página de inicio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2592</context>
+          <context context-type="linenumber">2600</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
@@ -14398,7 +14479,7 @@
         <target>Para códigos de bonificación: recomiende a los participantes que copien su código personal ahora (portapapeles) antes de abandonar la página; de lo contrario, pueden perderlo fácilmente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2597</context>
+          <context context-type="linenumber">2605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
@@ -14406,7 +14487,7 @@
         <target>¿Salir de la sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
@@ -14414,7 +14495,7 @@
         <target>Tu sesión aún está activa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
@@ -14422,7 +14503,7 @@
         <target>Todavía queda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2606</context>
+          <context context-type="linenumber">2614</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
@@ -14430,7 +14511,7 @@
         <target>Volver a la sesión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2607</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
@@ -14438,7 +14519,7 @@
         <target>Detener vista previa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2795</context>
+          <context context-type="linenumber">2803</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
@@ -14446,7 +14527,7 @@
         <target>Escucha la pista un momento (máx. 12 s)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2796</context>
+          <context context-type="linenumber">2804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
@@ -14454,7 +14535,7 @@
         <target>Sonido encendido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2808</context>
+          <context context-type="linenumber">2816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
@@ -14462,7 +14543,7 @@
         <target>Sonido apagado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2809</context>
+          <context context-type="linenumber">2817</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
@@ -14470,7 +14551,7 @@
         <target>Partícipe</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2866</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
@@ -14478,7 +14559,7 @@
         <target>participantes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2870</context>
+          <context context-type="linenumber">2878</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
@@ -14486,7 +14567,7 @@
         <target>1 conectado en vivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2887</context>
+          <context context-type="linenumber">2895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
@@ -14494,7 +14575,7 @@
         <target><x id="connectedCount" equiv-text="connectedCount"/> conectado en vivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2889</context>
+          <context context-type="linenumber">2897</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
@@ -14502,7 +14583,7 @@
         <target>Todavía no hay nadie en este equipo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2923</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
@@ -14510,7 +14591,7 @@
         <target>Evaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3729</context>
+          <context context-type="linenumber">3739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
@@ -14518,7 +14599,7 @@
         <target>Reseñas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3733</context>
+          <context context-type="linenumber">3743</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
@@ -14526,11 +14607,11 @@
         <target>Los resultados están disponibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3738</context>
+          <context context-type="linenumber">3748</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3745</context>
+          <context context-type="linenumber">3755</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
@@ -14538,11 +14619,11 @@
         <target>El tiempo expiró.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3739</context>
+          <context context-type="linenumber">3749</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3746</context>
+          <context context-type="linenumber">3756</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
@@ -14550,7 +14631,7 @@
         <target>Esperando reseñas…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3740</context>
+          <context context-type="linenumber">3750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
@@ -14558,7 +14639,7 @@
         <target>Esperando respuestas...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3747</context>
+          <context context-type="linenumber">3757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
@@ -14566,23 +14647,55 @@
         <target><x id="PH" equiv-text="votes"/> por <x id="PH_1" equiv-text="participants"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3761</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <target>Una persona todavía usa su tiempo ×10. Espera la cuenta atrás de la sala o hasta que termine el tiempo ×10.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3769</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihr persönliches Fenster.</source>
+        <target>Una persona todavía usa su tiempo ×10. «Publicar de todos modos» cierra su ventana personal.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3768</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> personas todavía usan su tiempo ×10. Espera la cuenta atrás de la sala o hasta que termine el tiempo ×10.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3774</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihre persönlichen Fenster.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> personas todavía usan su tiempo ×10. «Publicar de todos modos» cierra sus ventanas personales.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
-        <source>Eine Person mit Zeitanpassung antwortet noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
-        <target>Una persona con tiempo adicional todavía está respondiendo. «Mostrar resultado» cierra su plazo de respuesta.</target>
+        <source>Eine Person antwortet ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <target>Una persona responde sin plazo personal. «Mostrar resultado» cierra su respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
-        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen mit Zeitanpassung antworten noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
-        <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> personas con tiempo adicional todavía están respondiendo. «Mostrar resultado» cierra su plazo de respuesta.</target>
+        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen antworten ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> personas responden sin plazo personal. «Mostrar resultado» cierra su respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3758</context>
+          <context context-type="linenumber">3774</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
@@ -14590,7 +14703,7 @@
         <target><x id="votes" equiv-text="votes"/> de <x id="participants" equiv-text="participants"/> participantes votaron. Se alcanzó el <x id="percentage" equiv-text="percentage"/> por ciento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3764</context>
+          <context context-type="linenumber">3780</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
@@ -14598,7 +14711,7 @@
         <target><x id="votes" equiv-text="votes"/> de <x id="participants" equiv-text="participants"/> participantes han votado. Se alcanzó el <x id="percentage" equiv-text="percentage"/> por ciento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3766</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
@@ -14606,7 +14719,7 @@
         <target><x id="voteCount"/> de <x id="participantTotal"/> ha votado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
@@ -14614,7 +14727,7 @@
         <target><x id="voteCount"/> de <x id="participantTotal"/> han votado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3779</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
@@ -14622,7 +14735,7 @@
         <target><x id="voteCount"/> de <x id="participantTotal"/> ha valorado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3790</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
@@ -14630,7 +14743,7 @@
         <target><x id="voteCount"/> de <x id="participantTotal"/> han valorado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3792</context>
+          <context context-type="linenumber">3808</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
@@ -14638,7 +14751,7 @@
         <target><x id="correctCount"/> de <x id="voteTotal"/> completamente correctos (<x id="percentage"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3798</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
@@ -14646,7 +14759,7 @@
         <target><x id="changed"/> de <x id="both"/> (<x id="pct"/>%) cambiaron de opinión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3802</context>
+          <context context-type="linenumber">3818</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
@@ -14654,7 +14767,7 @@
         <target>↑ <x id="count"/> incorrecto → correcto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3806</context>
+          <context context-type="linenumber">3822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
@@ -14662,7 +14775,7 @@
         <target>↓ <x id="count"/> correcto → incorrecto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3810</context>
+          <context context-type="linenumber">3826</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
@@ -14670,7 +14783,7 @@
         <target>Media <x id="avg"/> de 5 estrellas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3816</context>
+          <context context-type="linenumber">3832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
@@ -14678,7 +14791,7 @@
         <target><x id="PH" equiv-text="total"/> reacción</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
@@ -14686,7 +14799,7 @@
         <target><x id="PH" equiv-text="total"/> reacciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
@@ -14694,7 +14807,7 @@
         <target>Lobby: las personas participantes pueden entrar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3873</context>
+          <context context-type="linenumber">3889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
@@ -14702,7 +14815,7 @@
         <target>Se está preparando la ronda de preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3874</context>
+          <context context-type="linenumber">3890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
@@ -14710,15 +14823,15 @@
         <target>La ronda de preguntas está en marcha</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3875</context>
+          <context context-type="linenumber">3891</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3877</context>
+          <context context-type="linenumber">3893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3878</context>
+          <context context-type="linenumber">3894</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
@@ -14726,7 +14839,7 @@
         <target>En pausa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3876</context>
+          <context context-type="linenumber">3892</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
@@ -14734,7 +14847,7 @@
         <target>Ronda de preguntas finalizada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3879</context>
+          <context context-type="linenumber">3895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
@@ -14742,7 +14855,7 @@
         <target>Votación finalizada – esperando evaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3884</context>
+          <context context-type="linenumber">3900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
@@ -14750,7 +14863,7 @@
         <target>Vestíbulo: los participantes pueden unirse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3887</context>
+          <context context-type="linenumber">3903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
@@ -14758,7 +14871,7 @@
         <target>Fase de lectura: respuestas aún bloqueadas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3888</context>
+          <context context-type="linenumber">3904</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
@@ -14766,7 +14879,7 @@
         <target>La votación está en curso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3889</context>
+          <context context-type="linenumber">3905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
@@ -14774,7 +14887,7 @@
         <target>En pausa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3890</context>
+          <context context-type="linenumber">3906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
@@ -14782,7 +14895,7 @@
         <target>Se muestran los resultados</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3891</context>
+          <context context-type="linenumber">3907</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
@@ -14790,7 +14903,7 @@
         <target>Fase de discusión – intercambio antes de la segunda ronda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3892</context>
+          <context context-type="linenumber">3908</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
@@ -14798,7 +14911,7 @@
         <target>Sesión finalizada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3893</context>
+          <context context-type="linenumber">3909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
@@ -14806,7 +14919,7 @@
         <target><x id="readyCount" equiv-text="readyCount"/> de <x id="connectedCount" equiv-text="connectedCount"/> listos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3904</context>
+          <context context-type="linenumber">3920</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
@@ -14814,7 +14927,7 @@
         <target><x id="PH" equiv-text="readyCount"/> de <x id="PH_1" equiv-text="connectedCount"/> conectado listo · <x id="PH_2" equiv-text="totalParticipantCount"/> total</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3906</context>
+          <context context-type="linenumber">3922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
@@ -14822,7 +14935,7 @@
         <target>Todas las personas participantes están listas; se pueden revelar las opciones de respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3911</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
@@ -14830,7 +14943,7 @@
         <target>Todas las personas participantes conectadas están listas; se pueden revelar las opciones de respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3913</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
@@ -14838,7 +14951,7 @@
         <target>1 segundo restante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3944</context>
+          <context context-type="linenumber">3960</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
@@ -14846,7 +14959,7 @@
         <target>Quedan <x id="seconds" equiv-text="seconds"/> segundos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3945</context>
+          <context context-type="linenumber">3961</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -14860,7 +14973,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4069,4072</context>
+          <context context-type="linenumber">4085,4088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -14874,7 +14987,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4114,4117</context>
+          <context context-type="linenumber">4130,4133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -14888,7 +15001,7 @@
       )"/> a <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4119,4122</context>
+          <context context-type="linenumber">4135,4138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -14903,7 +15016,7 @@
     )"/> a <x id="right" equiv-text="formatNumber(band.right, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4124,4127</context>
+          <context context-type="linenumber">4140,4143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
@@ -14911,7 +15024,7 @@
         <target>Mediana <x id="median" equiv-text="formatNumber(stats.median, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4242</context>
+          <context context-type="linenumber">4258</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
@@ -14919,7 +15032,7 @@
         <target>Estimaciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4275</context>
+          <context context-type="linenumber">4291</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
@@ -14927,7 +15040,7 @@
         <target>respuestas válidas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4277</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
@@ -14935,7 +15048,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4283</context>
+          <context context-type="linenumber">4299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
@@ -14943,7 +15056,7 @@
         <target>Promedio de todas las estimaciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4285</context>
+          <context context-type="linenumber">4301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
@@ -14951,7 +15064,7 @@
         <target>Mediana</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4291</context>
+          <context context-type="linenumber">4307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
@@ -14959,7 +15072,7 @@
         <target>Valor central ordenado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4293</context>
+          <context context-type="linenumber">4309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
@@ -14967,7 +15080,7 @@
         <target>Dispersión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4299</context>
+          <context context-type="linenumber">4315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
@@ -14975,7 +15088,7 @@
         <target>Desviación estándar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4301</context>
+          <context context-type="linenumber">4317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
@@ -14983,7 +15096,7 @@
         <target>50 % centrales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4307</context>
+          <context context-type="linenumber">4323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -14998,7 +15111,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4312,4315</context>
+          <context context-type="linenumber">4328,4331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
@@ -15006,7 +15119,7 @@
         <target>Rango</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
@@ -15014,7 +15127,7 @@
         <target>estimación menor a mayor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4326</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
@@ -15022,7 +15135,7 @@
         <target>En el intervalo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4332</context>
+          <context context-type="linenumber">4348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -15038,7 +15151,7 @@
         )"/>% aceptado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4338,4342</context>
+          <context context-type="linenumber">4354,4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
@@ -15046,7 +15159,7 @@
         <target>Distancia media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4348</context>
+          <context context-type="linenumber">4364</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
@@ -15054,7 +15167,7 @@
         <target>a la referencia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4350</context>
+          <context context-type="linenumber">4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
@@ -15062,7 +15175,7 @@
         <target>Mediana</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4358</context>
+          <context context-type="linenumber">4374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
@@ -15070,7 +15183,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4361</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
@@ -15078,7 +15191,7 @@
         <target>Estimaciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4363</context>
+          <context context-type="linenumber">4379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -15094,7 +15207,7 @@
     )"/> % en el rango aceptado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394,4398</context>
+          <context context-type="linenumber">4410,4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
@@ -15102,7 +15215,7 @@
         <target>Distancia media a la referencia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4412</context>
+          <context context-type="linenumber">4428</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
@@ -15110,7 +15223,7 @@
         <target>más cerca del valor de referencia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4426</context>
+          <context context-type="linenumber">4442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
@@ -15118,7 +15231,7 @@
         <target>Cambio medio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4443</context>
+          <context context-type="linenumber">4459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
@@ -15126,7 +15239,7 @@
         <target>cambio medio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4444</context>
+          <context context-type="linenumber">4460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -15141,7 +15254,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4455,4458</context>
+          <context context-type="linenumber">4471,4474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -15156,7 +15269,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4464,4467</context>
+          <context context-type="linenumber">4480,4483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -15172,7 +15285,7 @@
         )"/> puntos porcentuales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4476,4480</context>
+          <context context-type="linenumber">4492,4496</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -15196,7 +15309,7 @@
           )"/> estimaciones comparables han mejorado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4496,4504</context>
+          <context context-type="linenumber">4512,4520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -15220,7 +15333,7 @@
           )"/> estimaciones comparables están más lejos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4516</context>
+          <context context-type="linenumber">4524,4532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
@@ -15228,7 +15341,7 @@
         <target>La segunda ronda es mixta: las estimaciones más cercanas y más distantes se equilibran en la comparación de pares.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520</context>
+          <context context-type="linenumber">4536</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -15242,7 +15355,7 @@
           )"/> en la ronda 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4532,4535</context>
+          <context context-type="linenumber">4548,4551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -15256,7 +15369,7 @@
           )"/> mayor en la ronda 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4539,4542</context>
+          <context context-type="linenumber">4555,4558</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -15272,7 +15385,7 @@
         )"/> puntos porcentuales.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4554,4558</context>
+          <context context-type="linenumber">4570,4574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -15296,7 +15409,7 @@
         )"/> estimaciones están dentro de la banda de tolerancia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4573,4581</context>
+          <context context-type="linenumber">4589,4597</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -15310,7 +15423,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4586,4589</context>
+          <context context-type="linenumber">4602,4605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -15324,7 +15437,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4593,4596</context>
+          <context context-type="linenumber">4609,4612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
@@ -15332,11 +15445,11 @@
         <target>Quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4642</context>
+          <context context-type="linenumber">4658</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2195</context>
+          <context context-type="linenumber">2205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.questions" datatype="html">
@@ -15344,11 +15457,11 @@
         <target>Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4644</context>
+          <context context-type="linenumber">4660</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2197</context>
+          <context context-type="linenumber">2207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.questionsBadgeNew" datatype="html">
@@ -15356,11 +15469,11 @@
         <target><x id="count" equiv-text="this.qaUnseenCount()"/> nueva(s)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4652</context>
+          <context context-type="linenumber">4668</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4669</context>
+          <context context-type="linenumber">4685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelInactive" datatype="html">
@@ -15368,7 +15481,7 @@
         <target>Desactivado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4769</context>
+          <context context-type="linenumber">4785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelClosed" datatype="html">
@@ -15376,11 +15489,11 @@
         <target>Cerrado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4788</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2205</context>
+          <context context-type="linenumber">2215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7367446920402175749" datatype="html">
@@ -15388,11 +15501,11 @@
         <target>Pregunta de <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">615</context>
+          <context context-type="linenumber">618</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8913852475666331247" datatype="html">
@@ -15400,11 +15513,11 @@
         <target>Pregunta del público</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5574706582681662956" datatype="html">
@@ -15412,15 +15525,15 @@
         <target>Deseleccionar <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4835</context>
+          <context context-type="linenumber">4851</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">580</context>
+          <context context-type="linenumber">583</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">626</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2964749761557345284" datatype="html">
@@ -15428,15 +15541,15 @@
         <target>Resalte todas las preguntas de <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4836</context>
+          <context context-type="linenumber">4852</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">581</context>
+          <context context-type="linenumber">584</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">627</context>
+          <context context-type="linenumber">630</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPinned" datatype="html">
@@ -15444,11 +15557,11 @@
         <target>Se está respondiendo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4881</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusActive" datatype="html">
@@ -15456,11 +15569,11 @@
         <target>Abierta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4867</context>
+          <context context-type="linenumber">4883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2251</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPending" datatype="html">
@@ -15468,11 +15581,11 @@
         <target>Esperando aprobación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4869</context>
+          <context context-type="linenumber">4885</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2253</context>
+          <context context-type="linenumber">2263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusArchived" datatype="html">
@@ -15480,11 +15593,11 @@
         <target>Respondida</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4871</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2255</context>
+          <context context-type="linenumber">2265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusDeleted" datatype="html">
@@ -15492,11 +15605,11 @@
         <target>Eliminada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4873</context>
+          <context context-type="linenumber">4889</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionApprove" datatype="html">
@@ -15504,7 +15617,7 @@
         <target>Aprobar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4974</context>
+          <context context-type="linenumber">4990</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
@@ -15512,7 +15625,7 @@
         <target>Destacar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4976</context>
+          <context context-type="linenumber">4992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
@@ -15520,7 +15633,7 @@
         <target>Quitar resaltado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4978</context>
+          <context context-type="linenumber">4994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
@@ -15528,7 +15641,7 @@
         <target>Archivar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4980</context>
+          <context context-type="linenumber">4996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
@@ -15536,7 +15649,7 @@
         <target>Eliminar definitivamente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4983</context>
+          <context context-type="linenumber">4999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
@@ -15544,7 +15657,7 @@
         <target>Eliminar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4984</context>
+          <context context-type="linenumber">5000</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
@@ -15552,7 +15665,7 @@
         <target>Cerrar canal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5328</context>
+          <context context-type="linenumber">5344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
@@ -15560,7 +15673,7 @@
         <target>Reabrir canal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5329</context>
+          <context context-type="linenumber">5345</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
@@ -15568,7 +15681,7 @@
         <target>Pre-moderación activada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5743</context>
+          <context context-type="linenumber">5759</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
@@ -15576,7 +15689,7 @@
         <target>Pre-moderación desactivada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5744</context>
+          <context context-type="linenumber">5760</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
@@ -15584,7 +15697,7 @@
         <target>Pregunta aprobada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5777</context>
+          <context context-type="linenumber">5793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
@@ -15592,7 +15705,7 @@
         <target>Pregunta destacada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5779</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
@@ -15600,7 +15713,7 @@
         <target>Pregunta archivada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5781</context>
+          <context context-type="linenumber">5797</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
@@ -15608,7 +15721,7 @@
         <target>Pregunta eliminada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5782</context>
+          <context context-type="linenumber">5798</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
@@ -15616,7 +15729,7 @@
         <target>N.º pregunta;Texto;Tipo;Participantes;Ronda de agregación;Ø Puntos;Autoevaluación n;Consolidado;Riesgo de concepto erróneo;Frágil;Brecha reconocida;Indeciso;Respuesta incorrecta más frecuente con alta autoevaluación;Detalles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5995</context>
+          <context context-type="linenumber">6011</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
@@ -15624,7 +15737,7 @@
         <target>Nivel de aprendizaje y autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6049</context>
+          <context context-type="linenumber">6065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
@@ -15632,7 +15745,7 @@
         <target>Respuestas válidas;Preguntas evaluadas;No agregadas (&lt;5 respuestas con autoevaluación);Sólido;Riesgo de conceptos erróneos;Frágil;Brecha de conocimientos identificada;Indeciso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6052</context>
+          <context context-type="linenumber">6068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
@@ -15640,7 +15753,7 @@
         <target>Clasificación por equipos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6073</context>
+          <context context-type="linenumber">6089</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
@@ -15648,7 +15761,7 @@
         <target>Posición;Equipo;Color;Miembros;Puntos del equipo;Puntos medios por miembro</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6075</context>
+          <context context-type="linenumber">6091</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
@@ -15656,7 +15769,7 @@
         <target>Códigos de bonificación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6093</context>
+          <context context-type="linenumber">6109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
@@ -15664,7 +15777,7 @@
         <target>Posición;Alias;Código;Puntos;Generado el</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6095</context>
+          <context context-type="linenumber">6111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
@@ -15672,7 +15785,7 @@
         <target>Resultado CSV exportado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6103</context>
+          <context context-type="linenumber">6119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
@@ -15680,7 +15793,7 @@
         <target>Ver el plan de debriefing en PDF – 1 pregunta para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6115</context>
+          <context context-type="linenumber">6131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
@@ -15688,7 +15801,7 @@
         <target>Ver el plan de debriefing en PDF – <x id="count" equiv-text="count"/> preguntas para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6118</context>
+          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
@@ -15696,7 +15809,7 @@
         <target>Ver el plan de debriefing en PDF</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6120</context>
+          <context context-type="linenumber">6136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
@@ -15704,7 +15817,7 @@
         <target>1 pregunta recomendada para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6125</context>
+          <context context-type="linenumber">6141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
@@ -15712,7 +15825,7 @@
         <target><x id="count" equiv-text="count"/> preguntas recomendadas para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6127</context>
+          <context context-type="linenumber">6143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
@@ -15720,7 +15833,7 @@
         <target>Se crea el PDF (<x id="PH" equiv-text="exportData.questions.length"/> preguntas)…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6139</context>
+          <context context-type="linenumber">6155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
@@ -15728,7 +15841,7 @@
         <target>Resultados PDF descargados.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6145</context>
+          <context context-type="linenumber">6161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
@@ -15736,7 +15849,7 @@
         <target>Resultado PDF abierto para guardar.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
@@ -15744,7 +15857,7 @@
         <target>N.º;ID de pregunta;Estado;Pregunta;Puntuación;Votos positivos;Votos negativos;Votos totales;Puntuación de Wilson;Puntuación de controversia;Polémica;Creada el</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6173</context>
+          <context context-type="linenumber">6189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
@@ -15752,7 +15865,7 @@
         <target>CSV de Q&amp;A exportado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6196</context>
+          <context context-type="linenumber">6212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
@@ -15760,11 +15873,11 @@
         <target>Pregunta <x id="questionNumber" equiv-text="data.questionOrder + 1"/>: <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6359</context>
+          <context context-type="linenumber">6375</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6367</context>
+          <context context-type="linenumber">6383</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15780,7 +15893,7 @@
         <target>Se actualiza el texto libre en vivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6362</context>
+          <context context-type="linenumber">6378</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15792,7 +15905,7 @@
         <target>La pregunta actual no es una pregunta de texto libre.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6370</context>
+          <context context-type="linenumber">6386</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15804,7 +15917,7 @@
         <target>Aún no es una pregunta activa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6373</context>
+          <context context-type="linenumber">6389</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15816,7 +15929,7 @@
         <target>No se pudieron cargar datos de texto libre en vivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6377</context>
+          <context context-type="linenumber">6393</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -17575,12 +17688,100 @@
           <context context-type="linenumber">576</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
+        <source> Zeit anpassen</source>
+        <target>Ajustar tiempo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">14,16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
+        <source> Vor der Frage wählen · 10× Zeit = zehnfacher Raum-Countdown</source>
+        <target>Elige antes de la pregunta · Tiempo ×10 = diez veces la cuenta atrás de la sala</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.summary" datatype="html">
+        <source>So werden Punkte berechnet</source>
+        <target>Así se calculan los puntos</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.intro" datatype="html">
+        <source> So setzt sich deine Punktezahl zusammen: </source>
+        <target>Así se compone tu puntuación:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">29,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.base" datatype="html">
+        <source> Basis: Bis zu 1000 Punkte für eine richtige Antwort. </source>
+        <target>Base: hasta 1000 puntos por una respuesta correcta.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">33,35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.difficulty" datatype="html">
+        <source> Schwierigkeit: Leicht ×1, Mittel ×2, Schwer ×3. </source>
+        <target>Dificultad: Fácil ×1, Media ×2, Difícil ×3.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">36,38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.time" datatype="html">
+        <source> Zeit: Je früher du beim gemeinsamen Raum-Countdown richtig antwortest, desto höher der Zeitanteil. Nach Ablauf bleiben noch 10 % davon. Deine persönliche Frist ändert nur, wie lange du antworten darfst – nicht diese Zeitwertung. </source>
+        <target>Tiempo: cuanto antes respondas correctamente durante la cuenta atrás común de la sala, mayor es tu parte de tiempo. Tras acabarse, queda el 10 %. Tu plazo personal solo cambia cuánto tiempo puedes responder, no esta puntuación por tiempo.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">39,43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.streak" datatype="html">
+        <source> Serie: Mehrere richtige Antworten hintereinander geben Bonus – 1× ×1,0 · 2× ×1,1 · 3× ×1,2 · 4× ×1,3 · ab 5× ×1,5. Eine falsche bewertbare Antwort setzt die Serie zurück. Umfragen und unbewerteter Freitext unterbrechen sie nicht. </source>
+        <target>Racha: varias respuestas correctas seguidas dan bonificación – 1× ×1,0 · 2× ×1,1 · 3× ×1,2 · 4× ×1,3 · desde 5× ×1,5. Una respuesta incorrecta puntuable reinicia la racha. Las encuestas y el texto libre sin puntuación no la interrumpen.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">44,48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.preview" datatype="html">
+        <source> Die Live-Punktvorschau zeigt den aktuellen Stand ohne Serien-Bonus. </source>
+        <target>La vista previa de puntos en vivo muestra el valor actual sin la bonificación de racha.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">49,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
+        <source> Keine persönliche Frist · Punkte weiter nach dem Raum-Timer</source>
+        <target>Sin plazo personal · Los puntos siguen el temporizador de la sala</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">74,76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
+        <source> 10× Zeit aktiv · Das Ergebnis wartet auf dich</source>
+        <target>Tiempo ×10 activo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">83,85</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionVote.sessionEndGateTitle" datatype="html">
         <source> Session beendet</source>
         <target>Sesión finalizada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">21,23</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.bonusGateLead" datatype="html">
@@ -17588,7 +17789,7 @@
         <target>Has recibido un código de bonificación. Ahora cópielo en el portapapeles (por ejemplo, para enviar un correo electrónico a la gestión del evento) antes de ir a la página de inicio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">28,31</context>
+          <context context-type="linenumber">117,120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionEndFeedbackLead" datatype="html">
@@ -17596,7 +17797,7 @@
         <target>La sesión ha terminado. Si lo desea, califíquelo brevemente y luego podrá ir a la página de inicio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">44,47</context>
+          <context context-type="linenumber">133,136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionActionsAria" datatype="html">
@@ -17604,7 +17805,7 @@
         <target>Acciones de sesión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.voteAria" datatype="html">
@@ -17612,7 +17813,7 @@
         <target>Elegir área en directo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">232</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.pointsUnit" datatype="html">
@@ -17620,7 +17821,23 @@
         <target>puntos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">319</context>
+          <context context-type="linenumber">408</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.hide" datatype="html">
+        <source> Ausblenden</source>
+        <target>Esconder</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">416,418</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.show" datatype="html">
+        <source> Live-Punkte anzeigen</source>
+        <target>Ver puntos en vivo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">427,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.mediaAnswerHint" datatype="html">
@@ -17628,47 +17845,7 @@
         <target>La imagen es sólo para ver. Seleccione su respuesta a continuación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">985</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
-        <source> Zeit anpassen</source>
-        <target>Ajustar tiempo</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1010,1012</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
-        <source> Nur für dich · Der Quizablauf bleibt unverändert</source>
-        <target>Solo para ti · El flujo del quiz no cambia</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1016,1018</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.points" datatype="html">
-        <source> Punkte richten sich nach dem gemeinsamen Countdown</source>
-        <target>Los puntos se basan en la cuenta atrás común</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1021,1023</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
-        <source> Ohne Timer aktiv · Abgabe möglich, solange die Frage offen ist</source>
-        <target>Sin temporizador · Puedes responder mientras la pregunta esté abierta</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1043,1045</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
-        <source> 10× Zeit aktiv</source>
-        <target>Tiempo ×10 activo</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericLabel" datatype="html">
@@ -17676,7 +17853,7 @@
         <target>Tu estimación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1262,1264</context>
+          <context context-type="linenumber">1324,1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericPlaceholder" datatype="html">
@@ -17684,7 +17861,7 @@
         <target>Introduce un número…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1284</context>
+          <context context-type="linenumber">1346</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultPrefix" datatype="html">
@@ -17692,7 +17869,7 @@
         <target>Tu respuesta:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1933013871016789910" datatype="html">
@@ -17700,11 +17877,11 @@
         <target>En total</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1351</context>
+          <context context-type="linenumber">1413</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1717</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHeading" datatype="html">
@@ -17712,7 +17889,7 @@
         <target>¿Qué tan seguro estás de esta respuesta?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1404,1406</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHint" datatype="html">
@@ -17720,7 +17897,7 @@
         <target>Se relaciona con la respuesta que acaba de elegir.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1411,1413</context>
+          <context context-type="linenumber">1473,1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultPrefix" datatype="html">
@@ -17728,7 +17905,7 @@
         <target>Tu autoevaluación:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceSentPrefix" datatype="html">
@@ -17736,7 +17913,7 @@
         <target>Autoevaluación:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1480</context>
+          <context context-type="linenumber">1542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8052936664226936966" datatype="html">
@@ -17744,7 +17921,7 @@
         <target>Serie (×<x id="INTERPOLATION" equiv-text="{{ sc.streakMultiplier | number:&apos;1.1-1&apos; }}"/>)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1635</context>
+          <context context-type="linenumber">1697</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4068334453877547924" datatype="html">
@@ -17752,7 +17929,7 @@
         <target>tu rango</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1649</context>
+          <context context-type="linenumber">1711</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedNotice" datatype="html">
@@ -17760,7 +17937,7 @@
         <target>El canal de preguntas y respuestas ha sido cerrado por el profesorado. En este momento no se pueden enviar preguntas ni votar.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1865,1868</context>
+          <context context-type="linenumber">1927,1930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaIdentityHint" datatype="html">
@@ -17768,7 +17945,7 @@
         <target>preguntas como</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnAria" datatype="html">
@@ -17776,7 +17953,7 @@
         <target>Eliminar pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2039</context>
+          <context context-type="linenumber">2101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedHint" datatype="html">
@@ -17784,7 +17961,7 @@
         <target>Los contenidos anteriores están ocultos para los participantes hasta que el profesorado vuelva a abrir el canal.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2058,2061</context>
+          <context context-type="linenumber">2120,2123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackClosedTitle" datatype="html">
@@ -17792,7 +17969,7 @@
         <target>Blitzlicht cerrado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2077,2079</context>
+          <context context-type="linenumber">2139,2141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedActionsAria" datatype="html">
@@ -17800,7 +17977,7 @@
         <target>Acciones finales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2109</context>
+          <context context-type="linenumber">2171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.quizActionsAria" datatype="html">
@@ -17808,7 +17985,7 @@
         <target>Acciones del cuestionario</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2147</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaActionsAria" datatype="html">
@@ -17816,7 +17993,7 @@
         <target>Acciones de preguntas y respuestas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2166</context>
+          <context context-type="linenumber">2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2427920593873911865" datatype="html">
@@ -17824,7 +18001,7 @@
         <target>¡Perfecto! 🎯</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3996850202378161277" datatype="html">
@@ -17832,7 +18009,7 @@
         <target>¡Correcto! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1090604167231677526" datatype="html">
@@ -17840,7 +18017,7 @@
         <target>¡Golpe directo! ⭐</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3502096474885920612" datatype="html">
@@ -17848,7 +18025,7 @@
         <target>¡Fuerte! 🔥</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7691272538064479056" datatype="html">
@@ -17856,7 +18033,7 @@
         <target>¡Precisamente! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7790447949587239556" datatype="html">
@@ -17864,7 +18041,7 @@
         <target>¡Corre contigo! 🎸</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">175</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4185659153521425300" datatype="html">
@@ -17872,7 +18049,7 @@
         <target>¡Lo superó! 👏</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">175</context>
+          <context context-type="linenumber">176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS1" datatype="html">
@@ -17880,7 +18057,7 @@
         <target>Correcto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS2" datatype="html">
@@ -17888,7 +18065,7 @@
         <target>Correctamente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">179</context>
+          <context context-type="linenumber">180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS3" datatype="html">
@@ -17896,7 +18073,7 @@
         <target>La respuesta es correcta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3211338642099056060" datatype="html">
@@ -17904,7 +18081,7 @@
         <target>¡Justo al lado! 🤏</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1731892131220774983" datatype="html">
@@ -17912,7 +18089,7 @@
         <target>¡La próxima vez! 💡</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9186185663967902020" datatype="html">
@@ -17920,7 +18097,7 @@
         <target>¡Avanza! 🔄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3551623243824977572" datatype="html">
@@ -17928,7 +18105,7 @@
         <target>¡Todo estará bien! 📈</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5506746370181957809" datatype="html">
@@ -17936,7 +18113,7 @@
         <target>¡No te rindas! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS1" datatype="html">
@@ -17944,7 +18121,7 @@
         <target>No está bien.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS2" datatype="html">
@@ -17952,7 +18129,7 @@
         <target>Lamentablemente mal.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS3" datatype="html">
@@ -17960,7 +18137,7 @@
         <target>Vuelve a intentarlo con la siguiente pregunta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3145164147131753937" datatype="html">
@@ -17968,7 +18145,7 @@
         <target>¡Respuesta guardada! ✓</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">195</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3110097502695814008" datatype="html">
@@ -17976,7 +18153,7 @@
         <target>¡Gracias por tu respuesta! 📝</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4856001851461935545" datatype="html">
@@ -17984,7 +18161,7 @@
         <target>¡Avanza! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS1" datatype="html">
@@ -17992,7 +18169,7 @@
         <target>Respuesta guardada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">200</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS2" datatype="html">
@@ -18000,7 +18177,7 @@
         <target>Gracias, tu respuesta ha sido aceptada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6032822770375401279" datatype="html">
@@ -18008,7 +18185,7 @@
         <target>Me lo perdí: ¡la próxima ronda! ⏱️</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">204</context>
+          <context context-type="linenumber">205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3646778948280182955" datatype="html">
@@ -18016,7 +18193,7 @@
         <target>El tiempo fue demasiado corto – ¡tú puedes hacerlo! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">205</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5015240621073925218" datatype="html">
@@ -18024,7 +18201,7 @@
         <target>¡Funcionará la próxima vez! 🔄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="850308549833737974" datatype="html">
@@ -18032,7 +18209,7 @@
         <target>Mantén la cabeza en alto, ¡sigamos adelante! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3277616416884173208" datatype="html">
@@ -18040,7 +18217,7 @@
         <target>Tic-tac: ¡se acerca la próxima oportunidad! ⏰</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS1" datatype="html">
@@ -18048,7 +18225,7 @@
         <target>El tiempo expiró.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS2" datatype="html">
@@ -18056,7 +18233,7 @@
         <target>Se acabó el tiempo: espere la siguiente pregunta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">212</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS3" datatype="html">
@@ -18064,7 +18241,7 @@
         <target>Votó demasiado tarde. La próxima oportunidad sigue.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">213</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakPlayful" datatype="html">
@@ -18072,7 +18249,7 @@
         <target>¡En llamas! 🔥 ¡Serie <x id="c" equiv-text="sc.streakCount"/>!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">302</context>
+          <context context-type="linenumber">303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakSerious" datatype="html">
@@ -18080,7 +18257,7 @@
         <target><x id="c" equiv-text="sc.streakCount"/> respuestas correctas seguidas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">303</context>
+          <context context-type="linenumber">304</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Playful" datatype="html">
@@ -18088,7 +18265,7 @@
         <target>¡Un lugar arriba! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">308</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Serious" datatype="html">
@@ -18096,7 +18273,7 @@
         <target>Un rango más.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">310</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNPlayful" datatype="html">
@@ -18104,7 +18281,7 @@
         <target><x id="n" equiv-text="sc.rankChange"/> ¡Avanza! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">312</context>
+          <context context-type="linenumber">313</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNSerious" datatype="html">
@@ -18112,7 +18289,7 @@
         <target><x id="n" equiv-text="sc.rankChange"/> lugares arriba.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">313</context>
+          <context context-type="linenumber">314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakPlayful" datatype="html">
@@ -18120,7 +18297,7 @@
         <target>¡Racha rota! ¡Próxima ronda! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">320</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakSerious" datatype="html">
@@ -18128,7 +18305,7 @@
         <target>La serie terminó: la siguiente pregunta cuenta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">321</context>
+          <context context-type="linenumber">322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopPlayful" datatype="html">
@@ -18136,7 +18313,7 @@
         <target>¡Anímate, todavía estás mintiendo bien! 🏅</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopSerious" datatype="html">
@@ -18144,7 +18321,7 @@
         <target>Estás más arriba en la clasificación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">327</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChasePlayful" datatype="html">
@@ -18152,7 +18329,7 @@
         <target>Sigue así: ¡cada pregunta es una nueva oportunidad! 🌟</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChaseSerious" datatype="html">
@@ -18160,7 +18337,7 @@
         <target>Sigue practicando: la siguiente pregunta aporta nuevos puntos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">331</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivEvaluated" datatype="html">
@@ -18168,7 +18345,7 @@
         <target>Respuesta evaluada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">352</context>
+          <context context-type="linenumber">353</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivOutOfBand" datatype="html">
@@ -18176,7 +18353,7 @@
         <target>Fuera de la banda de tolerancia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">356</context>
+          <context context-type="linenumber">357</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivExact" datatype="html">
@@ -18184,7 +18361,7 @@
         <target>Exactamente en el valor de referencia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">361</context>
+          <context context-type="linenumber">362</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivInBand" datatype="html">
@@ -18192,11 +18369,11 @@
         <target>Dentro del intervalo aceptado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">367</context>
+          <context context-type="linenumber">368</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">376</context>
+          <context context-type="linenumber">377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivVeryClose" datatype="html">
@@ -18204,7 +18381,7 @@
         <target>Muy cerca del valor de referencia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">373</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixPlayful" datatype="html">
@@ -18212,7 +18389,7 @@
         <target>¡Perfecto!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixSerious" datatype="html">
@@ -18220,7 +18397,7 @@
         <target>Ahora estás en</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixPlayful" datatype="html">
@@ -18228,7 +18405,7 @@
         <target>ya te está esperando.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">547</context>
+          <context context-type="linenumber">550</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixSerious" datatype="html">
@@ -18236,7 +18413,7 @@
         <target>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">548</context>
+          <context context-type="linenumber">551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3932968695937052509" datatype="html">
@@ -18244,7 +18421,7 @@
         <target>Preguntas como <x id="PH" equiv-text="nick"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3719653345310622722" datatype="html">
@@ -18252,11 +18429,11 @@
         <target>Tu icono animal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">577</context>
+          <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.playerTeamBadgeAria" datatype="html">
@@ -18264,7 +18441,7 @@
         <target><x id="nickname" equiv-text="nick"/>, <x id="teamName" equiv-text="teamLabel"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">589</context>
+          <context context-type="linenumber">592</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5952222840612966712" datatype="html">
@@ -18272,7 +18449,7 @@
         <target>Tu pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.autoJoinFailed" datatype="html">
@@ -18280,7 +18457,7 @@
         <target>No se pudo preparar la participación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextTooLong" datatype="html">
@@ -18288,7 +18465,7 @@
         <target>Máximo <x id="maxLength" equiv-text="maxLength"/> caracteres permitidos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1325</context>
+          <context context-type="linenumber">1335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericInvalid" datatype="html">
@@ -18296,11 +18473,11 @@
         <target>La respuesta corta debe introducirse como un número en un formato compatible.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1333</context>
+          <context context-type="linenumber">1343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1471</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultInvalid" datatype="html">
@@ -18308,7 +18485,7 @@
         <target>Formato numérico no válido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1437</context>
+          <context context-type="linenumber">1447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultFull" datatype="html">
@@ -18316,7 +18493,7 @@
         <target>Totalmente valorada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1442</context>
+          <context context-type="linenumber">1452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultAccepted" datatype="html">
@@ -18324,7 +18501,7 @@
         <target>Aceptada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1443</context>
+          <context context-type="linenumber">1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultPartial" datatype="html">
@@ -18332,7 +18509,7 @@
         <target>Valorada parcialmente (<x id="points" equiv-text="result.points"/> %)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1457</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultRejected" datatype="html">
@@ -18340,7 +18517,7 @@
         <target>No aceptada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1450</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericNoMatch" datatype="html">
@@ -18348,7 +18525,7 @@
         <target>Ninguna respuesta de referencia quedó dentro de la tolerancia numérica configurada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultMatchedSolution" datatype="html">
@@ -18356,11 +18533,11 @@
         <target>Se ha asociado a la respuesta modelo « <x id="matchedModelAnswer" equiv-text="result.matchedModelAnswer"/> ».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1469</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1485</context>
+          <context context-type="linenumber">1495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonNoMatch" datatype="html">
@@ -18368,11 +18545,11 @@
         <target>Ninguna respuesta modelo quedó dentro de la tolerancia configurada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1477</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1501</context>
+          <context context-type="linenumber">1511</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonHamming" datatype="html">
@@ -18380,7 +18557,7 @@
         <target>Un pequeño error tipográfico con la misma longitud seguía dentro de la tolerancia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1495</context>
+          <context context-type="linenumber">1505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonDamerau" datatype="html">
@@ -18388,7 +18565,7 @@
         <target>Una transposición de letras seguía dentro de la tolerancia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1497</context>
+          <context context-type="linenumber">1507</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonLevenshtein" datatype="html">
@@ -18396,7 +18573,7 @@
         <target>Un carácter faltante o adicional seguía dentro de la tolerancia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1499</context>
+          <context context-type="linenumber">1509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingRequired" datatype="html">
@@ -18404,7 +18581,7 @@
         <target>El valor numérico coincidía, pero faltaba la unidad obligatoria.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1509</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalentRejected" datatype="html">
@@ -18412,7 +18589,7 @@
         <target>El valor numérico coincidía tras la conversión, pero solo se acepta la unidad configurada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonWrongFamily" datatype="html">
@@ -18420,7 +18597,7 @@
         <target>El valor numérico coincidía, pero la unidad pertenece a otra familia de magnitudes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1513</context>
+          <context context-type="linenumber">1523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonUnsupportedUnit" datatype="html">
@@ -18428,7 +18605,7 @@
         <target>El valor numérico coincidía, pero la unidad introducida queda fuera del conjunto de unidades compatibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1515</context>
+          <context context-type="linenumber">1525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonPartial" datatype="html">
@@ -18436,7 +18613,7 @@
         <target>El valor numérico coincidía, pero la unidad impidió la puntuación completa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1517</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalent" datatype="html">
@@ -18444,7 +18621,7 @@
         <target>El valor numérico y la unidad equivalente se convirtieron correctamente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingOptional" datatype="html">
@@ -18452,7 +18629,7 @@
         <target>El valor numérico coincidía; la unidad era opcional en esta pregunta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1525</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonTolerance" datatype="html">
@@ -18460,7 +18637,7 @@
         <target>El valor numérico quedó dentro de la tolerancia configurada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1528</context>
+          <context context-type="linenumber">1538</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonExact" datatype="html">
@@ -18468,7 +18645,7 @@
         <target>El valor numérico y la unidad coinciden exactamente con una respuesta modelo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1531</context>
+          <context context-type="linenumber">1541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeInteger" datatype="html">
@@ -18476,7 +18653,7 @@
         <target>Número entero</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1865</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeDecimal" datatype="html">
@@ -18484,7 +18661,7 @@
         <target>Número decimal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1856</context>
+          <context context-type="linenumber">1866</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatInteger" datatype="html">
@@ -18492,7 +18669,7 @@
         <target>Ingrese un número entero sin decimales.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1861</context>
+          <context context-type="linenumber">1871</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimalPlaces" datatype="html">
@@ -18500,7 +18677,7 @@
         <target>Puedes usar coma o punto, máximo <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> decimales.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1865</context>
+          <context context-type="linenumber">1875</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimal" datatype="html">
@@ -18508,7 +18685,7 @@
         <target>Puedes usar coma o punto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1867</context>
+          <context context-type="linenumber">1877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeBoth" datatype="html">
@@ -18520,7 +18697,7 @@
       )"/> a <x id="max" equiv-text="this.formatNumericResultValue(max)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1874,1876</context>
+          <context context-type="linenumber">1884,1886</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMin" datatype="html">
@@ -18532,7 +18709,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1879,1881</context>
+          <context context-type="linenumber">1889,1891</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMax" datatype="html">
@@ -18544,7 +18721,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1884,1886</context>
+          <context context-type="linenumber">1894,1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultInBand" datatype="html">
@@ -18552,7 +18729,7 @@
         <target>En la banda de tolerancia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultOutOfBand" datatype="html">
@@ -18560,7 +18737,7 @@
         <target>Fuera de la banda de tolerancia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2030</context>
+          <context context-type="linenumber">2040</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultReference" datatype="html">
@@ -18572,7 +18749,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2036,2038</context>
+          <context context-type="linenumber">2046,2048</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedSingle" datatype="html">
@@ -18584,7 +18761,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2049,2051</context>
+          <context context-type="linenumber">2059,2061</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedRange" datatype="html">
@@ -18596,7 +18773,7 @@
       )"/> a <x id="right" equiv-text="this.formatNumericResultValue(acceptedRight)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2053,2055</context>
+          <context context-type="linenumber">2063,2065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultToleranceBand" datatype="html">
@@ -18608,7 +18785,7 @@
     )"/> a <x id="right" equiv-text="this.formatNumericResultValue(band.right)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2057,2059</context>
+          <context context-type="linenumber">2067,2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultExact" datatype="html">
@@ -18616,7 +18793,7 @@
         <target>Exactamente al valor de referencia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2068</context>
+          <context context-type="linenumber">2078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultDistance" datatype="html">
@@ -18628,7 +18805,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2070,2072</context>
+          <context context-type="linenumber">2080,2082</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultImproved" datatype="html">
@@ -18640,7 +18817,7 @@
       )"/> más cerca del valor de referencia que en la ronda 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2109,2111</context>
+          <context context-type="linenumber">2119,2121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultWorse" datatype="html">
@@ -18652,7 +18829,7 @@
       )"/> más lejos del valor de referencia que en la ronda 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2114,2116</context>
+          <context context-type="linenumber">2124,2126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultUnchanged" datatype="html">
@@ -18660,7 +18837,7 @@
         <target>Tan cerca del valor de referencia como en la ronda 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2118</context>
+          <context context-type="linenumber">2128</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericRequired" datatype="html">
@@ -18668,7 +18845,7 @@
         <target>Por favor ingrese un número.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2139</context>
+          <context context-type="linenumber">2149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericIntegerRequired" datatype="html">
@@ -18676,7 +18853,7 @@
         <target>Ingrese un número entero en el formato admitido.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2143</context>
+          <context context-type="linenumber">2153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericDecimalPlacesExceeded" datatype="html">
@@ -18684,7 +18861,7 @@
         <target>Máximo de <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> decimales permitidos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2152</context>
+          <context context-type="linenumber">2162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInvalid" datatype="html">
@@ -18692,7 +18869,7 @@
         <target>Ingrese un número válido en el formato admitido.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2154</context>
+          <context context-type="linenumber">2164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericBelowMin" datatype="html">
@@ -18700,7 +18877,7 @@
         <target>Introduzca un valor de al menos <x id="min" equiv-text="min"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2160</context>
+          <context context-type="linenumber">2170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericAboveMax" datatype="html">
@@ -18708,7 +18885,7 @@
         <target>Introduzca un valor máximo de <x id="max" equiv-text="max"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2163</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinalScore" datatype="html">
@@ -18716,7 +18893,7 @@
         <target>Puntuación final</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2311</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleWinFin" datatype="html">
@@ -18724,7 +18901,7 @@
         <target>¡Su equipo gana!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2316</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinishedOther" datatype="html">
@@ -18732,7 +18909,7 @@
         <target>al final</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasingZero" datatype="html">
@@ -18740,7 +18917,7 @@
         <target>¡A remontar—aún podéis recuperar!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2321</context>
+          <context context-type="linenumber">2331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleAllZero" datatype="html">
@@ -18748,7 +18925,7 @@
         <target>¡Demostrad de lo que sois capaces!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2322</context>
+          <context context-type="linenumber">2332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleLeading" datatype="html">
@@ -18756,7 +18933,7 @@
         <target>Lideran por ahora</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2325</context>
+          <context context-type="linenumber">2335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasing" datatype="html">
@@ -18764,7 +18941,7 @@
         <target>Continuar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2327</context>
+          <context context-type="linenumber">2337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgWinFin" datatype="html">
@@ -18772,7 +18949,7 @@
         <target>¡Ganaron juntos: el primer puesto es suyo!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2345</context>
+          <context context-type="linenumber">2355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedAllZero" datatype="html">
@@ -18780,7 +18957,7 @@
         <target>Quiz terminado: ningún equipo sumó puntos de equipo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOwnZero" datatype="html">
@@ -18788,7 +18965,7 @@
         <target>Quiz terminado: vuestro equipo no sumó puntos de equipo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2351</context>
+          <context context-type="linenumber">2361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOther" datatype="html">
@@ -18796,7 +18973,7 @@
         <target>Terminas con <x id="totalScore" equiv-text="entry.totalScore"/> puntos en el lugar <x id="teamRank" equiv-text="entry.rank"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2353</context>
+          <context context-type="linenumber">2363</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgAllZero" datatype="html">
@@ -18804,7 +18981,7 @@
         <target>Las respuestas correctas suman puntos para vuestro equipo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2357</context>
+          <context context-type="linenumber">2367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgChasing" datatype="html">
@@ -18812,11 +18989,11 @@
         <target>Actualmente clasificado <x id="teamRank" equiv-text="entry.rank"/> con <x id="totalScore" equiv-text="entry.totalScore"/> puntos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2359</context>
+          <context context-type="linenumber">2369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgLeading" datatype="html">
@@ -18824,7 +19001,7 @@
         <target>Lideras con <x id="totalScore" equiv-text="entry.totalScore"/> puntos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2362</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulLoading" datatype="html">
@@ -18832,7 +19009,7 @@
         <target>Cargando tu resultado…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2406</context>
+          <context context-type="linenumber">2416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulNeutral" datatype="html">
@@ -18840,7 +19017,7 @@
         <target>Listo — ¡gracias por participar!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2411</context>
+          <context context-type="linenumber">2421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingNoRank" datatype="html">
@@ -18848,7 +19025,7 @@
         <target><x id="teamName" equiv-text="entry.teamName"/> con <x id="memberCountLabel" equiv-text="this.teamMemberLabel(entry.memberCount)"/> y <x id="totalScore" equiv-text="entry.totalScore"/> puntos de equipo — aún sin clasificación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2442</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingWithMembers" datatype="html">
@@ -18856,7 +19033,7 @@
         <target>Puesto <x id="teamRank"/>: <x id="teamName"/> con <x id="memberCountLabel"/> y <x id="totalScore"/> puntos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2602080285199874401" datatype="html">
@@ -18864,7 +19041,7 @@
         <target><x id="PH" equiv-text="stars"/> de 5 estrellas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2477</context>
+          <context context-type="linenumber">2487</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaOne" datatype="html">
@@ -18872,7 +19049,7 @@
         <target>1 segundo restante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2483</context>
+          <context context-type="linenumber">2493</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaMany" datatype="html">
@@ -18880,7 +19057,7 @@
         <target>Quedan <x id="seconds" equiv-text="seconds"/> segundos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2484</context>
+          <context context-type="linenumber">2494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.groupAria" datatype="html">
@@ -18888,7 +19065,7 @@
         <target>Tiempo personal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2488</context>
+          <context context-type="linenumber">2498</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.extended" datatype="html">
@@ -18896,15 +19073,15 @@
         <target>Tiempo ×10</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2494</context>
+          <context context-type="linenumber">2504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.off" datatype="html">
-        <source>Ohne Timer</source>
-        <target>Sin temporizador</target>
+        <source>Ohne Frist</source>
+        <target>Sin plazo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2496</context>
+          <context context-type="linenumber">2506</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.default" datatype="html">
@@ -18912,7 +19089,23 @@
         <target>Estándar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2498</context>
+          <context context-type="linenumber">2508</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsDefault" datatype="html">
+        <source>Punkte folgen dem gemeinsamen Countdown</source>
+        <target>Los puntos siguen la cuenta atrás común</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2514</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsOvertime" datatype="html">
+        <source>Früh abgeben lohnt sich · nach dem Countdown nur Mindestpunkte</source>
+        <target>Responder pronto compensa · después de la cuenta atrás solo el mínimo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.overtimeCorrect" datatype="html">
@@ -18920,7 +19113,7 @@
         <target>Tiempo adicional · respuesta correcta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2504</context>
+          <context context-type="linenumber">2521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.upToNow" datatype="html">
@@ -18928,7 +19121,7 @@
         <target>Puntuación completa ahora</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2507</context>
+          <context context-type="linenumber">2524</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.correctNow" datatype="html">
@@ -18936,7 +19129,7 @@
         <target>Respuesta correcta ahora</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2508</context>
+          <context context-type="linenumber">2525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.error" datatype="html">
@@ -18944,7 +19137,7 @@
         <target>No se pudo guardar el ajuste de hora.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2536</context>
+          <context context-type="linenumber">2561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeUpvoteAria" datatype="html">
@@ -18952,7 +19145,7 @@
         <target>Retirar voto positivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2547</context>
+          <context context-type="linenumber">2572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addUpvoteAria" datatype="html">
@@ -18960,7 +19153,7 @@
         <target>Votar a favor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2548</context>
+          <context context-type="linenumber">2573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeDownvoteAria" datatype="html">
@@ -18968,7 +19161,7 @@
         <target>Retirar voto negativo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2552</context>
+          <context context-type="linenumber">2577</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addDownvoteAria" datatype="html">
@@ -18976,7 +19169,7 @@
         <target>Votar en contra</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2553</context>
+          <context context-type="linenumber">2578</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5043949766391435553" datatype="html">
@@ -18984,7 +19177,7 @@
         <target>Clasificación de <x id="PH" equiv-text="this.ratingLabelMin()"/> a <x id="PH_1" equiv-text="this.ratingLabelMax()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2557</context>
+          <context context-type="linenumber">2582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2721187191897749624" datatype="html">
@@ -18992,7 +19185,7 @@
         <target>Calificación <x id="PH" equiv-text="value"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2561</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLabels" datatype="html">
@@ -19000,7 +19193,7 @@
         <target>Autoevaluación de 1 a 5, baja: <x id="low" equiv-text="low"/>, alta: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLow" datatype="html">
@@ -19008,7 +19201,7 @@
         <target>Autoevaluación de 1 a 5, baja: <x id="low" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2591</context>
+          <context context-type="linenumber">2616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithHigh" datatype="html">
@@ -19016,7 +19209,7 @@
         <target>Autoevaluación de 1 a 5, alta: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2594</context>
+          <context context-type="linenumber">2619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAria" datatype="html">
@@ -19024,7 +19217,7 @@
         <target>Autoevaluación de 1 a 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2596</context>
+          <context context-type="linenumber">2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceValueAria" datatype="html">
@@ -19032,7 +19225,7 @@
         <target>Autoevaluación <x id="value" equiv-text="value"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2600</context>
+          <context context-type="linenumber">2625</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithLowLabel" datatype="html">
@@ -19040,7 +19233,7 @@
         <target><x id="value" equiv-text="value"/> – <x id="label" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2611</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithHighLabel" datatype="html">
@@ -19048,7 +19241,7 @@
         <target><x id="value" equiv-text="value"/> – <x id="label" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2614</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="974858114847169012" datatype="html">
@@ -19056,7 +19249,7 @@
         <target>Responder con <x id="PH" equiv-text="emoji"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2634</context>
+          <context context-type="linenumber">2659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteLoadError" datatype="html">
@@ -19064,7 +19257,7 @@
         <target>No se pudieron cargar las preguntas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3519</context>
+          <context context-type="linenumber">3547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitSuccess" datatype="html">
@@ -19072,7 +19265,7 @@
         <target>Pregunta enviada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3562</context>
+          <context context-type="linenumber">3590</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitError" datatype="html">
@@ -19080,19 +19273,19 @@
         <target>No se pudo enviar la pregunta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3568</context>
+          <context context-type="linenumber">3596</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3588</context>
+          <context context-type="linenumber">3616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3617</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3625</context>
+          <context context-type="linenumber">3653</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.upvoteError" datatype="html">
@@ -19100,7 +19293,7 @@
         <target>No se pudo guardar el voto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3666</context>
+          <context context-type="linenumber">3694</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnError" datatype="html">
@@ -19108,7 +19301,7 @@
         <target>No se pudo eliminar la pregunta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3694</context>
+          <context context-type="linenumber">3722</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwnMany" datatype="html">
@@ -19116,7 +19309,7 @@
         <target>La moderación ha eliminado tus preguntas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3750</context>
+          <context context-type="linenumber">3778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwn" datatype="html">
@@ -19124,7 +19317,7 @@
         <target>La moderación ha eliminado tu pregunta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOthersMany" datatype="html">
@@ -19132,7 +19325,7 @@
         <target>La moderación ha eliminado varias preguntas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3755</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOther" datatype="html">
@@ -19140,7 +19333,7 @@
         <target>La moderación ha eliminado una pregunta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.readingReadyError" datatype="html">
@@ -19148,7 +19341,7 @@
         <target>No se pudo confirmar la disponibilidad.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4017</context>
+          <context context-type="linenumber">4045</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceRequired" datatype="html">
@@ -19156,7 +19349,7 @@
         <target>Indica tu autoevaluación antes de enviar.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4188</context>
+          <context context-type="linenumber">4216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9175670018185396326" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -4232,7 +4232,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4646</context>
+          <context context-type="linenumber">4662</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -4240,11 +4240,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2074,2076</context>
+          <context context-type="linenumber">2136,2138</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2199</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackHostTitle" datatype="html">
@@ -4284,7 +4284,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3609</context>
+          <context context-type="linenumber">3635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -4726,7 +4726,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1880</context>
+          <context context-type="linenumber">1888</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -4738,7 +4738,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1885</context>
+          <context context-type="linenumber">1893</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -4762,7 +4762,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -4774,7 +4774,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -4930,7 +4930,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackVoteTitle" datatype="html">
@@ -5090,7 +5090,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2082,2085</context>
+          <context context-type="linenumber">2144,2147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.voteMissing" datatype="html">
@@ -6922,11 +6922,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4958</context>
+          <context context-type="linenumber">4974</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2268</context>
+          <context context-type="linenumber">2278</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3532753318619772032" datatype="html">
@@ -6938,11 +6938,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4960</context>
+          <context context-type="linenumber">4976</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2270</context>
+          <context context-type="linenumber">2280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="74432774947660496" datatype="html">
@@ -6954,11 +6954,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="276214048875673948" datatype="html">
@@ -6970,11 +6970,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5356551916626450286" datatype="html">
@@ -6986,11 +6986,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3903113005127984737" datatype="html">
@@ -7002,11 +7002,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeRemoveSession" datatype="html">
@@ -7258,7 +7258,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7266,7 +7266,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6658206425619028413" datatype="html">
@@ -7278,7 +7278,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7286,7 +7286,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5683915683305860193" datatype="html">
@@ -7374,15 +7374,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2911</context>
+          <context context-type="linenumber">2919</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2449</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2458</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/preset-toast/preset-toast.component.ts</context>
@@ -9746,11 +9746,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4629</context>
+          <context context-type="linenumber">4645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.medium" datatype="html">
@@ -9766,11 +9766,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4631</context>
+          <context context-type="linenumber">4647</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1787</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.hard" datatype="html">
@@ -9786,11 +9786,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4633</context>
+          <context context-type="linenumber">4649</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1779</context>
+          <context context-type="linenumber">1789</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeExactLabel" datatype="html">
@@ -10958,11 +10958,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1348</context>
+          <context context-type="linenumber">1410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1612</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesExportCsv" datatype="html">
@@ -12470,7 +12470,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3027</context>
+          <context context-type="linenumber">3031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -12482,7 +12482,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3030</context>
+          <context context-type="linenumber">3034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -12494,7 +12494,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3035</context>
+          <context context-type="linenumber">3039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -12506,7 +12506,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3225</context>
+          <context context-type="linenumber">3229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -12518,7 +12518,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3229</context>
+          <context context-type="linenumber">3233</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -12530,7 +12530,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3232</context>
+          <context context-type="linenumber">3236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -12542,7 +12542,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3235</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -12698,7 +12698,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2735</context>
+          <context context-type="linenumber">2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -12726,7 +12726,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2998</context>
+          <context context-type="linenumber">3002</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -12930,7 +12930,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2968</context>
+          <context context-type="linenumber">2972</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -13134,8 +13134,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
-        <source> Teilnehmende können ihre persönliche Zeit bei Bedarf verlängern oder abschalten.</source>
-        <target>Les participants peuvent prolonger ou interrompre leur temps personnel si nécessaire.</target>
+        <source> Teilnehmende können ihre persönliche Frist bei Bedarf verlängern oder abschalten.</source>
+        <target>Les participants peuvent prolonger ou désactiver leur délai personnel si nécessaire.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">1441,1444</context>
@@ -13146,19 +13146,19 @@
         <target>Métadonnées de la question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1456</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">832</context>
+          <context context-type="linenumber">947</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">894</context>
+          <context context-type="linenumber">1013</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">961</context>
+          <context context-type="linenumber">1081</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4209613400308596118" datatype="html">
@@ -13166,7 +13166,7 @@
         <target>Phase de lecture</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1481</context>
+          <context context-type="linenumber">1485</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
@@ -13174,7 +13174,7 @@
         <target>Les réponses arrivent dans un instant.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1482,1484</context>
+          <context context-type="linenumber">1486,1488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
@@ -13182,7 +13182,7 @@
         <target>Échelle d&apos;évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1540</context>
+          <context context-type="linenumber">1544</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
@@ -13190,7 +13190,7 @@
         <target>Répartition des évaluations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1568</context>
+          <context context-type="linenumber">1572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
@@ -13198,7 +13198,7 @@
         <target>En attente des estimations…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1607,1609</context>
+          <context context-type="linenumber">1611,1613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
@@ -13206,7 +13206,7 @@
         <target><x id="INTERPOLATION"/> réponses reçues</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615,1617</context>
+          <context context-type="linenumber">1619,1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
@@ -13214,11 +13214,11 @@
         <target>Résumé des statistiques</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1627</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2060</context>
+          <context context-type="linenumber">2064</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
@@ -13226,7 +13226,7 @@
         <target>Tour 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1632</context>
+          <context context-type="linenumber">1636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
@@ -13234,11 +13234,11 @@
         <target>Accepté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1654</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2080</context>
+          <context context-type="linenumber">2084</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
@@ -13246,7 +13246,7 @@
         <target>Comparaison ronde</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
@@ -13254,7 +13254,7 @@
         <target>changement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1685</context>
+          <context context-type="linenumber">1689</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
@@ -13262,7 +13262,7 @@
         <target>Tour 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1706</context>
+          <context context-type="linenumber">1710</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
@@ -13270,7 +13270,7 @@
         <target>Tour 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1711</context>
+          <context context-type="linenumber">1715</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
@@ -13278,11 +13278,11 @@
         <target>Afficher les détails statistiques</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1898</context>
+          <context context-type="linenumber">1902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2197</context>
+          <context context-type="linenumber">2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
@@ -13290,7 +13290,7 @@
         <target>Tour 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1912,1914</context>
+          <context context-type="linenumber">1916,1918</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
@@ -13298,7 +13298,7 @@
         <target>Tour 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1940,1942</context>
+          <context context-type="linenumber">1944,1946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
@@ -13306,7 +13306,7 @@
         <target>Δ par paires : <x id="INTERPOLATION"/> plus proche, <x id="INTERPOLATION_1"/> plus loin, <x id="INTERPOLATION_2"/> inchangé (<x id="INTERPOLATION_3"/> paires)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1971,1979</context>
+          <context context-type="linenumber">1975,1983</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
@@ -13314,7 +13314,7 @@
         <target>Distribution Δx</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1989</context>
+          <context context-type="linenumber">1993</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
@@ -13322,7 +13322,7 @@
         <target>plus petit est plus proche</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2103</context>
+          <context context-type="linenumber">2107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
@@ -13330,7 +13330,7 @@
         <target>Tour de résultats</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2210,2212</context>
+          <context context-type="linenumber">2214,2216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
@@ -13338,7 +13338,7 @@
         <target>Aucune estimation reçue.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2237,2239</context>
+          <context context-type="linenumber">2241,2243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
@@ -13346,7 +13346,7 @@
         <target>Comparaison avant et après pour la Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
@@ -13354,7 +13354,7 @@
         <target>Tour 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> vote)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
@@ -13362,7 +13362,7 @@
         <target>Tour 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> votes)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2263</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
@@ -13370,7 +13370,7 @@
         <target>Tour 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> vote)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2271</context>
+          <context context-type="linenumber">2275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
@@ -13378,7 +13378,7 @@
         <target>Tour 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> votes)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
@@ -13386,7 +13386,7 @@
         <target>Correct&#160;: <x id="INTERPOLATION" equiv-text="{{ q.roundComparison.round1CorrectCount }}"/> au tour&#160;1, puis <x id="INTERPOLATION_1" equiv-text="{{ q.roundComparison.round2CorrectCount }}"/> au tour&#160;2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2289,2293</context>
+          <context context-type="linenumber">2293,2297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
@@ -13394,7 +13394,7 @@
         <target>Peer Instruction recommandée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2536,2538</context>
+          <context context-type="linenumber">2540,2542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
@@ -13402,7 +13402,7 @@
         <target>35–70 % entièrement corrects — 2e tour adapté.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2543,2545</context>
+          <context context-type="linenumber">2547,2549</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
@@ -13410,7 +13410,7 @@
         <target>1er tour encore masqué jusqu’à votre action.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2550,2552</context>
+          <context context-type="linenumber">2554,2556</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
@@ -13418,7 +13418,7 @@
         <target>Lancer la discussion ou afficher le résultat.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2557,2559</context>
+          <context context-type="linenumber">2561,2563</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
@@ -13426,7 +13426,7 @@
         <target>Autoévaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2615,2617</context>
+          <context context-type="linenumber">2619,2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
@@ -13434,7 +13434,7 @@
         <target> Juste ou faux — et avec quelle assurance ? Surtout : faux malgré une forte certitude de réponse. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2621,2624</context>
+          <context context-type="linenumber">2625,2628</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
@@ -13442,7 +13442,7 @@
         <target>Justesse et autoévaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2645</context>
+          <context context-type="linenumber">2649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
@@ -13450,7 +13450,7 @@
         <target> Souvent faux avec forte certitude de réponse </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2699,2701</context>
+          <context context-type="linenumber">2703,2705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
@@ -13458,7 +13458,7 @@
         <target>Mise à jour de la question …</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2744,2746</context>
+          <context context-type="linenumber">2748,2750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
@@ -13466,7 +13466,7 @@
         <target>Aucune question active. Commencez par « Question suivante ».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2748,2750</context>
+          <context context-type="linenumber">2752,2754</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -13474,7 +13474,7 @@
         <target>Réactions des participantes et participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2768</context>
+          <context context-type="linenumber">2772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
@@ -13482,7 +13482,7 @@
         <target>2e manche</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2774</context>
+          <context context-type="linenumber">2778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
@@ -13490,7 +13490,7 @@
         <target>nouveau</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2782</context>
+          <context context-type="linenumber">2786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
@@ -13498,7 +13498,7 @@
         <target>Aucune réaction pour l&apos;instant.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2805</context>
+          <context context-type="linenumber">2809</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
@@ -13506,7 +13506,7 @@
         <target>Top 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2818</context>
+          <context context-type="linenumber">2822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
@@ -13514,7 +13514,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ entry.totalScore | number }}"/> pts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2885</context>
+          <context context-type="linenumber">2889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
@@ -13522,7 +13522,7 @@
         <target>Égalité : temps de réponse.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
@@ -13530,7 +13530,7 @@
         <target>Score des équipes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2912</context>
+          <context context-type="linenumber">2916</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
@@ -13538,7 +13538,7 @@
         <target>pts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2959</context>
+          <context context-type="linenumber">2963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
@@ -13546,7 +13546,7 @@
         <target>Changer de quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2988</context>
+          <context context-type="linenumber">2992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
@@ -13554,7 +13554,7 @@
         <target>Modifier le titre Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3091</context>
+          <context context-type="linenumber">3095</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
@@ -13562,7 +13562,7 @@
         <target>Titre du Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3104</context>
+          <context context-type="linenumber">3108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
@@ -13570,7 +13570,7 @@
         <target>Questions sur l'événement...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3115</context>
+          <context context-type="linenumber">3119</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
@@ -13582,15 +13582,24 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1038</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
+        <source>Quiz-Session</source>
+        <target>Session quiz</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">889</context>
+        </context-group>
+      </trans-unit>
+
       <trans-unit id="sessionHost.qaTitleConfirmAria" datatype="html">
         <source>Titel speichern</source>
         <target>Enregistrer le titre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3127</context>
+          <context context-type="linenumber">3131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
@@ -13598,7 +13607,7 @@
         <target>Annuler la modification</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3138</context>
+          <context context-type="linenumber">3142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
@@ -13606,7 +13615,7 @@
         <target>Pré-modération</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3157,3159</context>
+          <context context-type="linenumber">3161,3163</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
@@ -13614,7 +13623,7 @@
         <target>La pré-modération est activée. Les nouvelles questions attendent d’abord votre validation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3161,3163</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
@@ -13622,7 +13631,7 @@
         <target>Pas encore de questions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3170,3172</context>
+          <context context-type="linenumber">3174,3176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
@@ -13630,7 +13639,7 @@
         <target>Total : <x id="INTERPOLATION" equiv-text="qaQuestions().length"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3182,3183</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
@@ -13638,7 +13647,7 @@
         <target>En attente de validation : <x id="INTERPOLATION" equiv-text="qaPendingCount()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3191,3192</context>
+          <context context-type="linenumber">3195,3196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
@@ -13646,7 +13655,7 @@
         <target>Afficher toutes les questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3244</context>
+          <context context-type="linenumber">3248</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
@@ -13654,7 +13663,7 @@
         <target>Tout afficher</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3247</context>
+          <context context-type="linenumber">3251</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
@@ -13662,7 +13671,7 @@
         <target>Afficher uniquement les questions épinglées</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3255</context>
+          <context context-type="linenumber">3259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
@@ -13670,7 +13679,7 @@
         <target>Épinglées seulement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3258</context>
+          <context context-type="linenumber">3262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
@@ -13678,7 +13687,7 @@
         <target>Afficher les nouvelles questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3270</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
@@ -13686,7 +13695,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ qaUnseenCount() }}"/> nouvelles questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3276</context>
+          <context context-type="linenumber">3280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
@@ -13694,7 +13703,7 @@
         <target>Exporter les questions en CSV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3308</context>
+          <context context-type="linenumber">3312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
@@ -13702,7 +13711,7 @@
         <target>Exporter les questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3311</context>
+          <context context-type="linenumber">3315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
@@ -13710,7 +13719,7 @@
         <target>Export en cours…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3319,3321</context>
+          <context context-type="linenumber">3323,3325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
@@ -13718,7 +13727,7 @@
         <target>Controversée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3388</context>
+          <context context-type="linenumber">3392</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
@@ -13726,7 +13735,7 @@
         <target><x id="INTERPOLATION" equiv-text="question.positiveVoteCount"/> positifs · <x id="INTERPOLATION_1" equiv-text="question.negativeVoteCount"/> négatifs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3416,3417</context>
+          <context context-type="linenumber">3420,3421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
@@ -13734,7 +13743,7 @@
         <target>Approbation fiable <x id="INTERPOLATION" equiv-text="formatQaPercent(question.bestScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3424,3425</context>
+          <context context-type="linenumber">3428,3429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
@@ -13742,7 +13751,7 @@
         <target>Réactions partagées <x id="INTERPOLATION" equiv-text="formatQaPercent(question.controversyScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3434,3436</context>
+          <context context-type="linenumber">3438,3440</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
@@ -13750,7 +13759,7 @@
         <target>Vue épinglée active – aucune question épinglée pour le moment.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3477,3479</context>
+          <context context-type="linenumber">3481,3483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
@@ -13758,7 +13767,7 @@
         <target>Afficher les options de réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3530</context>
+          <context context-type="linenumber">3534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
@@ -13766,7 +13775,7 @@
         <target>Démarrer la phase de discussion – échanger avant le deuxième vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3554</context>
+          <context context-type="linenumber">3570</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
@@ -13774,7 +13783,7 @@
         <target>Phase de discussion</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3557</context>
+          <context context-type="linenumber">3573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
@@ -13782,15 +13791,87 @@
         <target>Afficher quand même le résultat</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3591</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <target>Publier quand même</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">3588</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
-        <source> Ergebnis zeigen</source>
+        <source>Ergebnis zeigen</source>
         <target>Afficher le résultat</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3579,3581</context>
+          <context context-type="linenumber">3612</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
+        <source>Persönliche Fristen beenden?</source>
+        <target>Terminer les délais personnels ?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5926</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
+        <source>Du zeigst das Ergebnis, obwohl noch persönliche Timer laufen.</source>
+        <target>Tu affiches le résultat alors que des minuteurs personnels sont encore en cours.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5930</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
+        <source>Du startest die Diskussionsphase, obwohl noch persönliche Timer laufen.</source>
+        <target>Tu lances la phase de discussion alors que des minuteurs personnels sont encore en cours.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5929</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
+        <source>Die offene persönliche 10×-Frist dieser Person endet sofort.</source>
+        <target>Le délai personnel ×10 ouvert de cette personne se termine immédiatement.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> offene persönliche 10×-Fristen enden sofort.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> délais personnels ×10 ouverts se terminent immédiatement.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5921</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
+        <source>Danach ist keine weitere Antwort mehr möglich.</source>
+        <target>Ensuite, aucune autre réponse n’est possible.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5918</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <target>Publier quand même</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5932</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
+        <source>Weiter warten</source>
+        <target>Continuer d’attendre</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5933</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
@@ -13798,7 +13879,7 @@
         <target>Question suivante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3595,3597</context>
+          <context context-type="linenumber">3621,3623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
@@ -13806,7 +13887,7 @@
         <target>Passons à la question suivante sans deuxième vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3618</context>
+          <context context-type="linenumber">3644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
@@ -13814,7 +13895,7 @@
         <target>Passons à la question suivante sans deuxième vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
@@ -13822,7 +13903,7 @@
         <target>Réaffiche la question précédente avec son résultat et la bonne réponse (sans nouveau vote).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3638</context>
+          <context context-type="linenumber">3664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
@@ -13830,7 +13911,7 @@
         <target>Afficher à nouveau le résultat précédent</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3640,3642</context>
+          <context context-type="linenumber">3666,3668</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
@@ -13838,7 +13919,7 @@
         <target>Terminer la session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650,3652</context>
+          <context context-type="linenumber">3676,3678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -13846,7 +13927,7 @@
         <target>Vue hôte pour le lobby et le contrôle.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3658</context>
+          <context context-type="linenumber">3684</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
@@ -14174,7 +14255,7 @@
         <target>1 réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1526</context>
+          <context context-type="linenumber">1534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
@@ -14182,7 +14263,7 @@
         <target><x id="count" equiv-text="count"/> réponses</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1527</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
@@ -14190,7 +14271,7 @@
         <target>Faible · <x id="label" equiv-text="q.confidenceLabelLow"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1618</context>
+          <context context-type="linenumber">1626</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
@@ -14198,7 +14279,7 @@
         <target>Faible (1–2)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1619</context>
+          <context context-type="linenumber">1627</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
@@ -14206,7 +14287,7 @@
         <target>Moyen (3)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1623</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
@@ -14214,7 +14295,7 @@
         <target>Élevé · <x id="label" equiv-text="q.confidenceLabelHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1663</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
@@ -14222,7 +14303,7 @@
         <target>Élevé (4–5)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1656</context>
+          <context context-type="linenumber">1664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
@@ -14230,7 +14311,7 @@
         <target>Correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
@@ -14238,7 +14319,7 @@
         <target>Faux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1677</context>
+          <context context-type="linenumber">1685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
@@ -14246,7 +14327,7 @@
         <target><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1769</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
@@ -14254,7 +14335,7 @@
         <target>1 mauvaise réponse sûre – possible idée fausse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1774</context>
+          <context context-type="linenumber">1782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
@@ -14262,7 +14343,7 @@
         <target><x id="count" equiv-text="count"/> mauvaises réponses confiantes – idées fausses possibles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
@@ -14270,7 +14351,7 @@
         <target>Juste+élevé <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · Faux+élevé <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1786</context>
+          <context context-type="linenumber">1794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
@@ -14278,7 +14359,7 @@
         <target>2 (Instruction par les pairs)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
@@ -14286,7 +14367,7 @@
         <target>Tour 1 : <x id="r1" equiv-text="round1Count"/> voix · Agrégé : Tour 2 avec <x id="r2" equiv-text="round2Count"/> voix</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1824</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
@@ -14294,7 +14375,7 @@
         <target>Agrégation Round 2 (Instruction par les pairs)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1826</context>
+          <context context-type="linenumber">1834</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
@@ -14302,7 +14383,7 @@
         <target>Agrégation tour 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1837</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
@@ -14310,7 +14391,7 @@
         <target>Ça n’est pas passé tout de suite</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2427</context>
+          <context context-type="linenumber">2435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
@@ -14318,7 +14399,7 @@
         <target>Pas de stress, ça arrive (petit à-coup ou Wi‑Fi capricieux). Compte jusqu’à trois, puis appuie sur « Réessayer » — en général ça suffit.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2428</context>
+          <context context-type="linenumber">2436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
@@ -14326,7 +14407,7 @@
         <target>Avec les questions, ça bloque un instant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2435</context>
+          <context context-type="linenumber">2443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
@@ -14334,7 +14415,7 @@
         <target>Rien n’est cassé, ça n’a juste pas marché cette fois. Respire un coup, attends 2–3 secondes, puis « Réessayer » — souvent ça repart.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2436</context>
+          <context context-type="linenumber">2444</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
@@ -14342,7 +14423,7 @@
         <target>Export pas encore prêt</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2443</context>
+          <context context-type="linenumber">2451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
@@ -14350,7 +14431,7 @@
         <target>L’export PDF ou Excel n’est pas passé cette fois. Attends quelques secondes et appuie sur « Réessayer » — le deuxième essai fait souvent l’affaire.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
@@ -14358,7 +14439,7 @@
         <target>Les participants et la vue de la présentation sont redirigés vers la page d&apos;accueil.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2578</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
@@ -14366,7 +14447,7 @@
         <target>La séance se termine pour tout le monde ; il n&apos;est pas possible de continuer avec le même code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2579</context>
+          <context context-type="linenumber">2587</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
@@ -14374,7 +14455,7 @@
         <target>Il reste <x id="participantCount" equiv-text="participants"/> participant·es dans la session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2583</context>
+          <context context-type="linenumber">2591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
@@ -14382,7 +14463,7 @@
         <target>Vous avez déjà des résultats. Après avoir terminé, vous pouvez les exporter ou consulter les retours dans la vue finale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2596</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
@@ -14390,7 +14471,7 @@
         <target>Il n&apos;y a pas encore de résultats exploitables. Après avoir terminé, vous serez redirigé·e directement vers l&apos;accueil.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2592</context>
+          <context context-type="linenumber">2600</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
@@ -14398,7 +14479,7 @@
         <target>Codes bonus : demandez aux participant·es de copier maintenant leur code personnel dans le presse-papiers avant de quitter la page, sinon ils risquent de le perdre.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2597</context>
+          <context context-type="linenumber">2605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
@@ -14406,7 +14487,7 @@
         <target>Quitter la séance ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
@@ -14414,7 +14495,7 @@
         <target>Votre session est toujours active.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
@@ -14422,7 +14503,7 @@
         <target>Il reste toujours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2606</context>
+          <context context-type="linenumber">2614</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
@@ -14430,7 +14511,7 @@
         <target>Retour à la séance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2607</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
@@ -14438,7 +14519,7 @@
         <target>Arrêter l&apos;aperçu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2795</context>
+          <context context-type="linenumber">2803</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
@@ -14446,7 +14527,7 @@
         <target>Écouter brièvement le morceau (12 s max.)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2796</context>
+          <context context-type="linenumber">2804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
@@ -14454,7 +14535,7 @@
         <target>Son activé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2808</context>
+          <context context-type="linenumber">2816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
@@ -14462,7 +14543,7 @@
         <target>Son coupé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2809</context>
+          <context context-type="linenumber">2817</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
@@ -14470,7 +14551,7 @@
         <target>Participant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2866</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
@@ -14478,7 +14559,7 @@
         <target>participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2870</context>
+          <context context-type="linenumber">2878</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
@@ -14486,7 +14567,7 @@
         <target>1 participant connecté en live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2887</context>
+          <context context-type="linenumber">2895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
@@ -14494,7 +14575,7 @@
         <target><x id="connectedCount" equiv-text="connectedCount"/> participants connectés en live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2889</context>
+          <context context-type="linenumber">2897</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
@@ -14502,7 +14583,7 @@
         <target>Personne n’est encore dans cette équipe.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2923</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
@@ -14510,7 +14591,7 @@
         <target>Évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3729</context>
+          <context context-type="linenumber">3739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
@@ -14518,7 +14599,7 @@
         <target>Avis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3733</context>
+          <context context-type="linenumber">3743</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
@@ -14526,11 +14607,11 @@
         <target>Les résultats sont là.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3738</context>
+          <context context-type="linenumber">3748</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3745</context>
+          <context context-type="linenumber">3755</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
@@ -14538,11 +14619,11 @@
         <target>Le temps est écoulé.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3739</context>
+          <context context-type="linenumber">3749</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3746</context>
+          <context context-type="linenumber">3756</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
@@ -14550,7 +14631,7 @@
         <target>En attente des avis…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3740</context>
+          <context context-type="linenumber">3750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
@@ -14558,7 +14639,7 @@
         <target>En attente de réponses...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3747</context>
+          <context context-type="linenumber">3757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
@@ -14566,23 +14647,55 @@
         <target><x id="PH" equiv-text="votes"/> sur <x id="PH_1" equiv-text="participants"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3761</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <target>Une personne utilise encore son temps ×10. Attends le compte à rebours de la salle ou la fin du temps ×10.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3769</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihr persönliches Fenster.</source>
+        <target>Une personne utilise encore son temps ×10. « Publier quand même » termine sa fenêtre personnelle.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3768</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> personnes utilisent encore leur temps ×10. Attends le compte à rebours de la salle ou la fin du temps ×10.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3774</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihre persönlichen Fenster.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> personnes utilisent encore leur temps ×10. « Publier quand même » termine leurs fenêtres personnelles.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
-        <source>Eine Person mit Zeitanpassung antwortet noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
-        <target>Une personne disposant de temps supplémentaire répond encore. « Afficher le résultat » met fin à son délai de réponse.</target>
+        <source>Eine Person antwortet ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <target>Une personne répond sans délai personnel. « Afficher le résultat » ferme sa saisie.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
-        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen mit Zeitanpassung antworten noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
-        <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> personnes disposant de temps supplémentaire répondent encore. « Afficher le résultat » met fin à leur délai de réponse.</target>
+        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen antworten ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> personnes répondent sans délai personnel. « Afficher le résultat » ferme leur saisie.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3758</context>
+          <context context-type="linenumber">3774</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
@@ -14590,7 +14703,7 @@
         <target><x id="votes" equiv-text="votes"/> sur <x id="participants" equiv-text="participants"/> participants ont voté. <x id="percentage" equiv-text="percentage"/> pour cent atteint.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3764</context>
+          <context context-type="linenumber">3780</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
@@ -14598,7 +14711,7 @@
         <target><x id="votes" equiv-text="votes"/> des <x id="participants" equiv-text="participants"/> participants ont voté. <x id="percentage" equiv-text="percentage"/> pour cent atteint.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3766</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
@@ -14606,7 +14719,7 @@
         <target><x id="voteCount"/> sur <x id="participantTotal"/> a voté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
@@ -14614,7 +14727,7 @@
         <target><x id="voteCount"/> sur <x id="participantTotal"/> ont voté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3779</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
@@ -14622,7 +14735,7 @@
         <target><x id="voteCount"/> sur <x id="participantTotal"/> a noté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3790</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
@@ -14630,7 +14743,7 @@
         <target><x id="voteCount"/> sur <x id="participantTotal"/> ont noté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3792</context>
+          <context context-type="linenumber">3808</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
@@ -14638,7 +14751,7 @@
         <target><x id="correctCount"/> réponses entièrement correctes sur <x id="voteTotal"/> (<x id="percentage"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3798</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
@@ -14646,7 +14759,7 @@
         <target><x id="changed"/> sur <x id="both"/> (<x id="pct"/>%) ont changé d&apos;avis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3802</context>
+          <context context-type="linenumber">3818</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
@@ -14654,7 +14767,7 @@
         <target>↑ <x id="count"/> faux → correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3806</context>
+          <context context-type="linenumber">3822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
@@ -14662,7 +14775,7 @@
         <target>↓ <x id="count"/> correct → faux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3810</context>
+          <context context-type="linenumber">3826</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
@@ -14670,7 +14783,7 @@
         <target>Moyenne <x id="avg"/> sur 5 étoiles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3816</context>
+          <context context-type="linenumber">3832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
@@ -14678,7 +14791,7 @@
         <target>réaction <x id="PH" equiv-text="total"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
@@ -14686,7 +14799,7 @@
         <target><x id="PH" equiv-text="total"/> réactions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
@@ -14694,7 +14807,7 @@
         <target>Lobby – les participantes et participants peuvent rejoindre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3873</context>
+          <context context-type="linenumber">3889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
@@ -14702,7 +14815,7 @@
         <target>La session de questions se prépare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3874</context>
+          <context context-type="linenumber">3890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
@@ -14710,15 +14823,15 @@
         <target>Session de questions en cours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3875</context>
+          <context context-type="linenumber">3891</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3877</context>
+          <context context-type="linenumber">3893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3878</context>
+          <context context-type="linenumber">3894</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
@@ -14726,7 +14839,7 @@
         <target>En pause</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3876</context>
+          <context context-type="linenumber">3892</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
@@ -14734,7 +14847,7 @@
         <target>Session de questions terminée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3879</context>
+          <context context-type="linenumber">3895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
@@ -14742,7 +14855,7 @@
         <target>Vote terminé – en attente d’évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3884</context>
+          <context context-type="linenumber">3900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
@@ -14750,7 +14863,7 @@
         <target>Lobby – les participants peuvent se joindre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3887</context>
+          <context context-type="linenumber">3903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
@@ -14758,7 +14871,7 @@
         <target>Phase de lecture – réponses toujours bloquées</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3888</context>
+          <context context-type="linenumber">3904</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
@@ -14766,7 +14879,7 @@
         <target>Le vote est en cours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3889</context>
+          <context context-type="linenumber">3905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
@@ -14774,7 +14887,7 @@
         <target>En pause</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3890</context>
+          <context context-type="linenumber">3906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
@@ -14782,7 +14895,7 @@
         <target>Les résultats sont affichés</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3891</context>
+          <context context-type="linenumber">3907</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
@@ -14790,7 +14903,7 @@
         <target>Phase de discussion – échange avant le second tour</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3892</context>
+          <context context-type="linenumber">3908</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
@@ -14798,7 +14911,7 @@
         <target>Séance terminée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3893</context>
+          <context context-type="linenumber">3909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
@@ -14806,7 +14919,7 @@
         <target><x id="readyCount" equiv-text="readyCount"/> sur <x id="connectedCount" equiv-text="connectedCount"/> prêts</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3904</context>
+          <context context-type="linenumber">3920</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
@@ -14814,7 +14927,7 @@
         <target><x id="PH" equiv-text="readyCount"/> participant·es connecté·es prêt·es sur <x id="PH_1" equiv-text="connectedCount"/> · <x id="PH_2" equiv-text="totalParticipantCount"/> au total</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3906</context>
+          <context context-type="linenumber">3922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
@@ -14822,7 +14935,7 @@
         <target>Toutes les personnes participantes sont prêtes ; les options de réponse peuvent être affichées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3911</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
@@ -14830,7 +14943,7 @@
         <target>Toutes les personnes participantes connectées sont prêtes ; les options de réponse peuvent être affichées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3913</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
@@ -14838,7 +14951,7 @@
         <target>1 seconde restante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3944</context>
+          <context context-type="linenumber">3960</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
@@ -14846,7 +14959,7 @@
         <target><x id="seconds" equiv-text="seconds"/> secondes restantes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3945</context>
+          <context context-type="linenumber">3961</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -14860,7 +14973,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4069,4072</context>
+          <context context-type="linenumber">4085,4088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -14874,7 +14987,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4114,4117</context>
+          <context context-type="linenumber">4130,4133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -14888,7 +15001,7 @@
       )"/> à <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4119,4122</context>
+          <context context-type="linenumber">4135,4138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -14903,7 +15016,7 @@
     )"/> à <x id="right" equiv-text="formatNumber(band.right, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4124,4127</context>
+          <context context-type="linenumber">4140,4143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
@@ -14911,7 +15024,7 @@
         <target>Médiane <x id="median" equiv-text="formatNumber(stats.median, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4242</context>
+          <context context-type="linenumber">4258</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
@@ -14919,7 +15032,7 @@
         <target>Estimations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4275</context>
+          <context context-type="linenumber">4291</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
@@ -14927,7 +15040,7 @@
         <target>réponses valides</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4277</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
@@ -14935,7 +15048,7 @@
         <target>Moyenne</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4283</context>
+          <context context-type="linenumber">4299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
@@ -14943,7 +15056,7 @@
         <target>Moyenne de toutes les estimations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4285</context>
+          <context context-type="linenumber">4301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
@@ -14951,7 +15064,7 @@
         <target>Médiane</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4291</context>
+          <context context-type="linenumber">4307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
@@ -14959,7 +15072,7 @@
         <target>Valeur centrale triée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4293</context>
+          <context context-type="linenumber">4309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
@@ -14967,7 +15080,7 @@
         <target>Dispersion</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4299</context>
+          <context context-type="linenumber">4315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
@@ -14975,7 +15088,7 @@
         <target>Écart type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4301</context>
+          <context context-type="linenumber">4317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
@@ -14983,7 +15096,7 @@
         <target>50 % centraux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4307</context>
+          <context context-type="linenumber">4323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -14998,7 +15111,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4312,4315</context>
+          <context context-type="linenumber">4328,4331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
@@ -15006,7 +15119,7 @@
         <target>Étendue</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
@@ -15014,7 +15127,7 @@
         <target>de la plus petite à la plus grande estimation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4326</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
@@ -15022,7 +15135,7 @@
         <target>Dans l’intervalle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4332</context>
+          <context context-type="linenumber">4348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -15038,7 +15151,7 @@
         )"/>% accepté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4338,4342</context>
+          <context context-type="linenumber">4354,4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
@@ -15046,7 +15159,7 @@
         <target>Distance moy.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4348</context>
+          <context context-type="linenumber">4364</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
@@ -15054,7 +15167,7 @@
         <target>à la référence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4350</context>
+          <context context-type="linenumber">4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
@@ -15062,7 +15175,7 @@
         <target>Médian</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4358</context>
+          <context context-type="linenumber">4374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
@@ -15070,7 +15183,7 @@
         <target>Moyenne</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4361</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
@@ -15078,7 +15191,7 @@
         <target>Estimations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4363</context>
+          <context context-type="linenumber">4379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -15094,7 +15207,7 @@
     )"/> % dans la plage acceptée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394,4398</context>
+          <context context-type="linenumber">4410,4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
@@ -15102,7 +15215,7 @@
         <target>Distance moyenne à la référence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4412</context>
+          <context context-type="linenumber">4428</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
@@ -15110,7 +15223,7 @@
         <target>plus proche de la valeur de référence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4426</context>
+          <context context-type="linenumber">4442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
@@ -15118,7 +15231,7 @@
         <target>Changement médian</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4443</context>
+          <context context-type="linenumber">4459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
@@ -15126,7 +15239,7 @@
         <target>Changement moyen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4444</context>
+          <context context-type="linenumber">4460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -15141,7 +15254,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4455,4458</context>
+          <context context-type="linenumber">4471,4474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -15156,7 +15269,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4464,4467</context>
+          <context context-type="linenumber">4480,4483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -15172,7 +15285,7 @@
         )"/> points de pourcentage</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4476,4480</context>
+          <context context-type="linenumber">4492,4496</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -15196,7 +15309,7 @@
           )"/> estimations comparables se sont améliorées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4496,4504</context>
+          <context context-type="linenumber">4512,4520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -15220,7 +15333,7 @@
           )"/> estimations comparables sont plus éloignées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4516</context>
+          <context context-type="linenumber">4524,4532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
@@ -15228,7 +15341,7 @@
         <target>Le tour 2 est mitigé : les estimations plus proches et plus lointaines sont équilibrées dans la comparaison des paires.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520</context>
+          <context context-type="linenumber">4536</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -15242,7 +15355,7 @@
           )"/> au tour 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4532,4535</context>
+          <context context-type="linenumber">4548,4551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -15256,7 +15369,7 @@
           )"/> plus grande au tour 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4539,4542</context>
+          <context context-type="linenumber">4555,4558</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -15272,7 +15385,7 @@
         )"/> points de pourcentage.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4554,4558</context>
+          <context context-type="linenumber">4570,4574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -15296,7 +15409,7 @@
         )"/> estimations se situent dans la bande de tolérance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4573,4581</context>
+          <context context-type="linenumber">4589,4597</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -15310,7 +15423,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4586,4589</context>
+          <context context-type="linenumber">4602,4605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -15324,7 +15437,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4593,4596</context>
+          <context context-type="linenumber">4609,4612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
@@ -15332,11 +15445,11 @@
         <target>Quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4642</context>
+          <context context-type="linenumber">4658</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2195</context>
+          <context context-type="linenumber">2205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.questions" datatype="html">
@@ -15344,11 +15457,11 @@
         <target>Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4644</context>
+          <context context-type="linenumber">4660</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2197</context>
+          <context context-type="linenumber">2207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.questionsBadgeNew" datatype="html">
@@ -15356,11 +15469,11 @@
         <target><x id="count" equiv-text="this.qaUnseenCount()"/> nouvelle(s)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4652</context>
+          <context context-type="linenumber">4668</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4669</context>
+          <context context-type="linenumber">4685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelInactive" datatype="html">
@@ -15368,7 +15481,7 @@
         <target>Désactivé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4769</context>
+          <context context-type="linenumber">4785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelClosed" datatype="html">
@@ -15376,11 +15489,11 @@
         <target>Fermé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4788</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2205</context>
+          <context context-type="linenumber">2215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7367446920402175749" datatype="html">
@@ -15388,11 +15501,11 @@
         <target>Question de <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">615</context>
+          <context context-type="linenumber">618</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8913852475666331247" datatype="html">
@@ -15400,11 +15513,11 @@
         <target>Question du public</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5574706582681662956" datatype="html">
@@ -15412,15 +15525,15 @@
         <target>Désélectionner <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4835</context>
+          <context context-type="linenumber">4851</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">580</context>
+          <context context-type="linenumber">583</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">626</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2964749761557345284" datatype="html">
@@ -15428,15 +15541,15 @@
         <target>Mettez en surbrillance toutes les questions de <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4836</context>
+          <context context-type="linenumber">4852</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">581</context>
+          <context context-type="linenumber">584</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">627</context>
+          <context context-type="linenumber">630</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPinned" datatype="html">
@@ -15444,11 +15557,11 @@
         <target>En cours de réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4881</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusActive" datatype="html">
@@ -15456,11 +15569,11 @@
         <target>Ouverte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4867</context>
+          <context context-type="linenumber">4883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2251</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPending" datatype="html">
@@ -15468,11 +15581,11 @@
         <target>En attente de validation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4869</context>
+          <context context-type="linenumber">4885</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2253</context>
+          <context context-type="linenumber">2263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusArchived" datatype="html">
@@ -15480,11 +15593,11 @@
         <target>Répondue</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4871</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2255</context>
+          <context context-type="linenumber">2265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusDeleted" datatype="html">
@@ -15492,11 +15605,11 @@
         <target>Supprimée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4873</context>
+          <context context-type="linenumber">4889</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionApprove" datatype="html">
@@ -15504,7 +15617,7 @@
         <target>Valider</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4974</context>
+          <context context-type="linenumber">4990</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
@@ -15512,7 +15625,7 @@
         <target>Mettre en avant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4976</context>
+          <context context-type="linenumber">4992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
@@ -15520,7 +15633,7 @@
         <target>Retirer la mise en avant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4978</context>
+          <context context-type="linenumber">4994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
@@ -15528,7 +15641,7 @@
         <target>Archiver</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4980</context>
+          <context context-type="linenumber">4996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
@@ -15536,7 +15649,7 @@
         <target>Supprimer définitivement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4983</context>
+          <context context-type="linenumber">4999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
@@ -15544,7 +15657,7 @@
         <target>Supprimer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4984</context>
+          <context context-type="linenumber">5000</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
@@ -15552,7 +15665,7 @@
         <target>Fermer le canal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5328</context>
+          <context context-type="linenumber">5344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
@@ -15560,7 +15673,7 @@
         <target>Rouvrir le canal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5329</context>
+          <context context-type="linenumber">5345</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
@@ -15568,7 +15681,7 @@
         <target>Pré-modération activée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5743</context>
+          <context context-type="linenumber">5759</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
@@ -15576,7 +15689,7 @@
         <target>Pré-modération désactivée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5744</context>
+          <context context-type="linenumber">5760</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
@@ -15584,7 +15697,7 @@
         <target>Question validée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5777</context>
+          <context context-type="linenumber">5793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
@@ -15592,7 +15705,7 @@
         <target>Question mise en avant.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5779</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
@@ -15600,7 +15713,7 @@
         <target>Question archivée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5781</context>
+          <context context-type="linenumber">5797</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
@@ -15608,7 +15721,7 @@
         <target>Question supprimée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5782</context>
+          <context context-type="linenumber">5798</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
@@ -15616,7 +15729,7 @@
         <target>N° question;Texte;Type;Participants;Cycle d’agrégation;Ø Points;Autoévaluation n;Solidifié;Risque d’idée fausse;Fragile;Lacune reconnue;Indécis;Réponse fausse la plus fréquente avec forte certitude;Détails</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5995</context>
+          <context context-type="linenumber">6011</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
@@ -15624,7 +15737,7 @@
         <target>Niveau d&apos;apprentissage et autoévaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6049</context>
+          <context context-type="linenumber">6065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
@@ -15632,7 +15745,7 @@
         <target>Réponses valides;Questions évaluées;Non agrégées (&lt;5 réponses avec autoévaluation);Consolidé;Risque de fausse conception;Fragile;Lacune détectée;Indécis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6052</context>
+          <context context-type="linenumber">6068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
@@ -15640,7 +15753,7 @@
         <target>Classement des équipes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6073</context>
+          <context context-type="linenumber">6089</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
@@ -15648,7 +15761,7 @@
         <target>Rang;Équipe;Couleur;Membres;Points de l&apos;équipe;Points moyens par membre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6075</context>
+          <context context-type="linenumber">6091</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
@@ -15656,7 +15769,7 @@
         <target>Codes bonus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6093</context>
+          <context context-type="linenumber">6109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
@@ -15664,7 +15777,7 @@
         <target>Rang;Pseudonyme;Code;Points;Généré le</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6095</context>
+          <context context-type="linenumber">6111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
@@ -15672,7 +15785,7 @@
         <target>Résultat CSV exporté.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6103</context>
+          <context context-type="linenumber">6119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
@@ -15680,7 +15793,7 @@
         <target>Voir le plan de débriefing en PDF – 1 question à débriefer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6115</context>
+          <context context-type="linenumber">6131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
@@ -15688,7 +15801,7 @@
         <target>Voir le plan de débriefing en PDF – <x id="count" equiv-text="count"/> questions à débriefer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6118</context>
+          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
@@ -15696,7 +15809,7 @@
         <target>Voir le plan de débriefing en PDF</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6120</context>
+          <context context-type="linenumber">6136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
@@ -15704,7 +15817,7 @@
         <target>1 question recommandée pour le débriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6125</context>
+          <context context-type="linenumber">6141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
@@ -15712,7 +15825,7 @@
         <target><x id="count" equiv-text="count"/> questions recommandées pour le débriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6127</context>
+          <context context-type="linenumber">6143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
@@ -15720,7 +15833,7 @@
         <target>Le PDF est créé (<x id="PH" equiv-text="exportData.questions.length"/> questions)…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6139</context>
+          <context context-type="linenumber">6155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
@@ -15728,7 +15841,7 @@
         <target>Résultats PDF téléchargés.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6145</context>
+          <context context-type="linenumber">6161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
@@ -15736,7 +15849,7 @@
         <target>Résultat PDF ouvert pour enregistrement.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
@@ -15744,7 +15857,7 @@
         <target>N°;ID de question;Statut;Question;Score;Votes positifs;Votes négatifs;Votes au total;Score de Wilson;Score de controverse;Controversée;Créée le</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6173</context>
+          <context context-type="linenumber">6189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
@@ -15752,7 +15865,7 @@
         <target>CSV Q&amp;A exporté.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6196</context>
+          <context context-type="linenumber">6212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
@@ -15760,11 +15873,11 @@
         <target>Question <x id="questionNumber" equiv-text="data.questionOrder + 1"/> : <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6359</context>
+          <context context-type="linenumber">6375</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6367</context>
+          <context context-type="linenumber">6383</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15780,7 +15893,7 @@
         <target>Le texte gratuit en direct est mis à jour.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6362</context>
+          <context context-type="linenumber">6378</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15792,7 +15905,7 @@
         <target>La question actuelle n&apos;est pas une question à texte libre.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6370</context>
+          <context context-type="linenumber">6386</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15804,7 +15917,7 @@
         <target>Pas encore de question active.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6373</context>
+          <context context-type="linenumber">6389</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15816,7 +15929,7 @@
         <target>Impossible de charger les réponses libres en direct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6377</context>
+          <context context-type="linenumber">6393</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -17575,12 +17688,100 @@
           <context context-type="linenumber">576</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
+        <source> Zeit anpassen</source>
+        <target>Adapter le temps</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">14,16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
+        <source> Vor der Frage wählen · 10× Zeit = zehnfacher Raum-Countdown</source>
+        <target>À choisir avant la question · Temps ×10 = dix fois le compte à rebours de la salle</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.summary" datatype="html">
+        <source>So werden Punkte berechnet</source>
+        <target>Comment les points sont calculés</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.intro" datatype="html">
+        <source> So setzt sich deine Punktezahl zusammen: </source>
+        <target>Voici comment ton score est composé :</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">29,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.base" datatype="html">
+        <source> Basis: Bis zu 1000 Punkte für eine richtige Antwort. </source>
+        <target>Base : jusqu’à 1000 points pour une bonne réponse.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">33,35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.difficulty" datatype="html">
+        <source> Schwierigkeit: Leicht ×1, Mittel ×2, Schwer ×3. </source>
+        <target>Difficulté : Facile ×1, Moyen ×2, Difficile ×3.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">36,38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.time" datatype="html">
+        <source> Zeit: Je früher du beim gemeinsamen Raum-Countdown richtig antwortest, desto höher der Zeitanteil. Nach Ablauf bleiben noch 10 % davon. Deine persönliche Frist ändert nur, wie lange du antworten darfst – nicht diese Zeitwertung. </source>
+        <target>Temps : plus tu réponds correctement tôt pendant le compte à rebours commun de la salle, plus ta part de temps est élevée. Après expiration, il en reste 10 %. Ton délai personnel change seulement la durée pendant laquelle tu peux répondre — pas ce score lié au temps.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">39,43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.streak" datatype="html">
+        <source> Serie: Mehrere richtige Antworten hintereinander geben Bonus – 1× ×1,0 · 2× ×1,1 · 3× ×1,2 · 4× ×1,3 · ab 5× ×1,5. Eine falsche bewertbare Antwort setzt die Serie zurück. Umfragen und unbewerteter Freitext unterbrechen sie nicht. </source>
+        <target>Série : plusieurs bonnes réponses d’affilée donnent un bonus – 1× ×1,0 · 2× ×1,1 · 3× ×1,2 · 4× ×1,3 · à partir de 5× ×1,5. Une mauvaise réponse notée remet la série à zéro. Les sondages et le texte libre non noté ne l’interrompent pas.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">44,48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.preview" datatype="html">
+        <source> Die Live-Punktvorschau zeigt den aktuellen Stand ohne Serien-Bonus. </source>
+        <target>L’aperçu des points en direct montre la valeur actuelle sans le bonus de série.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">49,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
+        <source> Keine persönliche Frist · Punkte weiter nach dem Raum-Timer</source>
+        <target>Pas de délai personnel · Les points suivent toujours le minuteur de la salle</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">74,76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
+        <source> 10× Zeit aktiv · Das Ergebnis wartet auf dich</source>
+        <target>Temps ×10 activé · Le résultat attendra ta réponse</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">83,85</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionVote.sessionEndGateTitle" datatype="html">
         <source> Session beendet</source>
         <target>Séance terminée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">21,23</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.bonusGateLead" datatype="html">
@@ -17588,7 +17789,7 @@
         <target>Vous avez reçu un code bonus. Copiez-le maintenant dans le presse-papiers (par ex. pour un mail à l&apos;organisation), avant d&apos;aller à l&apos;accueil.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">28,31</context>
+          <context context-type="linenumber">117,120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionEndFeedbackLead" datatype="html">
@@ -17596,7 +17797,7 @@
         <target>La séance est terminée. Si vous le souhaitez, évaluez-la brièvement – ensuite vous pourrez passer à l&apos;accueil.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">44,47</context>
+          <context context-type="linenumber">133,136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionActionsAria" datatype="html">
@@ -17604,7 +17805,7 @@
         <target>Actions de session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.voteAria" datatype="html">
@@ -17612,7 +17813,7 @@
         <target>Choisir l’espace live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">232</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.pointsUnit" datatype="html">
@@ -17620,7 +17821,23 @@
         <target>points</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">319</context>
+          <context context-type="linenumber">408</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.hide" datatype="html">
+        <source> Ausblenden</source>
+        <target>Cacher</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">416,418</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.show" datatype="html">
+        <source> Live-Punkte anzeigen</source>
+        <target>Afficher les points en direct</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">427,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.mediaAnswerHint" datatype="html">
@@ -17628,47 +17845,7 @@
         <target>L&apos;image est uniquement destinée à la visualisation. Sélectionnez votre réponse ci-dessous.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">985</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
-        <source> Zeit anpassen</source>
-        <target>Adapter le temps</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1010,1012</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
-        <source> Nur für dich · Der Quizablauf bleibt unverändert</source>
-        <target>Pour toi uniquement · Le déroulement du quiz reste inchangé</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1016,1018</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.points" datatype="html">
-        <source> Punkte richten sich nach dem gemeinsamen Countdown</source>
-        <target>Les points dépendent du compte à rebours commun</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1021,1023</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
-        <source> Ohne Timer aktiv · Abgabe möglich, solange die Frage offen ist</source>
-        <target>Sans minuteur · Réponse possible tant que la question est ouverte</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1043,1045</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
-        <source> 10× Zeit aktiv</source>
-        <target>Temps ×10 activé</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericLabel" datatype="html">
@@ -17676,7 +17853,7 @@
         <target>Votre estimation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1262,1264</context>
+          <context context-type="linenumber">1324,1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericPlaceholder" datatype="html">
@@ -17684,7 +17861,7 @@
         <target>Entrer un nombre…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1284</context>
+          <context context-type="linenumber">1346</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultPrefix" datatype="html">
@@ -17692,7 +17869,7 @@
         <target>Votre réponse :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1933013871016789910" datatype="html">
@@ -17700,11 +17877,11 @@
         <target>En tout</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1351</context>
+          <context context-type="linenumber">1413</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1717</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHeading" datatype="html">
@@ -17712,7 +17889,7 @@
         <target>À quel point es-tu sûr de cette réponse ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1404,1406</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHint" datatype="html">
@@ -17720,7 +17897,7 @@
         <target>Correspond à la réponse que vous venez de choisir.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1411,1413</context>
+          <context context-type="linenumber">1473,1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultPrefix" datatype="html">
@@ -17728,7 +17905,7 @@
         <target>Ton autoévaluation :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceSentPrefix" datatype="html">
@@ -17736,7 +17913,7 @@
         <target>Autoévaluation :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1480</context>
+          <context context-type="linenumber">1542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8052936664226936966" datatype="html">
@@ -17744,7 +17921,7 @@
         <target>Série (×<x id="INTERPOLATION" equiv-text="{{ sc.streakMultiplier | number:&apos;1.1-1&apos; }}"/>)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1635</context>
+          <context context-type="linenumber">1697</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4068334453877547924" datatype="html">
@@ -17752,7 +17929,7 @@
         <target>Votre rang</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1649</context>
+          <context context-type="linenumber">1711</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedNotice" datatype="html">
@@ -17760,7 +17937,7 @@
         <target>Le canal Q&amp;A a été fermé par l’enseignant·e. Il n’est actuellement pas possible de poser des questions ni de voter.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1865,1868</context>
+          <context context-type="linenumber">1927,1930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaIdentityHint" datatype="html">
@@ -17768,7 +17945,7 @@
         <target>Vous posez votre question sous le nom</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnAria" datatype="html">
@@ -17776,7 +17953,7 @@
         <target>Supprimer la question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2039</context>
+          <context context-type="linenumber">2101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedHint" datatype="html">
@@ -17784,7 +17961,7 @@
         <target>Les contenus existants sont masqués pour les participant·e·s jusqu’à la réouverture du canal par l’enseignant·e.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2058,2061</context>
+          <context context-type="linenumber">2120,2123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackClosedTitle" datatype="html">
@@ -17792,7 +17969,7 @@
         <target>Feedback express fermé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2077,2079</context>
+          <context context-type="linenumber">2139,2141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedActionsAria" datatype="html">
@@ -17800,7 +17977,7 @@
         <target>Actions finales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2109</context>
+          <context context-type="linenumber">2171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.quizActionsAria" datatype="html">
@@ -17808,7 +17985,7 @@
         <target>Actions du quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2147</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaActionsAria" datatype="html">
@@ -17816,7 +17993,7 @@
         <target>Actions de questions-réponses</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2166</context>
+          <context context-type="linenumber">2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2427920593873911865" datatype="html">
@@ -17824,7 +18001,7 @@
         <target>Parfait ! 🎯</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3996850202378161277" datatype="html">
@@ -17832,7 +18009,7 @@
         <target>Bien joué ! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1090604167231677526" datatype="html">
@@ -17840,7 +18017,7 @@
         <target>Dans le mille ! ⭐</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3502096474885920612" datatype="html">
@@ -17848,7 +18025,7 @@
         <target>Solide ! 🔥</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7691272538064479056" datatype="html">
@@ -17856,7 +18033,7 @@
         <target>Exactement ! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7790447949587239556" datatype="html">
@@ -17864,7 +18041,7 @@
         <target>Vous assurez ! 🎸</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">175</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4185659153521425300" datatype="html">
@@ -17872,7 +18049,7 @@
         <target>Vous l’avez eu ! 👏</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">175</context>
+          <context context-type="linenumber">176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS1" datatype="html">
@@ -17880,7 +18057,7 @@
         <target>Correct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS2" datatype="html">
@@ -17888,7 +18065,7 @@
         <target>C’est correct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">179</context>
+          <context context-type="linenumber">180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS3" datatype="html">
@@ -17896,7 +18073,7 @@
         <target>La réponse est correcte.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3211338642099056060" datatype="html">
@@ -17904,7 +18081,7 @@
         <target>Juste à côté ! 🤏</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1731892131220774983" datatype="html">
@@ -17912,7 +18089,7 @@
         <target>La prochaine sera la bonne ! 💡</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9186185663967902020" datatype="html">
@@ -17920,7 +18097,7 @@
         <target>Continuez comme ça ! 🔄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3551623243824977572" datatype="html">
@@ -17928,7 +18105,7 @@
         <target>Tout ira bien ! 📈</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5506746370181957809" datatype="html">
@@ -17936,7 +18113,7 @@
         <target>N’abandonne pas ! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS1" datatype="html">
@@ -17944,7 +18121,7 @@
         <target>Ce n’est pas ça.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS2" datatype="html">
@@ -17952,7 +18129,7 @@
         <target>Mauvaise réponse.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS3" datatype="html">
@@ -17960,7 +18137,7 @@
         <target>Réessayez à la question suivante.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3145164147131753937" datatype="html">
@@ -17968,7 +18145,7 @@
         <target>Réponse enregistrée ! ✓</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">195</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3110097502695814008" datatype="html">
@@ -17976,7 +18153,7 @@
         <target>Merci pour votre réponse ! 📝</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4856001851461935545" datatype="html">
@@ -17984,7 +18161,7 @@
         <target>Continuez comme ça ! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS1" datatype="html">
@@ -17992,7 +18169,7 @@
         <target>Réponse enregistrée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">200</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS2" datatype="html">
@@ -18000,7 +18177,7 @@
         <target>Merci, votre réponse est bien enregistrée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6032822770375401279" datatype="html">
@@ -18008,7 +18185,7 @@
         <target>Raté de peu — prochain tour ! ⏱️</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">204</context>
+          <context context-type="linenumber">205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3646778948280182955" datatype="html">
@@ -18016,7 +18193,7 @@
         <target>Le temps était trop court — vous pouvez y arriver ! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">205</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5015240621073925218" datatype="html">
@@ -18024,7 +18201,7 @@
         <target>Ça marchera la prochaine fois ! 🔄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="850308549833737974" datatype="html">
@@ -18032,7 +18209,7 @@
         <target>Gardez le cap — ça continue ! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3277616416884173208" datatype="html">
@@ -18040,7 +18217,7 @@
         <target>Tic-tac – la prochaine chance arrive ! ⏰</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS1" datatype="html">
@@ -18048,7 +18225,7 @@
         <target>Le temps est écoulé.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS2" datatype="html">
@@ -18056,7 +18233,7 @@
         <target>Le temps est écoulé – attendez la prochaine question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">212</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS3" datatype="html">
@@ -18064,7 +18241,7 @@
         <target>Trop tard pour voter — une autre chance arrive.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">213</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakPlayful" datatype="html">
@@ -18072,7 +18249,7 @@
         <target>En feu ! 🔥 <x id="c" equiv-text="sc.streakCount"/> à la suite !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">302</context>
+          <context context-type="linenumber">303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakSerious" datatype="html">
@@ -18080,7 +18257,7 @@
         <target><x id="c" equiv-text="sc.streakCount"/> bonnes réponses consécutives.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">303</context>
+          <context context-type="linenumber">304</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Playful" datatype="html">
@@ -18088,7 +18265,7 @@
         <target>Une place gagnée ! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">308</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Serious" datatype="html">
@@ -18096,7 +18273,7 @@
         <target>Un rang plus haut.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">310</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNPlayful" datatype="html">
@@ -18104,7 +18281,7 @@
         <target>+<x id="n" equiv-text="sc.rankChange"/> places ! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">312</context>
+          <context context-type="linenumber">313</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNSerious" datatype="html">
@@ -18112,7 +18289,7 @@
         <target><x id="n" equiv-text="sc.rankChange"/> places gagnées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">313</context>
+          <context context-type="linenumber">314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakPlayful" datatype="html">
@@ -18120,7 +18297,7 @@
         <target>Série interrompue ! Prochain tour ! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">320</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakSerious" datatype="html">
@@ -18128,7 +18305,7 @@
         <target>Série terminée – la prochaine question compte.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">321</context>
+          <context context-type="linenumber">322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopPlayful" datatype="html">
@@ -18136,7 +18313,7 @@
         <target>Courage, vous restez bien placé·e ! 🏅</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopSerious" datatype="html">
@@ -18144,7 +18321,7 @@
         <target>Vous êtes plus haut dans le classement.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">327</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChasePlayful" datatype="html">
@@ -18152,7 +18329,7 @@
         <target>Continuez comme ça – chaque question est une nouvelle opportunité ! 🌟</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChaseSerious" datatype="html">
@@ -18160,7 +18337,7 @@
         <target>Continuez à vous entraîner – la question suivante apporte de nouveaux points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">331</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivEvaluated" datatype="html">
@@ -18168,7 +18345,7 @@
         <target>Réponse évaluée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">352</context>
+          <context context-type="linenumber">353</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivOutOfBand" datatype="html">
@@ -18176,7 +18353,7 @@
         <target>En dehors de la bande de tolérance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">356</context>
+          <context context-type="linenumber">357</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivExact" datatype="html">
@@ -18184,7 +18361,7 @@
         <target>Exactement sur la valeur de référence.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">361</context>
+          <context context-type="linenumber">362</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivInBand" datatype="html">
@@ -18192,11 +18369,11 @@
         <target>Dans la zone acceptée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">367</context>
+          <context context-type="linenumber">368</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">376</context>
+          <context context-type="linenumber">377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivVeryClose" datatype="html">
@@ -18204,7 +18381,7 @@
         <target>Très proche de la valeur de référence.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">373</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixPlayful" datatype="html">
@@ -18212,7 +18389,7 @@
         <target>Parfait !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixSerious" datatype="html">
@@ -18220,7 +18397,7 @@
         <target>Vous êtes maintenant dans</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixPlayful" datatype="html">
@@ -18228,7 +18405,7 @@
         <target>vous attend déjà.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">547</context>
+          <context context-type="linenumber">550</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixSerious" datatype="html">
@@ -18236,7 +18413,7 @@
         <target>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">548</context>
+          <context context-type="linenumber">551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3932968695937052509" datatype="html">
@@ -18244,7 +18421,7 @@
         <target>Vous posez votre question sous le nom <x id="PH" equiv-text="nick"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3719653345310622722" datatype="html">
@@ -18252,11 +18429,11 @@
         <target>Votre icône animale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">577</context>
+          <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.playerTeamBadgeAria" datatype="html">
@@ -18264,7 +18441,7 @@
         <target><x id="nickname" equiv-text="nick"/>, <x id="teamName" equiv-text="teamLabel"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">589</context>
+          <context context-type="linenumber">592</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5952222840612966712" datatype="html">
@@ -18272,7 +18449,7 @@
         <target>Votre question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.autoJoinFailed" datatype="html">
@@ -18280,7 +18457,7 @@
         <target>La participation n&apos;a pas pu être préparée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextTooLong" datatype="html">
@@ -18288,7 +18465,7 @@
         <target>Maximum de <x id="maxLength" equiv-text="maxLength"/> caractères autorisés.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1325</context>
+          <context context-type="linenumber">1335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericInvalid" datatype="html">
@@ -18296,11 +18473,11 @@
         <target>La réponse courte doit être saisie sous la forme d’un nombre dans un format pris en charge.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1333</context>
+          <context context-type="linenumber">1343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1471</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultInvalid" datatype="html">
@@ -18308,7 +18485,7 @@
         <target>Format numérique invalide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1437</context>
+          <context context-type="linenumber">1447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultFull" datatype="html">
@@ -18316,7 +18493,7 @@
         <target>Entièrement validé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1442</context>
+          <context context-type="linenumber">1452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultAccepted" datatype="html">
@@ -18324,7 +18501,7 @@
         <target>Accepté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1443</context>
+          <context context-type="linenumber">1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultPartial" datatype="html">
@@ -18332,7 +18509,7 @@
         <target>Partiellement validé (<x id="points" equiv-text="result.points"/> %)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1457</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultRejected" datatype="html">
@@ -18340,7 +18517,7 @@
         <target>Non accepté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1450</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericNoMatch" datatype="html">
@@ -18348,7 +18525,7 @@
         <target>Aucune réponse de référence n’entrait dans la tolérance numérique configurée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultMatchedSolution" datatype="html">
@@ -18356,11 +18533,11 @@
         <target>Rapprochée de la réponse modèle « <x id="matchedModelAnswer" equiv-text="result.matchedModelAnswer"/> ».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1469</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1485</context>
+          <context context-type="linenumber">1495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonNoMatch" datatype="html">
@@ -18368,11 +18545,11 @@
         <target>Aucune réponse modèle n&apos;entrait dans la tolérance configurée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1477</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1501</context>
+          <context context-type="linenumber">1511</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonHamming" datatype="html">
@@ -18380,7 +18557,7 @@
         <target>Une petite faute de frappe à longueur identique restait dans la tolérance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1495</context>
+          <context context-type="linenumber">1505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonDamerau" datatype="html">
@@ -18388,7 +18565,7 @@
         <target>Une inversion de lettres restait dans la tolérance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1497</context>
+          <context context-type="linenumber">1507</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonLevenshtein" datatype="html">
@@ -18396,7 +18573,7 @@
         <target>Un caractère manquant ou supplémentaire restait dans la tolérance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1499</context>
+          <context context-type="linenumber">1509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingRequired" datatype="html">
@@ -18404,7 +18581,7 @@
         <target>La valeur numérique était correcte, mais l’unité exigée manquait.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1509</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalentRejected" datatype="html">
@@ -18412,7 +18589,7 @@
         <target>La valeur numérique était correcte après conversion, mais seule l’unité configurée est acceptée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonWrongFamily" datatype="html">
@@ -18420,7 +18597,7 @@
         <target>La valeur numérique était correcte, mais l’unité appartient à une autre famille de grandeurs.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1513</context>
+          <context context-type="linenumber">1523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonUnsupportedUnit" datatype="html">
@@ -18428,7 +18605,7 @@
         <target>La valeur numérique était correcte, mais l’unité saisie n’appartient pas à l’ensemble d’unités pris en charge.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1515</context>
+          <context context-type="linenumber">1525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonPartial" datatype="html">
@@ -18436,7 +18613,7 @@
         <target>La valeur numérique était correcte, mais l’unité a empêché l’attribution de tous les points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1517</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalent" datatype="html">
@@ -18444,7 +18621,7 @@
         <target>La valeur numérique et l’unité équivalente ont été correctement converties.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingOptional" datatype="html">
@@ -18452,7 +18629,7 @@
         <target>La valeur numérique était correcte ; l’unité était facultative pour cette question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1525</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonTolerance" datatype="html">
@@ -18460,7 +18637,7 @@
         <target>La valeur numérique entrait dans la tolérance configurée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1528</context>
+          <context context-type="linenumber">1538</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonExact" datatype="html">
@@ -18468,7 +18645,7 @@
         <target>La valeur numérique et l’unité correspondent exactement à une réponse modèle.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1531</context>
+          <context context-type="linenumber">1541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeInteger" datatype="html">
@@ -18476,7 +18653,7 @@
         <target>Nombre entier</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1865</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeDecimal" datatype="html">
@@ -18484,7 +18661,7 @@
         <target>Nombre décimal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1856</context>
+          <context context-type="linenumber">1866</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatInteger" datatype="html">
@@ -18492,7 +18669,7 @@
         <target>Entrez un nombre entier sans décimales.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1861</context>
+          <context context-type="linenumber">1871</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimalPlaces" datatype="html">
@@ -18500,7 +18677,7 @@
         <target>Vous pouvez utiliser une virgule ou un point, maximum <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> décimales.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1865</context>
+          <context context-type="linenumber">1875</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimal" datatype="html">
@@ -18508,7 +18685,7 @@
         <target>Vous pouvez utiliser une virgule ou un point.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1867</context>
+          <context context-type="linenumber">1877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeBoth" datatype="html">
@@ -18520,7 +18697,7 @@
       )"/> à <x id="max" equiv-text="this.formatNumericResultValue(max)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1874,1876</context>
+          <context context-type="linenumber">1884,1886</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMin" datatype="html">
@@ -18532,7 +18709,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1879,1881</context>
+          <context context-type="linenumber">1889,1891</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMax" datatype="html">
@@ -18544,7 +18721,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1884,1886</context>
+          <context context-type="linenumber">1894,1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultInBand" datatype="html">
@@ -18552,7 +18729,7 @@
         <target>Dans la bande de tolérance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultOutOfBand" datatype="html">
@@ -18560,7 +18737,7 @@
         <target>En dehors de la bande de tolérance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2030</context>
+          <context context-type="linenumber">2040</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultReference" datatype="html">
@@ -18572,7 +18749,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2036,2038</context>
+          <context context-type="linenumber">2046,2048</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedSingle" datatype="html">
@@ -18584,7 +18761,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2049,2051</context>
+          <context context-type="linenumber">2059,2061</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedRange" datatype="html">
@@ -18596,7 +18773,7 @@
       )"/> à <x id="right" equiv-text="this.formatNumericResultValue(acceptedRight)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2053,2055</context>
+          <context context-type="linenumber">2063,2065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultToleranceBand" datatype="html">
@@ -18608,7 +18785,7 @@
     )"/> à <x id="right" equiv-text="this.formatNumericResultValue(band.right)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2057,2059</context>
+          <context context-type="linenumber">2067,2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultExact" datatype="html">
@@ -18616,7 +18793,7 @@
         <target>Exactement à la valeur de référence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2068</context>
+          <context context-type="linenumber">2078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultDistance" datatype="html">
@@ -18628,7 +18805,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2070,2072</context>
+          <context context-type="linenumber">2080,2082</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultImproved" datatype="html">
@@ -18640,7 +18817,7 @@
       )"/> plus proche de la valeur de référence qu&apos;au tour 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2109,2111</context>
+          <context context-type="linenumber">2119,2121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultWorse" datatype="html">
@@ -18652,7 +18829,7 @@
       )"/> plus éloigné de la valeur de référence qu&apos;au tour 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2114,2116</context>
+          <context context-type="linenumber">2124,2126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultUnchanged" datatype="html">
@@ -18660,7 +18837,7 @@
         <target>Aussi proche de la valeur de référence qu’au premier tour</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2118</context>
+          <context context-type="linenumber">2128</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericRequired" datatype="html">
@@ -18668,7 +18845,7 @@
         <target>Veuillez entrer un numéro.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2139</context>
+          <context context-type="linenumber">2149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericIntegerRequired" datatype="html">
@@ -18676,7 +18853,7 @@
         <target>Veuillez saisir un nombre entier dans le format pris en charge.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2143</context>
+          <context context-type="linenumber">2153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericDecimalPlacesExceeded" datatype="html">
@@ -18684,7 +18861,7 @@
         <target>Maximum de <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> décimales autorisées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2152</context>
+          <context context-type="linenumber">2162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInvalid" datatype="html">
@@ -18692,7 +18869,7 @@
         <target>Veuillez saisir un numéro valide dans le format pris en charge.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2154</context>
+          <context context-type="linenumber">2164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericBelowMin" datatype="html">
@@ -18700,7 +18877,7 @@
         <target>Veuillez saisir une valeur d&apos;au moins <x id="min" equiv-text="min"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2160</context>
+          <context context-type="linenumber">2170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericAboveMax" datatype="html">
@@ -18708,7 +18885,7 @@
         <target>Veuillez saisir une valeur d&apos;au plus <x id="max" equiv-text="max"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2163</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinalScore" datatype="html">
@@ -18716,7 +18893,7 @@
         <target>Score final</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2311</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleWinFin" datatype="html">
@@ -18724,7 +18901,7 @@
         <target>Votre équipe gagne !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2316</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinishedOther" datatype="html">
@@ -18732,7 +18909,7 @@
         <target>À l’arrivée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasingZero" datatype="html">
@@ -18740,7 +18917,7 @@
         <target>Appuyez sur l&apos;accélérateur — vous pouvez encore remonter !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2321</context>
+          <context context-type="linenumber">2331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleAllZero" datatype="html">
@@ -18748,7 +18925,7 @@
         <target>Montrez ce que vous avez dans le ventre !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2322</context>
+          <context context-type="linenumber">2332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleLeading" datatype="html">
@@ -18756,7 +18933,7 @@
         <target>Vous êtes en tête</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2325</context>
+          <context context-type="linenumber">2335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasing" datatype="html">
@@ -18764,7 +18941,7 @@
         <target>Continuer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2327</context>
+          <context context-type="linenumber">2337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgWinFin" datatype="html">
@@ -18772,7 +18949,7 @@
         <target>Victoire collective : la 1re place est à vous.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2345</context>
+          <context context-type="linenumber">2355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedAllZero" datatype="html">
@@ -18780,7 +18957,7 @@
         <target>Quiz terminé — aucune équipe n&apos;a marqué de points d&apos;équipe.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOwnZero" datatype="html">
@@ -18788,7 +18965,7 @@
         <target>Quiz terminé — votre équipe n&apos;a pas marqué de points d&apos;équipe.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2351</context>
+          <context context-type="linenumber">2361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOther" datatype="html">
@@ -18796,7 +18973,7 @@
         <target>Vous terminez avec <x id="totalScore" equiv-text="entry.totalScore"/> points, classés #<x id="teamRank" equiv-text="entry.rank"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2353</context>
+          <context context-type="linenumber">2363</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgAllZero" datatype="html">
@@ -18804,7 +18981,7 @@
         <target>Les bonnes réponses rapportent des points à votre équipe.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2357</context>
+          <context context-type="linenumber">2367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgChasing" datatype="html">
@@ -18812,11 +18989,11 @@
         <target>Actuellement classé <x id="teamRank" equiv-text="entry.rank"/> avec <x id="totalScore" equiv-text="entry.totalScore"/> points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2359</context>
+          <context context-type="linenumber">2369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgLeading" datatype="html">
@@ -18824,7 +19001,7 @@
         <target>Vous êtes en tête avec <x id="totalScore" equiv-text="entry.totalScore"/> points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2362</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulLoading" datatype="html">
@@ -18832,7 +19009,7 @@
         <target>Chargement du résultat…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2406</context>
+          <context context-type="linenumber">2416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulNeutral" datatype="html">
@@ -18840,7 +19017,7 @@
         <target>C&apos;est fini — merci d&apos;avoir participé !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2411</context>
+          <context context-type="linenumber">2421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingNoRank" datatype="html">
@@ -18848,7 +19025,7 @@
         <target><x id="teamName" equiv-text="entry.teamName"/> avec <x id="memberCountLabel" equiv-text="this.teamMemberLabel(entry.memberCount)"/> et <x id="totalScore" equiv-text="entry.totalScore"/> points d’équipe — pas encore de classement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2442</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingWithMembers" datatype="html">
@@ -18856,7 +19033,7 @@
         <target>Place <x id="teamRank"/> : <x id="teamName"/> avec <x id="memberCountLabel"/> et <x id="totalScore"/> points</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2602080285199874401" datatype="html">
@@ -18864,7 +19041,7 @@
         <target><x id="PH" equiv-text="stars"/> étoiles sur 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2477</context>
+          <context context-type="linenumber">2487</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaOne" datatype="html">
@@ -18872,7 +19049,7 @@
         <target>1 seconde restante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2483</context>
+          <context context-type="linenumber">2493</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaMany" datatype="html">
@@ -18880,7 +19057,7 @@
         <target><x id="seconds" equiv-text="seconds"/> secondes restantes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2484</context>
+          <context context-type="linenumber">2494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.groupAria" datatype="html">
@@ -18888,7 +19065,7 @@
         <target>Temps personnel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2488</context>
+          <context context-type="linenumber">2498</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.extended" datatype="html">
@@ -18896,15 +19073,15 @@
         <target>Temps ×10</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2494</context>
+          <context context-type="linenumber">2504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.off" datatype="html">
-        <source>Ohne Timer</source>
-        <target>Sans minuteur</target>
+        <source>Ohne Frist</source>
+        <target>Sans délai</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2496</context>
+          <context context-type="linenumber">2506</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.default" datatype="html">
@@ -18912,7 +19089,23 @@
         <target>Standard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2498</context>
+          <context context-type="linenumber">2508</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsDefault" datatype="html">
+        <source>Punkte folgen dem gemeinsamen Countdown</source>
+        <target>Les points suivent le compte à rebours commun</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2514</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsOvertime" datatype="html">
+        <source>Früh abgeben lohnt sich · nach dem Countdown nur Mindestpunkte</source>
+        <target>Répondre tôt rapporte · après le compte à rebours seulement le minimum</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.overtimeCorrect" datatype="html">
@@ -18920,7 +19113,7 @@
         <target>Temps supplémentaire · bonne réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2504</context>
+          <context context-type="linenumber">2521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.upToNow" datatype="html">
@@ -18928,7 +19121,7 @@
         <target>Note maximale maintenant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2507</context>
+          <context context-type="linenumber">2524</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.correctNow" datatype="html">
@@ -18936,7 +19129,7 @@
         <target>Bonne réponse maintenant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2508</context>
+          <context context-type="linenumber">2525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.error" datatype="html">
@@ -18944,7 +19137,7 @@
         <target>Le réglage du temps n&apos;a pas pu être enregistré.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2536</context>
+          <context context-type="linenumber">2561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeUpvoteAria" datatype="html">
@@ -18952,7 +19145,7 @@
         <target>Retirer le vote positif</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2547</context>
+          <context context-type="linenumber">2572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addUpvoteAria" datatype="html">
@@ -18960,7 +19153,7 @@
         <target>Voter positivement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2548</context>
+          <context context-type="linenumber">2573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeDownvoteAria" datatype="html">
@@ -18968,7 +19161,7 @@
         <target>Retirer le vote négatif</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2552</context>
+          <context context-type="linenumber">2577</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addDownvoteAria" datatype="html">
@@ -18976,7 +19169,7 @@
         <target>Voter négativement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2553</context>
+          <context context-type="linenumber">2578</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5043949766391435553" datatype="html">
@@ -18984,7 +19177,7 @@
         <target>Note de <x id="PH" equiv-text="this.ratingLabelMin()"/> à <x id="PH_1" equiv-text="this.ratingLabelMax()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2557</context>
+          <context context-type="linenumber">2582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2721187191897749624" datatype="html">
@@ -18992,7 +19185,7 @@
         <target>Note <x id="PH" equiv-text="value"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2561</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLabels" datatype="html">
@@ -19000,7 +19193,7 @@
         <target>Autoévaluation de 1 à 5, bas : <x id="low" equiv-text="low"/>, haut : <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLow" datatype="html">
@@ -19008,7 +19201,7 @@
         <target>Autoévaluation de 1 à 5, bas : <x id="low" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2591</context>
+          <context context-type="linenumber">2616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithHigh" datatype="html">
@@ -19016,7 +19209,7 @@
         <target>Autoévaluation de 1 à 5, haut : <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2594</context>
+          <context context-type="linenumber">2619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAria" datatype="html">
@@ -19024,7 +19217,7 @@
         <target>Autoévaluation de 1 à 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2596</context>
+          <context context-type="linenumber">2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceValueAria" datatype="html">
@@ -19032,7 +19225,7 @@
         <target>Autoévaluation <x id="value" equiv-text="value"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2600</context>
+          <context context-type="linenumber">2625</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithLowLabel" datatype="html">
@@ -19040,7 +19233,7 @@
         <target><x id="value" equiv-text="value"/> – <x id="label" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2611</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithHighLabel" datatype="html">
@@ -19048,7 +19241,7 @@
         <target><x id="value" equiv-text="value"/> – <x id="label" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2614</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="974858114847169012" datatype="html">
@@ -19056,7 +19249,7 @@
         <target>Réagir avec <x id="PH" equiv-text="emoji"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2634</context>
+          <context context-type="linenumber">2659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteLoadError" datatype="html">
@@ -19064,7 +19257,7 @@
         <target>Impossible de charger les questions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3519</context>
+          <context context-type="linenumber">3547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitSuccess" datatype="html">
@@ -19072,7 +19265,7 @@
         <target>Question envoyée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3562</context>
+          <context context-type="linenumber">3590</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitError" datatype="html">
@@ -19080,19 +19273,19 @@
         <target>Impossible d’envoyer la question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3568</context>
+          <context context-type="linenumber">3596</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3588</context>
+          <context context-type="linenumber">3616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3617</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3625</context>
+          <context context-type="linenumber">3653</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.upvoteError" datatype="html">
@@ -19100,7 +19293,7 @@
         <target>Impossible d’enregistrer le vote.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3666</context>
+          <context context-type="linenumber">3694</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnError" datatype="html">
@@ -19108,7 +19301,7 @@
         <target>Impossible de supprimer la question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3694</context>
+          <context context-type="linenumber">3722</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwnMany" datatype="html">
@@ -19116,7 +19309,7 @@
         <target>La modération a retiré vos questions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3750</context>
+          <context context-type="linenumber">3778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwn" datatype="html">
@@ -19124,7 +19317,7 @@
         <target>La modération a retiré votre question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOthersMany" datatype="html">
@@ -19132,7 +19325,7 @@
         <target>Plusieurs questions ont été retirées par la modération.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3755</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOther" datatype="html">
@@ -19140,7 +19333,7 @@
         <target>Une question a été retirée par la modération.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.readingReadyError" datatype="html">
@@ -19148,7 +19341,7 @@
         <target>Impossible de confirmer que vous êtes prêt·e.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4017</context>
+          <context context-type="linenumber">4045</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceRequired" datatype="html">
@@ -19156,7 +19349,7 @@
         <target>Indique ton autoévaluation avant d’envoyer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4188</context>
+          <context context-type="linenumber">4216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9175670018185396326" datatype="html">

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -4232,7 +4232,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4646</context>
+          <context context-type="linenumber">4662</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -4240,11 +4240,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2074,2076</context>
+          <context context-type="linenumber">2136,2138</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2199</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackHostTitle" datatype="html">
@@ -4284,7 +4284,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3609</context>
+          <context context-type="linenumber">3635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -4726,7 +4726,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1880</context>
+          <context context-type="linenumber">1888</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -4738,7 +4738,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1885</context>
+          <context context-type="linenumber">1893</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -4762,7 +4762,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -4774,7 +4774,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -4930,7 +4930,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackVoteTitle" datatype="html">
@@ -5090,7 +5090,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2082,2085</context>
+          <context context-type="linenumber">2144,2147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.voteMissing" datatype="html">
@@ -6922,11 +6922,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4958</context>
+          <context context-type="linenumber">4974</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2268</context>
+          <context context-type="linenumber">2278</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3532753318619772032" datatype="html">
@@ -6938,11 +6938,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4960</context>
+          <context context-type="linenumber">4976</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2270</context>
+          <context context-type="linenumber">2280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="74432774947660496" datatype="html">
@@ -6954,11 +6954,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="276214048875673948" datatype="html">
@@ -6970,11 +6970,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5356551916626450286" datatype="html">
@@ -6986,11 +6986,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3903113005127984737" datatype="html">
@@ -7002,11 +7002,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeRemoveSession" datatype="html">
@@ -7258,7 +7258,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7266,7 +7266,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6658206425619028413" datatype="html">
@@ -7278,7 +7278,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7286,7 +7286,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5683915683305860193" datatype="html">
@@ -7374,15 +7374,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2911</context>
+          <context context-type="linenumber">2919</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2449</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2458</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/preset-toast/preset-toast.component.ts</context>
@@ -9746,11 +9746,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4629</context>
+          <context context-type="linenumber">4645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.medium" datatype="html">
@@ -9766,11 +9766,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4631</context>
+          <context context-type="linenumber">4647</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1787</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.hard" datatype="html">
@@ -9786,11 +9786,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4633</context>
+          <context context-type="linenumber">4649</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1779</context>
+          <context context-type="linenumber">1789</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeExactLabel" datatype="html">
@@ -10958,11 +10958,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1348</context>
+          <context context-type="linenumber">1410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1612</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesExportCsv" datatype="html">
@@ -12470,7 +12470,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3027</context>
+          <context context-type="linenumber">3031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -12482,7 +12482,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3030</context>
+          <context context-type="linenumber">3034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -12494,7 +12494,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3035</context>
+          <context context-type="linenumber">3039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -12506,7 +12506,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3225</context>
+          <context context-type="linenumber">3229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -12518,7 +12518,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3229</context>
+          <context context-type="linenumber">3233</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -12530,7 +12530,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3232</context>
+          <context context-type="linenumber">3236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -12542,7 +12542,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3235</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -12698,7 +12698,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2735</context>
+          <context context-type="linenumber">2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -12726,7 +12726,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2998</context>
+          <context context-type="linenumber">3002</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -12930,7 +12930,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2968</context>
+          <context context-type="linenumber">2972</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -13134,8 +13134,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
-        <source> Teilnehmende können ihre persönliche Zeit bei Bedarf verlängern oder abschalten.</source>
-        <target>I partecipanti possono prolungare o interrompere il loro tempo personale, se necessario.</target>
+        <source> Teilnehmende können ihre persönliche Frist bei Bedarf verlängern oder abschalten.</source>
+        <target>I partecipanti possono prolungare o disattivare la loro scadenza personale, se necessario.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">1441,1444</context>
@@ -13146,19 +13146,19 @@
         <target>Metadati delle domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1456</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">832</context>
+          <context context-type="linenumber">947</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">894</context>
+          <context context-type="linenumber">1013</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">961</context>
+          <context context-type="linenumber">1081</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4209613400308596118" datatype="html">
@@ -13166,7 +13166,7 @@
         <target>Fase di lettura</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1481</context>
+          <context context-type="linenumber">1485</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
@@ -13174,7 +13174,7 @@
         <target>Le risposte arrivano tra un attimo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1482,1484</context>
+          <context context-type="linenumber">1486,1488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
@@ -13182,7 +13182,7 @@
         <target>Scala di valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1540</context>
+          <context context-type="linenumber">1544</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
@@ -13190,7 +13190,7 @@
         <target>Distribuzione delle valutazioni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1568</context>
+          <context context-type="linenumber">1572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
@@ -13198,7 +13198,7 @@
         <target>In attesa delle stime…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1607,1609</context>
+          <context context-type="linenumber">1611,1613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
@@ -13206,7 +13206,7 @@
         <target><x id="INTERPOLATION"/> risposte ricevute</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615,1617</context>
+          <context context-type="linenumber">1619,1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
@@ -13214,11 +13214,11 @@
         <target>Riepilogo delle statistiche</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1627</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2060</context>
+          <context context-type="linenumber">2064</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
@@ -13226,7 +13226,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1632</context>
+          <context context-type="linenumber">1636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
@@ -13234,11 +13234,11 @@
         <target>Accettata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1654</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2080</context>
+          <context context-type="linenumber">2084</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
@@ -13246,7 +13246,7 @@
         <target>Confronto circolare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
@@ -13254,7 +13254,7 @@
         <target>spostare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1685</context>
+          <context context-type="linenumber">1689</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
@@ -13262,7 +13262,7 @@
         <target>Round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1706</context>
+          <context context-type="linenumber">1710</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
@@ -13270,7 +13270,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1711</context>
+          <context context-type="linenumber">1715</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
@@ -13278,11 +13278,11 @@
         <target>Mostra dettagli statistici</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1898</context>
+          <context context-type="linenumber">1902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2197</context>
+          <context context-type="linenumber">2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
@@ -13290,7 +13290,7 @@
         <target>Round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1912,1914</context>
+          <context context-type="linenumber">1916,1918</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
@@ -13298,7 +13298,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1940,1942</context>
+          <context context-type="linenumber">1944,1946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
@@ -13306,7 +13306,7 @@
         <target>Δ a coppie: <x id="INTERPOLATION"/> più vicino, <x id="INTERPOLATION_1"/> più lontano, <x id="INTERPOLATION_2"/> invariato (<x id="INTERPOLATION_3"/> coppie)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1971,1979</context>
+          <context context-type="linenumber">1975,1983</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
@@ -13314,7 +13314,7 @@
         <target>Distribuzione Δx</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1989</context>
+          <context context-type="linenumber">1993</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
@@ -13322,7 +13322,7 @@
         <target>più piccolo è più vicino</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2103</context>
+          <context context-type="linenumber">2107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
@@ -13330,7 +13330,7 @@
         <target>Giro di risultati</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2210,2212</context>
+          <context context-type="linenumber">2214,2216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
@@ -13338,7 +13338,7 @@
         <target>Nessuna stima ricevuta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2237,2239</context>
+          <context context-type="linenumber">2241,2243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
@@ -13346,7 +13346,7 @@
         <target>Confronto prima e dopo per la Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
@@ -13354,7 +13354,7 @@
         <target>Round 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> voto)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
@@ -13362,7 +13362,7 @@
         <target>Round 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> voti)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2263</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
@@ -13370,7 +13370,7 @@
         <target>Round 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> voto)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2271</context>
+          <context context-type="linenumber">2275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
@@ -13378,7 +13378,7 @@
         <target>Round 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> voti)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
@@ -13386,7 +13386,7 @@
         <target>Corrette: <x id="INTERPOLATION" equiv-text="{{ q.roundComparison.round1CorrectCount }}"/> nel round 1, poi <x id="INTERPOLATION_1" equiv-text="{{ q.roundComparison.round2CorrectCount }}"/> nel round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2289,2293</context>
+          <context context-type="linenumber">2293,2297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
@@ -13394,7 +13394,7 @@
         <target>Peer Instruction consigliata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2536,2538</context>
+          <context context-type="linenumber">2540,2542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
@@ -13402,7 +13402,7 @@
         <target>35–70 % completamente corretti: secondo turno adatto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2543,2545</context>
+          <context context-type="linenumber">2547,2549</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
@@ -13410,7 +13410,7 @@
         <target>Primo turno ancora nascosto finché non procedi.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2550,2552</context>
+          <context context-type="linenumber">2554,2556</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
@@ -13418,7 +13418,7 @@
         <target>Avvia discussione o mostra risultato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2557,2559</context>
+          <context context-type="linenumber">2561,2563</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
@@ -13426,7 +13426,7 @@
         <target>Autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2615,2617</context>
+          <context context-type="linenumber">2619,2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
@@ -13434,7 +13434,7 @@
         <target> Giusto o sbagliato — e quanto sei sicuro? Soprattutto: sbagliato nonostante alta sicurezza di risposta. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2621,2624</context>
+          <context context-type="linenumber">2625,2628</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
@@ -13442,7 +13442,7 @@
         <target>Correttezza e autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2645</context>
+          <context context-type="linenumber">2649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
@@ -13450,7 +13450,7 @@
         <target> Spesso sbagliato con alta sicurezza di risposta </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2699,2701</context>
+          <context context-type="linenumber">2703,2705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
@@ -13458,7 +13458,7 @@
         <target>Aggiornamento della domanda …</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2744,2746</context>
+          <context context-type="linenumber">2748,2750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
@@ -13466,7 +13466,7 @@
         <target>Nessuna domanda attiva. Inizia con “Domanda successiva”.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2748,2750</context>
+          <context context-type="linenumber">2752,2754</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -13474,7 +13474,7 @@
         <target>Reazioni delle persone partecipanti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2768</context>
+          <context context-type="linenumber">2772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
@@ -13482,7 +13482,7 @@
         <target>2ª tornata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2774</context>
+          <context context-type="linenumber">2778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
@@ -13490,7 +13490,7 @@
         <target>nuovo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2782</context>
+          <context context-type="linenumber">2786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
@@ -13498,7 +13498,7 @@
         <target>Nessuna reazione ancora.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2805</context>
+          <context context-type="linenumber">2809</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
@@ -13506,7 +13506,7 @@
         <target>Primi 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2818</context>
+          <context context-type="linenumber">2822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
@@ -13514,7 +13514,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ entry.totalScore | number }}"/> punti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2885</context>
+          <context context-type="linenumber">2889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
@@ -13522,7 +13522,7 @@
         <target>Parità: conta il tempo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
@@ -13530,7 +13530,7 @@
         <target>Punteggio delle squadre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2912</context>
+          <context context-type="linenumber">2916</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
@@ -13538,7 +13538,7 @@
         <target>punti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2959</context>
+          <context context-type="linenumber">2963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
@@ -13546,7 +13546,7 @@
         <target>Cambia quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2988</context>
+          <context context-type="linenumber">2992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
@@ -13554,7 +13554,7 @@
         <target>Modifica titolo Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3091</context>
+          <context context-type="linenumber">3095</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
@@ -13562,7 +13562,7 @@
         <target>Titolo Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3104</context>
+          <context context-type="linenumber">3108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
@@ -13570,7 +13570,7 @@
         <target>Domande sull'evento...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3115</context>
+          <context context-type="linenumber">3119</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
@@ -13582,15 +13582,24 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1038</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
+        <source>Quiz-Session</source>
+        <target>Sessione quiz</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">889</context>
+        </context-group>
+      </trans-unit>
+
       <trans-unit id="sessionHost.qaTitleConfirmAria" datatype="html">
         <source>Titel speichern</source>
         <target>Salva titolo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3127</context>
+          <context context-type="linenumber">3131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
@@ -13598,7 +13607,7 @@
         <target>Annulla modifica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3138</context>
+          <context context-type="linenumber">3142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
@@ -13606,7 +13615,7 @@
         <target>Pre-moderazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3157,3159</context>
+          <context context-type="linenumber">3161,3163</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
@@ -13614,7 +13623,7 @@
         <target>La pre-moderazione è attiva. Le nuove domande aspettano prima la tua approvazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3161,3163</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
@@ -13622,7 +13631,7 @@
         <target>Ancora nessuna domanda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3170,3172</context>
+          <context context-type="linenumber">3174,3176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
@@ -13630,7 +13639,7 @@
         <target>Totale: <x id="INTERPOLATION" equiv-text="qaQuestions().length"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3182,3183</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
@@ -13638,7 +13647,7 @@
         <target>In attesa di approvazione: <x id="INTERPOLATION" equiv-text="qaPendingCount()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3191,3192</context>
+          <context context-type="linenumber">3195,3196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
@@ -13646,7 +13655,7 @@
         <target>Mostra tutte le domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3244</context>
+          <context context-type="linenumber">3248</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
@@ -13654,7 +13663,7 @@
         <target>Mostra tutte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3247</context>
+          <context context-type="linenumber">3251</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
@@ -13662,7 +13671,7 @@
         <target>Mostra solo le domande fissate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3255</context>
+          <context context-type="linenumber">3259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
@@ -13670,7 +13679,7 @@
         <target>Solo fissate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3258</context>
+          <context context-type="linenumber">3262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
@@ -13678,7 +13687,7 @@
         <target>Mostra nuove domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3270</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
@@ -13686,7 +13695,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ qaUnseenCount() }}"/> nuove domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3276</context>
+          <context context-type="linenumber">3280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
@@ -13694,7 +13703,7 @@
         <target>Esporta le domande come CSV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3308</context>
+          <context context-type="linenumber">3312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
@@ -13702,7 +13711,7 @@
         <target>Esporta domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3311</context>
+          <context context-type="linenumber">3315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
@@ -13710,7 +13719,7 @@
         <target>Esportazione in corso…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3319,3321</context>
+          <context context-type="linenumber">3323,3325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
@@ -13718,7 +13727,7 @@
         <target>Controversa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3388</context>
+          <context context-type="linenumber">3392</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
@@ -13726,7 +13735,7 @@
         <target><x id="INTERPOLATION" equiv-text="question.positiveVoteCount"/> positivi · <x id="INTERPOLATION_1" equiv-text="question.negativeVoteCount"/> negativi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3416,3417</context>
+          <context context-type="linenumber">3420,3421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
@@ -13734,7 +13743,7 @@
         <target>Approvazione affidabile <x id="INTERPOLATION" equiv-text="formatQaPercent(question.bestScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3424,3425</context>
+          <context context-type="linenumber">3428,3429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
@@ -13742,7 +13751,7 @@
         <target>Reazioni divise <x id="INTERPOLATION" equiv-text="formatQaPercent(question.controversyScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3434,3436</context>
+          <context context-type="linenumber">3438,3440</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
@@ -13750,7 +13759,7 @@
         <target>Vista fissate attiva – non ci sono ancora domande fissate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3477,3479</context>
+          <context context-type="linenumber">3481,3483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
@@ -13758,7 +13767,7 @@
         <target>Mostra opzioni di risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3530</context>
+          <context context-type="linenumber">3534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
@@ -13766,7 +13775,7 @@
         <target>Avvia la fase di discussione – confronto prima della seconda votazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3554</context>
+          <context context-type="linenumber">3570</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
@@ -13774,7 +13783,7 @@
         <target>Fase di discussione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3557</context>
+          <context context-type="linenumber">3573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
@@ -13782,15 +13791,87 @@
         <target>Mostra comunque il risultato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3591</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <target>Pubblica comunque</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">3588</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
-        <source> Ergebnis zeigen</source>
+        <source>Ergebnis zeigen</source>
         <target>Mostra risultato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3579,3581</context>
+          <context context-type="linenumber">3612</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
+        <source>Persönliche Fristen beenden?</source>
+        <target>Terminare le scadenze personali?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5926</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
+        <source>Du zeigst das Ergebnis, obwohl noch persönliche Timer laufen.</source>
+        <target>Mostri il risultato mentre i timer personali sono ancora in corso.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5930</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
+        <source>Du startest die Diskussionsphase, obwohl noch persönliche Timer laufen.</source>
+        <target>Avvii la fase di discussione mentre i timer personali sono ancora in corso.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5929</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
+        <source>Die offene persönliche 10×-Frist dieser Person endet sofort.</source>
+        <target>La scadenza personale ×10 aperta di questa persona termina subito.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> offene persönliche 10×-Fristen enden sofort.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> scadenze personali ×10 aperte terminano subito.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5921</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
+        <source>Danach ist keine weitere Antwort mehr möglich.</source>
+        <target>Dopo non sarà più possibile rispondere.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5918</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <target>Pubblica comunque</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5932</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
+        <source>Weiter warten</source>
+        <target>Continua ad aspettare</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5933</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
@@ -13798,7 +13879,7 @@
         <target>Prossima domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3595,3597</context>
+          <context context-type="linenumber">3621,3623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
@@ -13806,7 +13887,7 @@
         <target>Alla prossima domanda senza seconda votazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3618</context>
+          <context context-type="linenumber">3644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
@@ -13814,7 +13895,7 @@
         <target>Alla prossima domanda senza seconda votazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
@@ -13822,7 +13903,7 @@
         <target>Mostra di nuovo la domanda precedente con il risultato e la risposta corretta (senza una nuova votazione).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3638</context>
+          <context context-type="linenumber">3664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
@@ -13830,7 +13911,7 @@
         <target>Mostra di nuovo il risultato precedente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3640,3642</context>
+          <context context-type="linenumber">3666,3668</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
@@ -13838,7 +13919,7 @@
         <target>Termina sessione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650,3652</context>
+          <context context-type="linenumber">3676,3678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -13846,7 +13927,7 @@
         <target>Vista host per lobby e controllo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3658</context>
+          <context context-type="linenumber">3684</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
@@ -14174,7 +14255,7 @@
         <target>1 risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1526</context>
+          <context context-type="linenumber">1534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
@@ -14182,7 +14263,7 @@
         <target><x id="count" equiv-text="count"/> risposte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1527</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
@@ -14190,7 +14271,7 @@
         <target>Basso · <x id="label" equiv-text="q.confidenceLabelLow"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1618</context>
+          <context context-type="linenumber">1626</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
@@ -14198,7 +14279,7 @@
         <target>Basso (1–2)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1619</context>
+          <context context-type="linenumber">1627</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
@@ -14206,7 +14287,7 @@
         <target>Medio (3)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1623</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
@@ -14214,7 +14295,7 @@
         <target>Alto · <x id="label" equiv-text="q.confidenceLabelHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1663</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
@@ -14222,7 +14303,7 @@
         <target>Alto (4–5)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1656</context>
+          <context context-type="linenumber">1664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
@@ -14230,7 +14311,7 @@
         <target>Corretto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
@@ -14238,7 +14319,7 @@
         <target>Sbagliato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1677</context>
+          <context context-type="linenumber">1685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
@@ -14246,7 +14327,7 @@
         <target><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1769</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
@@ -14254,7 +14335,7 @@
         <target>1 risposta sbagliata sicura – possibile malinteso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1774</context>
+          <context context-type="linenumber">1782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
@@ -14262,7 +14343,7 @@
         <target><x id="count" equiv-text="count"/> risposte sbagliate sicure – possibili malintesi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
@@ -14270,7 +14351,7 @@
         <target>Corretto+alto <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · Sbagliato+alto <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1786</context>
+          <context context-type="linenumber">1794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
@@ -14278,7 +14359,7 @@
         <target>2 (Istruzione tra pari)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
@@ -14286,7 +14367,7 @@
         <target>Round 1: <x id="r1" equiv-text="round1Count"/> voti · Complessivo: round 2 con <x id="r2" equiv-text="round2Count"/> voti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1824</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
@@ -14294,7 +14375,7 @@
         <target>Turno di aggregazione 2 (Istruzione tra pari)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1826</context>
+          <context context-type="linenumber">1834</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
@@ -14302,7 +14383,7 @@
         <target>Turno di aggregazione 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1837</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
@@ -14310,7 +14391,7 @@
         <target>Questa volta non è passata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2427</context>
+          <context context-type="linenumber">2435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
@@ -14318,7 +14399,7 @@
         <target>Tranquillo, succede (un attimo di linea o Wi‑Fi ballerino). Aspetta qualche secondo e tocca « Riprova » — di solito basta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2428</context>
+          <context context-type="linenumber">2436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
@@ -14326,7 +14407,7 @@
         <target>Con le domande si incolla un attimo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2435</context>
+          <context context-type="linenumber">2443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
@@ -14334,7 +14415,7 @@
         <target>Non è rotto, è solo che non ha funzionato quel colpo. Aspetta 2–3 secondi e tocca « Riprova » — spesso si sistema subito.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2436</context>
+          <context context-type="linenumber">2444</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
@@ -14342,7 +14423,7 @@
         <target>Export non ancora pronto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2443</context>
+          <context context-type="linenumber">2451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
@@ -14350,7 +14431,7 @@
         <target>L’export PDF o Excel non è arrivato questa volta. Aspetta qualche secondo e tocca « Riprova » — al secondo tentativo di solito va.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
@@ -14358,7 +14439,7 @@
         <target>I partecipanti e la visualizzazione della presentazione vengono reindirizzati alla home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2578</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
@@ -14366,7 +14447,7 @@
         <target>La sessione termina per tutti; non è possibile proseguire con lo stesso codice.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2579</context>
+          <context context-type="linenumber">2587</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
@@ -14374,7 +14455,7 @@
         <target><x id="participantCount" equiv-text="participants"/> I partecipanti sono ancora nella sessione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2583</context>
+          <context context-type="linenumber">2591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
@@ -14382,7 +14463,7 @@
         <target>Hai già dei risultati. Dopo la chiusura puoi esportarli o vedere il feedback nella vista finale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2596</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
@@ -14390,7 +14471,7 @@
         <target>Non ci sono ancora risultati utilizzabili. Dopo la chiusura verrai portato direttamente alla home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2592</context>
+          <context context-type="linenumber">2600</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
@@ -14398,7 +14479,7 @@
         <target>Per i codici bonus: consigliare ai partecipanti di copiare ora il proprio codice personale (appunti) prima di lasciare la pagina, altrimenti potrebbero perderlo facilmente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2597</context>
+          <context context-type="linenumber">2605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
@@ -14406,7 +14487,7 @@
         <target>Lasciare la sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
@@ -14414,7 +14495,7 @@
         <target>La tua sessione è ancora attiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
@@ -14422,7 +14503,7 @@
         <target>Esci comunque</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2606</context>
+          <context context-type="linenumber">2614</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
@@ -14430,7 +14511,7 @@
         <target>Torna alla sessione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2607</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
@@ -14438,7 +14519,7 @@
         <target>Interrompi l&apos;anteprima</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2795</context>
+          <context context-type="linenumber">2803</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
@@ -14446,7 +14527,7 @@
         <target>Ascolta brevemente il brano (max. 12 secondi)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2796</context>
+          <context context-type="linenumber">2804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
@@ -14454,7 +14535,7 @@
         <target>Audio on</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2808</context>
+          <context context-type="linenumber">2816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
@@ -14462,7 +14543,7 @@
         <target>Audio off</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2809</context>
+          <context context-type="linenumber">2817</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
@@ -14470,7 +14551,7 @@
         <target>Partecipante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2866</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
@@ -14478,7 +14559,7 @@
         <target>partecipanti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2870</context>
+          <context context-type="linenumber">2878</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
@@ -14486,7 +14567,7 @@
         <target>1 connesso in diretta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2887</context>
+          <context context-type="linenumber">2895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
@@ -14494,7 +14575,7 @@
         <target><x id="connectedCount" equiv-text="connectedCount"/> connesso dal vivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2889</context>
+          <context context-type="linenumber">2897</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
@@ -14502,7 +14583,7 @@
         <target>Non c’è ancora nessuno in questa squadra.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2923</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
@@ -14510,7 +14591,7 @@
         <target>Valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3729</context>
+          <context context-type="linenumber">3739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
@@ -14518,7 +14599,7 @@
         <target>Recensioni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3733</context>
+          <context context-type="linenumber">3743</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
@@ -14526,11 +14607,11 @@
         <target>I risultati sono arrivati.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3738</context>
+          <context context-type="linenumber">3748</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3745</context>
+          <context context-type="linenumber">3755</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
@@ -14538,11 +14619,11 @@
         <target>Il tempo è scaduto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3739</context>
+          <context context-type="linenumber">3749</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3746</context>
+          <context context-type="linenumber">3756</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
@@ -14550,7 +14631,7 @@
         <target>In attesa di recensioni…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3740</context>
+          <context context-type="linenumber">3750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
@@ -14558,7 +14639,7 @@
         <target>In attesa di risposte...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3747</context>
+          <context context-type="linenumber">3757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
@@ -14566,23 +14647,55 @@
         <target><x id="PH" equiv-text="votes"/> di <x id="PH_1" equiv-text="participants"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3761</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <target>Una persona sta ancora usando il tempo ×10. Attendi il conto alla rovescia della stanza o la fine del tempo ×10.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3769</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihr persönliches Fenster.</source>
+        <target>Una persona sta ancora usando il tempo ×10. «Pubblica comunque» chiude la sua finestra personale.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3768</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <target>Le persone <x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> stanno ancora usando il tempo ×10. Attendi il conto alla rovescia della stanza o la fine del tempo ×10.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3774</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihre persönlichen Fenster.</source>
+        <target>Le persone <x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> stanno ancora usando il tempo ×10. «Pubblica comunque» chiude le loro finestre personali.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
-        <source>Eine Person mit Zeitanpassung antwortet noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
-        <target>Una persona con tempo aggiuntivo sta ancora rispondendo. «Mostra risultato» chiude il tempo a disposizione per rispondere.</target>
+        <source>Eine Person antwortet ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <target>Una persona risponde senza scadenza personale. «Mostra risultato» chiude la sua risposta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
-        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen mit Zeitanpassung antworten noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
-        <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> persone con tempo aggiuntivo stanno ancora rispondendo. «Mostra risultato» chiude il tempo a disposizione per rispondere.</target>
+        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen antworten ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> persone rispondono senza scadenza personale. «Mostra risultato» chiude la loro risposta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3758</context>
+          <context context-type="linenumber">3774</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
@@ -14590,7 +14703,7 @@
         <target>Hanno votato <x id="votes" equiv-text="votes"/> partecipanti su <x id="participants" equiv-text="participants"/>. Raggiunto il <x id="percentage" equiv-text="percentage"/> percento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3764</context>
+          <context context-type="linenumber">3780</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
@@ -14598,7 +14711,7 @@
         <target><x id="votes" equiv-text="votes"/> partecipanti su <x id="participants" equiv-text="participants"/> hanno votato. Raggiunto il <x id="percentage" equiv-text="percentage"/> percento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3766</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
@@ -14606,7 +14719,7 @@
         <target><x id="voteCount"/> su <x id="participantTotal"/> ha votato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
@@ -14614,7 +14727,7 @@
         <target><x id="voteCount"/> su <x id="participantTotal"/> hanno votato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3779</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
@@ -14622,7 +14735,7 @@
         <target><x id="voteCount"/> su <x id="participantTotal"/> ha valutato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3790</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
@@ -14630,7 +14743,7 @@
         <target><x id="voteCount"/> su <x id="participantTotal"/> hanno valutato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3792</context>
+          <context context-type="linenumber">3808</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
@@ -14638,7 +14751,7 @@
         <target><x id="correctCount"/> su <x id="voteTotal"/> completamente corretti (<x id="percentage"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3798</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
@@ -14646,7 +14759,7 @@
         <target><x id="changed"/> su <x id="both"/> (<x id="pct"/>%) hanno cambiato idea</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3802</context>
+          <context context-type="linenumber">3818</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
@@ -14654,7 +14767,7 @@
         <target>↑ <x id="count"/> sbagliato → corretto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3806</context>
+          <context context-type="linenumber">3822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
@@ -14662,7 +14775,7 @@
         <target>↓ <x id="count"/> corretto → sbagliato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3810</context>
+          <context context-type="linenumber">3826</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
@@ -14670,7 +14783,7 @@
         <target>Media <x id="avg"/> su 5 stelle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3816</context>
+          <context context-type="linenumber">3832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
@@ -14678,7 +14791,7 @@
         <target><x id="PH" equiv-text="total"/> reazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
@@ -14686,7 +14799,7 @@
         <target><x id="PH" equiv-text="total"/> reazioni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
@@ -14694,7 +14807,7 @@
         <target>Lobby: le persone partecipanti possono entrare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3873</context>
+          <context context-type="linenumber">3889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
@@ -14702,7 +14815,7 @@
         <target>Il giro di domande si sta preparando</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3874</context>
+          <context context-type="linenumber">3890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
@@ -14710,15 +14823,15 @@
         <target>Il giro di domande è in corso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3875</context>
+          <context context-type="linenumber">3891</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3877</context>
+          <context context-type="linenumber">3893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3878</context>
+          <context context-type="linenumber">3894</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
@@ -14726,7 +14839,7 @@
         <target>In pausa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3876</context>
+          <context context-type="linenumber">3892</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
@@ -14734,7 +14847,7 @@
         <target>Giro di domande terminato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3879</context>
+          <context context-type="linenumber">3895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
@@ -14742,7 +14855,7 @@
         <target>Votazione terminata – in attesa di valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3884</context>
+          <context context-type="linenumber">3900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
@@ -14750,7 +14863,7 @@
         <target>Lobby: i partecipanti possono unirsi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3887</context>
+          <context context-type="linenumber">3903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
@@ -14758,7 +14871,7 @@
         <target>Fase di lettura – risposte ancora bloccate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3888</context>
+          <context context-type="linenumber">3904</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
@@ -14766,7 +14879,7 @@
         <target>La votazione è in corso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3889</context>
+          <context context-type="linenumber">3905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
@@ -14774,7 +14887,7 @@
         <target>In pausa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3890</context>
+          <context context-type="linenumber">3906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
@@ -14782,7 +14895,7 @@
         <target>Vengono visualizzati i risultati</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3891</context>
+          <context context-type="linenumber">3907</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
@@ -14790,7 +14903,7 @@
         <target>Fase di discussione — confronto prima del secondo turno</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3892</context>
+          <context context-type="linenumber">3908</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
@@ -14798,7 +14911,7 @@
         <target>La sessione è terminata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3893</context>
+          <context context-type="linenumber">3909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
@@ -14806,7 +14919,7 @@
         <target><x id="readyCount" equiv-text="readyCount"/> su <x id="connectedCount" equiv-text="connectedCount"/> pronti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3904</context>
+          <context context-type="linenumber">3920</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
@@ -14814,7 +14927,7 @@
         <target><x id="PH" equiv-text="readyCount"/> di <x id="PH_1" equiv-text="connectedCount"/> connesso pronto · <x id="PH_2" equiv-text="totalParticipantCount"/> totale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3906</context>
+          <context context-type="linenumber">3922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
@@ -14822,7 +14935,7 @@
         <target>Tutte le persone partecipanti sono pronte: le opzioni di risposta possono essere mostrate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3911</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
@@ -14830,7 +14943,7 @@
         <target>Tutte le persone partecipanti collegate sono pronte: le opzioni di risposta possono essere mostrate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3913</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
@@ -14838,7 +14951,7 @@
         <target>1 secondo rimanente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3944</context>
+          <context context-type="linenumber">3960</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
@@ -14846,7 +14959,7 @@
         <target><x id="seconds" equiv-text="seconds"/> secondi rimanenti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3945</context>
+          <context context-type="linenumber">3961</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -14860,7 +14973,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4069,4072</context>
+          <context context-type="linenumber">4085,4088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -14874,7 +14987,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4114,4117</context>
+          <context context-type="linenumber">4130,4133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -14888,7 +15001,7 @@
       )"/> a <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4119,4122</context>
+          <context context-type="linenumber">4135,4138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -14903,7 +15016,7 @@
     )"/> a <x id="right" equiv-text="formatNumber(band.right, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4124,4127</context>
+          <context context-type="linenumber">4140,4143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
@@ -14911,7 +15024,7 @@
         <target>Mediana <x id="median" equiv-text="formatNumber(stats.median, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4242</context>
+          <context context-type="linenumber">4258</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
@@ -14919,7 +15032,7 @@
         <target>Stime</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4275</context>
+          <context context-type="linenumber">4291</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
@@ -14927,7 +15040,7 @@
         <target>risposte valide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4277</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
@@ -14935,7 +15048,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4283</context>
+          <context context-type="linenumber">4299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
@@ -14943,7 +15056,7 @@
         <target>Media di tutte le stime</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4285</context>
+          <context context-type="linenumber">4301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
@@ -14951,7 +15064,7 @@
         <target>Mediana</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4291</context>
+          <context context-type="linenumber">4307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
@@ -14959,7 +15072,7 @@
         <target>Valore centrale ordinato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4293</context>
+          <context context-type="linenumber">4309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
@@ -14967,7 +15080,7 @@
         <target>Dispersione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4299</context>
+          <context context-type="linenumber">4315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
@@ -14975,7 +15088,7 @@
         <target>Deviazione standard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4301</context>
+          <context context-type="linenumber">4317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
@@ -14983,7 +15096,7 @@
         <target>50% centrali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4307</context>
+          <context context-type="linenumber">4323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -14998,7 +15111,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4312,4315</context>
+          <context context-type="linenumber">4328,4331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
@@ -15006,7 +15119,7 @@
         <target>Intervallo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
@@ -15014,7 +15127,7 @@
         <target>stima minima e massima</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4326</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
@@ -15022,7 +15135,7 @@
         <target>Nell'intervallo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4332</context>
+          <context context-type="linenumber">4348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -15038,7 +15151,7 @@
         )"/>% accettato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4338,4342</context>
+          <context context-type="linenumber">4354,4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
@@ -15046,7 +15159,7 @@
         <target>Distanza media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4348</context>
+          <context context-type="linenumber">4364</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
@@ -15054,7 +15167,7 @@
         <target>dal riferimento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4350</context>
+          <context context-type="linenumber">4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
@@ -15062,7 +15175,7 @@
         <target>Mediano</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4358</context>
+          <context context-type="linenumber">4374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
@@ -15070,7 +15183,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4361</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
@@ -15078,7 +15191,7 @@
         <target>Stime</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4363</context>
+          <context context-type="linenumber">4379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -15094,7 +15207,7 @@
     )"/> % nell&apos;intervallo accettato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394,4398</context>
+          <context context-type="linenumber">4410,4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
@@ -15102,7 +15215,7 @@
         <target>Distanza media dal riferimento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4412</context>
+          <context context-type="linenumber">4428</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
@@ -15110,7 +15223,7 @@
         <target>più vicino al valore di riferimento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4426</context>
+          <context context-type="linenumber">4442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
@@ -15118,7 +15231,7 @@
         <target>Variazione mediana</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4443</context>
+          <context context-type="linenumber">4459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
@@ -15126,7 +15239,7 @@
         <target>Cambiamento medio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4444</context>
+          <context context-type="linenumber">4460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -15141,7 +15254,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4455,4458</context>
+          <context context-type="linenumber">4471,4474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -15156,7 +15269,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4464,4467</context>
+          <context context-type="linenumber">4480,4483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -15172,7 +15285,7 @@
         )"/> punti percentuali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4476,4480</context>
+          <context context-type="linenumber">4492,4496</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -15196,7 +15309,7 @@
           )"/> stime comparabili sono migliorate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4496,4504</context>
+          <context context-type="linenumber">4512,4520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -15220,7 +15333,7 @@
           )"/> stime comparabili sono più lontane.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4516</context>
+          <context context-type="linenumber">4524,4532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
@@ -15228,7 +15341,7 @@
         <target>Il secondo round è misto: le stime più vicine e quelle più distanti sono bilanciate nel confronto a coppie.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520</context>
+          <context context-type="linenumber">4536</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -15242,7 +15355,7 @@
           )"/> nel round 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4532,4535</context>
+          <context context-type="linenumber">4548,4551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -15256,7 +15369,7 @@
           )"/> maggiore nel round 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4539,4542</context>
+          <context context-type="linenumber">4555,4558</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -15272,7 +15385,7 @@
         )"/> punti percentuali.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4554,4558</context>
+          <context context-type="linenumber">4570,4574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -15296,7 +15409,7 @@
         )"/> stime rientrano nella fascia di tolleranza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4573,4581</context>
+          <context context-type="linenumber">4589,4597</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -15310,7 +15423,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4586,4589</context>
+          <context context-type="linenumber">4602,4605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -15324,7 +15437,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4593,4596</context>
+          <context context-type="linenumber">4609,4612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
@@ -15332,11 +15445,11 @@
         <target>Quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4642</context>
+          <context context-type="linenumber">4658</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2195</context>
+          <context context-type="linenumber">2205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.questions" datatype="html">
@@ -15344,11 +15457,11 @@
         <target>Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4644</context>
+          <context context-type="linenumber">4660</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2197</context>
+          <context context-type="linenumber">2207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.questionsBadgeNew" datatype="html">
@@ -15356,11 +15469,11 @@
         <target><x id="count" equiv-text="this.qaUnseenCount()"/> nuova/e</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4652</context>
+          <context context-type="linenumber">4668</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4669</context>
+          <context context-type="linenumber">4685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelInactive" datatype="html">
@@ -15368,7 +15481,7 @@
         <target>Disattivato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4769</context>
+          <context context-type="linenumber">4785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelClosed" datatype="html">
@@ -15376,11 +15489,11 @@
         <target>Chiuso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4788</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2205</context>
+          <context context-type="linenumber">2215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7367446920402175749" datatype="html">
@@ -15388,11 +15501,11 @@
         <target>Domanda da <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">615</context>
+          <context context-type="linenumber">618</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8913852475666331247" datatype="html">
@@ -15400,11 +15513,11 @@
         <target>Domanda dal pubblico</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5574706582681662956" datatype="html">
@@ -15412,15 +15525,15 @@
         <target>Deseleziona <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4835</context>
+          <context context-type="linenumber">4851</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">580</context>
+          <context context-type="linenumber">583</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">626</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2964749761557345284" datatype="html">
@@ -15428,15 +15541,15 @@
         <target>Evidenzia tutte le domande di <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4836</context>
+          <context context-type="linenumber">4852</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">581</context>
+          <context context-type="linenumber">584</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">627</context>
+          <context context-type="linenumber">630</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPinned" datatype="html">
@@ -15444,11 +15557,11 @@
         <target>In risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4881</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusActive" datatype="html">
@@ -15456,11 +15569,11 @@
         <target>Aperta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4867</context>
+          <context context-type="linenumber">4883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2251</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPending" datatype="html">
@@ -15468,11 +15581,11 @@
         <target>In attesa di approvazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4869</context>
+          <context context-type="linenumber">4885</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2253</context>
+          <context context-type="linenumber">2263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusArchived" datatype="html">
@@ -15480,11 +15593,11 @@
         <target>Risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4871</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2255</context>
+          <context context-type="linenumber">2265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusDeleted" datatype="html">
@@ -15492,11 +15605,11 @@
         <target>Rimossa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4873</context>
+          <context context-type="linenumber">4889</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionApprove" datatype="html">
@@ -15504,7 +15617,7 @@
         <target>Approva</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4974</context>
+          <context context-type="linenumber">4990</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
@@ -15512,7 +15625,7 @@
         <target>Metti in evidenza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4976</context>
+          <context context-type="linenumber">4992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
@@ -15520,7 +15633,7 @@
         <target>Rimuovi evidenziazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4978</context>
+          <context context-type="linenumber">4994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
@@ -15528,7 +15641,7 @@
         <target>Archivia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4980</context>
+          <context context-type="linenumber">4996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
@@ -15536,7 +15649,7 @@
         <target>Rimuovi definitivamente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4983</context>
+          <context context-type="linenumber">4999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
@@ -15544,7 +15657,7 @@
         <target>Elimina</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4984</context>
+          <context context-type="linenumber">5000</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
@@ -15552,7 +15665,7 @@
         <target>Chiudi canale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5328</context>
+          <context context-type="linenumber">5344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
@@ -15560,7 +15673,7 @@
         <target>Riapri canale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5329</context>
+          <context context-type="linenumber">5345</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
@@ -15568,7 +15681,7 @@
         <target>Pre-moderazione attivata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5743</context>
+          <context context-type="linenumber">5759</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
@@ -15576,7 +15689,7 @@
         <target>Pre-moderazione disattivata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5744</context>
+          <context context-type="linenumber">5760</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
@@ -15584,7 +15697,7 @@
         <target>Domanda approvata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5777</context>
+          <context context-type="linenumber">5793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
@@ -15592,7 +15705,7 @@
         <target>Domanda messa in evidenza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5779</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
@@ -15600,7 +15713,7 @@
         <target>Domanda archiviata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5781</context>
+          <context context-type="linenumber">5797</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
@@ -15608,7 +15721,7 @@
         <target>Domanda rimossa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5782</context>
+          <context context-type="linenumber">5798</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
@@ -15616,7 +15729,7 @@
         <target>N. domanda;Testo;Tipo;Partecipanti;Round di aggregazione;Ø Punti;Autovalutazione n;Consolidato;Rischio di idea errata;Fragile;Lacuna riconosciuta;Indeciso;Risposta errata più frequente con alta autovalutazione;Dettagli</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5995</context>
+          <context context-type="linenumber">6011</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
@@ -15624,7 +15737,7 @@
         <target>Livello di apprendimento e autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6049</context>
+          <context context-type="linenumber">6065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
@@ -15632,7 +15745,7 @@
         <target>Risposte valide;Domande valutate;Non aggregate (&lt;5 risposte con autovalutazione);Solido;Rischio di idee errate;Fragile;Lacuna di conoscenza identificata;Indeciso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6052</context>
+          <context context-type="linenumber">6068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
@@ -15640,7 +15753,7 @@
         <target>Classifica delle squadre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6073</context>
+          <context context-type="linenumber">6089</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
@@ -15648,7 +15761,7 @@
         <target>Posizione;Squadra;Colore;Membri;Punti squadra;Punti medi per membro</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6075</context>
+          <context context-type="linenumber">6091</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
@@ -15656,7 +15769,7 @@
         <target>Codici bonus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6093</context>
+          <context context-type="linenumber">6109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
@@ -15664,7 +15777,7 @@
         <target>Posizione;Nickname;Codice;Punti;Generato il</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6095</context>
+          <context context-type="linenumber">6111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
@@ -15672,7 +15785,7 @@
         <target>Risultato CSV esportato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6103</context>
+          <context context-type="linenumber">6119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
@@ -15680,7 +15793,7 @@
         <target>Vedi il piano di debriefing in PDF – 1 domanda da debriefare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6115</context>
+          <context context-type="linenumber">6131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
@@ -15688,7 +15801,7 @@
         <target>Vedi il piano di debriefing in PDF – <x id="count" equiv-text="count"/> domande da debriefare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6118</context>
+          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
@@ -15696,7 +15809,7 @@
         <target>Vedi il piano di debriefing in PDF</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6120</context>
+          <context context-type="linenumber">6136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
@@ -15704,7 +15817,7 @@
         <target>1 domanda consigliata per il debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6125</context>
+          <context context-type="linenumber">6141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
@@ -15712,7 +15825,7 @@
         <target><x id="count" equiv-text="count"/> domande consigliate per il debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6127</context>
+          <context context-type="linenumber">6143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
@@ -15720,7 +15833,7 @@
         <target>Il PDF viene creato (<x id="PH" equiv-text="exportData.questions.length"/> domande)...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6139</context>
+          <context context-type="linenumber">6155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
@@ -15728,7 +15841,7 @@
         <target>PDF dei risultati scaricato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6145</context>
+          <context context-type="linenumber">6161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
@@ -15736,7 +15849,7 @@
         <target>Risultato PDF aperto per il salvataggio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
@@ -15744,7 +15857,7 @@
         <target>N.;ID domanda;Stato;Domanda;Punteggio;Voti positivi;Voti negativi;Voti totali;Punteggio Wilson;Punteggio controversia;Controversa;Creata il</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6173</context>
+          <context context-type="linenumber">6189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
@@ -15752,7 +15865,7 @@
         <target>CSV Q&amp;A esportato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6196</context>
+          <context context-type="linenumber">6212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
@@ -15760,11 +15873,11 @@
         <target>Domanda <x id="questionNumber" equiv-text="data.questionOrder + 1"/>: <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6359</context>
+          <context context-type="linenumber">6375</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6367</context>
+          <context context-type="linenumber">6383</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15780,7 +15893,7 @@
         <target>Il testo libero in tempo reale viene aggiornato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6362</context>
+          <context context-type="linenumber">6378</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15792,7 +15905,7 @@
         <target>La domanda attuale non è una domanda a testo libero.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6370</context>
+          <context context-type="linenumber">6386</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15804,7 +15917,7 @@
         <target>Non è ancora una domanda attiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6373</context>
+          <context context-type="linenumber">6389</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15816,7 +15929,7 @@
         <target>Impossibile caricare i dati di testo libero in tempo reale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6377</context>
+          <context context-type="linenumber">6393</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -17575,12 +17688,100 @@
           <context context-type="linenumber">576</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
+        <source> Zeit anpassen</source>
+        <target>Adatta il tempo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">14,16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
+        <source> Vor der Frage wählen · 10× Zeit = zehnfacher Raum-Countdown</source>
+        <target>Scegli prima della domanda · Tempo ×10 = dieci volte il conto alla rovescia della stanza</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.summary" datatype="html">
+        <source>So werden Punkte berechnet</source>
+        <target>Come vengono calcolati i punti</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.intro" datatype="html">
+        <source> So setzt sich deine Punktezahl zusammen: </source>
+        <target>Ecco come si compone il tuo punteggio:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">29,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.base" datatype="html">
+        <source> Basis: Bis zu 1000 Punkte für eine richtige Antwort. </source>
+        <target>Base: fino a 1000 punti per una risposta corretta.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">33,35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.difficulty" datatype="html">
+        <source> Schwierigkeit: Leicht ×1, Mittel ×2, Schwer ×3. </source>
+        <target>Difficoltà: Facile ×1, Media ×2, Difficile ×3.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">36,38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.time" datatype="html">
+        <source> Zeit: Je früher du beim gemeinsamen Raum-Countdown richtig antwortest, desto höher der Zeitanteil. Nach Ablauf bleiben noch 10 % davon. Deine persönliche Frist ändert nur, wie lange du antworten darfst – nicht diese Zeitwertung. </source>
+        <target>Tempo: più rispondi correttamente presto durante il conto alla rovescia comune della stanza, più alta è la quota di tempo. Dopo la scadenza ne resta il 10 %. La tua scadenza personale cambia solo per quanto tempo puoi rispondere, non questo punteggio legato al tempo.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">39,43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.streak" datatype="html">
+        <source> Serie: Mehrere richtige Antworten hintereinander geben Bonus – 1× ×1,0 · 2× ×1,1 · 3× ×1,2 · 4× ×1,3 · ab 5× ×1,5. Eine falsche bewertbare Antwort setzt die Serie zurück. Umfragen und unbewerteter Freitext unterbrechen sie nicht. </source>
+        <target>Serie: più risposte corrette di fila danno un bonus – 1× ×1,0 · 2× ×1,1 · 3× ×1,2 · 4× ×1,3 · da 5× ×1,5. Una risposta sbagliata valutata azzera la serie. Sondaggi e testo libero non valutato non la interrompono.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">44,48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.preview" datatype="html">
+        <source> Die Live-Punktvorschau zeigt den aktuellen Stand ohne Serien-Bonus. </source>
+        <target>L’anteprima punti in tempo reale mostra il valore attuale senza il bonus di serie.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">49,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
+        <source> Keine persönliche Frist · Punkte weiter nach dem Raum-Timer</source>
+        <target>Nessuna scadenza personale · I punti seguono il timer della stanza</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">74,76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
+        <source> 10× Zeit aktiv · Das Ergebnis wartet auf dich</source>
+        <target>Tempo ×10 attivo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">83,85</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionVote.sessionEndGateTitle" datatype="html">
         <source> Session beendet</source>
         <target>La sessione è terminata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">21,23</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.bonusGateLead" datatype="html">
@@ -17588,7 +17789,7 @@
         <target>Hai ricevuto un codice bonus. Ora copialo negli appunti (ad esempio per un&apos;e-mail alla direzione dell&apos;evento) prima di andare alla home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">28,31</context>
+          <context context-type="linenumber">117,120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionEndFeedbackLead" datatype="html">
@@ -17596,7 +17797,7 @@
         <target>La sessione è finita. Se vuoi, valutalo brevemente, poi puoi andare alla home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">44,47</context>
+          <context context-type="linenumber">133,136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionActionsAria" datatype="html">
@@ -17604,7 +17805,7 @@
         <target>Azioni della sessione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.voteAria" datatype="html">
@@ -17612,7 +17813,7 @@
         <target>Scegli l’area live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">232</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.pointsUnit" datatype="html">
@@ -17620,7 +17821,23 @@
         <target>punti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">319</context>
+          <context context-type="linenumber">408</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.hide" datatype="html">
+        <source> Ausblenden</source>
+        <target>Nascondere</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">416,418</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.show" datatype="html">
+        <source> Live-Punkte anzeigen</source>
+        <target>Visualizza punti in tempo reale</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">427,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.mediaAnswerHint" datatype="html">
@@ -17628,47 +17845,7 @@
         <target>L&apos;immagine è solo per la visualizzazione. Seleziona la tua risposta qui sotto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">985</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
-        <source> Zeit anpassen</source>
-        <target>Adatta il tempo</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1010,1012</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
-        <source> Nur für dich · Der Quizablauf bleibt unverändert</source>
-        <target>Solo per te · Il flusso del quiz resta invariato</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1016,1018</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.points" datatype="html">
-        <source> Punkte richten sich nach dem gemeinsamen Countdown</source>
-        <target>I punti si basano sul conto alla rovescia comune</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1021,1023</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
-        <source> Ohne Timer aktiv · Abgabe möglich, solange die Frage offen ist</source>
-        <target>Senza timer · Puoi rispondere finché la domanda è aperta</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1043,1045</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
-        <source> 10× Zeit aktiv</source>
-        <target>Tempo ×10 attivo</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericLabel" datatype="html">
@@ -17676,7 +17853,7 @@
         <target>La tua stima</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1262,1264</context>
+          <context context-type="linenumber">1324,1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericPlaceholder" datatype="html">
@@ -17684,7 +17861,7 @@
         <target>Inserisci un numero…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1284</context>
+          <context context-type="linenumber">1346</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultPrefix" datatype="html">
@@ -17692,7 +17869,7 @@
         <target>La tua risposta:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1933013871016789910" datatype="html">
@@ -17700,11 +17877,11 @@
         <target>In totale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1351</context>
+          <context context-type="linenumber">1413</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1717</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHeading" datatype="html">
@@ -17712,7 +17889,7 @@
         <target>Quanto sei sicuro di questa risposta?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1404,1406</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHint" datatype="html">
@@ -17720,7 +17897,7 @@
         <target>Si riferisce alla risposta che hai appena scelto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1411,1413</context>
+          <context context-type="linenumber">1473,1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultPrefix" datatype="html">
@@ -17728,7 +17905,7 @@
         <target>La tua autovalutazione:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceSentPrefix" datatype="html">
@@ -17736,7 +17913,7 @@
         <target>Autovalutazione:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1480</context>
+          <context context-type="linenumber">1542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8052936664226936966" datatype="html">
@@ -17744,7 +17921,7 @@
         <target>Serie (×<x id="INTERPOLATION" equiv-text="{{ sc.streakMultiplier | number:&apos;1.1-1&apos; }}"/>)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1635</context>
+          <context context-type="linenumber">1697</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4068334453877547924" datatype="html">
@@ -17752,7 +17929,7 @@
         <target>Il tuo grado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1649</context>
+          <context context-type="linenumber">1711</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedNotice" datatype="html">
@@ -17760,7 +17937,7 @@
         <target>Il canale Q&amp;A è stato chiuso dal docente. Al momento non è possibile inviare domande o votare.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1865,1868</context>
+          <context context-type="linenumber">1927,1930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaIdentityHint" datatype="html">
@@ -17768,7 +17945,7 @@
         <target>Chiedi come</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnAria" datatype="html">
@@ -17776,7 +17953,7 @@
         <target>Elimina domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2039</context>
+          <context context-type="linenumber">2101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedHint" datatype="html">
@@ -17784,7 +17961,7 @@
         <target>I contenuti precedenti sono nascosti ai partecipanti finché il docente non riapre il canale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2058,2061</context>
+          <context context-type="linenumber">2120,2123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackClosedTitle" datatype="html">
@@ -17792,7 +17969,7 @@
         <target>Blitzlicht chiuso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2077,2079</context>
+          <context context-type="linenumber">2139,2141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedActionsAria" datatype="html">
@@ -17800,7 +17977,7 @@
         <target>Azioni finali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2109</context>
+          <context context-type="linenumber">2171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.quizActionsAria" datatype="html">
@@ -17808,7 +17985,7 @@
         <target>Azioni del quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2147</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaActionsAria" datatype="html">
@@ -17816,7 +17993,7 @@
         <target>Azioni di domande e risposte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2166</context>
+          <context context-type="linenumber">2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2427920593873911865" datatype="html">
@@ -17824,7 +18001,7 @@
         <target>Perfetto! 🎯</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3996850202378161277" datatype="html">
@@ -17832,7 +18009,7 @@
         <target>Corretto! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1090604167231677526" datatype="html">
@@ -17840,7 +18017,7 @@
         <target>Colpo diretto! ⭐</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3502096474885920612" datatype="html">
@@ -17848,7 +18025,7 @@
         <target>Forte! 🔥</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7691272538064479056" datatype="html">
@@ -17856,7 +18033,7 @@
         <target>Proprio! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7790447949587239556" datatype="html">
@@ -17864,7 +18041,7 @@
         <target>Alla grande! 🎸</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">175</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4185659153521425300" datatype="html">
@@ -17872,7 +18049,7 @@
         <target>Azzeccato! 👏</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">175</context>
+          <context context-type="linenumber">176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS1" datatype="html">
@@ -17880,7 +18057,7 @@
         <target>Corretto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS2" datatype="html">
@@ -17888,7 +18065,7 @@
         <target>Correttamente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">179</context>
+          <context context-type="linenumber">180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS3" datatype="html">
@@ -17896,7 +18073,7 @@
         <target>La risposta è corretta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3211338642099056060" datatype="html">
@@ -17904,7 +18081,7 @@
         <target>Mancata di poco! 🤏</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1731892131220774983" datatype="html">
@@ -17912,7 +18089,7 @@
         <target>Andrà meglio! 💡</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9186185663967902020" datatype="html">
@@ -17920,7 +18097,7 @@
         <target>Continua così! 🔄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3551623243824977572" datatype="html">
@@ -17928,7 +18105,7 @@
         <target>Migliorerai! 📈</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5506746370181957809" datatype="html">
@@ -17936,7 +18113,7 @@
         <target>Non arrenderti! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS1" datatype="html">
@@ -17944,7 +18121,7 @@
         <target>Non è giusto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS2" datatype="html">
@@ -17952,7 +18129,7 @@
         <target>Purtroppo sbagliato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS3" datatype="html">
@@ -17960,7 +18137,7 @@
         <target>Riprova alla domanda successiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3145164147131753937" datatype="html">
@@ -17968,7 +18145,7 @@
         <target>Risposta salvata! ✓</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">195</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3110097502695814008" datatype="html">
@@ -17976,7 +18153,7 @@
         <target>Grazie per la tua risposta! 📝</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4856001851461935545" datatype="html">
@@ -17984,7 +18161,7 @@
         <target>Continua così! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS1" datatype="html">
@@ -17992,7 +18169,7 @@
         <target>Risposta salvata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">200</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS2" datatype="html">
@@ -18000,7 +18177,7 @@
         <target>Grazie, la tua risposta è stata accettata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6032822770375401279" datatype="html">
@@ -18008,7 +18185,7 @@
         <target>L&apos;ho mancato per poco: prossimo round! ⏱️</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">204</context>
+          <context context-type="linenumber">205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3646778948280182955" datatype="html">
@@ -18016,7 +18193,7 @@
         <target>Il tempo era troppo breve: puoi farcela! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">205</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5015240621073925218" datatype="html">
@@ -18024,7 +18201,7 @@
         <target>Funzionerà la prossima volta! 🔄</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="850308549833737974" datatype="html">
@@ -18032,7 +18209,7 @@
         <target>Tieni la testa alta: andiamo avanti! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3277616416884173208" datatype="html">
@@ -18040,7 +18217,7 @@
         <target>Tic-tac: la prossima occasione sta arrivando! ⏰</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS1" datatype="html">
@@ -18048,7 +18225,7 @@
         <target>Il tempo è scaduto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS2" datatype="html">
@@ -18056,7 +18233,7 @@
         <target>Il tempo è scaduto: attendi la domanda successiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">212</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS3" datatype="html">
@@ -18064,7 +18241,7 @@
         <target>Votato troppo tardi. Segue la prossima occasione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">213</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakPlayful" datatype="html">
@@ -18072,7 +18249,7 @@
         <target>On fire! 🔥 Serie di <x id="c" equiv-text="sc.streakCount"/>!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">302</context>
+          <context context-type="linenumber">303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakSerious" datatype="html">
@@ -18080,7 +18257,7 @@
         <target><x id="c" equiv-text="sc.streakCount"/> risposte corrette di seguito.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">303</context>
+          <context context-type="linenumber">304</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Playful" datatype="html">
@@ -18088,7 +18265,7 @@
         <target>Una posizione in su! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">308</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Serious" datatype="html">
@@ -18096,7 +18273,7 @@
         <target>Una posizione in su.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">310</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNPlayful" datatype="html">
@@ -18104,7 +18281,7 @@
         <target><x id="n" equiv-text="sc.rankChange"/> posizioni in su! 🚀</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">312</context>
+          <context context-type="linenumber">313</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNSerious" datatype="html">
@@ -18112,7 +18289,7 @@
         <target><x id="n" equiv-text="sc.rankChange"/> posizioni in su.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">313</context>
+          <context context-type="linenumber">314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakPlayful" datatype="html">
@@ -18120,7 +18297,7 @@
         <target>Serie interrotta! Al prossimo turno! 💪</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">320</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakSerious" datatype="html">
@@ -18128,7 +18305,7 @@
         <target>La serie è terminata: conta la domanda successiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">321</context>
+          <context context-type="linenumber">322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopPlayful" datatype="html">
@@ -18136,7 +18313,7 @@
         <target>Coraggio — sei ancora in ottima posizione! 🏅</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopSerious" datatype="html">
@@ -18144,7 +18321,7 @@
         <target>Sei più in alto nella classifica.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">327</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChasePlayful" datatype="html">
@@ -18152,7 +18329,7 @@
         <target>Continua così: ogni domanda è una nuova opportunità! 🌟</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChaseSerious" datatype="html">
@@ -18160,7 +18337,7 @@
         <target>Continua a esercitarti: la domanda successiva porta nuovi punti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">331</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivEvaluated" datatype="html">
@@ -18168,7 +18345,7 @@
         <target>Risposta valutata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">352</context>
+          <context context-type="linenumber">353</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivOutOfBand" datatype="html">
@@ -18176,7 +18353,7 @@
         <target>Fuori dalla fascia di tolleranza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">356</context>
+          <context context-type="linenumber">357</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivExact" datatype="html">
@@ -18184,7 +18361,7 @@
         <target>Esattamente sul valore di riferimento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">361</context>
+          <context context-type="linenumber">362</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivInBand" datatype="html">
@@ -18192,11 +18369,11 @@
         <target>Nell'intervallo accettato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">367</context>
+          <context context-type="linenumber">368</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">376</context>
+          <context context-type="linenumber">377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivVeryClose" datatype="html">
@@ -18204,7 +18381,7 @@
         <target>Molto vicino al valore di riferimento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">373</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixPlayful" datatype="html">
@@ -18212,7 +18389,7 @@
         <target>Perfetto!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixSerious" datatype="html">
@@ -18220,7 +18397,7 @@
         <target>Ora sei in</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixPlayful" datatype="html">
@@ -18228,7 +18405,7 @@
         <target>ti sta già aspettando.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">547</context>
+          <context context-type="linenumber">550</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixSerious" datatype="html">
@@ -18236,7 +18413,7 @@
         <target>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">548</context>
+          <context context-type="linenumber">551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3932968695937052509" datatype="html">
@@ -18244,7 +18421,7 @@
         <target>Lo chiedi come <x id="PH" equiv-text="nick"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3719653345310622722" datatype="html">
@@ -18252,11 +18429,11 @@
         <target>L&apos;icona del tuo animale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">577</context>
+          <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.playerTeamBadgeAria" datatype="html">
@@ -18264,7 +18441,7 @@
         <target><x id="nickname" equiv-text="nick"/>, <x id="teamName" equiv-text="teamLabel"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">589</context>
+          <context context-type="linenumber">592</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5952222840612966712" datatype="html">
@@ -18272,7 +18449,7 @@
         <target>La tua domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.autoJoinFailed" datatype="html">
@@ -18280,7 +18457,7 @@
         <target>Non è stato possibile preparare la partecipazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextTooLong" datatype="html">
@@ -18288,7 +18465,7 @@
         <target>Massimo <x id="maxLength" equiv-text="maxLength"/> caratteri consentiti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1325</context>
+          <context context-type="linenumber">1335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericInvalid" datatype="html">
@@ -18296,11 +18473,11 @@
         <target>La risposta breve deve essere inserita come numero in un formato supportato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1333</context>
+          <context context-type="linenumber">1343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1471</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultInvalid" datatype="html">
@@ -18308,7 +18485,7 @@
         <target>Formato numerico non valido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1437</context>
+          <context context-type="linenumber">1447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultFull" datatype="html">
@@ -18316,7 +18493,7 @@
         <target>Valutata completamente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1442</context>
+          <context context-type="linenumber">1452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultAccepted" datatype="html">
@@ -18324,7 +18501,7 @@
         <target>Accettata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1443</context>
+          <context context-type="linenumber">1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultPartial" datatype="html">
@@ -18332,7 +18509,7 @@
         <target>Valutata parzialmente (<x id="points" equiv-text="result.points"/> %)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1457</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultRejected" datatype="html">
@@ -18340,7 +18517,7 @@
         <target>Non accettata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1450</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericNoMatch" datatype="html">
@@ -18348,7 +18525,7 @@
         <target>Nessuna risposta di riferimento rientrava nella tolleranza numerica configurata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultMatchedSolution" datatype="html">
@@ -18356,11 +18533,11 @@
         <target>Ricondotta alla soluzione modello « <x id="matchedModelAnswer" equiv-text="result.matchedModelAnswer"/> ».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1469</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1485</context>
+          <context context-type="linenumber">1495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonNoMatch" datatype="html">
@@ -18368,11 +18545,11 @@
         <target>Nessuna soluzione modello rientrava nella tolleranza configurata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1477</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1501</context>
+          <context context-type="linenumber">1511</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonHamming" datatype="html">
@@ -18380,7 +18557,7 @@
         <target>Un piccolo refuso della stessa lunghezza rientrava ancora nella tolleranza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1495</context>
+          <context context-type="linenumber">1505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonDamerau" datatype="html">
@@ -18388,7 +18565,7 @@
         <target>Un&apos;inversione di lettere rientrava ancora nella tolleranza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1497</context>
+          <context context-type="linenumber">1507</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonLevenshtein" datatype="html">
@@ -18396,7 +18573,7 @@
         <target>Un carattere mancante o aggiuntivo rientrava ancora nella tolleranza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1499</context>
+          <context context-type="linenumber">1509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingRequired" datatype="html">
@@ -18404,7 +18581,7 @@
         <target>Il valore numerico coincideva, ma mancava l’unità richiesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1509</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalentRejected" datatype="html">
@@ -18412,7 +18589,7 @@
         <target>Il valore numerico coincideva dopo la conversione, ma è accettata solo l’unità configurata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonWrongFamily" datatype="html">
@@ -18420,7 +18597,7 @@
         <target>Il valore numerico coincideva, ma l’unità appartiene a un’altra famiglia di grandezze.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1513</context>
+          <context context-type="linenumber">1523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonUnsupportedUnit" datatype="html">
@@ -18428,7 +18605,7 @@
         <target>Il valore numerico coincideva, ma l’unità inserita è fuori dall’insieme di unità supportate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1515</context>
+          <context context-type="linenumber">1525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonPartial" datatype="html">
@@ -18436,7 +18613,7 @@
         <target>Il valore numerico coincideva, ma l’unità ha impedito la valutazione piena.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1517</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalent" datatype="html">
@@ -18444,7 +18621,7 @@
         <target>Il valore numerico e l’unità equivalente sono stati convertiti correttamente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingOptional" datatype="html">
@@ -18452,7 +18629,7 @@
         <target>Il valore numerico coincideva; l’unità era facoltativa in questa domanda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1525</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonTolerance" datatype="html">
@@ -18460,7 +18637,7 @@
         <target>Il valore numerico rientrava nella tolleranza configurata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1528</context>
+          <context context-type="linenumber">1538</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonExact" datatype="html">
@@ -18468,7 +18645,7 @@
         <target>Il valore numerico e l’unità coincidono esattamente con una soluzione modello.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1531</context>
+          <context context-type="linenumber">1541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeInteger" datatype="html">
@@ -18476,7 +18653,7 @@
         <target>Numero intero</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1865</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeDecimal" datatype="html">
@@ -18484,7 +18661,7 @@
         <target>Numero decimale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1856</context>
+          <context context-type="linenumber">1866</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatInteger" datatype="html">
@@ -18492,7 +18669,7 @@
         <target>Inserisci un numero intero senza cifre decimali.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1861</context>
+          <context context-type="linenumber">1871</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimalPlaces" datatype="html">
@@ -18500,7 +18677,7 @@
         <target>Puoi usare virgola o punto, massimo <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> cifre decimali.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1865</context>
+          <context context-type="linenumber">1875</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimal" datatype="html">
@@ -18508,7 +18685,7 @@
         <target>Puoi usare virgola o punto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1867</context>
+          <context context-type="linenumber">1877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeBoth" datatype="html">
@@ -18520,7 +18697,7 @@
       )"/> a <x id="max" equiv-text="this.formatNumericResultValue(max)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1874,1876</context>
+          <context context-type="linenumber">1884,1886</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMin" datatype="html">
@@ -18532,7 +18709,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1879,1881</context>
+          <context context-type="linenumber">1889,1891</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMax" datatype="html">
@@ -18544,7 +18721,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1884,1886</context>
+          <context context-type="linenumber">1894,1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultInBand" datatype="html">
@@ -18552,7 +18729,7 @@
         <target>Nella fascia di tolleranza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultOutOfBand" datatype="html">
@@ -18560,7 +18737,7 @@
         <target>Fuori dalla fascia di tolleranza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2030</context>
+          <context context-type="linenumber">2040</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultReference" datatype="html">
@@ -18572,7 +18749,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2036,2038</context>
+          <context context-type="linenumber">2046,2048</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedSingle" datatype="html">
@@ -18584,7 +18761,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2049,2051</context>
+          <context context-type="linenumber">2059,2061</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedRange" datatype="html">
@@ -18596,7 +18773,7 @@
       )"/> a <x id="right" equiv-text="this.formatNumericResultValue(acceptedRight)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2053,2055</context>
+          <context context-type="linenumber">2063,2065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultToleranceBand" datatype="html">
@@ -18608,7 +18785,7 @@
     )"/> a <x id="right" equiv-text="this.formatNumericResultValue(band.right)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2057,2059</context>
+          <context context-type="linenumber">2067,2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultExact" datatype="html">
@@ -18616,7 +18793,7 @@
         <target>Esattamente al valore di riferimento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2068</context>
+          <context context-type="linenumber">2078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultDistance" datatype="html">
@@ -18628,7 +18805,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2070,2072</context>
+          <context context-type="linenumber">2080,2082</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultImproved" datatype="html">
@@ -18640,7 +18817,7 @@
       )"/> più vicino al valore di riferimento rispetto al round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2109,2111</context>
+          <context context-type="linenumber">2119,2121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultWorse" datatype="html">
@@ -18652,7 +18829,7 @@
       )"/> più lontano dal valore di riferimento rispetto al round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2114,2116</context>
+          <context context-type="linenumber">2124,2126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultUnchanged" datatype="html">
@@ -18660,7 +18837,7 @@
         <target>Proprio vicino al valore di riferimento come nel round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2118</context>
+          <context context-type="linenumber">2128</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericRequired" datatype="html">
@@ -18668,7 +18845,7 @@
         <target>Inserisci un numero.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2139</context>
+          <context context-type="linenumber">2149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericIntegerRequired" datatype="html">
@@ -18676,7 +18853,7 @@
         <target>Inserisci un numero intero nel formato supportato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2143</context>
+          <context context-type="linenumber">2153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericDecimalPlacesExceeded" datatype="html">
@@ -18684,7 +18861,7 @@
         <target>Sono consentite massime <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> cifre decimali.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2152</context>
+          <context context-type="linenumber">2162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInvalid" datatype="html">
@@ -18692,7 +18869,7 @@
         <target>Inserisci un numero valido nel formato supportato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2154</context>
+          <context context-type="linenumber">2164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericBelowMin" datatype="html">
@@ -18700,7 +18877,7 @@
         <target>Inserisci un valore pari almeno a <x id="min" equiv-text="min"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2160</context>
+          <context context-type="linenumber">2170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericAboveMax" datatype="html">
@@ -18708,7 +18885,7 @@
         <target>Inserisci un valore massimo di <x id="max" equiv-text="max"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2163</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinalScore" datatype="html">
@@ -18716,7 +18893,7 @@
         <target>Punteggio finale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2311</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleWinFin" datatype="html">
@@ -18724,7 +18901,7 @@
         <target>La vostra squadra vince!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2316</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinishedOther" datatype="html">
@@ -18732,7 +18909,7 @@
         <target>Al traguardo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasingZero" datatype="html">
@@ -18740,7 +18917,7 @@
         <target>Recuperate terreno—potete ancora farcela!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2321</context>
+          <context context-type="linenumber">2331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleAllZero" datatype="html">
@@ -18748,7 +18925,7 @@
         <target>Mostrate di cosa siete capaci!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2322</context>
+          <context context-type="linenumber">2332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleLeading" datatype="html">
@@ -18756,7 +18933,7 @@
         <target>Al momento siete in testa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2325</context>
+          <context context-type="linenumber">2335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasing" datatype="html">
@@ -18764,7 +18941,7 @@
         <target>Proseguire</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2327</context>
+          <context context-type="linenumber">2337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgWinFin" datatype="html">
@@ -18772,7 +18949,7 @@
         <target>Avete vinto insieme: il 1° posto è vostro.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2345</context>
+          <context context-type="linenumber">2355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedAllZero" datatype="html">
@@ -18780,7 +18957,7 @@
         <target>Quiz finito: nessun team ha raccolto punti di squadra.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOwnZero" datatype="html">
@@ -18788,7 +18965,7 @@
         <target>Quiz finito: il vostro team non ha raccolto punti di squadra.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2351</context>
+          <context context-type="linenumber">2361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOther" datatype="html">
@@ -18796,7 +18973,7 @@
         <target>Finisci con <x id="totalScore" equiv-text="entry.totalScore"/> punti sul posto <x id="teamRank" equiv-text="entry.rank"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2353</context>
+          <context context-type="linenumber">2363</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgAllZero" datatype="html">
@@ -18804,7 +18981,7 @@
         <target>Le risposte giuste valgono punti per il vostro team.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2357</context>
+          <context context-type="linenumber">2367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgChasing" datatype="html">
@@ -18812,11 +18989,11 @@
         <target>Attualmente classificato <x id="teamRank" equiv-text="entry.rank"/> con <x id="totalScore" equiv-text="entry.totalScore"/> punti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2359</context>
+          <context context-type="linenumber">2369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgLeading" datatype="html">
@@ -18824,7 +19001,7 @@
         <target>Sei in vantaggio con <x id="totalScore" equiv-text="entry.totalScore"/> punti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2362</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulLoading" datatype="html">
@@ -18832,7 +19009,7 @@
         <target>Caricamento del risultato…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2406</context>
+          <context context-type="linenumber">2416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulNeutral" datatype="html">
@@ -18840,7 +19017,7 @@
         <target>Finito — grazie per aver partecipato!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2411</context>
+          <context context-type="linenumber">2421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingNoRank" datatype="html">
@@ -18848,7 +19025,7 @@
         <target><x id="teamName" equiv-text="entry.teamName"/> con <x id="memberCountLabel" equiv-text="this.teamMemberLabel(entry.memberCount)"/> e <x id="totalScore" equiv-text="entry.totalScore"/> punti di team — ancora senza classifica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2442</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingWithMembers" datatype="html">
@@ -18856,7 +19033,7 @@
         <target>Posto <x id="teamRank"/>: <x id="teamName"/> con <x id="memberCountLabel"/> e <x id="totalScore"/> punti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2602080285199874401" datatype="html">
@@ -18864,7 +19041,7 @@
         <target><x id="PH" equiv-text="stars"/> su 5 stelle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2477</context>
+          <context context-type="linenumber">2487</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaOne" datatype="html">
@@ -18872,7 +19049,7 @@
         <target>1 secondo rimanente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2483</context>
+          <context context-type="linenumber">2493</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaMany" datatype="html">
@@ -18880,7 +19057,7 @@
         <target><x id="seconds" equiv-text="seconds"/> secondi rimanenti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2484</context>
+          <context context-type="linenumber">2494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.groupAria" datatype="html">
@@ -18888,7 +19065,7 @@
         <target>Tempo personale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2488</context>
+          <context context-type="linenumber">2498</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.extended" datatype="html">
@@ -18896,15 +19073,15 @@
         <target>Tempo ×10</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2494</context>
+          <context context-type="linenumber">2504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.off" datatype="html">
-        <source>Ohne Timer</source>
-        <target>Senza timer</target>
+        <source>Ohne Frist</source>
+        <target>Senza scadenza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2496</context>
+          <context context-type="linenumber">2506</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.default" datatype="html">
@@ -18912,7 +19089,23 @@
         <target>Standard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2498</context>
+          <context context-type="linenumber">2508</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsDefault" datatype="html">
+        <source>Punkte folgen dem gemeinsamen Countdown</source>
+        <target>I punti seguono il conto alla rovescia comune</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2514</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsOvertime" datatype="html">
+        <source>Früh abgeben lohnt sich · nach dem Countdown nur Mindestpunkte</source>
+        <target>Rispondere presto conviene · dopo il conto alla rovescia solo il minimo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.overtimeCorrect" datatype="html">
@@ -18920,7 +19113,7 @@
         <target>Tempo extra · risposta corretta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2504</context>
+          <context context-type="linenumber">2521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.upToNow" datatype="html">
@@ -18928,7 +19121,7 @@
         <target>Punteggio pieno adesso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2507</context>
+          <context context-type="linenumber">2524</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.correctNow" datatype="html">
@@ -18936,7 +19129,7 @@
         <target>Risposta corretta adesso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2508</context>
+          <context context-type="linenumber">2525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.error" datatype="html">
@@ -18944,7 +19137,7 @@
         <target>Impossibile salvare la regolazione del tempo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2536</context>
+          <context context-type="linenumber">2561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeUpvoteAria" datatype="html">
@@ -18952,7 +19145,7 @@
         <target>Rimuovi voto positivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2547</context>
+          <context context-type="linenumber">2572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addUpvoteAria" datatype="html">
@@ -18960,7 +19153,7 @@
         <target>Vota positivamente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2548</context>
+          <context context-type="linenumber">2573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeDownvoteAria" datatype="html">
@@ -18968,7 +19161,7 @@
         <target>Rimuovi voto negativo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2552</context>
+          <context context-type="linenumber">2577</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addDownvoteAria" datatype="html">
@@ -18976,7 +19169,7 @@
         <target>Vota negativamente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2553</context>
+          <context context-type="linenumber">2578</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5043949766391435553" datatype="html">
@@ -18984,7 +19177,7 @@
         <target>Valutazione da <x id="PH" equiv-text="this.ratingLabelMin()"/> a <x id="PH_1" equiv-text="this.ratingLabelMax()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2557</context>
+          <context context-type="linenumber">2582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2721187191897749624" datatype="html">
@@ -18992,7 +19185,7 @@
         <target>Valutazione <x id="PH" equiv-text="value"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2561</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLabels" datatype="html">
@@ -19000,7 +19193,7 @@
         <target>Autovalutazione da 1 a 5, bassa: <x id="low" equiv-text="low"/>, alta: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLow" datatype="html">
@@ -19008,7 +19201,7 @@
         <target>Autovalutazione da 1 a 5, bassa: <x id="low" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2591</context>
+          <context context-type="linenumber">2616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithHigh" datatype="html">
@@ -19016,7 +19209,7 @@
         <target>Autovalutazione da 1 a 5, alta: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2594</context>
+          <context context-type="linenumber">2619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAria" datatype="html">
@@ -19024,7 +19217,7 @@
         <target>Autovalutazione da 1 a 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2596</context>
+          <context context-type="linenumber">2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceValueAria" datatype="html">
@@ -19032,7 +19225,7 @@
         <target>Autovalutazione <x id="value" equiv-text="value"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2600</context>
+          <context context-type="linenumber">2625</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithLowLabel" datatype="html">
@@ -19040,7 +19233,7 @@
         <target><x id="value" equiv-text="value"/> – <x id="label" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2611</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithHighLabel" datatype="html">
@@ -19048,7 +19241,7 @@
         <target><x id="value" equiv-text="value"/> – <x id="label" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2614</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="974858114847169012" datatype="html">
@@ -19056,7 +19249,7 @@
         <target>Rispondi con <x id="PH" equiv-text="emoji"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2634</context>
+          <context context-type="linenumber">2659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteLoadError" datatype="html">
@@ -19064,7 +19257,7 @@
         <target>Non è stato possibile caricare le domande.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3519</context>
+          <context context-type="linenumber">3547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitSuccess" datatype="html">
@@ -19072,7 +19265,7 @@
         <target>Domanda inviata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3562</context>
+          <context context-type="linenumber">3590</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitError" datatype="html">
@@ -19080,19 +19273,19 @@
         <target>Non è stato possibile inviare la domanda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3568</context>
+          <context context-type="linenumber">3596</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3588</context>
+          <context context-type="linenumber">3616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3617</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3625</context>
+          <context context-type="linenumber">3653</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.upvoteError" datatype="html">
@@ -19100,7 +19293,7 @@
         <target>Non è stato possibile salvare il voto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3666</context>
+          <context context-type="linenumber">3694</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnError" datatype="html">
@@ -19108,7 +19301,7 @@
         <target>Non è stato possibile eliminare la domanda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3694</context>
+          <context context-type="linenumber">3722</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwnMany" datatype="html">
@@ -19116,7 +19309,7 @@
         <target>La moderazione ha rimosso le tue domande.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3750</context>
+          <context context-type="linenumber">3778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwn" datatype="html">
@@ -19124,7 +19317,7 @@
         <target>La moderazione ha rimosso la tua domanda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOthersMany" datatype="html">
@@ -19132,7 +19325,7 @@
         <target>Più domande sono state rimosse dalla moderazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3755</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOther" datatype="html">
@@ -19140,7 +19333,7 @@
         <target>Una domanda è stata rimossa dalla moderazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.readingReadyError" datatype="html">
@@ -19148,7 +19341,7 @@
         <target>Impossibile confermare la disponibilità.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4017</context>
+          <context context-type="linenumber">4045</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceRequired" datatype="html">
@@ -19156,7 +19349,7 @@
         <target>Indica la tua autovalutazione prima di inviare.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4188</context>
+          <context context-type="linenumber">4216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9175670018185396326" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -3715,7 +3715,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4646</context>
+          <context context-type="linenumber">4662</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -3723,11 +3723,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2074,2076</context>
+          <context context-type="linenumber">2136,2138</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2199</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackHostTitle" datatype="html">
@@ -3763,7 +3763,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3609</context>
+          <context context-type="linenumber">3635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -4157,7 +4157,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1880</context>
+          <context context-type="linenumber">1888</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -4168,7 +4168,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1885</context>
+          <context context-type="linenumber">1893</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -4190,7 +4190,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -4201,7 +4201,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4728</context>
+          <context context-type="linenumber">4744</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -4339,7 +4339,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackVoteTitle" datatype="html">
@@ -4480,7 +4480,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2082,2085</context>
+          <context context-type="linenumber">2144,2147</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.voteMissing" datatype="html">
@@ -6101,11 +6101,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4958</context>
+          <context context-type="linenumber">4974</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2268</context>
+          <context context-type="linenumber">2278</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3532753318619772032" datatype="html">
@@ -6116,11 +6116,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4960</context>
+          <context context-type="linenumber">4976</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2270</context>
+          <context context-type="linenumber">2280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="74432774947660496" datatype="html">
@@ -6131,11 +6131,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="276214048875673948" datatype="html">
@@ -6146,11 +6146,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4963</context>
+          <context context-type="linenumber">4979</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2273</context>
+          <context context-type="linenumber">2283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5356551916626450286" datatype="html">
@@ -6161,11 +6161,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3903113005127984737" datatype="html">
@@ -6176,11 +6176,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4965</context>
+          <context context-type="linenumber">4981</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2275</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeRemoveSession" datatype="html">
@@ -6402,7 +6402,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -6410,7 +6410,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6658206425619028413" datatype="html">
@@ -6421,7 +6421,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -6429,7 +6429,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2463</context>
+          <context context-type="linenumber">2473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5683915683305860193" datatype="html">
@@ -6507,15 +6507,15 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2911</context>
+          <context context-type="linenumber">2919</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2449</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2458</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/preset-toast/preset-toast.component.ts</context>
@@ -8643,11 +8643,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4629</context>
+          <context context-type="linenumber">4645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.medium" datatype="html">
@@ -8662,11 +8662,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4631</context>
+          <context context-type="linenumber">4647</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1787</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.hard" datatype="html">
@@ -8681,11 +8681,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4633</context>
+          <context context-type="linenumber">4649</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1779</context>
+          <context context-type="linenumber">1789</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeExactLabel" datatype="html">
@@ -9720,11 +9720,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1348</context>
+          <context context-type="linenumber">1410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1612</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesExportCsv" datatype="html">
@@ -11051,7 +11051,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3027</context>
+          <context context-type="linenumber">3031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -11062,7 +11062,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3030</context>
+          <context context-type="linenumber">3034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -11073,7 +11073,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3035</context>
+          <context context-type="linenumber">3039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -11084,7 +11084,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3225</context>
+          <context context-type="linenumber">3229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -11095,7 +11095,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3229</context>
+          <context context-type="linenumber">3233</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -11106,7 +11106,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3232</context>
+          <context context-type="linenumber">3236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -11117,7 +11117,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3235</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -11255,7 +11255,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2735</context>
+          <context context-type="linenumber">2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -11281,7 +11281,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2998</context>
+          <context context-type="linenumber">3002</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -11460,7 +11460,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2968</context>
+          <context context-type="linenumber">2972</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -11639,7 +11639,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
-        <source> Teilnehmende können ihre persönliche Zeit bei Bedarf verlängern oder abschalten. </source>
+        <source> Teilnehmende können ihre persönliche Frist bei Bedarf verlängern oder abschalten. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">1441,1444</context>
@@ -11649,381 +11649,381 @@
         <source>Frage-Metadaten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1456</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">832</context>
+          <context context-type="linenumber">947</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">894</context>
+          <context context-type="linenumber">1013</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">961</context>
+          <context context-type="linenumber">1081</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4209613400308596118" datatype="html">
         <source>Lesephase</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1481</context>
+          <context context-type="linenumber">1485</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
         <source> Antworten folgen gleich. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1482,1484</context>
+          <context context-type="linenumber">1486,1488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
         <source>Bewertungsskala</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1540</context>
+          <context context-type="linenumber">1544</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
         <source>Bewertungsverteilung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1568</context>
+          <context context-type="linenumber">1572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
         <source> Warte auf Schätzungen… </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1607,1609</context>
+          <context context-type="linenumber">1611,1613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ formatCount(numericVoteCount) }}"/> Antworten eingegangen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615,1617</context>
+          <context context-type="linenumber">1619,1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
         <source>Statistik-Kurzfassung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1627</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2060</context>
+          <context context-type="linenumber">2064</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
         <source>Runde 2</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1632</context>
+          <context context-type="linenumber">1636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
         <source>Akzeptiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1654</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2080</context>
+          <context context-type="linenumber">2084</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
         <source>Rundenvergleich</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
         <source>Verschiebung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1685</context>
+          <context context-type="linenumber">1689</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
         <source>Runde 1</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1706</context>
+          <context context-type="linenumber">1710</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
         <source>Runde 2</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1711</context>
+          <context context-type="linenumber">1715</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
         <source>Statistische Details anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1898</context>
+          <context context-type="linenumber">1902</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2197</context>
+          <context context-type="linenumber">2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
         <source> Runde 1 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1912,1914</context>
+          <context context-type="linenumber">1916,1918</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
         <source> Runde 2 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1940,1942</context>
+          <context context-type="linenumber">1944,1946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
         <source> Paarvergleich: <x id="INTERPOLATION" equiv-text="{{ formatCount(rc.pairedAnalysis.closerCount) }}"/> näher, <x id="INTERPOLATION_1" equiv-text="{{ formatCount(rc.pairedAnalysis.fartherCount) }}"/> weiter weg, <x id="INTERPOLATION_2" equiv-text="{{ formatCount(rc.pairedAnalysis.unchangedCount) }}"/> gleich (<x id="INTERPOLATION_3" equiv-text="{{ formatCount(rc.pairedAnalysis.pairedCount) }}"/> Paare) </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1971,1979</context>
+          <context context-type="linenumber">1975,1983</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
         <source>Veränderung pro Person</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1989</context>
+          <context context-type="linenumber">1993</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
         <source>kleiner ist näher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2103</context>
+          <context context-type="linenumber">2107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
         <source> Ergebnisrunde </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2210,2212</context>
+          <context context-type="linenumber">2214,2216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
         <source> Keine Schätzungen eingegangen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2237,2239</context>
+          <context context-type="linenumber">2241,2243</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
         <source>Vorher/Nachher-Vergleich Peer Instruction</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
         <source>Runde 1 (<x id="INTERPOLATION" equiv-text="{{ formatCount(round1Votes) }}"/> Stimme)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
         <source>Runde 1 (<x id="INTERPOLATION" equiv-text="{{ formatCount(round1Votes) }}"/> Stimmen)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2263</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
         <source>Runde 2 (<x id="INTERPOLATION" equiv-text="{{ formatCount(round2Votes) }}"/> Stimme)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2271</context>
+          <context context-type="linenumber">2275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
         <source>Runde 2 (<x id="INTERPOLATION" equiv-text="{{ formatCount(round2Votes) }}"/> Stimmen)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
         <source>Richtig: <x id="INTERPOLATION" equiv-text="{{ formatCount(q.roundComparison.round1CorrectCount) }}"/> in Runde 1, danach <x id="INTERPOLATION_1" equiv-text="{{ formatCount(q.roundComparison.round2CorrectCount) }}"/> in Runde 2</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2289,2293</context>
+          <context context-type="linenumber">2293,2297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
         <source> Peer Instruction empfohlen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2536,2538</context>
+          <context context-type="linenumber">2540,2542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
         <source> 35–70 % vollständig korrekt — zweite Runde passt. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2543,2545</context>
+          <context context-type="linenumber">2547,2549</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
         <source> Erste Runde noch verborgen, bis du weiter machst. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2550,2552</context>
+          <context context-type="linenumber">2554,2556</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
         <source> Diskussion starten oder Ergebnis zeigen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2557,2559</context>
+          <context context-type="linenumber">2561,2563</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
         <source> Selbsteinschätzung </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2615,2617</context>
+          <context context-type="linenumber">2619,2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
         <source> Richtig oder falsch — und wie sicher? Besonders wichtig: falsch trotz hoher Antwortsicherheit. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2621,2624</context>
+          <context context-type="linenumber">2625,2628</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
         <source>Korrektheit und Selbsteinschätzung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2645</context>
+          <context context-type="linenumber">2649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
         <source> Häufig falsch mit hoher Antwortsicherheit </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2699,2701</context>
+          <context context-type="linenumber">2703,2705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
         <source> Frage wird aktualisiert … </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2744,2746</context>
+          <context context-type="linenumber">2748,2750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
         <source> Keine Frage aktiv. Mit „Nächste Frage“ starten. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2748,2750</context>
+          <context context-type="linenumber">2752,2754</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
         <source>Reaktionen der Teilnehmenden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2768</context>
+          <context context-type="linenumber">2772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
         <source>2. Runde</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2774</context>
+          <context context-type="linenumber">2778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
         <source>neu</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2782</context>
+          <context context-type="linenumber">2786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
         <source>Noch keine Reaktionen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2805</context>
+          <context context-type="linenumber">2809</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
         <source>Top 5</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2818</context>
+          <context context-type="linenumber">2822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="entry.totalScore | number }}"/> Pkt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2885</context>
+          <context context-type="linenumber">2889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
         <source>Gleichstand: Antwortzeit zählt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
         <source>Team-Wertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2912</context>
+          <context context-type="linenumber">2916</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
         <source>Pkt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2959</context>
+          <context context-type="linenumber">2963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
         <source>Quiz wechseln</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2988</context>
+          <context context-type="linenumber">2992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
         <source>Q&amp;A-Titel bearbeiten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3091</context>
+          <context context-type="linenumber">3095</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
         <source>Titel für Q&amp;A</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3104</context>
+          <context context-type="linenumber">3108</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
         <source>Fragen zur Veranstaltung...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3115</context>
+          <context context-type="linenumber">3119</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
@@ -12035,238 +12035,308 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1038</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
+        <source>Quiz-Session</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleConfirmAria" datatype="html">
         <source>Titel speichern</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3127</context>
+          <context context-type="linenumber">3131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
         <source>Bearbeiten abbrechen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3138</context>
+          <context context-type="linenumber">3142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
         <source> Vorab-Moderation </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3157,3159</context>
+          <context context-type="linenumber">3161,3163</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
         <source> Neue Fragen warten erst auf deine Freigabe. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3161,3163</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
         <source> Noch keine Fragen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3170,3172</context>
+          <context context-type="linenumber">3174,3176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
         <source>Gesamt: <x id="INTERPOLATION" equiv-text="{{ formatCount(qaForumQuestionCount()) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3182,3183</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
         <source>Warten auf Freigabe: <x id="INTERPOLATION" equiv-text="{{ formatCount(qaPendingCount()) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3191,3192</context>
+          <context context-type="linenumber">3195,3196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
         <source>Alle Fragen anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3244</context>
+          <context context-type="linenumber">3248</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
         <source>Alle anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3247</context>
+          <context context-type="linenumber">3251</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
         <source>Nur angeheftete Fragen anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3255</context>
+          <context context-type="linenumber">3259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
         <source>Nur angeheftete</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3258</context>
+          <context context-type="linenumber">3262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
         <source>Neue Fragen anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3270</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
         <source><x id="INTERPOLATION"/> neue Fragen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3276</context>
+          <context context-type="linenumber">3280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
         <source>Fragen als CSV exportieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3308</context>
+          <context context-type="linenumber">3312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
         <source>Fragen exportieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3311</context>
+          <context context-type="linenumber">3315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
         <source> Wird exportiert… </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3319,3321</context>
+          <context context-type="linenumber">3323,3325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
         <source>Umstritten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3388</context>
+          <context context-type="linenumber">3392</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="veVoteCount) }}"/> positiv · <x id="INTERPOLATION_1" equiv-text="{{ formatCount(question.negativeVoteCount) }}"/> negativ</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3416,3417</context>
+          <context context-type="linenumber">3420,3421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
         <source>Belastbare Zustimmung <x id="INTERPOLATION" equiv-text="{{ formatQaPercent(question.bestScore) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3424,3425</context>
+          <context context-type="linenumber">3428,3429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
         <source>Geteilte Reaktionen <x id="INTERPOLATION" equiv-text="{{ formatQaPercent(question.controversyScore) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3434,3436</context>
+          <context context-type="linenumber">3438,3440</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
         <source> Nur angeheftete aktiv – noch keine angehefteten Fragen vorhanden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3477,3479</context>
+          <context context-type="linenumber">3481,3483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
         <source>Antwortoptionen freigeben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3530</context>
+          <context context-type="linenumber">3534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
         <source>Diskussionsphase starten – Austausch vor zweiter Abstimmung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3554</context>
+          <context context-type="linenumber">3570</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
         <source>Diskussionsphase</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3557</context>
+          <context context-type="linenumber">3573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
         <source>Ergebnis trotzdem zeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3591</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">3588</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
-        <source> Ergebnis zeigen </source>
+        <source>Ergebnis zeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3579,3581</context>
+          <context context-type="linenumber">3612</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
+        <source>Persönliche Fristen beenden?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5926</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
+        <source>Du zeigst das Ergebnis, obwohl noch persönliche Timer laufen.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5930</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
+        <source>Du startest die Diskussionsphase, obwohl noch persönliche Timer laufen.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5929</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
+        <source>Die offene persönliche 10×-Frist dieser Person endet sofort.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> offene persönliche 10×-Fristen enden sofort.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5921</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
+        <source>Danach ist keine weitere Antwort mehr möglich.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5918</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
+        <source>Trotzdem freigeben</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5932</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
+        <source>Weiter warten</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">5933</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
         <source> Nächste Frage </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3595,3597</context>
+          <context context-type="linenumber">3621,3623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
         <source>Zur nächsten Frage ohne zweite Abstimmung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3618</context>
+          <context context-type="linenumber">3644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
         <source>Zur nächsten Frage ohne zweite Abstimmung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
         <source>Zeigt die letzte Frage mit Ergebnis und richtiger Lösung erneut an (ohne neue Abstimmung).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3638</context>
+          <context context-type="linenumber">3664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
         <source> Letztes Ergebnis erneut anzeigen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3640,3642</context>
+          <context context-type="linenumber">3666,3668</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
         <source> Session beenden </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650,3652</context>
+          <context context-type="linenumber">3676,3678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
         <source>Host-Ansicht für Lobby und Steuerung.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3658</context>
+          <context context-type="linenumber">3684</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
@@ -12557,597 +12627,625 @@
         <source>1 Antwort</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1526</context>
+          <context context-type="linenumber">1534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
         <source><x id="count" equiv-text="count"/> Antworten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1527</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
         <source>Niedrig · <x id="label" equiv-text="q.confidenceLabelLow"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1618</context>
+          <context context-type="linenumber">1626</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
         <source>Niedrig (1–2)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1619</context>
+          <context context-type="linenumber">1627</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
         <source>Mitte (3)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1623</context>
+          <context context-type="linenumber">1631</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
         <source>Hoch · <x id="label" equiv-text="q.confidenceLabelHigh"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1663</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
         <source>Hoch (4–5)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1656</context>
+          <context context-type="linenumber">1664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
         <source>Richtig</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1670</context>
+          <context context-type="linenumber">1678</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
         <source>Falsch</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1677</context>
+          <context context-type="linenumber">1685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
         <source><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1769</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
         <source>1 selbstsicher falsche Antwort – mögliches Fehlkonzept</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1774</context>
+          <context context-type="linenumber">1782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
         <source><x id="count" equiv-text="count"/> selbstsicher falsche Antworten – mögliche Fehlkonzepte</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1775</context>
+          <context context-type="linenumber">1783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
         <source>Kreuz richtig/hoch <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · falsch/hoch <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1786</context>
+          <context context-type="linenumber">1794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
         <source>2 (Peer Instruction)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
         <source>Runde 1: <x id="r1" equiv-text="round1Count"/> Stimmen · Aggregiert: Runde 2 mit <x id="r2" equiv-text="round2Count"/> Stimmen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1824</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
         <source>Aggregationsrunde 2 (Peer Instruction)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1826</context>
+          <context context-type="linenumber">1834</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
         <source>Aggregationsrunde 1</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1837</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
         <source>Das ist gerade nicht angekommen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2427</context>
+          <context context-type="linenumber">2435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
         <source>Kein Stress – so was passiert manchmal (kurzer Ruckler oder instabiles WLAN). Warte zwei, drei Sekunden und tippe auf „Nochmal probieren“ – meist reicht das.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2428</context>
+          <context context-type="linenumber">2436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
         <source>Mit den Fragen klappt es gerade nicht</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2435</context>
+          <context context-type="linenumber">2443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
         <source>Hier ist nichts kaputt – es hat nur gerade nicht geklappt. Kurz durchatmen, 2–3 Sekunden warten, dann „Nochmal probieren“ – oft läuft es gleich wieder.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2436</context>
+          <context context-type="linenumber">2444</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
         <source>Export noch nicht bereit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2443</context>
+          <context context-type="linenumber">2451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
         <source>PDF- oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
         <source>Teilnehmende und die Präsentationsansicht werden zur Startseite weitergeleitet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2578</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
         <source>Die Session endet für alle; ein Fortsetzen mit demselben Code ist nicht möglich.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2579</context>
+          <context context-type="linenumber">2587</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
         <source><x id="participantCount" equiv-text="participants"/> Teilnehmende sind noch in der Session.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2583</context>
+          <context context-type="linenumber">2591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
         <source>Du hast bereits Ergebnisse. Nach dem Beenden kannst du sie in der Abschlussansicht exportieren oder Feedback ansehen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2596</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
         <source>Es liegen noch keine verwertbaren Ergebnisse vor. Nach dem Beenden wirst du direkt zur Startseite geführt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2592</context>
+          <context context-type="linenumber">2600</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
         <source>Für Bonus-Codes: Weise die Teilnehmenden darauf hin, ihren persönlichen Code jetzt zu kopieren (Zwischenablage), bevor sie die Seite verlassen – sonst können sie ihn leicht verlieren.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2597</context>
+          <context context-type="linenumber">2605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
         <source>Session verlassen?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
         <source>Deine Session ist noch aktiv.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
         <source>Trotzdem verlassen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2606</context>
+          <context context-type="linenumber">2614</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
         <source>Zurück zur Session</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2607</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
         <source>Vorschau stoppen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2795</context>
+          <context context-type="linenumber">2803</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
         <source>Track kurz anhören (max. 12 Sekunden)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2796</context>
+          <context context-type="linenumber">2804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
         <source>Ton an</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2808</context>
+          <context context-type="linenumber">2816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
         <source>Ton aus</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2809</context>
+          <context context-type="linenumber">2817</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
         <source>teilnehmende Person</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2866</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
         <source>Teilnehmende</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2870</context>
+          <context context-type="linenumber">2878</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
         <source>1 live verbunden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2887</context>
+          <context context-type="linenumber">2895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
         <source><x id="connectedCount" equiv-text="formatLocaleCount(connectedCount, this.localeId)"/> live verbunden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2889</context>
+          <context context-type="linenumber">2897</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
         <source>Noch niemand in diesem Team.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2923</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
         <source>Bewertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3729</context>
+          <context context-type="linenumber">3739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
         <source>Bewertungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3733</context>
+          <context context-type="linenumber">3743</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
         <source>Die Ergebnisse liegen vor.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3738</context>
+          <context context-type="linenumber">3748</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3745</context>
+          <context context-type="linenumber">3755</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
         <source>Zeit abgelaufen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3739</context>
+          <context context-type="linenumber">3749</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3746</context>
+          <context context-type="linenumber">3756</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
         <source>Warte auf Bewertungen…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3740</context>
+          <context context-type="linenumber">3750</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
         <source>Warte auf Antworten…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3747</context>
+          <context context-type="linenumber">3757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
         <source><x id="PH" equiv-text="formatLocaleCount(votes, this.localeId)"/> von <x id="PH_1" equiv-text="formatLocaleCount(participants, this.localeId)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3761</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3769</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
+        <source>Eine Person nutzt noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihr persönliches Fenster.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3768</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3774</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihre persönlichen Fenster.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">3773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
-        <source>Eine Person mit Zeitanpassung antwortet noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <source>Eine Person antwortet ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3772</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
-        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen mit Zeitanpassung antworten noch. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
+        <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen antworten ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3758</context>
+          <context context-type="linenumber">3774</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
         <source><x id="votes" equiv-text="formatLocaleCount(votes, this.localeId)"/> von <x id="participants" equiv-text="formatLocaleCount(participants, this.localeId)"/> Teilnehmenden hat abgestimmt. <x id="percentage" equiv-text="formattedPercentage"/> Prozent erreicht.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3764</context>
+          <context context-type="linenumber">3780</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
         <source><x id="votes" equiv-text="formatLocaleCount(votes, this.localeId)"/> von <x id="participants" equiv-text="formatLocaleCount(participants, this.localeId)"/> Teilnehmenden haben abgestimmt. <x id="percentage" equiv-text="formattedPercentage"/> Prozent erreicht.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3766</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
         <source><x id="voteCount" equiv-text="voteCount"/> von <x id="participantTotal" equiv-text="totalStr"/> hat abgestimmt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
         <source><x id="voteCount" equiv-text="voteCount"/> von <x id="participantTotal" equiv-text="totalStr"/> haben abgestimmt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3779</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
         <source><x id="voteCount" equiv-text="voteCount"/> von <x id="participantTotal" equiv-text="totalStr"/> hat bewertet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3790</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
         <source><x id="voteCount" equiv-text="voteCount"/> von <x id="participantTotal" equiv-text="totalStr"/> haben bewertet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3792</context>
+          <context context-type="linenumber">3808</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
         <source><x id="correctCount" equiv-text="formatLocaleCount(correct, this.localeId)"/> von <x id="voteTotal" equiv-text="formatLocaleCount(total, this.localeId)"/> komplett richtig (<x id="percentage" equiv-text="formatLocaleCount(pct, this.localeId)"/> %)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3798</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
         <source><x id="changed" equiv-text="formatLocaleCount(changed, this.localeId)"/> von <x id="both" equiv-text="formatLocaleCount(both, this.localeId)"/> (<x id="pct" equiv-text="formatLocaleCount(pct, this.localeId)"/> %) änderten ihre Meinung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3802</context>
+          <context context-type="linenumber">3818</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
         <source>↑ <x id="count" equiv-text="count"/> falsch → richtig</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3806</context>
+          <context context-type="linenumber">3822</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
         <source>↓ <x id="count" equiv-text="count"/> richtig → falsch</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3810</context>
+          <context context-type="linenumber">3826</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
         <source>Durchschnitt <x id="avg" equiv-text="formatted"/> von 5 Sternen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3816</context>
+          <context context-type="linenumber">3832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
         <source><x id="PH" equiv-text="total"/> Reaktion</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
         <source><x id="PH" equiv-text="total"/> Reaktionen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3836</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
         <source>Lobby – Teilnehmende können beitreten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3873</context>
+          <context context-type="linenumber">3889</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
         <source>Fragerunde wird vorbereitet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3874</context>
+          <context context-type="linenumber">3890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
         <source>Fragerunde läuft</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3875</context>
+          <context context-type="linenumber">3891</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3877</context>
+          <context context-type="linenumber">3893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3878</context>
+          <context context-type="linenumber">3894</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
         <source>Pausiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3876</context>
+          <context context-type="linenumber">3892</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
         <source>Fragerunde beendet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3879</context>
+          <context context-type="linenumber">3895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
         <source>Abstimmung beendet – warte auf Auswertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3884</context>
+          <context context-type="linenumber">3900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
         <source>Lobby – Teilnehmende können beitreten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3887</context>
+          <context context-type="linenumber">3903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
         <source>Lesephase – Antworten noch gesperrt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3888</context>
+          <context context-type="linenumber">3904</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
         <source>Abstimmung läuft</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3889</context>
+          <context context-type="linenumber">3905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
         <source>Pausiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3890</context>
+          <context context-type="linenumber">3906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
         <source>Ergebnisse werden angezeigt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3891</context>
+          <context context-type="linenumber">3907</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
         <source>Diskussionsphase – Austausch vor zweiter Runde</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3892</context>
+          <context context-type="linenumber">3908</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
         <source>Session beendet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3893</context>
+          <context context-type="linenumber">3909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
         <source><x id="readyCount" equiv-text="readyCount"/> von <x id="connectedCount" equiv-text="connectedCount"/> bereit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3904</context>
+          <context context-type="linenumber">3920</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
         <source><x id="PH" equiv-text="readyCount"/> von <x id="PH_1" equiv-text="connectedCount"/> verbunden bereit · <x id="PH_2" equiv-text="totalParticipantCount"/> insgesamt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3906</context>
+          <context context-type="linenumber">3922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
         <source>Alle Teilnehmenden sind bereit – Antwortoptionen können freigegeben werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3911</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
         <source>Alle verbundenen Teilnehmenden sind bereit – Antwortoptionen können freigegeben werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3913</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
         <source>1 Sekunde verbleibend</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3944</context>
+          <context context-type="linenumber">3960</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
         <source><x id="seconds" equiv-text="seconds"/> Sekunden verbleibend</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3945</context>
+          <context context-type="linenumber">3961</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -13157,7 +13255,7 @@
     )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4069,4072</context>
+          <context context-type="linenumber">4085,4088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -13167,7 +13265,7 @@
         )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4114,4117</context>
+          <context context-type="linenumber">4130,4133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -13177,7 +13275,7 @@
       )"/> bis <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4119,4122</context>
+          <context context-type="linenumber">4135,4138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -13187,77 +13285,77 @@
     )"/> bis <x id="right" equiv-text="this.formatNumericHostValue(band.right, question)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4124,4127</context>
+          <context context-type="linenumber">4140,4143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
         <source>Median <x id="median" equiv-text="this.formatNumericHostStatValue(stats.median, question)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4242</context>
+          <context context-type="linenumber">4258</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
         <source>Schätzungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4275</context>
+          <context context-type="linenumber">4291</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
         <source>gültige Antworten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4277</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
         <source>Mittelwert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4283</context>
+          <context context-type="linenumber">4299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
         <source>Durchschnitt aller Schätzungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4285</context>
+          <context context-type="linenumber">4301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
         <source>Median</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4291</context>
+          <context context-type="linenumber">4307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
         <source>Mitte der sortierten Werte</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4293</context>
+          <context context-type="linenumber">4309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
         <source>Streuung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4299</context>
+          <context context-type="linenumber">4315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
         <source>Standardabweichung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4301</context>
+          <context context-type="linenumber">4317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
         <source>Mittlere 50 %</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4307</context>
+          <context context-type="linenumber">4323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -13267,28 +13365,28 @@
         )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4312,4315</context>
+          <context context-type="linenumber">4328,4331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
         <source>Spanne</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
         <source>kleinste bis größte Schätzung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4326</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
         <source>Im Band</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4332</context>
+          <context context-type="linenumber">4348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -13299,42 +13397,42 @@
         )"/> % akzeptiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4338,4342</context>
+          <context context-type="linenumber">4354,4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
         <source>Mittlerer Abstand</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4348</context>
+          <context context-type="linenumber">4364</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
         <source>zur Referenz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4350</context>
+          <context context-type="linenumber">4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
         <source>Median</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4358</context>
+          <context context-type="linenumber">4374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
         <source>Mittelwert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4361</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
         <source>Schätzungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4363</context>
+          <context context-type="linenumber">4379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -13345,35 +13443,35 @@
     )"/> % im akzeptierten Bereich</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394,4398</context>
+          <context context-type="linenumber">4410,4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
         <source>Mittlerer Abstand zur Referenz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4412</context>
+          <context context-type="linenumber">4428</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
         <source>näher am Referenzwert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4426</context>
+          <context context-type="linenumber">4442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
         <source>Median-Veränderung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4443</context>
+          <context context-type="linenumber">4459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
         <source>Mittelwert-Veränderung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4444</context>
+          <context context-type="linenumber">4460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -13383,7 +13481,7 @@
         )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4455,4458</context>
+          <context context-type="linenumber">4471,4474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -13393,7 +13491,7 @@
         )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4464,4467</context>
+          <context context-type="linenumber">4480,4483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -13404,7 +13502,7 @@
         )"/> Prozentpunkte</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4476,4480</context>
+          <context context-type="linenumber">4492,4496</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -13419,7 +13517,7 @@
           )"/> vergleichbaren Schätzungen haben sich verbessert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4496,4504</context>
+          <context context-type="linenumber">4512,4520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -13434,14 +13532,14 @@
           )"/> vergleichbaren Schätzungen sind weiter entfernt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4516</context>
+          <context context-type="linenumber">4524,4532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
         <source>Runde 2 ist gemischt: näher und weiter entfernte Schätzungen halten sich im Paarvergleich die Waage.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520</context>
+          <context context-type="linenumber">4536</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -13451,7 +13549,7 @@
           )"/> kleiner.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4532,4535</context>
+          <context context-type="linenumber">4548,4551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -13461,7 +13559,7 @@
           )"/> größer.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4539,4542</context>
+          <context context-type="linenumber">4555,4558</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -13472,7 +13570,7 @@
         )"/> Prozentpunkte.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4554,4558</context>
+          <context context-type="linenumber">4570,4574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -13487,7 +13585,7 @@
         )"/> Schätzungen liegen im Toleranzband.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4573,4581</context>
+          <context context-type="linenumber">4589,4597</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -13497,7 +13595,7 @@
         )"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4586,4589</context>
+          <context context-type="linenumber">4602,4605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -13507,400 +13605,400 @@
         )"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4593,4596</context>
+          <context context-type="linenumber">4609,4612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
         <source>Quiz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4642</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2195</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionTabs.questions" datatype="html">
-        <source>Q&amp;A</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4644</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2197</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionTabs.questionsBadgeNew" datatype="html">
-        <source><x id="count" equiv-text="formatLocaleCount(this.qaUnseenCount(), this.localeId)"/> neu</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4652</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4669</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionTabs.channelInactive" datatype="html">
-        <source>Aus</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4769</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionTabs.channelClosed" datatype="html">
-        <source>Zu</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4658</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
           <context context-type="linenumber">2205</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionTabs.questions" datatype="html">
+        <source>Q&amp;A</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">4660</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2207</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionTabs.questionsBadgeNew" datatype="html">
+        <source><x id="count" equiv-text="formatLocaleCount(this.qaUnseenCount(), this.localeId)"/> neu</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">4668</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">4685</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionTabs.channelInactive" datatype="html">
+        <source>Aus</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">4785</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionTabs.channelClosed" datatype="html">
+        <source>Zu</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">4788</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2215</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="7367446920402175749" datatype="html">
         <source>Frage von <x id="PH" equiv-text="nickname"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">615</context>
+          <context context-type="linenumber">618</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8913852475666331247" datatype="html">
         <source>Frage aus dem Publikum</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4821</context>
+          <context context-type="linenumber">4837</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5574706582681662956" datatype="html">
         <source>Auswahl für <x id="PH" equiv-text="nickname"/> aufheben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4835</context>
+          <context context-type="linenumber">4851</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">580</context>
+          <context context-type="linenumber">583</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">626</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2964749761557345284" datatype="html">
         <source>Alle Fragen von <x id="PH" equiv-text="nickname"/> hervorheben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4836</context>
+          <context context-type="linenumber">4852</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">581</context>
+          <context context-type="linenumber">584</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">627</context>
+          <context context-type="linenumber">630</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPinned" datatype="html">
         <source>Wird beantwortet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4881</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2249</context>
+          <context context-type="linenumber">2259</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusActive" datatype="html">
         <source>Offen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4867</context>
+          <context context-type="linenumber">4883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2251</context>
+          <context context-type="linenumber">2261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusPending" datatype="html">
         <source>Wartet auf Freigabe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4869</context>
+          <context context-type="linenumber">4885</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2253</context>
+          <context context-type="linenumber">2263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusArchived" datatype="html">
         <source>Beantwortet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4871</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2255</context>
+          <context context-type="linenumber">2265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.statusDeleted" datatype="html">
         <source>Entfernt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4873</context>
+          <context context-type="linenumber">4889</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2257</context>
+          <context context-type="linenumber">2267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionApprove" datatype="html">
         <source>Freigeben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4974</context>
+          <context context-type="linenumber">4990</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
         <source>Hervorheben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4976</context>
+          <context context-type="linenumber">4992</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
         <source>Hervorhebung aufheben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4978</context>
+          <context context-type="linenumber">4994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
         <source>Archivieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4980</context>
+          <context context-type="linenumber">4996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
         <source>Endgültig entfernen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4983</context>
+          <context context-type="linenumber">4999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
         <source>Löschen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4984</context>
+          <context context-type="linenumber">5000</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
         <source>Kanal schließen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5328</context>
+          <context context-type="linenumber">5344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
         <source>Kanal wieder öffnen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5329</context>
+          <context context-type="linenumber">5345</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
         <source>Vorab-Moderation aktiviert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5743</context>
+          <context context-type="linenumber">5759</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
         <source>Vorab-Moderation deaktiviert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5744</context>
+          <context context-type="linenumber">5760</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
         <source>Frage freigegeben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5777</context>
+          <context context-type="linenumber">5793</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
         <source>Frage hervorgehoben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5779</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
         <source>Frage archiviert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5781</context>
+          <context context-type="linenumber">5797</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
         <source>Frage entfernt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5782</context>
+          <context context-type="linenumber">5798</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
         <source>Frage Nr.;Fragentext;Typ;Teilnehmende;Aggregationsrunde;Ø Punkte;Selbsteinschätzung n;Gefestigt;Fehlkonzept-Hinweis;Fragil;Erkannte Wissenslücke;Unentschieden;Häufigste selbstsicher falsche Antwort;Details</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5995</context>
+          <context context-type="linenumber">6011</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
         <source>Lernstand und Selbsteinschätzung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6049</context>
+          <context context-type="linenumber">6065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
         <source>Gültige Antworten;Ausgewertete Fragen;Nicht aggregiert (&lt;5 Antworten mit Selbsteinschätzung);Gefestigt;Fehlkonzept-Hinweis;Fragil;Erkannte Wissenslücke;Unentschieden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6052</context>
+          <context context-type="linenumber">6068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
         <source>Team-Wertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6073</context>
+          <context context-type="linenumber">6089</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
         <source>Rang;Team;Farbe;Mitglieder;Team-Punkte;Ø Punkte pro Mitglied</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6075</context>
+          <context context-type="linenumber">6091</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
         <source>Bonus-Codes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6093</context>
+          <context context-type="linenumber">6109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
         <source>Rang;Nickname;Code;Punkte;Generiert am</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6095</context>
+          <context context-type="linenumber">6111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
         <source>Ergebnis-CSV exportiert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6103</context>
+          <context context-type="linenumber">6119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
         <source>Nachbesprechungsplan als PDF ansehen – 1 Frage zur Nachbesprechung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6115</context>
+          <context context-type="linenumber">6131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
         <source>Nachbesprechungsplan als PDF ansehen – <x id="count" equiv-text="count"/> Fragen zur Nachbesprechung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6118</context>
+          <context context-type="linenumber">6134</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
         <source>Nachbesprechungsplan als PDF ansehen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6120</context>
+          <context context-type="linenumber">6136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
         <source>1 Frage zur Nachbesprechung empfohlen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6125</context>
+          <context context-type="linenumber">6141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
         <source><x id="count" equiv-text="count"/> Fragen zur Nachbesprechung empfohlen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6127</context>
+          <context context-type="linenumber">6143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
         <source>PDF wird erstellt (<x id="PH" equiv-text="questionCount"/> Fragen)…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6139</context>
+          <context context-type="linenumber">6155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
         <source>Ergebnis-PDF heruntergeladen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6145</context>
+          <context context-type="linenumber">6161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
         <source>Ergebnis-PDF zum Speichern geöffnet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
         <source>Nr.;Frage-ID;Status;Frage;Score;Positive Stimmen;Negative Stimmen;Stimmen gesamt;Wilson-Score;Kontroverse-Score;Umstritten;Erstellt am</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6173</context>
+          <context context-type="linenumber">6189</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
         <source>Q&amp;A-CSV exportiert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6196</context>
+          <context context-type="linenumber">6212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
         <source>Frage <x id="questionNumber" equiv-text="data.questionOrder + 1"/>: <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6359</context>
+          <context context-type="linenumber">6375</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6367</context>
+          <context context-type="linenumber">6383</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13915,7 +14013,7 @@
         <source>Live-Freitext wird aktualisiert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6362</context>
+          <context context-type="linenumber">6378</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13926,7 +14024,7 @@
         <source>Aktuelle Frage ist keine Freitext-Frage.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6370</context>
+          <context context-type="linenumber">6386</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13937,7 +14035,7 @@
         <source>Noch keine aktive Frage.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6373</context>
+          <context context-type="linenumber">6389</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13948,7 +14046,7 @@
         <source>Live-Freitextdaten konnten nicht geladen werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6377</context>
+          <context context-type="linenumber">6393</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -15491,826 +15589,882 @@
           <context context-type="linenumber">576</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
+        <source> Zeit anpassen </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">14,16</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
+        <source> Vor der Frage wählen · 10× Zeit = zehnfacher Raum-Countdown </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.summary" datatype="html">
+        <source>So werden Punkte berechnet</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.intro" datatype="html">
+        <source> So setzt sich deine Punktezahl zusammen: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">29,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.base" datatype="html">
+        <source> Basis: Bis zu 1000 Punkte für eine richtige Antwort. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">33,35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.difficulty" datatype="html">
+        <source> Schwierigkeit: Leicht ×1, Mittel ×2, Schwer ×3. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">36,38</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.time" datatype="html">
+        <source> Zeit: Je früher du beim gemeinsamen Raum-Countdown richtig antwortest, desto höher der Zeitanteil. Nach Ablauf bleiben noch 10 % davon. Deine persönliche Frist ändert nur, wie lange du antworten darfst – nicht diese Zeitwertung. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">39,43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.streak" datatype="html">
+        <source> Serie: Mehrere richtige Antworten hintereinander geben Bonus – 1× ×1,0 · 2× ×1,1 · 3× ×1,2 · 4× ×1,3 · ab 5× ×1,5. Eine falsche bewertbare Antwort setzt die Serie zurück. Umfragen und unbewerteter Freitext unterbrechen sie nicht. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">44,48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scoringInfo.preview" datatype="html">
+        <source> Die Live-Punktvorschau zeigt den aktuellen Stand ohne Serien-Bonus. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">49,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
+        <source> Keine persönliche Frist · Punkte weiter nach dem Raum-Timer </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">74,76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
+        <source> 10× Zeit aktiv · Das Ergebnis wartet auf dich </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">83,85</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionVote.sessionEndGateTitle" datatype="html">
         <source> Session beendet </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">21,23</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.bonusGateLead" datatype="html">
         <source> Du hast einen Bonus-Code erhalten. Kopiere ihn jetzt in die Zwischenablage (z. B. für eine Mail an die Veranstaltungsleitung), bevor du zur Startseite gehst. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">28,31</context>
+          <context context-type="linenumber">117,120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionEndFeedbackLead" datatype="html">
         <source> Die Session ist beendet. Wenn du magst, bewerte sie kurz – danach kannst du zur Startseite wechseln. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">44,47</context>
+          <context context-type="linenumber">133,136</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.sessionActionsAria" datatype="html">
         <source>Session-Aktionen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.voteAria" datatype="html">
         <source>Live-Bereich wählen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">232</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.pointsUnit" datatype="html">
         <source>Punkte</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">319</context>
+          <context context-type="linenumber">408</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.hide" datatype="html">
+        <source> Ausblenden </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">416,418</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.scorePreview.show" datatype="html">
+        <source> Live-Punkte anzeigen </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
+          <context context-type="linenumber">427,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.mediaAnswerHint" datatype="html">
         <source>Das Bild ist nur zur Ansicht. Wähle deine Antwort unten aus.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">985</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.legend" datatype="html">
-        <source> Zeit anpassen </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1010,1012</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.help" datatype="html">
-        <source> Nur für dich · Der Quizablauf bleibt unverändert </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1016,1018</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.points" datatype="html">
-        <source> Punkte richten sich nach dem gemeinsamen Countdown </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1021,1023</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.offStatus" datatype="html">
-        <source> Ohne Timer aktiv · Abgabe möglich, solange die Frage offen ist </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1043,1045</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="sessionVote.timerAccommodation.extendedStatus" datatype="html">
-        <source> 10× Zeit aktiv </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericLabel" datatype="html">
         <source> Deine Schätzung </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1262,1264</context>
+          <context context-type="linenumber">1324,1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericPlaceholder" datatype="html">
         <source>Zahl eingeben…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1284</context>
+          <context context-type="linenumber">1346</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultPrefix" datatype="html">
         <source>Deine Antwort:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1933013871016789910" datatype="html">
         <source>Gesamt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1351</context>
+          <context context-type="linenumber">1413</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1655</context>
+          <context context-type="linenumber">1717</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHeading" datatype="html">
         <source> Wie sicher bist du bei dieser Antwort? </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1404,1406</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceHint" datatype="html">
         <source> Bezieht sich auf deine gerade gewählte Antwort. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1411,1413</context>
+          <context context-type="linenumber">1473,1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultPrefix" datatype="html">
         <source>Deine Selbsteinschätzung:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceSentPrefix" datatype="html">
         <source>Selbsteinschätzung:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1480</context>
+          <context context-type="linenumber">1542</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8052936664226936966" datatype="html">
         <source>Serie (×<x id="INTERPOLATION" equiv-text="{{ sc.streakMultiplier | number: &apos;1.1-1&apos; }}"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1635</context>
+          <context context-type="linenumber">1697</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4068334453877547924" datatype="html">
         <source>Dein Rang</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1649</context>
+          <context context-type="linenumber">1711</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedNotice" datatype="html">
         <source> Der Q&amp;A-Kanal wurde von der Lehrperson geschlossen. Fragen und Bewertungen sind gerade nicht möglich. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1865,1868</context>
+          <context context-type="linenumber">1927,1930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaIdentityHint" datatype="html">
         <source>Du fragst als</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnAria" datatype="html">
         <source>Frage löschen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2039</context>
+          <context context-type="linenumber">2101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaClosedHint" datatype="html">
         <source> Die bisherigen Inhalte sind für Teilnehmende ausgeblendet, bis die Lehrperson den Kanal wieder öffnet. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2058,2061</context>
+          <context context-type="linenumber">2120,2123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quickFeedbackClosedTitle" datatype="html">
         <source> Blitzlicht geschlossen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2077,2079</context>
+          <context context-type="linenumber">2139,2141</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedActionsAria" datatype="html">
         <source>Abschluss-Aktionen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2109</context>
+          <context context-type="linenumber">2171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.quizActionsAria" datatype="html">
         <source>Quiz-Aktionen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2147</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.qaActionsAria" datatype="html">
         <source>Q&amp;A-Aktionen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
-          <context context-type="linenumber">2166</context>
+          <context context-type="linenumber">2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2427920593873911865" datatype="html">
         <source>Perfekt! 🎯</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">169</context>
+          <context context-type="linenumber">170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3996850202378161277" datatype="html">
         <source>Richtig! 💪</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">170</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1090604167231677526" datatype="html">
         <source>Volltreffer! ⭐</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">171</context>
+          <context context-type="linenumber">172</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3502096474885920612" datatype="html">
         <source>Stark! 🔥</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">172</context>
+          <context context-type="linenumber">173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7691272538064479056" datatype="html">
         <source>Genau richtig! 🚀</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">173</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7790447949587239556" datatype="html">
         <source>Läuft bei dir! 🎸</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">175</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4185659153521425300" datatype="html">
         <source>Nailed it! 👏</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">175</context>
+          <context context-type="linenumber">176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS1" datatype="html">
         <source>Richtig.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">178</context>
+          <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS2" datatype="html">
         <source>Korrekt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">179</context>
+          <context context-type="linenumber">180</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgCorrectS3" datatype="html">
         <source>Antwort stimmt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">180</context>
+          <context context-type="linenumber">181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3211338642099056060" datatype="html">
         <source>Knapp daneben! 🤏</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">183</context>
+          <context context-type="linenumber">184</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1731892131220774983" datatype="html">
         <source>Nächstes Mal! 💡</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9186185663967902020" datatype="html">
         <source>Weiter dranbleiben! 🔄</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">185</context>
+          <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3551623243824977572" datatype="html">
         <source>Das wird schon! 📈</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">186</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5506746370181957809" datatype="html">
         <source>Nicht aufgeben! 💪</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">187</context>
+          <context context-type="linenumber">188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS1" datatype="html">
         <source>Nicht richtig.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS2" datatype="html">
         <source>Leider falsch.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgWrongS3" datatype="html">
         <source>Versuch es bei der nächsten Frage erneut.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">192</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3145164147131753937" datatype="html">
         <source>Antwort gespeichert! ✓</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">195</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3110097502695814008" datatype="html">
         <source>Danke für deine Antwort! 📝</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4856001851461935545" datatype="html">
         <source>Weiter so! 🚀</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS1" datatype="html">
         <source>Antwort gespeichert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">200</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgNeutralS2" datatype="html">
         <source>Danke, deine Antwort wurde übernommen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6032822770375401279" datatype="html">
         <source>Knapp verpasst – nächste Runde! ⏱️</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">204</context>
+          <context context-type="linenumber">205</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3646778948280182955" datatype="html">
         <source>Die Zeit war zu kurz – du schaffst das! 💪</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">205</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5015240621073925218" datatype="html">
         <source>Beim nächsten Mal klappt&apos;s! 🔄</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="850308549833737974" datatype="html">
         <source>Kopf hoch – gleich geht&apos;s weiter! 🚀</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3277616416884173208" datatype="html">
         <source>Tick-tock – nächste Chance kommt! ⏰</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">208</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS1" datatype="html">
         <source>Zeit abgelaufen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">211</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS2" datatype="html">
         <source>Die Zeit ist um – warte auf die nächste Frage.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">212</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.msgTimeoutS3" datatype="html">
         <source>Zu spät abgestimmt. Nächste Chance folgt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">213</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakPlayful" datatype="html">
         <source>On fire! 🔥 <x id="c" equiv-text="sc.streakCount"/>er-Serie!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">302</context>
+          <context context-type="linenumber">303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakSerious" datatype="html">
         <source><x id="c" equiv-text="sc.streakCount"/> richtige Antworten in Folge.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">303</context>
+          <context context-type="linenumber">304</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Playful" datatype="html">
         <source>Ein Platz nach oben! 🚀</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">308</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRank1Serious" datatype="html">
         <source>Ein Rang nach oben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">310</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNPlayful" datatype="html">
         <source><x id="n" equiv-text="sc.rankChange"/> Plätze nach oben! 🚀</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">312</context>
+          <context context-type="linenumber">313</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivRankNSerious" datatype="html">
         <source><x id="n" equiv-text="sc.rankChange"/> Plätze nach oben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">313</context>
+          <context context-type="linenumber">314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakPlayful" datatype="html">
         <source>Streak gerissen! Nächste Runde! 💪</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">320</context>
+          <context context-type="linenumber">321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivStreakBreakSerious" datatype="html">
         <source>Serie beendet – nächste Frage zählt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">321</context>
+          <context context-type="linenumber">322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopPlayful" datatype="html">
         <source>Kopf hoch – du liegst noch gut! 🏅</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivTopSerious" datatype="html">
         <source>Du befindest dich weiter vorn in der Rangliste.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">327</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChasePlayful" datatype="html">
         <source>Weiter so – jede Frage ist eine neue Chance! 🌟</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.motivChaseSerious" datatype="html">
         <source>Weiter üben – die nächste Frage bringt neue Punkte.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">331</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivEvaluated" datatype="html">
         <source>Antwort ausgewertet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">352</context>
+          <context context-type="linenumber">353</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivOutOfBand" datatype="html">
         <source>Außerhalb des Toleranzbands.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">356</context>
+          <context context-type="linenumber">357</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivExact" datatype="html">
         <source>Volltreffer: genau am Referenzwert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">361</context>
+          <context context-type="linenumber">362</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivInBand" datatype="html">
         <source>Im akzeptierten Bereich.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">367</context>
+          <context context-type="linenumber">368</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">376</context>
+          <context context-type="linenumber">377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericEstimateMotivVeryClose" datatype="html">
         <source>Sehr nah am Referenzwert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">373</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixPlayful" datatype="html">
         <source>Perfekt!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalPrefixSerious" datatype="html">
         <source>Du bist jetzt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixPlayful" datatype="html">
         <source>wartet schon auf dich.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">547</context>
+          <context context-type="linenumber">550</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamArrivalSuffixSerious" datatype="html">
         <source>zugeordnet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">548</context>
+          <context context-type="linenumber">551</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3932968695937052509" datatype="html">
         <source>Du fragst als <x id="PH" equiv-text="nick"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3719653345310622722" datatype="html">
         <source>Dein Tier-Icon</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">574</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">577</context>
+          <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.playerTeamBadgeAria" datatype="html">
         <source><x id="nickname" equiv-text="nick"/>, <x id="teamName" equiv-text="teamLabel"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">589</context>
+          <context context-type="linenumber">592</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5952222840612966712" datatype="html">
         <source>Deine Frage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">617</context>
+          <context context-type="linenumber">620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.autoJoinFailed" datatype="html">
         <source>Teilnahme konnte nicht vorbereitet werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">785</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextTooLong" datatype="html">
         <source>Maximal <x id="maxLength" equiv-text="maxLength"/> Zeichen erlaubt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1325</context>
+          <context context-type="linenumber">1335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericInvalid" datatype="html">
         <source>Kurzantwort muss als Zahl im unterstützten Format eingegeben werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1333</context>
+          <context context-type="linenumber">1343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1471</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultInvalid" datatype="html">
         <source>Ungültiges Zahlenformat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1437</context>
+          <context context-type="linenumber">1447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultFull" datatype="html">
         <source>Voll gewertet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1442</context>
+          <context context-type="linenumber">1452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultAccepted" datatype="html">
         <source>Akzeptiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1443</context>
+          <context context-type="linenumber">1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultPartial" datatype="html">
         <source>Teilweise gewertet (<x id="points" equiv-text="result.points"/> %)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1457</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultRejected" datatype="html">
         <source>Nicht akzeptiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1450</context>
+          <context context-type="linenumber">1460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericNoMatch" datatype="html">
         <source>Keine Referenzlösung lag innerhalb der eingestellten Zahltoleranz.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultMatchedSolution" datatype="html">
         <source>Gewertet als Musterlösung „<x id="matchedModelAnswer" equiv-text="result.matchedModelAnswer"/>“.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1469</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1485</context>
+          <context context-type="linenumber">1495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonNoMatch" datatype="html">
         <source>Keine Musterlösung lag innerhalb der eingestellten Toleranz.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1477</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1501</context>
+          <context context-type="linenumber">1511</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonHamming" datatype="html">
         <source>Kleiner Tippfehler bei gleicher Länge lag noch innerhalb der Toleranz.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1495</context>
+          <context context-type="linenumber">1505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonDamerau" datatype="html">
         <source>Ein Buchstabendreher lag noch innerhalb der Toleranz.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1497</context>
+          <context context-type="linenumber">1507</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextResultReasonLevenshtein" datatype="html">
         <source>Ein fehlendes oder zusätzliches Zeichen lag noch innerhalb der Toleranz.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1499</context>
+          <context context-type="linenumber">1509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingRequired" datatype="html">
         <source>Der Zahlenwert stimmte, aber die verlangte Einheit fehlte.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1509</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalentRejected" datatype="html">
         <source>Der Zahlenwert stimmte nach Umrechnung, aber nur die hinterlegte Einheit ist zugelassen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonWrongFamily" datatype="html">
         <source>Der Zahlenwert passte, aber die Einheit gehört zu einer anderen Größenfamilie.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1513</context>
+          <context context-type="linenumber">1523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonUnsupportedUnit" datatype="html">
         <source>Der Zahlenwert passte, aber die eingegebene Einheit liegt außerhalb des unterstützten Einheitensets.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1515</context>
+          <context context-type="linenumber">1525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonPartial" datatype="html">
         <source>Der Zahlenwert passte, aber die Einheit verhinderte die volle Wertung.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1517</context>
+          <context context-type="linenumber">1527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonEquivalent" datatype="html">
         <source>Zahlenwert und äquivalente Einheit wurden korrekt umgerechnet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonMissingOptional" datatype="html">
         <source>Der Zahlenwert passte; die Einheit war in dieser Frage optional.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1525</context>
+          <context context-type="linenumber">1535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonTolerance" datatype="html">
         <source>Der Zahlenwert lag innerhalb der eingestellten Toleranz.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1528</context>
+          <context context-type="linenumber">1538</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.shortTextNumericReasonExact" datatype="html">
         <source>Zahlenwert und Einheit stimmen exakt mit einer Musterlösung überein.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1531</context>
+          <context context-type="linenumber">1541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeInteger" datatype="html">
         <source>Ganzzahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1865</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputModeDecimal" datatype="html">
         <source>Dezimalzahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1856</context>
+          <context context-type="linenumber">1866</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatInteger" datatype="html">
         <source>Gib eine ganze Zahl ohne Nachkommastellen ein.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1861</context>
+          <context context-type="linenumber">1871</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimalPlaces" datatype="html">
         <source>Komma oder Punkt möglich, maximal <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> Nachkommastellen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1865</context>
+          <context context-type="linenumber">1875</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericFormatDecimal" datatype="html">
         <source>Komma oder Punkt möglich.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1867</context>
+          <context context-type="linenumber">1877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeBoth" datatype="html">
@@ -16319,7 +16473,7 @@
       )"/> bis <x id="max" equiv-text="this.formatNumericResultValue(max)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1874,1876</context>
+          <context context-type="linenumber">1884,1886</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMin" datatype="html">
@@ -16328,7 +16482,7 @@
       )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1879,1881</context>
+          <context context-type="linenumber">1889,1891</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInputRangeMax" datatype="html">
@@ -16337,21 +16491,21 @@
       )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">1884,1886</context>
+          <context context-type="linenumber">1894,1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultInBand" datatype="html">
         <source>Im Toleranzband</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultOutOfBand" datatype="html">
         <source>Außerhalb des Toleranzbands</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2030</context>
+          <context context-type="linenumber">2040</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultReference" datatype="html">
@@ -16360,7 +16514,7 @@
     )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2036,2038</context>
+          <context context-type="linenumber">2046,2048</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedSingle" datatype="html">
@@ -16369,7 +16523,7 @@
         )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2049,2051</context>
+          <context context-type="linenumber">2059,2061</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultAcceptedRange" datatype="html">
@@ -16378,7 +16532,7 @@
       )"/> bis <x id="right" equiv-text="this.formatNumericResultValue(acceptedRight)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2053,2055</context>
+          <context context-type="linenumber">2063,2065</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultToleranceBand" datatype="html">
@@ -16387,14 +16541,14 @@
     )"/> bis <x id="right" equiv-text="this.formatNumericResultValue(band.right)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2057,2059</context>
+          <context context-type="linenumber">2067,2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultExact" datatype="html">
         <source>Genau am Referenzwert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2068</context>
+          <context context-type="linenumber">2078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultDistance" datatype="html">
@@ -16403,7 +16557,7 @@
     )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2070,2072</context>
+          <context context-type="linenumber">2080,2082</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultImproved" datatype="html">
@@ -16412,7 +16566,7 @@
       )"/> näher am Referenzwert als in Runde 1</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2109,2111</context>
+          <context context-type="linenumber">2119,2121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultWorse" datatype="html">
@@ -16421,450 +16575,464 @@
       )"/> weiter weg vom Referenzwert als in Runde 1</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2114,2116</context>
+          <context context-type="linenumber">2124,2126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericResultUnchanged" datatype="html">
         <source>Gleich nah am Referenzwert wie in Runde 1</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2118</context>
+          <context context-type="linenumber">2128</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericRequired" datatype="html">
         <source>Bitte gib eine Zahl ein.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2139</context>
+          <context context-type="linenumber">2149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericIntegerRequired" datatype="html">
         <source>Bitte gib eine ganze Zahl im unterstützten Format ein.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2143</context>
+          <context context-type="linenumber">2153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericDecimalPlacesExceeded" datatype="html">
         <source>Maximal <x id="maxDecimalPlaces" equiv-text="maxDecimalPlaces"/> Nachkommastellen erlaubt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2152</context>
+          <context context-type="linenumber">2162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericInvalid" datatype="html">
         <source>Bitte gib eine gültige Zahl im unterstützten Format ein.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2154</context>
+          <context context-type="linenumber">2164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericBelowMin" datatype="html">
         <source>Bitte gib einen Wert von mindestens <x id="min" equiv-text="min"/> ein.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2160</context>
+          <context context-type="linenumber">2170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.numericAboveMax" datatype="html">
         <source>Bitte gib einen Wert von höchstens <x id="max" equiv-text="max"/> ein.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2163</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinalScore" datatype="html">
         <source>Finaler Score</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2311</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleWinFin" datatype="html">
         <source>Ihr gewinnt als Team!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2316</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleFinishedOther" datatype="html">
         <source>Im Ziel</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasingZero" datatype="html">
         <source>Jetzt nachlegen – ihr holt das noch!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2321</context>
+          <context context-type="linenumber">2331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleAllZero" datatype="html">
         <source>Zeigt, was in euch steckt!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2322</context>
+          <context context-type="linenumber">2332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleLeading" datatype="html">
         <source>Ihr führt gerade</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2325</context>
+          <context context-type="linenumber">2335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardTitleChasing" datatype="html">
         <source>Weitermachen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2327</context>
+          <context context-type="linenumber">2337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgWinFin" datatype="html">
         <source>Gemeinsam gewonnen: Platz 1 für euch.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2345</context>
+          <context context-type="linenumber">2355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedAllZero" datatype="html">
         <source>Quiz beendet – es wurden keine Team-Punkte vergeben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOwnZero" datatype="html">
         <source>Quiz beendet – ihr habt keine Team-Punkte gesammelt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2351</context>
+          <context context-type="linenumber">2361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgFinishedOther" datatype="html">
         <source>Ihr beendet mit <x id="totalScore" equiv-text="formatLocaleCount(entry.totalScore, getEffectiveLocale())"/> Punkten auf Platz <x id="teamRank" equiv-text="formatLocaleCount(entry.rank, getEffectiveLocale())"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2353</context>
+          <context context-type="linenumber">2363</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgAllZero" datatype="html">
         <source>Mit richtigen Antworten sammelt ihr Punkte fürs Team.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2357</context>
+          <context context-type="linenumber">2367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgChasing" datatype="html">
         <source>Aktuell Platz <x id="teamRank" equiv-text="formatLocaleCount(entry.rank, getEffectiveLocale())"/> mit <x id="totalScore" equiv-text="formatLocaleCount(entry.totalScore, getEffectiveLocale())"/> Punkten.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2359</context>
+          <context context-type="linenumber">2369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamRewardMsgLeading" datatype="html">
         <source>Mit <x id="totalScore" equiv-text="formatLocaleCount(entry.totalScore, getEffectiveLocale())"/> Punkten führt ihr.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2362</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulLoading" datatype="html">
         <source>Ergebnis wird geladen…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2406</context>
+          <context context-type="linenumber">2416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.finishedTitlePlayfulNeutral" datatype="html">
         <source>Das war&apos;s – danke fürs Mitmachen!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2411</context>
+          <context context-type="linenumber">2421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingNoRank" datatype="html">
         <source><x id="teamName" equiv-text="teamLabel"/> mit <x id="memberCountLabel" equiv-text="this.teamMemberLabel(entry.memberCount)"/> und <x id="totalScore" equiv-text="formatLocaleCount(entry.totalScore, getEffectiveLocale())"/> Team-Punkten, noch ohne Rang</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2442</context>
+          <context context-type="linenumber">2452</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.teamStandingWithMembers" datatype="html">
         <source>Platz <x id="teamRank" equiv-text="formatLocaleCount(entry.rank, getEffectiveLocale())"/>: <x id="teamName" equiv-text="teamLabel"/> mit <x id="memberCountLabel" equiv-text="this.teamMemberLabel(entry.memberCount)"/> und <x id="totalScore" equiv-text="formatLocaleCount(entry.totalScore, getEffectiveLocale())"/> Punkten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2444</context>
+          <context context-type="linenumber">2454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2602080285199874401" datatype="html">
         <source><x id="PH" equiv-text="stars"/> von 5 Sternen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2477</context>
+          <context context-type="linenumber">2487</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaOne" datatype="html">
         <source>1 Sekunde verbleibend</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2483</context>
+          <context context-type="linenumber">2493</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.countdownAriaMany" datatype="html">
         <source><x id="seconds" equiv-text="seconds"/> Sekunden verbleibend</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2484</context>
+          <context context-type="linenumber">2494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.groupAria" datatype="html">
         <source>Persönliche Zeit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2488</context>
+          <context context-type="linenumber">2498</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.extended" datatype="html">
         <source>10× Zeit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2494</context>
+          <context context-type="linenumber">2504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.off" datatype="html">
-        <source>Ohne Timer</source>
+        <source>Ohne Frist</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2496</context>
+          <context context-type="linenumber">2506</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.default" datatype="html">
         <source>Standard</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2498</context>
+          <context context-type="linenumber">2508</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsDefault" datatype="html">
+        <source>Punkte folgen dem gemeinsamen Countdown</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2514</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionVote.timerAccommodation.pointsOvertime" datatype="html">
+        <source>Früh abgeben lohnt sich · nach dem Countdown nur Mindestpunkte</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
+          <context context-type="linenumber">2516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.overtimeCorrect" datatype="html">
         <source>Nachlaufzeit · richtige Antwort</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2504</context>
+          <context context-type="linenumber">2521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.upToNow" datatype="html">
         <source>Volle Wertung jetzt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2507</context>
+          <context context-type="linenumber">2524</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.scorePreview.correctNow" datatype="html">
         <source>Richtige Antwort jetzt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2508</context>
+          <context context-type="linenumber">2525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.timerAccommodation.error" datatype="html">
         <source>Zeitanpassung konnte nicht gespeichert werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2536</context>
+          <context context-type="linenumber">2561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeUpvoteAria" datatype="html">
         <source>Positivbewertung zurücknehmen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2547</context>
+          <context context-type="linenumber">2572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addUpvoteAria" datatype="html">
         <source>Positiv bewerten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2548</context>
+          <context context-type="linenumber">2573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.removeDownvoteAria" datatype="html">
         <source>Negativbewertung zurücknehmen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2552</context>
+          <context context-type="linenumber">2577</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.addDownvoteAria" datatype="html">
         <source>Negativ bewerten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2553</context>
+          <context context-type="linenumber">2578</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5043949766391435553" datatype="html">
         <source>Bewertung von <x id="PH" equiv-text="this.ratingLabelMin()"/> bis <x id="PH_1" equiv-text="this.ratingLabelMax()"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2557</context>
+          <context context-type="linenumber">2582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2721187191897749624" datatype="html">
         <source>Bewertung <x id="PH" equiv-text="value"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2561</context>
+          <context context-type="linenumber">2586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLabels" datatype="html">
         <source>Selbsteinschätzung von 1 bis 5, niedrig: <x id="low" equiv-text="low"/>, hoch: <x id="high" equiv-text="high"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2588</context>
+          <context context-type="linenumber">2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithLow" datatype="html">
         <source>Selbsteinschätzung von 1 bis 5, niedrig: <x id="low" equiv-text="low"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2591</context>
+          <context context-type="linenumber">2616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAriaWithHigh" datatype="html">
         <source>Selbsteinschätzung von 1 bis 5, hoch: <x id="high" equiv-text="high"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2594</context>
+          <context context-type="linenumber">2619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceAria" datatype="html">
         <source>Selbsteinschätzung von 1 bis 5</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2596</context>
+          <context context-type="linenumber">2621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceValueAria" datatype="html">
         <source>Selbsteinschätzung <x id="value" equiv-text="value"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2600</context>
+          <context context-type="linenumber">2625</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithLowLabel" datatype="html">
         <source><x id="value" equiv-text="value"/> – <x id="label" equiv-text="low"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2611</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceResultWithHighLabel" datatype="html">
         <source><x id="value" equiv-text="value"/> – <x id="label" equiv-text="high"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2614</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="974858114847169012" datatype="html">
         <source>Reagiere mit <x id="PH" equiv-text="emoji"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">2634</context>
+          <context context-type="linenumber">2659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteLoadError" datatype="html">
         <source>Fragen konnten nicht geladen werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3519</context>
+          <context context-type="linenumber">3547</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitSuccess" datatype="html">
         <source>Frage gesendet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3562</context>
+          <context context-type="linenumber">3590</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.submitError" datatype="html">
         <source>Frage konnte nicht gesendet werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3568</context>
+          <context context-type="linenumber">3596</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3588</context>
+          <context context-type="linenumber">3616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3617</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3625</context>
+          <context context-type="linenumber">3653</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.upvoteError" datatype="html">
         <source>Stimme konnte nicht gespeichert werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3666</context>
+          <context context-type="linenumber">3694</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.deleteOwnError" datatype="html">
         <source>Frage konnte nicht gelöscht werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3694</context>
+          <context context-type="linenumber">3722</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwnMany" datatype="html">
         <source>Die Moderation hat deine Fragen entfernt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3750</context>
+          <context context-type="linenumber">3778</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOwn" datatype="html">
         <source>Die Moderation hat deine Frage entfernt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3751</context>
+          <context context-type="linenumber">3779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOthersMany" datatype="html">
         <source>Mehrere Fragen wurden von der Moderation entfernt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3755</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.snackModeratorRemovedOther" datatype="html">
         <source>Eine Frage wurde von der Moderation entfernt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">3756</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.readingReadyError" datatype="html">
         <source>Bereitschaft konnte nicht bestätigt werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4017</context>
+          <context context-type="linenumber">4045</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionVote.confidenceRequired" datatype="html">
         <source>Gib deine Selbsteinschätzung an, bevor du absendest.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
-          <context context-type="linenumber">4188</context>
+          <context context-type="linenumber">4216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9175670018185396326" datatype="html">

--- a/docs/praktikum/ACCESSIBILITY-AUDIT-WCAG-2.2-AA.md
+++ b/docs/praktikum/ACCESSIBILITY-AUDIT-WCAG-2.2-AA.md
@@ -244,19 +244,20 @@ bestehen PDF/UA-1. Die Reader-/Screenreader-Abnahme bleibt offen.
 ### 4.9 Persönliche Zeitanpassung
 
 - Teilnehmende können für getimte Fragen `Standard`, `10× Zeit` oder
-  `Ohne Timer` wählen;
+  `Ohne Frist` wählen (Lobby und ACTIVE);
 - Präferenz wird am Participant und auf dem Gerät gespeichert und bei Rejoin
   wiederhergestellt;
 - persönliche Deadline und gemeinsamer Session-Timer sind getrennt;
-- die persönliche Deadline gilt derzeit nur im Status `ACTIVE`; eine vorzeitige
-  Ergebnisfreigabe durch den Host beendet auch angepasste Eingabefenster;
+- `EXTENDED`-Fenster blockieren Host-Freigabe bis zum Ablauf bzw. bis zum
+  bestätigten Host-Override nach Raum-Countdown (`forceClosePersonalTimers`);
+- `Ohne Frist` endet mit Host-Freigabe (kein Host-Block); der Hinweis macht das
+  transparent;
 - die Punktelogik bleibt am gemeinsamen Countdown, damit der
   Nachteilsausgleich keinen Zeitbonus erzeugt;
-- eine lokale Punktvorschau kennzeichnet die Nachlaufzeit mit festem
-  zeitabhängigem Mindestwert;
-- der Host sieht vor „Ergebnis zeigen“, wie viele Personen mit
-  Zeitanpassung noch antworten, und bleibt für den Ablauf verantwortlich; der
-  Hinweis ersetzt keine technische Garantie des persönlichen Zeitfensters.
+- eine lokale Punktvorschau kann ausgeblendet werden (WCAG 2.2.2); der Zustand
+  bleibt geräteweit gespeichert und ohne sekündliche Live-Region;
+- der Host sieht vor „Ergebnis zeigen“, wie viele Personen mit Zeitanpassung
+  noch antworten, und bleibt für den Ablauf verantwortlich.
 
 ### 4.10 Accessibility, UX und Design
 
@@ -630,31 +631,23 @@ gepflegt.
 `apps/backend/src/routers/vote.ts` und Vote-UI in
 `apps/frontend/src/app/features/session/session-vote/`
 
-**Umsetzungsstand 2026-07-20:** Teilweise umgesetzt, Konformitätsrisiko offen
-(PR #101). Teilnehmende können `10× Zeit` oder `Ohne Timer` wählen. Solange die
-Frage `ACTIVE` ist, setzt das Backend die persönliche Deadline durch; Scoring
-und gemeinsamer Ablauf bleiben am Session-Timer. Der Host erhält einen Hinweis
-auf noch offene angepasste Eingabefenster.
-
-Wechselt der Host vor Ablauf dieser Fenster zu `RESULTS` oder `DISCUSSION`,
-weist das Backend weitere Antworten zurück. Bei `EXTENDED` liegt der
-Statuswechsel dann vor der persönlichen Deadline; bei `OFF` existiert keine
-Deadline, die eine Abgabe außerhalb von `ACTIVE` erlauben könnte. Der
-Host-Hinweis ist damit eine informierte Ablaufentscheidung, aber keine
-technische Garantie des Nachteilsausgleichs.
+**Umsetzungsstand 2026-07-20:** Weitgehend geschlossen auf Branch
+`a11y/wcag22-final-compliance`. Teilnehmende wählen `Standard`, `10× Zeit` oder
+`Ohne Frist` bereits in der Lobby und während `ACTIVE`. `EXTENDED`-Fenster
+blockieren `revealResults`/`startDiscussion`, bis die persönliche Frist endet
+oder der Host nach Ablauf des Raum-Countdowns mit Bestätigung
+`forceClosePersonalTimers` setzt (geloggt). Scoring bleibt am Session-Timer.
 
 **Ausgangsbefund:** Für getimte Fragen gab es nur den gemeinsamen Host-Timer.
 Eine globale timerlose Session war möglich, aber kein persönlicher
 Nachteilsausgleich während einer getimten Veranstaltung.
 
 **Umgesetzt:** Schema-first-Erweiterung von Prisma, Shared Contracts, tRPC,
-Vote-Deadline, MD3-Segmented-Control, Punktvorschau und Host-Fortschritt.
+Vote-Deadline, MD3-Segmented-Control, Lobby-Auswahl, Punktvorschau,
+Host-Fortschritt und bestätigter Host-Override nach Raum-Countdown.
 
-**Noch erforderlich:** Entweder muss der Statuswechsel offene persönliche
-Fenster technisch respektieren, oder eine beanspruchte Ausnahme für
-zeitkritische Echtzeitereignisse muss fachlich begründet, eng abgegrenzt und
-manuell gegen WCAG 2.2.1 bewertet werden. Eine Vote-Annahme nach sichtbarer
-Ergebnisfreigabe darf dabei keine Lösungsdaten oder Wertungsvorteile eröffnen.
+**Rest:** `Ohne Frist` bleibt bewusst host-steuerbar (kein Sabotagevektor).
+Manuelle Abnahme der Timing-Fälle in den Prüfmatrizen steht aus.
 
 ### 5.14 Unvollständige Überschriftenhierarchie auf Home und Admin
 
@@ -675,25 +668,57 @@ bildeten aber nicht durchgängig die semantische Seitenhierarchie ab.
 **Umgesetzt:** Semantische Heading-Elemente bei unveränderter visueller
 Material-Darstellung und Regressionstests für die Startseite.
 
+### 5.15 Autoaktualisierte Punktvorschau ohne Nutzerkontrolle
+
+**WCAG:** 2.2.2 Pause, Stop, Hide, Level A
+
+**Evidenz:**
+`apps/frontend/src/app/features/session/session-vote/session-vote.component.{ts,html}`
+
+**Umsetzungsstand 2026-07-20:** Geschlossen im Working Tree. Die sekündliche
+Punktvorschau besitzt „Ausblenden“ / „Live-Punkte anzeigen“, Persistenz in
+`localStorage` (`arsnova-live-score-preview`) und keine `aria-live`-Region für
+Sekundenupdates. Der Raum-Countdown bleibt als essential timing getrennt.
+
+**Ausgangsbefund (2. GPT-Evaluation):** Die optionale Punktvorschau ist
+autoaktualisierte Parallelinformation; die Essential-Ausnahme des Countdowns
+überträgt sich nicht automatisch darauf.
+
+### 5.16 Session-Überschriften nur visuell
+
+**WCAG:** 1.3.1 Info and Relationships, Level A (Risiko)
+
+**Evidenz:** Host-Lobby, Host-Frage, Vote-Frage, Session-Fehler, Wortwolke
+
+**Umsetzungsstand 2026-07-20:** Bereinigt. Lobby und Quiz-Frage nutzen natives
+`h1`; Vote hat `h1` plus benannte Region; Session-Fehler und Wortwolke nutzen
+`h1`/`h2 mat-card-title`. Nicht jeder visuelle Fragetext muss selbst Heading
+sein, solange die Seitenregion programmatisch benannt ist.
+
+**Ausgangsbefund (2. GPT-Evaluation):** Mehrere Session-Titel wirkten wie
+Überschriften, ohne durchgängig native Heading-Semantik.
+
 ## 6. Weitere Risiken und noch erforderliche Nachweise
 
 Die folgenden Punkte sind nicht automatisch als Verstoß zu werten, müssen vor
 einer AA-Freigabe aber gezielt geprüft werden:
 
-| Prüfbereich      | Nachweis                                                                                         |
-| ---------------- | ------------------------------------------------------------------------------------------------ |
-| Kontrast         | 4,5:1 für normalen Text, 3:1 für große Schrift sowie 3:1 für UI-Komponenten und Fokusindikatoren |
-| Reflow           | keine Funktions- oder Informationsverluste bei 320 CSS-Pixel und 400 % Zoom                      |
-| Zielgröße        | 2.5.8 einschließlich 24-Pixel-Minimum und Abstands-Ausnahmen auf allen Controls                  |
-| Fokus verdeckt   | Sticky Header, Bottom-Actions, Snackbars, virtuelle Tastatur und Overlays                        |
-| Tastatur         | vollständige Kernprozesse ohne Maus oder Touch                                                   |
-| Screenreader     | NVDA/Firefox und VoiceOver/Safari, insbesondere Live-Phasen und Dialoge                          |
-| Statusmeldungen  | weder fehlende noch übermäßig häufige Ansagen                                                    |
-| Wortwolke/Charts | textuelle Alternativen für Häufigkeit, Rang und Datenbeziehungen                                 |
-| High Contrast    | Forced Colors und Betriebssystem-Hochkontrast                                                    |
-| Timing           | Host-Freigabe beendet angepasste Fenster; 2.2.1 technisch schließen oder Ausnahme begründen      |
-| Locales          | alle Kernflows in `de`, `en`, `fr`, `es`, `it`                                                   |
-| PDF/UA           | veraPDF/PAC, Tagstruktur, Lesereihenfolge, Links und Alternativtexte                             |
+| Prüfbereich      | Nachweis                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| Kontrast         | 4,5:1 für normalen Text, 3:1 für große Schrift sowie 3:1 für UI-Komponenten und Fokusindikatoren        |
+| Reflow           | keine Funktions- oder Informationsverluste bei 320 CSS-Pixel und 400 % Zoom                             |
+| Zielgröße        | 2.5.8 einschließlich 24-Pixel-Minimum und Abstands-Ausnahmen auf allen Controls                         |
+| Fokus verdeckt   | Sticky Header, Bottom-Actions, Snackbars, virtuelle Tastatur und Overlays                               |
+| Tastatur         | vollständige Kernprozesse ohne Maus oder Touch                                                          |
+| Screenreader     | NVDA/Firefox und VoiceOver/Safari, insbesondere Live-Phasen und Dialoge                                 |
+| Statusmeldungen  | weder fehlende noch übermäßig häufige Ansagen                                                           |
+| Wortwolke/Charts | textuelle Alternativen für Häufigkeit, Rang und Datenbeziehungen                                        |
+| High Contrast    | Forced Colors und Betriebssystem-Hochkontrast                                                           |
+| Timing           | `EXTENDED` blockiert Freigabe; Host-Override erst nach Raum-Countdown mit Bestätigung; manuell abnehmen |
+| Locales          | alle Kernflows in `de`, `en`, `fr`, `es`, `it`                                                          |
+| PDF/UA           | veraPDF/PAC, Tagstruktur, Lesereihenfolge, Links und Alternativtexte                                    |
+| Manuelle Matrix  | 63 offene Fälle (35 allgemein + 28 PR-101); NVDA/VoiceOver/Zoom/Forced Colors                           |
+| Scoring          | Inklusionsrisiko, kein eindeutiger WCAG-Verstoß; Transparenz über Vorschau und Regeltext                |
 
 ## 7. Lücken in Tooling und Prozess
 
@@ -996,9 +1021,8 @@ spezifische manuelle Abnahmeprotokoll.
 
 **Offene Abnahme**
 
-- Statuswechsel muss persönliche `EXTENDED`-/`OFF`-Fenster respektieren oder
-  als zulässige Echtzeit-Ausnahme begründet werden;
-- 25 Fälle der PR-101-Matrix;
+- manuelle Timing-, Punktvorschau- und Heading-Fälle der Prüfmatrizen
+  (35 allgemein + 28 PR-101);
 - VoiceOver/Safari, NVDA/Firefox und Windows Forced Colors;
 - echter 200-/400-%-Browserzoom und PDF-Reader.
 

--- a/docs/praktikum/ACCESSIBILITY-MANUELLE-PRUEFMATRIX-PR101.md
+++ b/docs/praktikum/ACCESSIBILITY-MANUELLE-PRUEFMATRIX-PR101.md
@@ -62,21 +62,23 @@ angesagtem Namen, Rolle, Zustand und gegebenenfalls Fehlermeldung.
 | A01 | 2.1.1, 3.3.2, 4.1.2    | Vote-Ansicht per Tastatur öffnen; „Zeit anpassen“ und alle drei Segmente mit Screenreader durchlaufen. | Titel, Hilfetext, Gruppenrolle, gewählter Zustand und Optionen werden verständlich angesagt; Bedienung ohne Zeiger möglich.                                       | offen  |       |           |          |          |
 | A02 | 1.4.10, 1.4.12, 2.4.11 | Segmented-Control bei 320 CSS-Pixel, 200 % und 400 % Zoom prüfen.                                      | Beschriftungen sind vertikal zentriert, dürfen umbrechen und werden weder abgeschnitten noch vom Fokusindikator verdeckt.                                         | offen  |       |           |          |          |
 | A03 | 2.2.1                  | T2 auf `10× Zeit` setzen, gemeinsamen Countdown ablaufen lassen und Frage `ACTIVE` lassen.             | T2 kann nach 30 Sekunden weiter antworten; persönliche Restzeit und Eingabemöglichkeit bleiben erhalten.                                                          | offen  |       |           |          |          |
-| A04 | 2.2.1                  | T3 auf `Ohne Timer` setzen und gemeinsamen Countdown ablaufen lassen.                                  | Persönlicher Countdown verschwindet; Eingabe bleibt bis zur Host-Aktion möglich.                                                                                  | offen  |       |           |          |          |
+| A04 | 2.2.1                  | T3 auf `Ohne Frist` setzen und gemeinsamen Countdown ablaufen lassen.                                  | Persönlicher Countdown verschwindet; Eingabe bleibt bis zur Host-Aktion möglich; Label lautet „Ohne Frist“.                                                       | offen  |       |           |          |          |
 | A05 | 2.2.1, 3.2.2           | Zeitanpassung wechseln, Seite neu laden und Session erneut betreten.                                   | Gespeicherte Auswahl wird wiederhergestellt; der Wechsel löst keine unerwartete Navigation oder Abgabe aus.                                                       | offen  |       |           |          |          |
 | A06 | 1.3.1, 1.4.10          | Punktvorschau während des gemeinsamen Countdowns beobachten.                                           | Zahl und Einheit bleiben zusammen; der Text lautet je nach Fragetyp verständlich „Richtige Antwort jetzt“ oder „Volle Wertung jetzt“.                             | offen  |       |           |          |          |
 | A07 | 2.2.1, 3.2.4           | Punktvorschau nach Ablauf des gemeinsamen Countdowns beobachten.                                       | Der zeitabhängige Wert bleibt konstant; die Anzeige lautet „Nachlaufzeit · richtige Antwort“ und verwendet kein irreführendes „bis zu“ oder „bei voller Wertung“. | offen  |       |           |          |          |
 | A08 | 4.1.3                  | Punktvorschau mindestens 15 Sekunden mit Screenreader beobachten.                                      | Der sichtbare Sekunden-/Punkte-Ticker erzeugt keine fortlaufenden störenden Live-Ansagen.                                                                         | offen  |       |           |          |          |
+| A09 | 2.2.2                  | Punktvorschau ausblenden, Seite neu laden, wieder einblenden.                                          | Ausgeblendeter Zustand bleibt erhalten; Wiedereinblenden ist per Tastatur möglich; keine `aria-live`-Spam.                                                        | offen  |       |           |          |          |
 
 ## B – Informierte Host-Entscheidung
 
-| ID  | WCAG 2.2       | Prüfschritte                                                            | Erwartung                                                                                                             | Status | Datum | Prüfer:in | Umgebung | Artefakt |
-| --- | -------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------ | ----- | --------- | -------- | -------- |
-| B01 | 2.2.1, 3.3.2   | T2 und T3 noch nicht antworten lassen; Host-Aktionsbereich prüfen.      | Vor „Ergebnis zeigen“ erscheint die konkrete Zahl noch antwortender Personen mit Zeitanpassung.                       | offen  |       |           |          |          |
-| B02 | 4.1.3          | Während der Host-Ansicht antwortet T2, T3 bleibt offen.                 | Der Statushinweis wird höflich aktualisiert und zählt nur noch T3; keine übermäßige Wiederholung.                     | offen  |       |           |          |          |
-| B03 | 3.2.2, 3.3.2   | Host wählt trotz offener Zeitanpassung „Ergebnis zeigen“.               | Host behält die Entscheidung; der vorherige Hinweis erklärt eindeutig, dass die Aktion offene Eingabefenster beendet. | offen  |       |           |          |          |
-| B04 | 2.2.1          | Host wartet, bis T2 und T3 geantwortet haben.                           | Hinweis verschwindet bei null offenen angepassten Eingabefenstern; alle gültigen Antworten sind erfasst.              | offen  |       |           |          |          |
-| B05 | 1.4.10, 2.4.11 | Host-Hinweis und Aktionsleiste bei 320 CSS-Pixel und 400 % Zoom prüfen. | Hinweis steht vollständig oberhalb der Aktionen; Schaltflächen und Fokus werden nicht verdeckt.                       | offen  |       |           |          |          |
+| ID  | WCAG 2.2       | Prüfschritte                                                            | Erwartung                                                                                                | Status | Datum | Prüfer:in | Umgebung | Artefakt |
+| --- | -------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------ | ----- | --------- | -------- | -------- |
+| B01 | 2.2.1, 3.3.2   | T2 und T3 noch nicht antworten lassen; Host-Aktionsbereich prüfen.      | Vor „Ergebnis zeigen“ erscheint die konkrete Zahl noch antwortender Personen mit Zeitanpassung.          | offen  |       |           |          |          |
+| B02 | 4.1.3          | Während der Host-Ansicht antwortet T2, T3 bleibt offen.                 | Der Statushinweis wird höflich aktualisiert und zählt nur noch T3; keine übermäßige Wiederholung.        | offen  |       |           |          |          |
+| B03 | 2.2.1, 3.2.2   | Nach Raum-Countdown „Trotzdem freigeben“ wählen und Dialog bestätigen.  | Bestätigung erklärt Ende persönlicher Fenster; danach RESULTS; Override wird geloggt.                    | offen  |       |           |          |          |
+| B04 | 2.2.1          | Vor Raum-Countdown versuchen freizugeben, während `EXTENDED` offen ist. | Aktion bleibt gesperrt bzw. Backend lehnt Force-Close ab.                                                | offen  |       |           |          |          |
+| B05 | 2.2.1          | Host wartet, bis T2 und T3 geantwortet haben.                           | Hinweis verschwindet bei null offenen angepassten Eingabefenstern; alle gültigen Antworten sind erfasst. | offen  |       |           |          |          |
+| B06 | 1.4.10, 2.4.11 | Host-Hinweis und Aktionsleiste bei 320 CSS-Pixel und 400 % Zoom prüfen. | Hinweis steht vollständig oberhalb der Aktionen; Schaltflächen und Fokus werden nicht verdeckt.          | offen  |       |           |          |          |
 
 ## C – Fokus, Reflow und Fehlerbehandlung
 
@@ -96,9 +98,10 @@ angesagtem Namen, Rolle, Zustand und gegebenenfalls Fehlermeldung.
 | --- | ------------ | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------ | ----- | --------- | -------- | -------- |
 | D01 | 1.3.1, 2.4.6 | Startseite über die Überschriftennavigation des Screenreaders prüfen.               | Genau ein sinnvolles `h1`; die Kartenüberschriften folgen als `h2`.                                                      | offen  |       |           |          |          |
 | D02 | 1.3.1, 2.4.6 | Admin-Login und Admin-Inhalt über Überschriftennavigation prüfen.                   | „Admin-Login“ ist `h1`; nachgelagerte Bereiche besitzen eine nachvollziehbare `h2`-Struktur.                             | offen  |       |           |          |          |
-| D03 | 2.5.3, 4.1.2 | `/quiz` öffnen und jede Quizkarte mit Screenreader sowie Sprachsteuerung ansteuern. | Der zugängliche Linkname enthält den sichtbaren Quiznamen; sichtbarer Text und Accessible Name widersprechen sich nicht. | offen  |       |           |          |          |
-| D04 | 3.1.1, 3.1.2 | A01–D03 in `en` und stichprobenartig `fr` oder `it` wiederholen.                    | Seitensprache stimmt; neue Timer- und Host-Texte enthalten keine deutschen Reste oder falschen Pronomen.                 | offen  |       |           |          |          |
-| D05 | 1.4.10       | Neue Texte in `fr` und `it` bei 320 CSS-Pixel prüfen.                               | Host-Hinweis, Segmente und Punktanzeige umbrechen ohne Überlauf oder abgeschnittene Pflichtinformation.                  | offen  |       |           |          |          |
+| D03 | 1.3.1, 2.4.6 | Host-Lobby, aktive Frage, Vote-Frage, Session-Fehler und Wortwolke prüfen.          | Lobby/Frage/Fehler haben `h1`; Vote Region+`h1`; Wortwolke `h2 mat-card-title`.                                          | offen  |       |           |          |          |
+| D04 | 2.5.3, 4.1.2 | `/quiz` öffnen und jede Quizkarte mit Screenreader sowie Sprachsteuerung ansteuern. | Der zugängliche Linkname enthält den sichtbaren Quiznamen; sichtbarer Text und Accessible Name widersprechen sich nicht. | offen  |       |           |          |          |
+| D05 | 3.1.1, 3.1.2 | A01–D04 in `en` und stichprobenartig `fr` oder `it` wiederholen.                    | Seitensprache stimmt; neue Timer- und Host-Texte enthalten keine deutschen Reste oder falschen Pronomen.                 | offen  |       |           |          |          |
+| D06 | 1.4.10       | Neue Texte in `fr` und `it` bei 320 CSS-Pixel prüfen.                               | Host-Hinweis, Segmente und Punktanzeige umbrechen ohne Überlauf oder abgeschnittene Pflichtinformation.                  | offen  |       |           |          |          |
 
 ## Automatische Vorbedingungen
 
@@ -114,17 +117,17 @@ Vor dem manuellen Lauf müssen folgende Checks für denselben Commit grün sein:
 - Prisma Migration Drift;
 - PDF/UA-1 Validation.
 
-Diese Checks sind Vorbedingungen, aber kein Ersatz für A01–D05.
+Diese Checks sind Vorbedingungen, aber kein Ersatz für A01–D06.
 
 ## Ergebniszusammenfassung
 
 | Bereich                      | Bestanden | Fehlgeschlagen | Blockiert | Offen  | Bemerkung |
 | ---------------------------- | --------- | -------------- | --------- | ------ | --------- |
-| A – Zeitanpassung und Punkte | 0         | 0              | 0         | 8      |           |
-| B – Host-Entscheidung        | 0         | 0              | 0         | 5      |           |
+| A – Zeitanpassung und Punkte | 0         | 0              | 0         | 9      |           |
+| B – Host-Entscheidung        | 0         | 0              | 0         | 6      |           |
 | C – Fokus und Reflow         | 0         | 0              | 0         | 7      |           |
-| D – Semantik und i18n        | 0         | 0              | 0         | 5      |           |
-| **Gesamt**                   | **0**     | **0**          | **0**     | **25** |           |
+| D – Semantik und i18n        | 0         | 0              | 0         | 6      |           |
+| **Gesamt**                   | **0**     | **0**          | **0**     | **28** |           |
 
 ## Freigabeentscheidung
 

--- a/docs/praktikum/ACCESSIBILITY-UMSETZUNGSJOURNAL.md
+++ b/docs/praktikum/ACCESSIBILITY-UMSETZUNGSJOURNAL.md
@@ -1340,6 +1340,33 @@ Persönliche Präferenz am `Participant` (`timerAccommodation`: `DEFAULT` |
 - VoiceOver/NVDA für Segmented-Control und Statusansage;
 - keine WCAG-2.2-AA-Gesamtabnahme allein durch diesen Schritt.
 
+## PR 9c – Host-Override, 2.2.2-Punktvorschau und Session-Semantik
+
+**Datum:** 2026-07-20
+**Status:** umgesetzt
+**WCAG:** 2.2.1, 2.2.2, 1.3.1 / 2.4.6
+**PR/Commit:** Branch `a11y/wcag22-final-compliance` (Working Tree)
+
+### Ausgangsproblem
+
+Zweite GPT-Evaluation: persönliche Zeit nicht garantiert; Punktvorschau ohne
+Pause/Hide; Session-Titel teilweise ohne native Headings; 60 manuelle Fälle
+offen.
+
+### Konkrete Umsetzung
+
+- Host-Override `forceClosePersonalTimers` erst nach Raum-Countdown mit
+  Bestätigungsdialog und Structured Logging;
+- Punktvorschau ausblendbar, persistent, ohne `aria-live`-Spam;
+- Host-Lobby-Fallback-`h1`, natives `h1 mat-card-title` für die Frage,
+  Vote-/Fehler-/Wortwolken-Headings;
+- Audit §§5.13–5.16 und PR-101-Matrix (A09, B03–B06, D03) synchronisiert.
+
+### Offene Risiken und manuelle Abnahme
+
+- 35 + 28 manuelle Fälle weiterhin offen;
+- AA-Freigabe erst nach AT-/Zoom-/Forced-Colors-Abnahme.
+
 ## Vorlage für weitere Einträge
 
 ```markdown

--- a/libs/shared-types/src/schemas.ts
+++ b/libs/shared-types/src/schemas.ts
@@ -2033,6 +2033,18 @@ export const GetSessionInfoInputSchema = z.object({
 });
 export type GetSessionInfoInput = z.infer<typeof GetSessionInfoInputSchema>;
 
+/**
+ * Input: Host-Steuerung mit optionalem Override für persönliche Timer-Fenster (WCAG 2.2.1).
+ * `forceClosePersonalTimers` darf serverseitig erst nach Ablauf des Raum-Countdowns greifen.
+ */
+export const HostSteeringWithTimerOverrideInputSchema = GetSessionInfoInputSchema.extend({
+  /** Offene 10×-Fenster vorzeitig beenden (nur nach Raum-Countdown). */
+  forceClosePersonalTimers: z.boolean().optional(),
+});
+export type HostSteeringWithTimerOverrideInput = z.infer<
+  typeof HostSteeringWithTimerOverrideInputSchema
+>;
+
 /** Input: Nächste Frage steuern (optional inkl. Überspringen der zuletzt gezeigten Ergebnisfrage). */
 export const NextQuestionInputSchema = GetSessionInfoInputSchema.extend({
   /** Nur für den Rücksprung-Fall: überspringt genau die bereits gezeigte Ergebnisfrage. */
@@ -2378,6 +2390,8 @@ export const HostVoteProgressDTOSchema = z.object({
   totalVotes: z.number().int().min(0),
   /** Personen mit persönlicher Zeitanpassung, die in dieser Runde noch nicht geantwortet haben. */
   pendingTimerAccommodationCount: z.number().int().min(0).optional(),
+  /** Davon Personen, deren garantiertes 10×-Zeitfenster noch läuft. */
+  blockingTimerAccommodationCount: z.number().int().min(0).optional(),
   correctVoterCount: z.number().int().min(0).optional(),
   incorrectVoterCount: z.number().int().min(0).optional(),
   peerInstructionSuggestion: PeerInstructionSuggestionDTOSchema.optional(),

--- a/prisma/migrations/20260720120000_participant_timer_accommodation_index/migration.sql
+++ b/prisma/migrations/20260720120000_participant_timer_accommodation_index/migration.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "Participant_sessionId_timerAccommodation_idx"
+ON "Participant"("sessionId", "timerAccommodation");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -170,6 +170,7 @@ model Participant {
   joinedAt   DateTime @default(now())
 
   @@unique([sessionId, nickname]) // Kein doppelter Nickname pro Session
+  @@index([sessionId, timerAccommodation]) // Host-Fortschritt für persönliche Zeitfenster
 }
 
 // Singleton-Zeile: plattformweite Kennzahlen (höchste Teilnehmerzahl je Session)


### PR DESCRIPTION
## Summary
- Persönliche 10×-Frist blockiert Host-Freigabe bis Ablauf bzw. bestätigtem Override nach Raum-Countdown (`forceClosePersonalTimers`, geloggt).
- Live-Punktvorschau ist ausblendbar/persistent (WCAG 2.2.2); Session-Headings (Lobby, Frage, Vote, Fehler, Wortwolke) sind semantisch.
- Audit, Umsetzungsjournal und PR-101-Matrix an die 2. GPT-Evaluation angeglichen; i18n für neue Host-/Vote-Texte.

## Test plan
- [x] `npm test` (shared-types, session-export-report, backend, frontend)
- [x] Localized production build (`npm run build:localize -w @arsnova/frontend`)
- [x] ESLint + Prettier auf geänderte Dateien; `check:i18n`
- [ ] CI: Localized Build, Playwright Smoke, Lighthouse, axe, Typecheck, CodeQL/Trivy
- [ ] Manuell: EXTENDED nach Raum-Countdown → „Trotzdem freigeben“ mit Dialog; Punktvorschau ausblenden/neu laden; Lobby-/Frage-Headings mit Screenreader


Made with [Cursor](https://cursor.com)