### PR TITLE
fix(security): Restic-SFTP-Aufruf vervollständigen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
             -v "$PWD:/repo:ro" \
             debian:12-slim \
             bash -c 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq restic openssh-client openssh-server >/dev/null && /repo/scripts/backup/tests/restic-sftp-integration.sh'
+          scripts/backup/tests/postgres-readiness-integration.sh
           sudo install -o root -g root -m 0750 scripts/backup/*.sh /usr/local/sbin/
           sudo install -o root -g root -m 0700 -d \
             /etc/arsnova-backup \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,12 @@ jobs:
       - name: Validate backup shell scripts
         run: |
           bash -n scripts/backup/*.sh
-          shellcheck scripts/backup/*.sh
+          bash -n scripts/backup/tests/*.sh
+          shellcheck scripts/backup/*.sh scripts/backup/tests/*.sh
+          docker run --rm \
+            -v "$PWD:/repo:ro" \
+            debian:12-slim \
+            bash -c 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq restic openssh-client openssh-server >/dev/null && /repo/scripts/backup/tests/restic-sftp-integration.sh'
           sudo install -o root -g root -m 0750 scripts/backup/*.sh /usr/local/sbin/
           sudo install -o root -g root -m 0700 -d \
             /etc/arsnova-backup \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
           bash -n scripts/backup/tests/*.sh
           shellcheck scripts/backup/*.sh scripts/backup/tests/*.sh
           docker run --rm \
+            -e ARSNOVA_BACKUP_TEST_CONTAINER=1 \
             -v "$PWD:/repo:ro" \
             debian:12-slim \
             bash -c 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq restic openssh-client openssh-server >/dev/null && /repo/scripts/backup/tests/restic-sftp-integration.sh'

--- a/docs/implementation/W3.6-EXTERNAL-BACKUPS-ABNAHME.md
+++ b/docs/implementation/W3.6-EXTERNAL-BACKUPS-ABNAHME.md
@@ -74,6 +74,8 @@ Vor Merge:
   unter systemd
 - Initialisierung eines echten Restic-Repository über den konfigurierten
   SSH-Befehl und einen lokalen OpenSSH-SFTP-Server unter Debian 12
+- Bereitschaftsprüfung des finalen PostgreSQL-Hauptprozesses, ohne den
+  temporären Init-Server des offiziellen Images als betriebsbereit zu werten
 - vollständiger Backup-Lauf gegen ein temporäres PostgreSQL-16 und ein
   verschlüsseltes lokales Restic-Testrepository
 - vollständiger Restore aus diesem Repository in den gehärteten, netzlosen

--- a/docs/implementation/W3.6-EXTERNAL-BACKUPS-ABNAHME.md
+++ b/docs/implementation/W3.6-EXTERNAL-BACKUPS-ABNAHME.md
@@ -73,7 +73,9 @@ Vor Merge:
 - echte Starts beider gehärteter Services mit einem Lock-Smoke-`ExecStart`
   unter systemd
 - Initialisierung eines echten Restic-Repository über den konfigurierten
-  SSH-Befehl und einen lokalen OpenSSH-SFTP-Server unter Debian 12
+  SSH-Befehl und einen lokalen OpenSSH-SFTP-Server unter Debian 12; der Test
+  verweigert Ausführung außerhalb seines explizit markierten Wegwerf-Containers
+  und verwendet ausschließlich temporäre Konfigurations- und Schlüsselpfade
 - Bereitschaftsprüfung des finalen PostgreSQL-Hauptprozesses, ohne den
   temporären Init-Server des offiziellen Images als betriebsbereit zu werten
 - vollständiger Backup-Lauf gegen ein temporäres PostgreSQL-16 und ein

--- a/docs/implementation/W3.6-EXTERNAL-BACKUPS-ABNAHME.md
+++ b/docs/implementation/W3.6-EXTERNAL-BACKUPS-ABNAHME.md
@@ -72,6 +72,8 @@ Vor Merge:
 - `systemd-analyze verify` für die vier Units
 - echte Starts beider gehärteter Services mit einem Lock-Smoke-`ExecStart`
   unter systemd
+- Initialisierung eines echten Restic-Repository über den konfigurierten
+  SSH-Befehl und einen lokalen OpenSSH-SFTP-Server unter Debian 12
 - vollständiger Backup-Lauf gegen ein temporäres PostgreSQL-16 und ein
   verschlüsseltes lokales Restic-Testrepository
 - vollständiger Restore aus diesem Repository in den gehärteten, netzlosen

--- a/scripts/backup/arsnova-restic.sh
+++ b/scripts/backup/arsnova-restic.sh
@@ -44,5 +44,5 @@ require_root_owned_private_file "$RESTIC_PASSWORD_FILE" "Restic-Passwortdatei"
 require_root_owned_private_file "$ARSNOVA_BACKUP_SSH_CONFIG" "SSH-Konfiguration"
 
 exec restic \
-  -o "sftp.command=ssh -F ${ARSNOVA_BACKUP_SSH_CONFIG}" \
+  -o "sftp.command=ssh -F ${ARSNOVA_BACKUP_SSH_CONFIG} arsnova-storagebox -s sftp" \
   "$@"

--- a/scripts/backup/arsnova-restore-check.sh
+++ b/scripts/backup/arsnova-restore-check.sh
@@ -109,7 +109,8 @@ docker run -d --rm \
 
 ready=false
 for _ in {1..60}; do
-  if docker exec "$CONTAINER_NAME" pg_isready -U postgres >/dev/null 2>&1; then
+  if docker exec "$CONTAINER_NAME" sh -eu -c \
+    'test "$(cat /proc/1/comm)" = postgres && pg_isready -U postgres >/dev/null'; then
     ready=true
     break
   fi

--- a/scripts/backup/tests/postgres-readiness-integration.sh
+++ b/scripts/backup/tests/postgres-readiness-integration.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+command -v docker >/dev/null 2>&1 || {
+  echo "Docker fehlt für den PostgreSQL-Bereitschaftstest." >&2
+  exit 1
+}
+
+CONTAINER_NAME="arsnova-postgres-readiness-test-$$"
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run -d --rm \
+  --name "$CONTAINER_NAME" \
+  --network none \
+  --user 70:70 \
+  --read-only \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  --pids-limit 128 \
+  --memory 2g \
+  --cpus 1 \
+  --tmpfs /var/lib/postgresql/data:rw,noexec,nosuid,nodev,size=1g,uid=70,gid=70,mode=0700 \
+  --tmpfs /var/run/postgresql:rw,noexec,nosuid,nodev,size=16m,uid=70,gid=70,mode=0755 \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=70,gid=70,mode=1777 \
+  -e POSTGRES_HOST_AUTH_METHOD=trust \
+  postgres:16-alpine >/dev/null
+
+ready=false
+for _ in {1..60}; do
+  if docker exec "$CONTAINER_NAME" sh -eu -c \
+    'test "$(cat /proc/1/comm)" = postgres && pg_isready -U postgres >/dev/null'; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+
+[[ "$ready" == "true" ]] || {
+  docker logs "$CONTAINER_NAME" >&2
+  echo "Der finale PostgreSQL-Prozess wurde nicht rechtzeitig bereit." >&2
+  exit 1
+}
+
+docker exec "$CONTAINER_NAME" createdb -U postgres readiness_test

--- a/scripts/backup/tests/restic-sftp-integration.sh
+++ b/scripts/backup/tests/restic-sftp-integration.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[[ "${EUID:-$(id -u)}" -eq 0 ]] || {
+  echo "Der SFTP-Integrationstest muss als root laufen." >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/arsnova-restic.sh"
+TEST_USER="arsnova_restic_test"
+TEST_HOME="/home/$TEST_USER"
+SSHD_PID_FILE="/run/arsnova-restic-test-sshd.pid"
+
+cleanup() {
+  if [[ -f "$SSHD_PID_FILE" ]]; then
+    kill "$(cat "$SSHD_PID_FILE")" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+for command_name in restic ssh sshd ssh-keygen useradd; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "Benötigtes Testkommando fehlt: $command_name" >&2
+    exit 1
+  }
+done
+
+useradd -m -s /bin/bash "$TEST_USER"
+echo "$TEST_USER:test-password" | chpasswd
+install -d -o "$TEST_USER" -g "$TEST_USER" -m 0700 "$TEST_HOME/.ssh"
+
+ssh-keygen -q -t ed25519 -N "" -f /tmp/arsnova-restic-client-key
+install -o "$TEST_USER" -g "$TEST_USER" -m 0600 \
+  /tmp/arsnova-restic-client-key.pub \
+  "$TEST_HOME/.ssh/authorized_keys"
+
+ssh-keygen -A >/dev/null
+install -d -m 0755 /run/sshd
+/usr/sbin/sshd -p 2222 -o "PidFile=$SSHD_PID_FILE"
+
+install -d -m 0700 /etc/arsnova-backup
+cat >/etc/arsnova-backup/ssh_config <<'EOF'
+Host arsnova-storagebox
+  HostName 127.0.0.1
+  User arsnova_restic_test
+  Port 2222
+  IdentityFile /tmp/arsnova-restic-client-key
+  IdentitiesOnly yes
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+EOF
+
+cat >/etc/arsnova-backup/backup.env <<'EOF'
+RESTIC_REPOSITORY=sftp:arsnova-storagebox:restic-repository
+RESTIC_PASSWORD_FILE=/etc/arsnova-backup/restic-password
+ARSNOVA_BACKUP_SSH_CONFIG=/etc/arsnova-backup/ssh_config
+EOF
+
+printf 'integration-password\n' >/etc/arsnova-backup/restic-password
+chmod 0600 /etc/arsnova-backup/backup.env
+chmod 0600 /etc/arsnova-backup/restic-password
+chmod 0600 /etc/arsnova-backup/ssh_config
+
+ARSNOVA_BACKUP_CONFIG=/etc/arsnova-backup/backup.env "$WRAPPER" init >/dev/null
+ARSNOVA_BACKUP_CONFIG=/etc/arsnova-backup/backup.env "$WRAPPER" snapshots --json |
+  grep -Eq '^\[\]$'
+
+test -f "$TEST_HOME/restic-repository/config"

--- a/scripts/backup/tests/restic-sftp-integration.sh
+++ b/scripts/backup/tests/restic-sftp-integration.sh
@@ -7,64 +7,69 @@ set -euo pipefail
   exit 1
 }
 
+[[ -f /.dockerenv && "${ARSNOVA_BACKUP_TEST_CONTAINER:-}" == "1" ]] || {
+  echo "Abbruch: Dieser destruktive Test darf nur im vorgesehenen Wegwerf-Container laufen." >&2
+  exit 1
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WRAPPER="$SCRIPT_DIR/arsnova-restic.sh"
-TEST_USER="arsnova_restic_test"
-TEST_HOME="/home/$TEST_USER"
-SSHD_PID_FILE="/run/arsnova-restic-test-sshd.pid"
+TEST_ROOT="$(mktemp -d)"
+SSHD_PID_FILE="$TEST_ROOT/sshd.pid"
 
 cleanup() {
   if [[ -f "$SSHD_PID_FILE" ]]; then
     kill "$(cat "$SSHD_PID_FILE")" >/dev/null 2>&1 || true
   fi
+  rm -rf -- "$TEST_ROOT"
 }
 trap cleanup EXIT
 
-for command_name in restic ssh sshd ssh-keygen useradd; do
+for command_name in restic ssh sshd ssh-keygen; do
   command -v "$command_name" >/dev/null 2>&1 || {
     echo "Benötigtes Testkommando fehlt: $command_name" >&2
     exit 1
   }
 done
 
-useradd -m -s /bin/bash "$TEST_USER"
-echo "$TEST_USER:test-password" | chpasswd
-install -d -o "$TEST_USER" -g "$TEST_USER" -m 0700 "$TEST_HOME/.ssh"
+ssh-keygen -q -t ed25519 -N "" -f "$TEST_ROOT/client-key"
+install -m 0600 "$TEST_ROOT/client-key.pub" "$TEST_ROOT/authorized_keys"
+ssh-keygen -q -t ed25519 -N "" -f "$TEST_ROOT/sshd-host-key"
 
-ssh-keygen -q -t ed25519 -N "" -f /tmp/arsnova-restic-client-key
-install -o "$TEST_USER" -g "$TEST_USER" -m 0600 \
-  /tmp/arsnova-restic-client-key.pub \
-  "$TEST_HOME/.ssh/authorized_keys"
-
-ssh-keygen -A >/dev/null
 install -d -m 0755 /run/sshd
-/usr/sbin/sshd -p 2222 -o "PidFile=$SSHD_PID_FILE"
+/usr/sbin/sshd \
+  -p 2222 \
+  -h "$TEST_ROOT/sshd-host-key" \
+  -o "PidFile=$SSHD_PID_FILE" \
+  -o PermitRootLogin=yes \
+  -o PasswordAuthentication=no \
+  -o "AuthorizedKeysFile=$TEST_ROOT/authorized_keys" \
+  -o StrictModes=no
 
-install -d -m 0700 /etc/arsnova-backup
-cat >/etc/arsnova-backup/ssh_config <<'EOF'
+cat >"$TEST_ROOT/ssh_config" <<EOF
 Host arsnova-storagebox
   HostName 127.0.0.1
-  User arsnova_restic_test
+  User root
   Port 2222
-  IdentityFile /tmp/arsnova-restic-client-key
+  IdentityFile $TEST_ROOT/client-key
   IdentitiesOnly yes
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
 EOF
 
-cat >/etc/arsnova-backup/backup.env <<'EOF'
-RESTIC_REPOSITORY=sftp:arsnova-storagebox:restic-repository
-RESTIC_PASSWORD_FILE=/etc/arsnova-backup/restic-password
-ARSNOVA_BACKUP_SSH_CONFIG=/etc/arsnova-backup/ssh_config
+cat >"$TEST_ROOT/backup.env" <<EOF
+RESTIC_REPOSITORY=sftp:arsnova-storagebox:$TEST_ROOT/restic-repository
+RESTIC_PASSWORD_FILE=$TEST_ROOT/restic-password
+ARSNOVA_BACKUP_SSH_CONFIG=$TEST_ROOT/ssh_config
 EOF
 
-printf 'integration-password\n' >/etc/arsnova-backup/restic-password
-chmod 0600 /etc/arsnova-backup/backup.env
-chmod 0600 /etc/arsnova-backup/restic-password
-chmod 0600 /etc/arsnova-backup/ssh_config
+printf 'integration-password\n' >"$TEST_ROOT/restic-password"
+chmod 0600 "$TEST_ROOT/backup.env"
+chmod 0600 "$TEST_ROOT/restic-password"
+chmod 0600 "$TEST_ROOT/ssh_config"
 
-ARSNOVA_BACKUP_CONFIG=/etc/arsnova-backup/backup.env "$WRAPPER" init >/dev/null
-ARSNOVA_BACKUP_CONFIG=/etc/arsnova-backup/backup.env "$WRAPPER" snapshots --json |
+ARSNOVA_BACKUP_CONFIG="$TEST_ROOT/backup.env" "$WRAPPER" init >/dev/null
+ARSNOVA_BACKUP_CONFIG="$TEST_ROOT/backup.env" "$WRAPPER" snapshots --json |
   grep -Eq '^\[\]$'
 
-test -f "$TEST_HOME/restic-repository/config"
+test -f "$TEST_ROOT/restic-repository/config"


### PR DESCRIPTION
## Summary
- vervollständigt den benutzerdefinierten Restic-SFTP-Befehl um Zielhost und SFTP-Subsystem
- ergänzt einen echten Debian-12-Integrationstest mit Restic und OpenSSH-SFTP
- verhindert eine erneute Auslieferung des auf Produktion gefundenen Initialisierungsfehlers

## Test plan
- [x] echter lokaler Restic-`init`- und `snapshots`-Lauf über OpenSSH-SFTP
- [x] ShellCheck und Bash-Syntaxprüfung
- [x] Actionlint
- [x] vollständige Typechecks und Unit-Tests über Pre-Commit-Hooks

Made with [Cursor](https://cursor.com)