### PR TITLE
fix(a11y): Race nach Session-Ende vor axe absichern

### DIFF
--- a/apps/frontend/scripts/check-unified-session-flow.mjs
+++ b/apps/frontend/scripts/check-unified-session-flow.mjs
@@ -600,6 +600,9 @@ async function endSessionAndScan(host, participant, hardFailures) {
   // Nach Session-Ende erfolgt oft ein schneller Redirect nach Home. Axe darf
   // nicht mitten in der Navigation laufen: der Tempo-Spotlight-Button existiert
   // dann schon als leere Shell ohne Text/aria-label (button-name).
+  // Nur #vote-session-end-anchor zählt als settled Gate — #finished-heading
+  // erscheint schon im transienten FINISHED-Zustand, bevor runSessionEndRedirect
+  // entscheidet (Home vs. End-Gate); sonst gewinnt gateVisible zu früh.
   const homeNamed = participant
     .waitForFunction(
       (homePathSource) => {
@@ -616,7 +619,7 @@ async function endSessionAndScan(host, participant, hardFailures) {
     )
     .then(() => 'home');
   const gateVisible = participant
-    .locator('#vote-session-end-anchor, #finished-heading')
+    .locator('#vote-session-end-anchor')
     .first()
     .waitFor({ state: 'visible', timeout: 20_000 })
     .then(() => 'gate');

--- a/apps/frontend/scripts/check-unified-session-flow.mjs
+++ b/apps/frontend/scripts/check-unified-session-flow.mjs
@@ -622,17 +622,20 @@ async function endSessionAndScan(host, participant, hardFailures) {
     .then(() => 'gate');
   const settled = await Promise.race([homeNamed, gateVisible]).catch(() => null);
 
-  let returnedHome =
-    settled === 'home' || homePathRe.test(new URL(participant.url()).pathname);
+  let returnedHome = settled === 'home' || homePathRe.test(new URL(participant.url()).pathname);
   if (returnedHome) {
     const ready = await participant
-      .waitForFunction(() => {
-        const btn = document.querySelector('.home-feedback-tempo-spotlight');
-        if (!(btn instanceof HTMLElement)) return false;
-        const label = (btn.getAttribute('aria-label') || '').trim();
-        const text = (btn.innerText || '').trim();
-        return label.length > 0 || text.length > 0;
-      }, undefined, { timeout: 15_000 })
+      .waitForFunction(
+        () => {
+          const btn = document.querySelector('.home-feedback-tempo-spotlight');
+          if (!(btn instanceof HTMLElement)) return false;
+          const label = (btn.getAttribute('aria-label') || '').trim();
+          const text = (btn.innerText || '').trim();
+          return label.length > 0 || text.length > 0;
+        },
+        undefined,
+        { timeout: 15_000 },
+      )
       .then(() => true)
       .catch(() => false);
     if (!ready) {

--- a/apps/frontend/scripts/check-unified-session-flow.mjs
+++ b/apps/frontend/scripts/check-unified-session-flow.mjs
@@ -583,14 +583,87 @@ async function endSessionAndScan(host, participant, hardFailures) {
   await scanA11y(host, 'end-confirmation');
   await confirmation.click();
 
+  const homePathRe = /^\/(?:de|en|fr|it|es)\/?$/;
+
   await participant.waitForFunction(
-    () =>
-      Boolean(document.querySelector('#vote-session-end-anchor, #finished-heading')) ||
-      /^\/(?:de|en|fr|it|es)\/?$/.test(window.location.pathname),
-    undefined,
+    (homePathSource) => {
+      const homePath = new RegExp(homePathSource);
+      return (
+        Boolean(document.querySelector('#vote-session-end-anchor, #finished-heading')) ||
+        homePath.test(window.location.pathname)
+      );
+    },
+    homePathRe.source,
     { timeout: 30_000 },
   );
-  const returnedHome = /^\/(?:de|en|fr|it|es)\/?$/.test(new URL(participant.url()).pathname);
+
+  // Nach Session-Ende erfolgt oft ein schneller Redirect nach Home. Axe darf
+  // nicht mitten in der Navigation laufen: der Tempo-Spotlight-Button existiert
+  // dann schon als leere Shell ohne Text/aria-label (button-name).
+  const homeNamed = participant
+    .waitForFunction(
+      (homePathSource) => {
+        const homePath = new RegExp(homePathSource);
+        if (!homePath.test(window.location.pathname)) return false;
+        const btn = document.querySelector('.home-feedback-tempo-spotlight');
+        if (!(btn instanceof HTMLElement)) return false;
+        const label = (btn.getAttribute('aria-label') || '').trim();
+        const text = (btn.innerText || '').trim();
+        return label.length > 0 || text.length > 0;
+      },
+      homePathRe.source,
+      { timeout: 20_000 },
+    )
+    .then(() => 'home');
+  const gateVisible = participant
+    .locator('#vote-session-end-anchor, #finished-heading')
+    .first()
+    .waitFor({ state: 'visible', timeout: 20_000 })
+    .then(() => 'gate');
+  const settled = await Promise.race([homeNamed, gateVisible]).catch(() => null);
+
+  let returnedHome =
+    settled === 'home' || homePathRe.test(new URL(participant.url()).pathname);
+  if (returnedHome) {
+    const ready = await participant
+      .waitForFunction(() => {
+        const btn = document.querySelector('.home-feedback-tempo-spotlight');
+        if (!(btn instanceof HTMLElement)) return false;
+        const label = (btn.getAttribute('aria-label') || '').trim();
+        const text = (btn.innerText || '').trim();
+        return label.length > 0 || text.length > 0;
+      }, undefined, { timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!ready) {
+      hardFailures.push(
+        'Home after session end did not expose a named tempo-spotlight button before axe.',
+      );
+      return;
+    }
+  } else if (settled !== 'gate') {
+    // Redirect kann zwischen Gate und Home liegen: noch einmal auf Home warten.
+    const redirectedHome = await participant
+      .waitForFunction(
+        (homePathSource) => {
+          const homePath = new RegExp(homePathSource);
+          if (!homePath.test(window.location.pathname)) return false;
+          const btn = document.querySelector('.home-feedback-tempo-spotlight');
+          if (!(btn instanceof HTMLElement)) return false;
+          const label = (btn.getAttribute('aria-label') || '').trim();
+          const text = (btn.innerText || '').trim();
+          return label.length > 0 || text.length > 0;
+        },
+        homePathRe.source,
+        { timeout: 10_000 },
+      )
+      .then(() => true)
+      .catch(() => false);
+    if (redirectedHome) {
+      returnedHome = true;
+    }
+  }
+
   await scanA11y(
     participant,
     returnedHome ? 'participant-session-ended-home' : 'participant-session-ended',

--- a/apps/frontend/src/app/features/home/home.component.html
+++ b/apps/frontend/src/app/features/home/home.component.html
@@ -282,8 +282,11 @@
           class="home-feedback-tempo-spotlight"
           (click)="startQuickFeedback(quickFeedbackTempoSpotlight.type)"
           [disabled]="!!quickFeedbackStarting()"
-          [attr.aria-busy]="quickFeedbackStarting() === quickFeedbackTempoSpotlight.type"
-          [attr.aria-label]="quickFeedbackTempoSpotlight.actionLabel"
+          [attr.aria-busy]="
+            quickFeedbackStarting() === quickFeedbackTempoSpotlight.type ? true : null
+          "
+          i18n-aria-label="@@feedback.tempoSpotlightAction"
+          aria-label="Tempo-Feedback"
         >
           <span class="home-feedback-tempo-spotlight__copy">
             <span class="home-feedback-tempo-spotlight__eyebrow">{{


### PR DESCRIPTION
## Summary
- Post-Merge-CI auf `main` (Run [29803232617](https://github.com/kqc-real/arsnova.eu/actions/runs/29803232617)) scheiterte in **Playwright Smoke E2E** / `smoke:unified-session` an `button-name` auf `.home-feedback-tempo-spotlight`.
- Ursache: nach Session-Ende redirected der Participant schnell auf `/de/`; axe lief auf einer noch leeren Button-Shell (kein Text, kein `aria-label`). PR #106 selbst war grün — das Failure war der anschließende `push` auf `main`.
- Fix: Smoke wartet auf benannten Spotlight-Button bzw. stabile End-Gate-UI; Spotlight-Button bekommt statisches `i18n-aria-label` für den First Paint.

## Test plan
- [ ] CI Playwright Smoke E2E auf diesem PR grün
- [ ] Optional lokal: `npm run smoke:unified-session -w @arsnova/frontend` gegen laufendes Frontend/Backend
- [ ] Manuell: Session beenden → Participant landet auf Home, Tempo-Blitzlicht-Button hat zugänglichen Namen


Made with [Cursor](https://cursor.com)