### PR TITLE
fix(a11y): Tab-Navigation im News-Archiv absichern

### DIFF
--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.html
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.html
@@ -67,6 +67,7 @@
                     <a
                       class="news-archive-page__entry-title-link"
                       [attr.href]="'#motd-archive-' + it.id"
+                      (click)="onArchiveTitleLinkClick($event, it.id)"
                       >{{ archiveItemTitle(it.id) }}</a
                     >
                   </h2>

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.html
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.html
@@ -63,7 +63,13 @@
               @for (it of items(); track it.id) {
                 @let archiveMeta = formatArchiveDate(it.startsAt);
                 <section class="news-archive-page__entry" [attr.id]="'motd-archive-' + it.id">
-                  <h2 class="news-archive-page__entry-title">{{ archiveItemTitle(it.id) }}</h2>
+                  <h2 class="news-archive-page__entry-title">
+                    <a
+                      class="news-archive-page__entry-title-link"
+                      [attr.href]="'#motd-archive-' + it.id"
+                      >{{ archiveItemTitle(it.id) }}</a
+                    >
+                  </h2>
                   @if (archiveMeta) {
                     <p class="news-archive-page__entry-meta">
                       <time [attr.datetime]="it.startsAt">{{ archiveMeta }}</time>

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.scss
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.scss
@@ -89,6 +89,22 @@
   font-weight: 600;
 }
 
+/* In-page-Anker: Tab-Navigation zwischen Meldungen, optisch wie Überschrift. */
+.news-archive-page__entry-title-link {
+  color: inherit;
+  text-decoration: none;
+  border-radius: 2px;
+}
+
+.news-archive-page__entry-title-link:hover {
+  text-decoration: underline;
+}
+
+.news-archive-page__entry-title-link:focus-visible {
+  outline: 2px solid var(--mat-sys-primary);
+  outline-offset: 0.25rem;
+}
+
 .news-archive-page__entry-meta {
   margin: 0 0 1rem;
   font: var(--mat-sys-body-large);

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.spec.ts
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.spec.ts
@@ -117,4 +117,55 @@ describe('NewsArchivePageComponent', () => {
     expect(links.map((l) => l.textContent?.trim())).toEqual(['Zweite Meldung', 'Erste Meldung']);
     expect(links.every((l) => l.tabIndex >= 0)).toBe(true);
   });
+
+  it('setzt den Fragment-Anker per replaceState ohne History-Push', () => {
+    const withItems: NewsArchiveInitialModel = {
+      ...emptyResolved,
+      items: [
+        {
+          id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          contentVersion: 1,
+          markdown: '# Erste Meldung\n\nText',
+          startsAt: '2026-01-10T10:00:00.000Z',
+          endsAt: '2026-01-15T18:00:00.000Z',
+        },
+      ],
+      titleById: {
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa': 'Erste Meldung',
+      },
+      htmlById: {},
+    };
+
+    TestBed.configureTestingModule({
+      imports: [NewsArchivePageComponent],
+      providers: [
+        { provide: LOCALE_ID, useValue: 'de' },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { data: { newsArchive: withItems } } },
+        },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(NewsArchivePageComponent);
+    fixture.detectChanges();
+
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    const link = (fixture.nativeElement as HTMLElement).querySelector<HTMLAnchorElement>(
+      '.news-archive-page__entry-title-link',
+    );
+    expect(link).toBeTruthy();
+    link!.click();
+
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(String(replaceStateSpy.mock.calls[0]?.[2] ?? '')).toContain(
+      '#motd-archive-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    );
+    expect(pushStateSpy).not.toHaveBeenCalled();
+    replaceStateSpy.mockRestore();
+    pushStateSpy.mockRestore();
+  });
 });

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.spec.ts
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.spec.ts
@@ -59,4 +59,62 @@ describe('NewsArchivePageComponent', () => {
     expect(listArchiveQuery).not.toHaveBeenCalled();
     expect(fixture.componentInstance.items().length).toBe(0);
   });
+
+  it('macht Meldungstitel als In-Page-Anker per Tab erreichbar', () => {
+    const withItems: NewsArchiveInitialModel = {
+      ...emptyResolved,
+      items: [
+        {
+          id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          contentVersion: 1,
+          markdown: '# Erste Meldung\n\nText',
+          startsAt: '2026-01-10T10:00:00.000Z',
+          endsAt: '2026-01-15T18:00:00.000Z',
+        },
+        {
+          id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          contentVersion: 1,
+          markdown: '# Zweite Meldung\n\nText',
+          startsAt: '2026-01-12T10:00:00.000Z',
+          endsAt: '2026-01-16T18:00:00.000Z',
+        },
+      ],
+      titleById: {
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa': 'Erste Meldung',
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb': 'Zweite Meldung',
+      },
+      htmlById: {},
+      archiveMaxEndsAtIso: '2026-01-16T18:00:00.000Z',
+      archiveUnreadCount: 2,
+    };
+
+    TestBed.configureTestingModule({
+      imports: [NewsArchivePageComponent],
+      providers: [
+        { provide: LOCALE_ID, useValue: 'de' },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { data: { newsArchive: withItems } } },
+        },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(NewsArchivePageComponent);
+    fixture.detectChanges();
+
+    const links = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLAnchorElement>(
+        '.news-archive-page__entry-title-link',
+      ),
+    );
+    expect(links).toHaveLength(2);
+    expect(links.map((l) => l.getAttribute('href'))).toEqual([
+      '#motd-archive-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      '#motd-archive-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    ]);
+    expect(links.map((l) => l.textContent?.trim())).toEqual(['Zweite Meldung', 'Erste Meldung']);
+    expect(links.every((l) => l.tabIndex >= 0)).toBe(true);
+  });
 });

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.ts
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.ts
@@ -94,6 +94,31 @@ export class NewsArchivePageComponent {
     return this.titleById()[id] ?? this.archiveItemFallbackTitle;
   }
 
+  /**
+   * In-Page-Anker ohne History-Eintrag: nativer Fragment-Klick würde
+   * `Location.back()` („Zurück“) nur zum vorherigen Hash führen.
+   * Modifier-Klicks (neuer Tab usw.) behalten das native Verhalten.
+   */
+  onArchiveTitleLinkClick(event: MouseEvent, id: string): void {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const hash = `#motd-archive-${id}`;
+    const nextUrl = `${window.location.pathname}${window.location.search}${hash}`;
+    window.history.replaceState(window.history.state, '', nextUrl);
+  }
+
   back(): void {
     this.location.back();
   }

--- a/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html
+++ b/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html
@@ -54,7 +54,7 @@
         <mat-accordion class="motd-archive__accordion" [multi]="true">
           @for (it of items(); track it.id) {
             @let archiveMeta = formatArchiveDate(it.startsAt);
-            <mat-expansion-panel class="motd-archive__panel">
+            <mat-expansion-panel #archivePanel class="motd-archive__panel">
               <mat-expansion-panel-header>
                 <mat-panel-title class="motd-archive__panel-title">
                   <span
@@ -70,7 +70,11 @@
                 }
               </mat-expansion-panel-header>
               @if (htmlById()[it.id]; as safe) {
-                <div class="motd-archive__body markdown-body" [innerHTML]="safe"></div>
+                <div
+                  class="motd-archive__body markdown-body"
+                  [attr.inert]="archivePanel.expanded ? null : ''"
+                  [innerHTML]="safe"
+                ></div>
               }
             </mat-expansion-panel>
           }

--- a/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.spec.ts
+++ b/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.spec.ts
@@ -212,4 +212,45 @@ describe('MotdArchiveDialogComponent', () => {
     expect(snackSpy).toHaveBeenCalled();
     expect(notifySpy).toHaveBeenCalled();
   });
+
+  it('setzt inert auf zugeklappte Panel-Inhalte, damit Tab die Header erreicht', async () => {
+    getHeaderStateQuery.mockResolvedValue({
+      ...defaultHeaderState,
+      hasArchiveEntries: true,
+      archiveCount: 1,
+      archiveMaxEndsAtIso: '2026-01-20T00:00:00.000Z',
+      archiveUnreadCount: 1,
+    });
+    listArchiveQuery.mockResolvedValue({
+      items: [
+        {
+          id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          contentVersion: 1,
+          markdown: '# Titel\n\n[Link](https://arsnova.eu)',
+          startsAt: '2026-01-10T10:00:00.000Z',
+          endsAt: '2026-01-15T18:00:00.000Z',
+        },
+      ],
+      nextCursor: null,
+    });
+    configureDialog();
+    const fixture = TestBed.createComponent(MotdArchiveDialogComponent);
+    fixture.detectChanges();
+    await vi.waitFor(() => expect(fixture.componentInstance.loading()).toBe(false));
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const body = root.querySelector('.motd-archive__body');
+    expect(body).toBeTruthy();
+    expect(body!.hasAttribute('inert')).toBe(true);
+
+    const header = root.querySelector<HTMLElement>('.mat-expansion-panel-header');
+    expect(header).toBeTruthy();
+    header!.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(body!.hasAttribute('inert')).toBe(false);
+  });
 });

