### PR TITLE
chore(deps): Dependabot-Majors für Astro vorerst ignorieren

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,14 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular-devkit/*'
         update-types: ['version-update:semver-major']
+      # Astro 7 ist Major (Vite 8/Rolldown, Rust-Compiler, neues Markdown-Default).
+      # Dependabot-Bump 6→7 bricht denselben Monorepo-`npm ci`/`build:landing`-Lauf:
+      # Astro erwartet cookie v2 (`parseCookie`), gehoistetes `cookie@0.7` ist CJS ohne Named Export.
+      # Upgrade bewusst koordiniert (nicht per Dependabot), inkl. Cookie-Hoisting und Landing-CI.
+      - dependency-name: 'astro'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@astrojs/*'
+        update-types: ['version-update:semver-major']
       # @y/websocket-server 0.1.5 kollidiert mit @y/y (yjs 14) und Root-Override (yjs 13.6.31).
       # exclude-patterns in groups reicht nicht — Dependabot öffnet sonst weiterhin Einzel-PRs.
       - dependency-name: '@y/websocket-server'

--- a/package-lock.json
+++ b/package-lock.json
@@ -17886,9 +17886,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
   },
   "overrides": {
     "@hono/node-server": "^1.19.11",
+    "fast-uri": "^3.1.4",
     "hono": "^4.12.5",
     "minimatch": "^10.2.1",
     "tar": "^7.5.8",


### PR DESCRIPTION
## Summary

- Ignoriert Dependabot-**Major**-Updates für `astro` und `@astrojs/*` in `.github/dependabot.yml` (analog zu `@angular/*`).
- Begründung und Ablehnung des Dependabot-Bumps: https://github.com/kqc-real/arsnova.eu/pull/109 (Astro 6.4.8 → 7.1.3, CI-Fail + Major-Migration).

## Why

Astro 7.1.3 bricht *Build Landing* im Monorepo (`cookie` CJS vs. erwartete Named Exports / cookie v2). Astro 7 ist zudem ein koordinationspflichtiger Major (Vite 8, Rust-Compiler, Markdown-Default). Wir bleiben auf Astro 6 (`^6.4.8`), bis ein bewusstes Upgrade steht.

Dependabot hat auf #109 bereits bestätigt, Astro 7.x nicht erneut vorzuschlagen; diese YAML-Regel macht die Sperre repo-sichtbar und persistent.

## Test plan

- [ ] Nach Merge: keine neuen Dependabot-PRs für Astro 7
- [ ] Astro-6 minor/patch weiterhin möglich
- [x] PR #109 geschlossen / Major 7 ignoriert