### PR TITLE
Docs/backlog astro 7 plan

### DIFF
--- a/Backlog.md
+++ b/Backlog.md
@@ -346,7 +346,7 @@ Eine Story gilt als **fertig**, wenn **alle** folgenden Kriterien erfüllt sind:
   - **Akzeptanzkriterien:**
     - [ ] `apps/landing` und Root-Workspace nutzen **Astro ≥ 7.1.x** (XSS-Advisories ohne 6.x-Backport).
     - [ ] Root-`overrides` (oder gleichwertige Auflösung) stellen `cookie@2` für Astro bereit, **ohne** Express/Backend-Cookie-Pfade zu brechen; `npm ci` im Monorepo ist grün.
-    - [ ] `npm run build:landing` (Node gemäß Workspace/`.nvmrc`-Matrix) ist grün; Landing-A11y-/CI-Gates bleiben grün.
+    - [ ] `npm run build:landing` auf **Node ≥22.12** (Landing-`engines` in `apps/landing/package.json` bzw. CI-Job `landing-build` mit Node 22 — **nicht** `.nvmrc`/Node 20) ist grün; Landing-A11y-/CI-Gates bleiben grün.
     - [ ] Kurzer visueller Smoke der Landing (Start + Legal-Seiten) — keine Design-Regression erwartet, aber einmal prüfen.
     - [ ] Nach Erfolg: Dependabot-Major-Ignore für `astro`/`@astrojs/*` in `.github/dependabot.yml` entfernen oder lockern; zugehörige Dependabot-Alerts schließen sich bzw. werden verifiziert.
   - **Aufwand (Richtwert):** ~½–1 Tag, Schwerpunkt Cookie-Override und Landing-CI — nicht „Dependabot mergen und fertig“.


### PR DESCRIPTION
## Zusammenfassung

-

## Validierung

- [ ] Betroffene Unit-/Contract-Tests ergänzt oder aktualisiert
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n- oder Produktionsänderungen

## Risikobezogene Checks

- [ ] Nicht zutreffend oder betroffene Browser-Smokes ausgeführt
- [ ] Nicht zutreffend oder Realtime-/WebSocket-/Yjs-Szenarien ausgeführt
- [ ] Nicht zutreffend oder Prisma-Migrationskette auf frischer Datenbank geprüft
- [ ] Nicht zutreffend oder Last-/Performance-Budget geprüft
- [ ] Nicht zutreffend oder alle Locales (`de`, `en`, `fr`, `es`, `it`) synchronisiert

## Betrieb und Rollback

- [ ] Keine Betriebsänderung oder Rollback-Auswirkung beschrieben
- [ ] Keine neuen Secrets, Zugangsdaten oder lokalen Artefakte eingecheckt

## Nachweise

<!-- CI-Run, Testreport, Screenshot oder kurze Begründung für nicht zutreffende Punkte. -->
