### PR TITLE
fix(security): tRPC-Request-Bodies auf 2 MiB begrenzen

### DIFF
--- a/apps/backend/src/__tests__/request-body-limit.test.ts
+++ b/apps/backend/src/__tests__/request-body-limit.test.ts
@@ -105,4 +105,28 @@ describe('tRPC request body limit', () => {
       },
     });
   });
+
+  it('liefert den 413-Fehler für Batch-Requests im tRPC-Arrayformat', async () => {
+    const baseUrl = await startTestServer();
+    const response = await fetch(`${baseUrl}/trpc/echo?batch=1`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        0: { value: 'x'.repeat(TRPC_MAX_BODY_SIZE_BYTES) },
+      }),
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject([
+      {
+        error: {
+          message: `Die Anfrage ist zu groß. Maximal ${TRPC_MAX_BODY_SIZE_LABEL} sind erlaubt.`,
+          data: {
+            code: 'PAYLOAD_TOO_LARGE',
+            httpStatus: 413,
+          },
+        },
+      },
+    ]);
+  });
 });

--- a/apps/backend/src/__tests__/request-body-limit.test.ts
+++ b/apps/backend/src/__tests__/request-body-limit.test.ts
@@ -2,6 +2,7 @@ import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
+import { QuizUploadInputSchema } from '@arsnova/shared-types';
 import express from 'express';
 import { z } from 'zod';
 import { TRPC_MAX_BODY_SIZE_BYTES, TRPC_MAX_BODY_SIZE_LABEL } from '../lib/requestLimits';
