### PR TITLE
docs(security): add vulnerability reporting policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,11 +4,11 @@ Vielen Dank, dass du dazu beiträgst, arsnova.eu sicher zu halten. Sicherheitsme
 
 ## Unterstützte Versionen
 
-| Bereich | Sicherheitsunterstützung |
-| --- | --- |
-| Aktuell auf [arsnova.eu](https://arsnova.eu/) betriebene Version | Ja |
-| Aktueller Stand des Branches `main` | Ja |
-| Ältere Versionen, eigene Forks und fremde Installationen | Nein |
+| Bereich                                                          | Sicherheitsunterstützung |
+| ---------------------------------------------------------------- | ------------------------ |
+| Aktuell auf [arsnova.eu](https://arsnova.eu/) betriebene Version | Ja                       |
+| Aktueller Stand des Branches `main`                              | Ja                       |
+| Ältere Versionen, eigene Forks und fremde Installationen         | Nein                     |
 
 ## Sicherheitslücke vertraulich melden
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,67 @@
+# Sicherheitsrichtlinie
+
+Vielen Dank, dass du dazu beiträgst, arsnova.eu sicher zu halten. Sicherheitsmeldungen können auf Deutsch oder Englisch eingereicht werden.
+
+## Unterstützte Versionen
+
+| Bereich | Sicherheitsunterstützung |
+| --- | --- |
+| Aktuell auf [arsnova.eu](https://arsnova.eu/) betriebene Version | Ja |
+| Aktueller Stand des Branches `main` | Ja |
+| Ältere Versionen, eigene Forks und fremde Installationen | Nein |
+
+## Sicherheitslücke vertraulich melden
+
+Bitte veröffentliche vermutete Sicherheitslücken **nicht** als öffentliches GitHub-Issue, in einer GitHub-Diskussion, in einem Pull Request oder über andere öffentliche Kanäle.
+
+Nutze stattdessen die im [Impressum von arsnova.eu](https://arsnova.eu/de/legal/imprint/) angegebene E-Mail-Adresse. Verwende möglichst folgenden Betreff:
+
+```text
+[SECURITY] arsnova.eu – kurze Beschreibung
+```
+
+Eine normale E-Mail ist nicht automatisch Ende-zu-Ende-verschlüsselt. Falls deine Meldung besonders sensible Informationen enthält, sende zunächst nur eine kurze Kontaktanfrage ohne technische Details und bitte um die Abstimmung eines geschützten Übertragungswegs.
+
+## Inhalt einer hilfreichen Meldung
+
+Bitte gib – soweit möglich – folgende Informationen an:
+
+- betroffene URL, Funktion, Komponente oder Version;
+- nachvollziehbare Schritte zur Reproduktion;
+- erwartete und tatsächlich beobachtete Auswirkungen;
+- Einschätzung, welche Daten oder Funktionen gefährdet sein könnten;
+- einen möglichst kleinen Proof of Concept ohne personenbezogene oder produktive Daten;
+- Hinweise auf mögliche Gegenmaßnahmen;
+- eine Kontaktmöglichkeit für Rückfragen;
+- ob und wie du bei einer späteren Veröffentlichung genannt werden möchtest.
+
+Bitte übermittle keine Zugangsdaten, geheimen Schlüssel oder unnötigen personenbezogenen Daten.
+
+## Unser Umgang mit Meldungen
+
+Wir bemühen uns,
+
+- den Eingang innerhalb von sieben Kalendertagen zu bestätigen;
+- innerhalb von 14 Kalendertagen eine erste Einschätzung abzugeben;
+- über wesentliche Fortschritte und die geplante Behebung zu informieren;
+- eine mögliche Veröffentlichung mit der meldenden Person abzustimmen.
+
+Die tatsächliche Bearbeitungszeit hängt von Schweregrad, Komplexität und notwendiger Koordination ab. Sicherheitsrelevante Details sollen erst veröffentlicht werden, wenn eine Behebung oder eine geeignete Schutzmaßnahme verfügbar ist.
+
+## Regeln für verantwortungsvolle Sicherheitsforschung
+
+Bitte
+
+- vermeide Beeinträchtigungen des laufenden Betriebs;
+- führe keine Last-, Denial-of-Service- oder automatisierten Massentests ohne vorherige Zustimmung durch;
+- greife nicht auf Daten anderer Personen zu und verändere oder lösche keine fremden Daten;
+- verwende weder Social Engineering noch Phishing;
+- beende die Untersuchung, wenn du unbeabsichtigt auf personenbezogene Daten, Zugangsdaten oder andere vertrauliche Informationen stößt;
+- speichere, verwende oder veröffentliche solche Informationen nicht;
+- räume uns angemessene Zeit zur Prüfung und Behebung ein.
+
+Diese Richtlinie erteilt keine Genehmigung für Handlungen, die gegen geltendes Recht verstoßen oder Systeme und Daten Dritter betreffen.
+
+## Keine Sicherheitslücke?
+
+Normale Fehler, Funktionswünsche und Fragen können weiterhin über die [öffentlichen GitHub-Issues](https://github.com/kqc-real/arsnova.eu/issues) gemeldet werden.


### PR DESCRIPTION
## Zusammenfassung

- ergänzt `.github/SECURITY.md` als zentrale Sicherheitsrichtlinie
- verweist für nicht öffentliche Meldungen auf die Kontaktadresse im arsnova.eu-Impressum
- beschreibt benötigte Angaben, erwartete Reaktionszeiten und Regeln für verantwortungsvolle Sicherheitsforschung
- trennt Sicherheitsmeldungen von normalen öffentlichen Issues

## Motivation

GitHub meldet bislang keine Security Policy. Sicherheitsforschende benötigen einen klaren, nicht öffentlichen Meldeweg, damit technische Details nicht versehentlich in Issues oder Diskussionen veröffentlicht werden.

## Auswirkungen

Keine funktionalen oder betrieblichen Änderungen an arsnova.eu. Die Änderung betrifft ausschließlich die Projektdokumentation und GitHubs Security-Anzeige.

## Validierung

- Markdown-Inhalt lokal geprüft
- Datei auf dem Branch unter `.github/SECURITY.md` erneut gelesen und vollständig verifiziert
- Impressums-Link: `https://arsnova.eu/de/legal/imprint/`