--- a/apps/frontend/src/app/shared/styles/dialog-title-header.scss
+++ b/apps/frontend/src/app/shared/styles/dialog-title-header.scss
@@ -55,6 +55,19 @@ h3.dialog-title-header__heading {
   margin: 0;
 }
 
+/**
+ * Nach SPA-Navigation setzt focusPrimaryContent() Fokus auf das Seiten-h1 (tabindex=-1).
+ * Padding + negativer Margin: Innenluft zum Fokusrahmen ohne Layoutsprung.
+ */
+h1.dialog-title-header__heading:focus,
+h1.dialog-title-header__heading:focus-visible {
+  outline: 2px solid var(--mat-sys-primary);
+  outline-offset: 0.2rem;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.4rem;
+  margin: -0.25rem -0.4rem;
+}
+
 /* Volle Seiten / Kartenkopf: kein Dialog-Innenpadding */
 .dialog-title-header--page {
   padding-inline: 0;


### PR DESCRIPTION
## Summary
- Archiv-Seite: Meldungstitel als In-Page-Anker, damit Tab zwischen Einträgen springt
- Archiv-Dialog: zugeklappte Panel-Inhalte mit `inert`, damit Fokus nicht in versteckten Links/Bildern hängen bleibt
- Specs für Anker und `inert`-Umschaltung ergänzt

## Test plan
- [ ] `/news-archive`: Tab von „Zurück“ über „Alles als gelesen“ zu den Meldungstiteln
- [ ] Toolbar „News und Archiv“: Tab zwischen Panel-Headern; Links erst nach Aufklappen erreichbar
- [ ] Fokusring an Titel-Ankern sichtbar (`:focus-visible`)
- [ ] CI grün


Made with [Cursor](https://cursor.com)