@@ -11,7 +12,7 @@ const testRouter = router({
   echo: publicProcedure
     .input(z.object({ value: z.string() }))
     .mutation(({ input }) => ({ length: input.value.length })),
-  acceptPayload: publicProcedure.input(z.unknown()).mutation(() => ({ ok: true })),
+  acceptQuizUpload: publicProcedure.input(QuizUploadInputSchema).mutation(() => ({ ok: true })),
 });
 
 describe('tRPC request body limit', () => {
@@ -63,9 +64,19 @@ describe('tRPC request body limit', () => {
     const classroomQuiz = {
       name: 'Classroom-Quiz',
       description: 'd'.repeat(5_000),
+      showLeaderboard: true,
+      allowCustomNicknames: false,
+      enableSoundEffects: true,
+      enableRewardEffects: true,
+      enableMotivationMessages: true,
+      enableEmojiReactions: true,
+      anonymousMode: false,
+      teamMode: false,
+      nicknameTheme: 'NOBEL_LAUREATES',
       questions: Array.from({ length: 200 }, (_, order) => ({
         text: 'f'.repeat(2_000),
         type: 'MULTIPLE_CHOICE',
+        difficulty: 'MEDIUM',
         order,
         answers: Array.from({ length: 10 }, (_, answerIndex) => ({
           text: 'a'.repeat(500),
@@ -76,7 +87,7 @@ describe('tRPC request body limit', () => {
     const body = JSON.stringify(classroomQuiz);
     expect(Buffer.byteLength(body)).toBeLessThan(TRPC_MAX_BODY_SIZE_BYTES);
 
-    const response = await fetch(`${baseUrl}/trpc/acceptPayload`, {
+    const response = await fetch(`${baseUrl}/trpc/acceptQuizUpload`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body,

--- a/apps/backend/src/__tests__/request-body-limit.test.ts
+++ b/apps/backend/src/__tests__/request-body-limit.test.ts
@@ -1,0 +1,108 @@
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
+import express from 'express';
+import { z } from 'zod';
+import { TRPC_MAX_BODY_SIZE_BYTES, TRPC_MAX_BODY_SIZE_LABEL } from '../lib/requestLimits';
+import { publicProcedure, router } from '../trpc';
+
+const testRouter = router({
+  echo: publicProcedure
+    .input(z.object({ value: z.string() }))
+    .mutation(({ input }) => ({ length: input.value.length })),
+  acceptPayload: publicProcedure.input(z.unknown()).mutation(() => ({ ok: true })),
+});
+
+describe('tRPC request body limit', () => {
+  let server: Server | undefined;
+
+  afterEach(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        if (!server) {
+          resolve();
+          return;
+        }
+        server.close((error) => (error ? reject(error) : resolve()));
+        server = undefined;
+      }),
+  );
+
+  async function startTestServer(): Promise<string> {
+    const app = express();
+    app.use(
+      '/trpc',
+      createExpressMiddleware({
+        router: testRouter,
+        maxBodySize: TRPC_MAX_BODY_SIZE_BYTES,
+      }),
+    );
+
+    server = await new Promise<Server>((resolve) => {
+      const listeningServer = app.listen(0, '127.0.0.1', () => resolve(listeningServer));
+    });
+    const address = server.address() as AddressInfo;
+    return `http://127.0.0.1:${address.port}`;
+  }
+
+  it('akzeptiert normale Payloads unterhalb des Limits', async () => {
+    const baseUrl = await startTestServer();
+    const response = await fetch(`${baseUrl}/trpc/echo`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ value: 'Classroom-Quiz' }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ result: { data: { length: 14 } } });
+  });
+
+  it('lässt ein großzügig dimensioniertes Classroom-Quiz unterhalb des Limits durch', async () => {
+    const baseUrl = await startTestServer();
+    const classroomQuiz = {
+      name: 'Classroom-Quiz',
+      description: 'd'.repeat(5_000),
+      questions: Array.from({ length: 200 }, (_, order) => ({
+        text: 'f'.repeat(2_000),
+        type: 'MULTIPLE_CHOICE',
+        order,
+        answers: Array.from({ length: 10 }, (_, answerIndex) => ({
+          text: 'a'.repeat(500),
+          isCorrect: answerIndex === 0,
+        })),
+      })),
+    };
+    const body = JSON.stringify(classroomQuiz);
+    expect(Buffer.byteLength(body)).toBeLessThan(TRPC_MAX_BODY_SIZE_BYTES);
+
+    const response = await fetch(`${baseUrl}/trpc/acceptPayload`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ result: { data: { ok: true } } });
+  });
+
+  it('weist übergroße Payloads mit 413 und klarer Fehlermeldung ab', async () => {
+    const baseUrl = await startTestServer();
+    const response = await fetch(`${baseUrl}/trpc/echo`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ value: 'x'.repeat(TRPC_MAX_BODY_SIZE_BYTES) }),
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message: `Die Anfrage ist zu groß. Maximal ${TRPC_MAX_BODY_SIZE_LABEL} sind erlaubt.`,
+        data: {
+          code: 'PAYLOAD_TOO_LARGE',
+          httpStatus: 413,
+        },
+      },
+    });
+  });
+});

--- a/apps/backend/src/__tests__/websocket-payload-limit.test.ts
+++ b/apps/backend/src/__tests__/websocket-payload-limit.test.ts
@@ -1,0 +1,111 @@
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyWSSHandler } from '@trpc/server/adapters/ws';
+import WebSocket, { WebSocketServer } from 'ws';
+import { z } from 'zod';
+import { TRPC_MAX_BODY_SIZE_BYTES } from '../lib/requestLimits';
+import { publicProcedure, router } from '../trpc';
+
+describe('tRPC WebSocket payload limit', () => {
+  let client: WebSocket | undefined;
+  let wss: WebSocketServer | undefined;
+  let resolverInvocations = 0;
+
+  const testRouter = router({
+    echo: publicProcedure.input(z.object({ value: z.string() })).mutation(({ input }) => {
+      resolverInvocations += 1;
+      return { length: input.value.length };
+    }),
+    updates: publicProcedure.subscription(async function* () {
+      yield { status: 'ready' as const };
+    }),
+  });
+
+  beforeEach(() => {
+    resolverInvocations = 0;
+  });
+
+  afterEach(async () => {
+    client?.terminate();
+    client = undefined;
+    await new Promise<void>((resolve) => {
+      if (!wss) {
+        resolve();
+        return;
+      }
+      wss.close(() => resolve());
+      wss = undefined;
+    });
+  });
+
+  async function startTestServer(): Promise<string> {
+    wss = new WebSocketServer({
+      host: '127.0.0.1',
+      port: 0,
+      maxPayload: TRPC_MAX_BODY_SIZE_BYTES,
+    });
+    applyWSSHandler({ wss, router: testRouter });
+    await new Promise<void>((resolve) => wss!.once('listening', resolve));
+    const address = wss.address() as AddressInfo;
+    return `ws://127.0.0.1:${address.port}`;
+  }
+
+  async function connect(url: string): Promise<WebSocket> {
+    const socket = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      socket.once('open', resolve);
+      socket.once('error', reject);
+    });
+    client = socket;
+    return socket;
+  }
+
+  it('schließt übergroße Nachrichten mit 1009, bevor ein Resolver läuft', async () => {
+    const socket = await connect(await startTestServer());
+    const closed = new Promise<number>((resolve) => {
+      socket.once('close', (code) => resolve(code));
+    });
+
+    socket.send(
+      JSON.stringify({
+        id: 1,
+        method: 'mutation',
+        params: {
+          path: 'echo',
+          input: { value: 'x'.repeat(TRPC_MAX_BODY_SIZE_BYTES) },
+        },
+      }),
+    );
+
+    await expect(closed).resolves.toBe(1009);
+    expect(resolverInvocations).toBe(0);
+  });
+
+  it('lässt normale Subscriptions weiterhin Nachrichten liefern', async () => {
+    const socket = await connect(await startTestServer());
+    const ready = new Promise<unknown>((resolve, reject) => {
+      socket.on('message', (data) => {
+        const message = JSON.parse(data.toString()) as {
+          result?: { type?: string; data?: unknown };
+        };
+        if (message.result?.type === 'data') {
+          resolve(message.result.data);
+        }
+      });
+      socket.once('error', reject);
+    });
+
+    socket.send(
+      JSON.stringify({
+        id: 1,
+        method: 'subscription',
+        params: {
+          path: 'updates',
+          input: null,
+        },
+      }),
+    );
+
+    await expect(ready).resolves.toEqual({ status: 'ready' });
+  });
+});

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -15,6 +15,7 @@ import { appRouter } from './routers';
 import { getRedis, closeRedis } from './redis';
 import { logger } from './lib/logger';
 import { pickLocaleFromAcceptLanguage } from './lib/pick-locale-from-accept-language';
+import { TRPC_MAX_BODY_SIZE_BYTES } from './lib/requestLimits';
 import { startSessionCleanupScheduler, stopSessionCleanupScheduler } from './lib/sessionCleanup';
 
 const PORT = Number(process.env['PORT']) || 3000;
@@ -38,6 +39,7 @@ app.use(
   createExpressMiddleware({
     router: appRouter,
     createContext: async ({ req }) => ({ req }),
+    maxBodySize: TRPC_MAX_BODY_SIZE_BYTES,
   }),
 );
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -176,7 +176,10 @@ const server = app.listen(PORT, () => {
 });
 
 // WebSocket-Server für tRPC-Subscriptions (Story 0.2)
-const wss = new WebSocketServer({ port: WS_PORT });
+const wss = new WebSocketServer({
+  port: WS_PORT,
+  maxPayload: TRPC_MAX_BODY_SIZE_BYTES,
+});
 const wsHandler = applyWSSHandler({
   wss,
   router: appRouter,

--- a/apps/backend/src/lib/requestLimits.ts
+++ b/apps/backend/src/lib/requestLimits.ts
@@ -1,0 +1,5 @@
+/** Global HTTP ceiling for tRPC request bodies (2 MiB). */
+export const TRPC_MAX_BODY_SIZE_BYTES = 2 * 1024 * 1024;
+
+/** Human-readable equivalent used in API errors and operator documentation. */
+export const TRPC_MAX_BODY_SIZE_LABEL = '2 MiB';

--- a/apps/backend/src/lib/requestLimits.ts
+++ b/apps/backend/src/lib/requestLimits.ts
@@ -1,4 +1,4 @@
-/** Global HTTP ceiling for tRPC request bodies (2 MiB). */
+/** Global 2 MiB ceiling for tRPC HTTP request bodies and WebSocket messages. */
 export const TRPC_MAX_BODY_SIZE_BYTES = 2 * 1024 * 1024;
 
 /** Human-readable equivalent used in API errors and operator documentation. */

--- a/apps/backend/src/trpc.ts
+++ b/apps/backend/src/trpc.ts
@@ -5,6 +5,7 @@ import { initTRPC, TRPCError } from '@trpc/server';
 import type { IncomingMessage } from 'node:http';
 import { extractAdminToken, isAdminSessionTokenValid } from './lib/adminAuth';
 import { extractHostTokenFromContext, isHostSessionTokenValid } from './lib/hostAuth';
+import { TRPC_MAX_BODY_SIZE_LABEL } from './lib/requestLimits';
 import { isTrackedLiveProcedure, recordLiveRequestTelemetry } from './lib/sloTelemetry';
 
 export type Context = {
@@ -15,7 +16,18 @@ export type Context = {
   hostSessionCode?: string;
 };
 
-const t = initTRPC.context<Context>().create();
+const t = initTRPC.context<Context>().create({
+  errorFormatter({ shape, error }) {
+    if (error.code !== 'PAYLOAD_TOO_LARGE') {
+      return shape;
+    }
+
+    return {
+      ...shape,
+      message: `Die Anfrage ist zu groß. Maximal ${TRPC_MAX_BODY_SIZE_LABEL} sind erlaubt.`,
+    };
+  },
+});
 const telemetryProcedure = t.procedure.use(async ({ path, type, next }) => {
   if (type === 'subscription' || !isTrackedLiveProcedure(path)) {
     return next();

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -48,6 +48,10 @@ Variablen, die der Node-Backend-Prozess unter `apps/backend` typischerweise lies
 
 `HOST_SESSION_TTL_SECONDS` ist ein optionaler Backend-Reader und wird in den Example-Dateien nicht gesetzt, weil der 8h-Standard für Dev und Produktion der vorgesehene Normalfall ist.
 
+### HTTP-Body-Limit
+
+tRPC-HTTP-Anfragen sind fest auf **2 MiB** begrenzt (`TRPC_MAX_BODY_SIZE_BYTES` in `apps/backend/src/lib/requestLimits.ts`). Die Nginx-Produktionskonfiguration muss mit `client_max_body_size 2m;` denselben oder einen strengeren Wert verwenden. Das Limit ist bewusst nicht per Env abschaltbar; Änderungen erfordern Code-, Test- und Deployment-Review.
+
 ### `JWT_SECRET` (`.env.example`)
 
 In **`.env.example`** und **Docker-/Deploy-Vorlagen** enthalten; im aktuellen **`apps/backend`-Quellcode** gibt es dafür keinen direkten Leser. Für **Produktions-Compose** trotzdem einen starken Wert setzen, solange Deploy-/Operations-Doku diese Variable weiter mitführt oder künftige Features darauf aufbauen.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -50,7 +50,7 @@ Variablen, die der Node-Backend-Prozess unter `apps/backend` typischerweise lies
 
 ### HTTP-Body-Limit
 
-tRPC-HTTP-Anfragen sind fest auf **2 MiB** begrenzt (`TRPC_MAX_BODY_SIZE_BYTES` in `apps/backend/src/lib/requestLimits.ts`). Die Nginx-Produktionskonfiguration muss mit `client_max_body_size 2m;` denselben oder einen strengeren Wert verwenden. Das Limit ist bewusst nicht per Env abschaltbar; Änderungen erfordern Code-, Test- und Deployment-Review.
+tRPC-HTTP-Anfragen sind fest auf **2 MiB** begrenzt (`TRPC_MAX_BODY_SIZE_BYTES` in `apps/backend/src/lib/requestLimits.ts`). Die Nginx-Produktionskonfiguration verwendet mit `client_max_body_size 8m;` ein separates Infrastruktur-Hard-Cap oberhalb dieser Grenze. Dadurch erzeugt tRPC die anwendungsspezifische, auch für `httpBatchLink` kompatible HTTP-413-Antwort; Nginx verwirft nur deutlich größere Requests vor dem Backend. Beide Limits sind bewusst nicht per Env abschaltbar; Änderungen erfordern Code-, Test- und Deployment-Review.
 
 ### `JWT_SECRET` (`.env.example`)
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -48,9 +48,9 @@ Variablen, die der Node-Backend-Prozess unter `apps/backend` typischerweise lies
 
 `HOST_SESSION_TTL_SECONDS` ist ein optionaler Backend-Reader und wird in den Example-Dateien nicht gesetzt, weil der 8h-Standard für Dev und Produktion der vorgesehene Normalfall ist.
 
-### HTTP-Body-Limit
+### tRPC-Payload-Limits
 
-tRPC-HTTP-Anfragen sind fest auf **2 MiB** begrenzt (`TRPC_MAX_BODY_SIZE_BYTES` in `apps/backend/src/lib/requestLimits.ts`). Die Nginx-Produktionskonfiguration verwendet mit `client_max_body_size 8m;` ein separates Infrastruktur-Hard-Cap oberhalb dieser Grenze. Dadurch erzeugt tRPC die anwendungsspezifische, auch für `httpBatchLink` kompatible HTTP-413-Antwort; Nginx verwirft nur deutlich größere Requests vor dem Backend. Beide Limits sind bewusst nicht per Env abschaltbar; Änderungen erfordern Code-, Test- und Deployment-Review.
+tRPC-HTTP-Anfragen und tRPC-WebSocket-Nachrichten sind fest auf **2 MiB** begrenzt (`TRPC_MAX_BODY_SIZE_BYTES` in `apps/backend/src/lib/requestLimits.ts`). Übergroße WebSocket-Nachrichten werden mit Close-Code `1009` beendet. Die Nginx-Produktionskonfiguration verwendet für HTTP mit `client_max_body_size 8m;` ein separates Infrastruktur-Hard-Cap oberhalb dieser Grenze. Dadurch erzeugt tRPC die anwendungsspezifische, auch für `httpBatchLink` kompatible HTTP-413-Antwort; Nginx verwirft nur deutlich größere HTTP-Requests vor dem Backend. Die Limits sind bewusst nicht per Env abschaltbar; Änderungen erfordern Code-, Test- und Deployment-Review.
 
 ### `JWT_SECRET` (`.env.example`)
 

--- a/docs/SECURITY-OVERVIEW.md
+++ b/docs/SECURITY-OVERVIEW.md
@@ -41,7 +41,7 @@ Die App **ersetzt keine** organisationsweite IAM- oder VPN-Lösung.
 
 Redis-basierte Limits u. a. für Session-Code-Fehlversuche und Session-Erstellung **pro IP**, Votes **pro Teilnehmenden-ID** sowie die **MOTD-Öffentliche-API pro IP** — konfigurierbar über Env ([ENVIRONMENT.md](ENVIRONMENT.md), `rateLimit.ts`). Hinter Nginx muss `TRUST_PROXY_HOPS=1` gesetzt sein, damit `x-forwarded-for` / `x-real-ip` korrekt ausgewertet werden und nicht alle Clients im Proxy-Bucket landen.
 
-HTTP-Anfragen an tRPC sind im Backend auf **2 MiB** begrenzt; Nginx setzt davor ein **8-MiB-Infrastruktur-Hard-Cap**. Requests oberhalb des Anwendungslimits werden dadurch regulär von tRPC mit HTTP **413** und dem auch für Batch-Requests passenden Code `PAYLOAD_TOO_LARGE` abgewiesen. Das schützt insbesondere öffentliche Create-/Quiz-Upload-Pfade; fachliche Array- und Feldgrenzen bleiben zusätzlich erforderlich.
+HTTP-Anfragen und WebSocket-Nachrichten an tRPC sind im Backend auf **2 MiB** begrenzt; Nginx setzt für HTTP davor ein **8-MiB-Infrastruktur-Hard-Cap**. HTTP-Requests oberhalb des Anwendungslimits werden dadurch regulär von tRPC mit HTTP **413** und dem auch für Batch-Requests passenden Code `PAYLOAD_TOO_LARGE` abgewiesen; übergroße WebSocket-Nachrichten schließen mit Code `1009`, bevor ein Resolver ausgeführt wird. Das schützt insbesondere öffentliche Create-/Quiz-Upload-Pfade; fachliche Array- und Feldgrenzen bleiben zusätzlich erforderlich.
 
 ---
 

--- a/docs/SECURITY-OVERVIEW.md
+++ b/docs/SECURITY-OVERVIEW.md
@@ -4,7 +4,7 @@
 
 Kurzreferenz für **Annahmen, Grenzen und eingebaute Kontrollen**. Kein vollständiges Threat-Model und keine Rechtsberatung; technische Tiefe: Handbuch, ADRs, Prisma, `session.ts` / DTO-Schicht.
 
-**Stand:** 2026-07-05 — abgeglichen mit Root-[README](../README.md), [docs/README.md](README.md), [deployment-debian-root-server.md](deployment-debian-root-server.md), [ENVIRONMENT.md](ENVIRONMENT.md), [TESTING.md](TESTING.md), Admin-Flow und aktuellem Backend. Enthalten sind Host-/Feedback-Host-Token, Admin-Tokens, besitzgebundene Quiz-Historie (`accessProof`), MOTD, Server-Status (`health.footerBundle` / `health.stats`) und Plattformstatistik (`PlatformStatistic`, `DailyStatistic`).
+**Stand:** 2026-07-23 — abgeglichen mit Root-[README](../README.md), [docs/README.md](README.md), [deployment-debian-root-server.md](deployment-debian-root-server.md), [ENVIRONMENT.md](ENVIRONMENT.md), [TESTING.md](TESTING.md), Admin-Flow und aktuellem Backend. Enthalten sind Host-/Feedback-Host-Token, Admin-Tokens, besitzgebundene Quiz-Historie (`accessProof`), MOTD, Server-Status (`health.footerBundle` / `health.stats`) und Plattformstatistik (`PlatformStatistic`, `DailyStatistic`).
 
 ---
 
@@ -40,6 +40,8 @@ Die App **ersetzt keine** organisationsweite IAM- oder VPN-Lösung.
 ## 4. Missbrauch & Last (Rate-Limiting)
 
 Redis-basierte Limits u. a. für Session-Code-Fehlversuche und Session-Erstellung **pro IP**, Votes **pro Teilnehmenden-ID** sowie die **MOTD-Öffentliche-API pro IP** — konfigurierbar über Env ([ENVIRONMENT.md](ENVIRONMENT.md), `rateLimit.ts`). Hinter Nginx muss `TRUST_PROXY_HOPS=1` gesetzt sein, damit `x-forwarded-for` / `x-real-ip` korrekt ausgewertet werden und nicht alle Clients im Proxy-Bucket landen.
+
+HTTP-Anfragen an tRPC sind im Backend und in der dokumentierten Nginx-Konfiguration auf **2 MiB** begrenzt. Übergroße Bodies werden mit HTTP **413** und dem tRPC-Code `PAYLOAD_TOO_LARGE` abgewiesen. Das schützt insbesondere öffentliche Create-/Quiz-Upload-Pfade; fachliche Array- und Feldgrenzen bleiben zusätzlich erforderlich.
 
 ---
 

--- a/docs/SECURITY-OVERVIEW.md
+++ b/docs/SECURITY-OVERVIEW.md
@@ -41,7 +41,7 @@ Die App **ersetzt keine** organisationsweite IAM- oder VPN-Lösung.
 
 Redis-basierte Limits u. a. für Session-Code-Fehlversuche und Session-Erstellung **pro IP**, Votes **pro Teilnehmenden-ID** sowie die **MOTD-Öffentliche-API pro IP** — konfigurierbar über Env ([ENVIRONMENT.md](ENVIRONMENT.md), `rateLimit.ts`). Hinter Nginx muss `TRUST_PROXY_HOPS=1` gesetzt sein, damit `x-forwarded-for` / `x-real-ip` korrekt ausgewertet werden und nicht alle Clients im Proxy-Bucket landen.
 
-HTTP-Anfragen an tRPC sind im Backend und in der dokumentierten Nginx-Konfiguration auf **2 MiB** begrenzt. Übergroße Bodies werden mit HTTP **413** und dem tRPC-Code `PAYLOAD_TOO_LARGE` abgewiesen. Das schützt insbesondere öffentliche Create-/Quiz-Upload-Pfade; fachliche Array- und Feldgrenzen bleiben zusätzlich erforderlich.
+HTTP-Anfragen an tRPC sind im Backend auf **2 MiB** begrenzt; Nginx setzt davor ein **8-MiB-Infrastruktur-Hard-Cap**. Requests oberhalb des Anwendungslimits werden dadurch regulär von tRPC mit HTTP **413** und dem auch für Batch-Requests passenden Code `PAYLOAD_TOO_LARGE` abgewiesen. Das schützt insbesondere öffentliche Create-/Quiz-Upload-Pfade; fachliche Array- und Feldgrenzen bleiben zusätzlich erforderlich.
 
 ---
 

--- a/docs/deployment-debian-root-server.md
+++ b/docs/deployment-debian-root-server.md
@@ -342,14 +342,9 @@ server {
     access_log /var/log/nginx/arsnova_click_access.log;
     error_log  /var/log/nginx/arsnova_click_error.log;
 
-    # Synchron zum tRPC-Backend-Limit; übergroße Create-/Upload-Bodies enden mit HTTP 413.
-    client_max_body_size 2m;
-    error_page 413 = @payload_too_large;
-
-    location @payload_too_large {
-        default_type application/json;
-        return 413 '{"error":{"message":"Die Anfrage ist zu groß. Maximal 2 MiB sind erlaubt.","code":-32013,"data":{"code":"PAYLOAD_TOO_LARGE","httpStatus":413}}}';
-    }
+    # Infrastruktur-Hard-Cap oberhalb des 2-MiB-tRPC-Limits:
+    # tRPC erzeugt dadurch selbst die batch-kompatible HTTP-413-Fehlerantwort.
+    client_max_body_size 8m;
 
     # API + tRPC HTTP + statisches Frontend → App-Container auf Port 3000
     location / {

--- a/docs/deployment-debian-root-server.md
+++ b/docs/deployment-debian-root-server.md
@@ -342,6 +342,15 @@ server {
     access_log /var/log/nginx/arsnova_click_access.log;
     error_log  /var/log/nginx/arsnova_click_error.log;
 
+    # Synchron zum tRPC-Backend-Limit; übergroße Create-/Upload-Bodies enden mit HTTP 413.
+    client_max_body_size 2m;
+    error_page 413 = @payload_too_large;
+
+    location @payload_too_large {
+        default_type application/json;
+        return 413 '{"error":{"message":"Die Anfrage ist zu groß. Maximal 2 MiB sind erlaubt.","code":-32013,"data":{"code":"PAYLOAD_TOO_LARGE","httpStatus":413}}}';
+    }
+
     # API + tRPC HTTP + statisches Frontend → App-Container auf Port 3000
     location / {
         proxy_pass http://app_http;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18573,9 +18573,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
   "overrides": {
     "@hono/node-server": "2.0.11",
     "fast-uri": "^3.1.4",
+    "find-my-way": "^9.7.0",
     "hono": "^4.12.5",
     "minimatch": "^10.2.1",
     "sharp": "^0.35.0",


### PR DESCRIPTION
## Summary
- begrenzt tRPC-HTTP-Request-Bodies im Backend streamend auf 2 MiB und liefert batch-kompatible `PAYLOAD_TOO_LARGE`-Antworten mit HTTP 413
- begrenzt tRPC-WebSocket-Nachrichten ebenfalls auf 2 MiB; übergroße Frames schließen mit Code `1009`, bevor ein Resolver ausgeführt wird
- dokumentiert Nginx mit einem separaten 8-MiB-Infrastruktur-Hard-Cap, sodass das 2-MiB-Anwendungslimit regulär durch tRPC beantwortet wird
- belegt mit dem produktiven `QuizUploadInputSchema`, dass ein großzügiges Classroom-Quiz mit 200 Fragen unter dem Cap bleibt

## Maßnahme W0.1
- **Owner:** Security/Core-Team
- **Ticket / Issue:** dieser PR (Slice W0.1 aus `SECURITY-HARDENING-PLAN.md`)
- **Abhängigkeiten:** keine; W1.3 ergänzt fachliche Zod- und Rate-Limits, W2.3 verengt den WS-Router und ergänzt weitere WS-Caps
- **Rollback:** Commits revertieren und Backend-/WebSocket-Grenzen sowie das Nginx-Infrastruktur-Cap gemeinsam auf einen geprüften Stand zurücksetzen

## Test plan
- [x] HTTP: normale Payload akzeptiert
- [x] HTTP: schema-valides 200-Fragen-Classroom-Quiz akzeptiert
- [x] HTTP: übergroße Einzel-Payload ergibt 413 + `PAYLOAD_TOO_LARGE`
- [x] HTTP-Batch: übergroße Payload ergibt eine `httpBatchLink`-kompatible Fehlerantwort
- [x] WebSocket: übergroße Nachricht schließt mit `1009`, Resolver wird nicht ausgeführt
- [x] WebSocket: normale Subscription bleibt funktionsfähig
- [x] vollständiger Typecheck (Shared Types, Export-Lib, Backend, Frontend)
- [x] vollständige Tests: 28 Shared Types, 64 Export-Lib, 435 Backend, 991 Frontend
- [x] ESLint, Prettier und `git diff --check`

Die unversionierte Entwickler-Playbook-PDF ist nicht Bestandteil dieses PRs.

Made with [Cursor](https://cursor.com)