### PR TITLE
fix(monitoring): abgelaufene Blitzlicht-Polls stoppen

### DIFF
--- a/apps/backend/src/__tests__/quickFeedback.vote-session.test.ts
+++ b/apps/backend/src/__tests__/quickFeedback.vote-session.test.ts
@@ -141,10 +141,12 @@ describe('quickFeedback.vote und Session-Status', () => {
         key: string,
         cKey: string,
         _bucketKey: string,
+        _knownKey: string,
         voterId: string,
         value: string,
         _ttl: string,
         _bucket: string,
+        _knownTtl: string,
         ...tempoValues: string[]
       ) => {
         const raw = (await redisMock.get(key)) as string | null;
@@ -203,7 +205,15 @@ describe('quickFeedback.vote und Session-Status', () => {
   });
 
   it('liefert aktive Standalone-Runden ohne Session-Nachschlag', async () => {
-    redisMock.exists.mockResolvedValue(1);
+    redisMock.get.mockResolvedValue(
+      JSON.stringify({
+        type: 'YESNO',
+        locked: false,
+        totalVotes: 0,
+        distribution: { YES: 0, NO: 0, MAYBE: 0 },
+        sessionBound: false,
+      }),
+    );
 
     await expect(
       caller.isActive({
@@ -215,22 +225,44 @@ describe('quickFeedback.vote und Session-Status', () => {
     expect(rejectInvalidSessionCodeMock).not.toHaveBeenCalled();
   });
 
+  it('liefert für aktive Session-Blitzlichter die Routing-Metadaten mit', async () => {
+    redisMock.get.mockResolvedValue(
+      JSON.stringify({
+        type: 'YESNO',
+        locked: false,
+        totalVotes: 0,
+        distribution: { YES: 0, NO: 0, MAYBE: 0 },
+        sessionBound: true,
+      }),
+    );
+    prismaMock.session.findUnique.mockResolvedValue({ status: 'ACTIVE', type: 'QUIZ' });
+
+    await expect(caller.isActive({ sessionCode: 'ABC123' })).resolves.toEqual({
+      active: true,
+      sessionStatus: 'ACTIVE',
+      sessionType: 'QUIZ',
+    });
+
+    expect(prismaMock.session.findUnique).toHaveBeenCalledOnce();
+    expect(rejectInvalidSessionCodeMock).not.toHaveBeenCalled();
+  });
+
   it('löst inaktive Blitzlicht-Codes mit genau einem Session-Nachschlag auf', async () => {
-    redisMock.exists.mockResolvedValue(0);
-    prismaMock.session.findUnique.mockResolvedValue({ status: 'LOBBY' });
+    redisMock.get.mockResolvedValue(null);
+    prismaMock.session.findUnique.mockResolvedValue({ status: 'LOBBY', type: 'QUIZ' });
 
     await expect(
       caller.isActive({
         sessionCode: 'ABC123',
       }),
-    ).resolves.toEqual({ active: false, sessionStatus: 'LOBBY' });
+    ).resolves.toEqual({ active: false, sessionStatus: 'LOBBY', sessionType: 'QUIZ' });
 
     expect(prismaMock.session.findUnique).toHaveBeenCalledOnce();
     expect(rejectInvalidSessionCodeMock).not.toHaveBeenCalled();
   });
 
   it('klassifiziert den Startseiten-Resolver ohne Blitzlicht oder Session als Lookup', async () => {
-    redisMock.exists.mockResolvedValue(0);
+    redisMock.get.mockResolvedValue(null);
     prismaMock.session.findUnique.mockResolvedValue(null);
 
     await expect(
@@ -248,7 +280,7 @@ describe('quickFeedback.vote und Session-Status', () => {
   });
 
   it('klassifiziert einen abgelaufenen Recent-Code als Poll/Reconnect', async () => {
-    redisMock.exists.mockResolvedValue(0);
+    redisMock.get.mockResolvedValue(null);
     prismaMock.session.findUnique.mockResolvedValue(null);
 
     await expect(
@@ -265,7 +297,7 @@ describe('quickFeedback.vote und Session-Status', () => {
     );
   });
 
-  it('zählt Ergebnisabrufe beendeter Standalone-Blitzlichter nicht als Code-Fehler', async () => {
+  it('zählt Ergebnisabrufe natürlich abgelaufener bekannter Blitzlichter nicht als Code-Fehler', async () => {
     redisMock.get.mockResolvedValue(null);
     redisMock.exists.mockResolvedValue(1);
     prismaMock.session.findUnique.mockResolvedValue(null);
@@ -277,7 +309,7 @@ describe('quickFeedback.vote und Session-Status', () => {
     expect(rejectInvalidSessionCodeMock).not.toHaveBeenCalled();
   });
 
-  it('beendet Ergebnis-Subscriptions beendeter Standalone-Blitzlichter ohne Code-Fehler', async () => {
+  it('beendet Ergebnis-Subscriptions natürlich abgelaufener Blitzlichter ohne Code-Fehler', async () => {
     redisMock.get.mockResolvedValue(null);
     redisMock.exists.mockResolvedValue(1);
     prismaMock.session.findUnique.mockResolvedValue(null);
@@ -306,7 +338,7 @@ describe('quickFeedback.vote und Session-Status', () => {
     const multi = redisMock.multi.mock.results.at(-1)?.value as {
       set: ReturnType<typeof vi.fn>;
     };
-    expect(multi.set).toHaveBeenCalledWith('qf:ended:OLD999', '1', 'EX', 300);
+    expect(multi.set).toHaveBeenCalledWith('qf:known:OLD999', '1', 'EX', 300);
     expect(invalidateFeedbackHostTokenMock).toHaveBeenCalledWith('OLD999');
   });
 
@@ -447,12 +479,14 @@ describe('quickFeedback.vote und Session-Status', () => {
     expect(redisMock.hget).toHaveBeenCalledWith('qf:choices:ABCDEF', VOTER_ID);
     expect(redisMock.eval).toHaveBeenCalledWith(
       expect.any(String),
-      3,
+      4,
       'qf:ABCDEF',
       'qf:choices:ABCDEF',
       'qf:tempo:buckets:ABCDEF',
+      'qf:known:ABCDEF',
       VOTER_ID,
       'SLOW_DOWN',
+      expect.any(String),
       expect.any(String),
       expect.any(String),
       'SPEED_UP',
@@ -939,6 +973,10 @@ describe('quickFeedback.vote und Session-Status', () => {
     expect(result.hostToken).toBe('feedback-owner-token');
     expect(createFeedbackHostTokenMock).toHaveBeenCalledWith(result.sessionCode);
     expect(redisMock.multi).toHaveBeenCalledTimes(1);
+    const multi = redisMock.multi.mock.results[0]?.value as {
+      set: ReturnType<typeof vi.fn>;
+    };
+    expect(multi.set).toHaveBeenCalledWith(`qf:known:${result.sessionCode}`, '1', 'EX', 2_100);
   });
 
   it('ignoriert gefälschte Proxy-Header für den Standalone-Create-Bucket', async () => {

--- a/apps/backend/src/__tests__/quickFeedback.vote-session.test.ts
+++ b/apps/backend/src/__tests__/quickFeedback.vote-session.test.ts
@@ -265,6 +265,51 @@ describe('quickFeedback.vote und Session-Status', () => {
     );
   });
 
+  it('zählt Ergebnisabrufe beendeter Standalone-Blitzlichter nicht als Code-Fehler', async () => {
+    redisMock.get.mockResolvedValue(null);
+    redisMock.exists.mockResolvedValue(1);
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(caller.results({ sessionCode: 'OLD999' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+
+    expect(rejectInvalidSessionCodeMock).not.toHaveBeenCalled();
+  });
+
+  it('beendet Ergebnis-Subscriptions beendeter Standalone-Blitzlichter ohne Code-Fehler', async () => {
+    redisMock.get.mockResolvedValue(null);
+    redisMock.exists.mockResolvedValue(1);
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    const stream = await caller.onResults({ sessionCode: 'OLD999' });
+    await expect(stream[Symbol.asyncIterator]().next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    expect(rejectInvalidSessionCodeMock).not.toHaveBeenCalled();
+  });
+
+  it('markiert beendete Blitzlichter für das auslaufende Client-Polling', async () => {
+    redisMock.get.mockResolvedValue(
+      JSON.stringify({
+        type: 'YESNO',
+        locked: false,
+        totalVotes: 0,
+        distribution: { YES: 0, NO: 0, MAYBE: 0 },
+      }),
+    );
+
+    await expect(hostCaller.end({ sessionCode: 'OLD999' })).resolves.toEqual({ ok: true });
+
+    const multi = redisMock.multi.mock.results.at(-1)?.value as {
+      set: ReturnType<typeof vi.fn>;
+    };
+    expect(multi.set).toHaveBeenCalledWith('qf:ended:OLD999', '1', 'EX', 300);
+    expect(invalidateFeedbackHostTokenMock).toHaveBeenCalledWith('OLD999');
+  });
+
   it('lehnt ab, wenn die Live-Session beendet ist', async () => {
     redisMock.get.mockResolvedValue(
       JSON.stringify({

--- a/apps/backend/src/routers/quickFeedback.ts
+++ b/apps/backend/src/routers/quickFeedback.ts
@@ -48,7 +48,8 @@ import type { SessionCodeFailureSource } from '../lib/abuseTelemetry';
 import { rejectInvalidSessionCode } from '../lib/invalidSessionCode';
 
 const FEEDBACK_TTL_SECONDS = 30 * 60;
-const ENDED_FEEDBACK_GRACE_SECONDS = 5 * 60;
+const KNOWN_FEEDBACK_GRACE_SECONDS = 5 * 60;
+const KNOWN_FEEDBACK_TTL_SECONDS = FEEDBACK_TTL_SECONDS + KNOWN_FEEDBACK_GRACE_SECONDS;
 const QUICK_FEEDBACK_POLL_ACTIVE_MS = 500;
 const QUICK_FEEDBACK_POLL_IDLE_MS = 1200;
 const TEMPO_DEFAULT_VALUE = 'FOLLOWING';
@@ -71,7 +72,7 @@ end
 local valid = {}
 local existingDistribution = result['distribution'] or {}
 local distribution = {}
-for i = 5, #ARGV do
+for i = 6, #ARGV do
   local value = ARGV[i]
   valid[value] = true
   distribution[value] = tonumber(existingDistribution[value]) or 0
@@ -98,7 +99,7 @@ distribution[nextValue] = (tonumber(distribution[nextValue]) or 0) + 1
 redis.call('HSET', KEYS[2], ARGV[1], nextValue)
 
 local totalVotes = 0
-for i = 5, #ARGV do
+for i = 6, #ARGV do
   totalVotes = totalVotes + (tonumber(distribution[ARGV[i]]) or 0)
 end
 
@@ -114,6 +115,7 @@ result['tempoTrend'] = nil
 local ttl = tonumber(ARGV[3])
 redis.call('SET', KEYS[1], cjson.encode(result), 'EX', ttl)
 redis.call('EXPIRE', KEYS[2], ttl)
+redis.call('SET', KEYS[4], '1', 'EX', tonumber(ARGV[5]))
 redis.call(
   'HSET',
   KEYS[3],
@@ -137,15 +139,15 @@ function feedbackKey(code: string): string {
   return `qf:${code}`;
 }
 
-function endedFeedbackKey(code: string): string {
-  return `qf:ended:${code}`;
+function knownFeedbackKey(code: string): string {
+  return `qf:known:${code}`;
 }
 
 async function protectMissingQuickFeedbackCode(
   code: string,
   source: SessionCodeFailureSource,
 ): Promise<void> {
-  if ((await getRedis().exists(endedFeedbackKey(code))) === 1) {
+  if ((await getRedis().exists(knownFeedbackKey(code))) === 1) {
     return;
   }
   const session = await prisma.session.findUnique({
@@ -163,17 +165,34 @@ async function resolveQuickFeedbackAvailability(
 ) {
   const code = input.sessionCode.toUpperCase();
   const redis = getRedis();
-  const n = await redis.exists(feedbackKey(code));
-  if (n === 1) return { active: true as const };
+  const raw = await redis.get(feedbackKey(code));
+  if (raw) {
+    const feedback = JSON.parse(raw) as StoredQuickFeedbackResult;
+    if (feedback.sessionBound !== true) {
+      return { active: true as const };
+    }
+  }
 
   const session = await prisma.session.findUnique({
     where: { code },
-    select: { status: true },
+    select: { status: true, type: true },
   });
+  if (raw && session) {
+    return {
+      active: true as const,
+      sessionStatus: session.status,
+      sessionType: session.type,
+    };
+  }
+  if (raw) return { active: true as const };
   if (!session) {
     return rejectInvalidSessionCode(input.anonymousClientId, code, source);
   }
-  return { active: false as const, sessionStatus: session.status };
+  return {
+    active: false as const,
+    sessionStatus: session.status,
+    sessionType: session.type,
+  };
 }
 
 function votersKey(code: string): string {
@@ -459,7 +478,7 @@ export const quickFeedbackRouter = router({
       multi.del(choicesKey(code));
       multi.del(choicesR1Key(code));
       multi.del(tempoBucketsKey(code));
-      multi.del(endedFeedbackKey(code));
+      multi.set(knownFeedbackKey(code), '1', 'EX', KNOWN_FEEDBACK_TTL_SECONDS);
       await multi.exec();
 
       const hostToken = sessionBound ? null : await createFeedbackHostToken(code);
@@ -490,6 +509,7 @@ export const quickFeedbackRouter = router({
       multi.del(choicesKey(code));
       multi.del(choicesR1Key(code));
       multi.del(tempoBucketsKey(code));
+      multi.set(knownFeedbackKey(code), '1', 'EX', KNOWN_FEEDBACK_TTL_SECONDS);
       await multi.exec();
 
       return { ok: true };
@@ -518,6 +538,7 @@ export const quickFeedbackRouter = router({
       multi.del(choicesKey(code));
       multi.del(choicesR1Key(code));
       multi.del(tempoBucketsKey(code));
+      multi.set(knownFeedbackKey(code), '1', 'EX', KNOWN_FEEDBACK_TTL_SECONDS);
       await multi.exec();
 
       return { ok: true };
@@ -537,7 +558,7 @@ export const quickFeedbackRouter = router({
       multi.del(choicesKey(code));
       multi.del(choicesR1Key(code));
       multi.del(tempoBucketsKey(code));
-      multi.set(endedFeedbackKey(code), '1', 'EX', ENDED_FEEDBACK_GRACE_SECONDS);
+      multi.set(knownFeedbackKey(code), '1', 'EX', KNOWN_FEEDBACK_GRACE_SECONDS);
       await multi.exec();
       await invalidateFeedbackHostToken(code);
 
@@ -553,7 +574,10 @@ export const quickFeedbackRouter = router({
       const result = await loadQuickFeedbackForHost(ctx, code);
       result.locked = !result.locked;
 
-      await redis.set(key, JSON.stringify(result), 'EX', FEEDBACK_TTL_SECONDS);
+      const multi = redis.multi();
+      multi.set(key, JSON.stringify(result), 'EX', FEEDBACK_TTL_SECONDS);
+      multi.set(knownFeedbackKey(code), '1', 'EX', KNOWN_FEEDBACK_TTL_SECONDS);
+      await multi.exec();
       return { locked: result.locked };
     }),
 
@@ -581,6 +605,7 @@ export const quickFeedbackRouter = router({
 
       const multi = redis.multi();
       multi.set(key, JSON.stringify(result), 'EX', FEEDBACK_TTL_SECONDS);
+      multi.set(knownFeedbackKey(code), '1', 'EX', KNOWN_FEEDBACK_TTL_SECONDS);
       if (Object.keys(currentChoices).length > 0) {
         multi.del(r1Key);
         multi.hset(r1Key, currentChoices);
@@ -611,6 +636,7 @@ export const quickFeedbackRouter = router({
 
       const multi = redis.multi();
       multi.set(key, JSON.stringify(result), 'EX', FEEDBACK_TTL_SECONDS);
+      multi.set(knownFeedbackKey(code), '1', 'EX', KNOWN_FEEDBACK_TTL_SECONDS);
       multi.del(votersKey(code));
       multi.del(choicesKey(code));
       await multi.exec();
@@ -678,6 +704,7 @@ export const quickFeedbackRouter = router({
     const cKey = choicesKey(code);
     const multi = redis.multi();
     multi.set(key, JSON.stringify(result), 'EX', FEEDBACK_TTL_SECONDS);
+    multi.set(knownFeedbackKey(code), '1', 'EX', KNOWN_FEEDBACK_TTL_SECONDS);
     multi.sadd(vKey, input.voterId);
     multi.expire(vKey, FEEDBACK_TTL_SECONDS);
     multi.hset(cKey, input.voterId, input.value);
@@ -821,14 +848,16 @@ async function submitTempoVote(input: QuickFeedbackVoteInput, key: string): Prom
   const bucketKey = tempoBucketsKey(code);
   const raw = await redis.eval(
     TEMPO_VOTE_SCRIPT,
-    3,
+    4,
     key,
     cKey,
     bucketKey,
+    knownFeedbackKey(code),
     input.voterId,
     input.value,
     String(FEEDBACK_TTL_SECONDS),
     String(tempoBucketStartMs()),
+    String(KNOWN_FEEDBACK_TTL_SECONDS),
     ...TempoValueEnum.options,
   );
   const payload =
@@ -902,6 +931,7 @@ async function clearTempoVote(
   const bucketKey = tempoBucketsKey(code);
   const multi = redis.multi();
   multi.set(key, JSON.stringify(result), 'EX', FEEDBACK_TTL_SECONDS);
+  multi.set(knownFeedbackKey(code), '1', 'EX', KNOWN_FEEDBACK_TTL_SECONDS);
   multi.hdel(cKey, input.voterId);
   multi.expire(cKey, FEEDBACK_TTL_SECONDS);
   multi.hset(bucketKey, String(tempoBucketStartMs()), bucketPayload);

--- a/apps/backend/src/routers/quickFeedback.ts
+++ b/apps/backend/src/routers/quickFeedback.ts
@@ -48,6 +48,7 @@ import type { SessionCodeFailureSource } from '../lib/abuseTelemetry';
 import { rejectInvalidSessionCode } from '../lib/invalidSessionCode';
 
 const FEEDBACK_TTL_SECONDS = 30 * 60;
+const ENDED_FEEDBACK_GRACE_SECONDS = 5 * 60;
 const QUICK_FEEDBACK_POLL_ACTIVE_MS = 500;
 const QUICK_FEEDBACK_POLL_IDLE_MS = 1200;
 const TEMPO_DEFAULT_VALUE = 'FOLLOWING';
@@ -136,10 +137,17 @@ function feedbackKey(code: string): string {
   return `qf:${code}`;
 }
 
+function endedFeedbackKey(code: string): string {
+  return `qf:ended:${code}`;
+}
+
 async function protectMissingQuickFeedbackCode(
   code: string,
   source: SessionCodeFailureSource,
 ): Promise<void> {
+  if ((await getRedis().exists(endedFeedbackKey(code))) === 1) {
+    return;
+  }
   const session = await prisma.session.findUnique({
     where: { code },
     select: { id: true },
@@ -451,6 +459,7 @@ export const quickFeedbackRouter = router({
       multi.del(choicesKey(code));
       multi.del(choicesR1Key(code));
       multi.del(tempoBucketsKey(code));
+      multi.del(endedFeedbackKey(code));
       await multi.exec();
 
       const hostToken = sessionBound ? null : await createFeedbackHostToken(code);
@@ -528,6 +537,7 @@ export const quickFeedbackRouter = router({
       multi.del(choicesKey(code));
       multi.del(choicesR1Key(code));
       multi.del(tempoBucketsKey(code));
+      multi.set(endedFeedbackKey(code), '1', 'EX', ENDED_FEEDBACK_GRACE_SECONDS);
       await multi.exec();
       await invalidateFeedbackHostToken(code);
 

--- a/apps/frontend/src/app/features/feedback/feedback-vote.component.spec.ts
+++ b/apps/frontend/src/app/features/feedback/feedback-vote.component.spec.ts
@@ -6,12 +6,14 @@ import { ThemePresetService } from '../../core/theme-preset.service';
 
 const {
   getInfoQueryMock,
+  quickFeedbackIsActiveQueryMock,
   quickFeedbackResultsQueryMock,
   quickFeedbackVoteMutateMock,
   quickFeedbackLeaveTempoMutateMock,
   quickFeedbackOnResultsSubscribeMock,
 } = vi.hoisted(() => ({
   getInfoQueryMock: vi.fn(),
+  quickFeedbackIsActiveQueryMock: vi.fn(),
   quickFeedbackResultsQueryMock: vi.fn(),
   quickFeedbackVoteMutateMock: vi.fn(),
   quickFeedbackLeaveTempoMutateMock: vi.fn(),
@@ -24,6 +26,7 @@ vi.mock('../../core/trpc.client', () => ({
       getInfo: { query: getInfoQueryMock },
     },
     quickFeedback: {
+      isActive: { query: quickFeedbackIsActiveQueryMock },
       results: { query: quickFeedbackResultsQueryMock },
       vote: { mutate: quickFeedbackVoteMutateMock },
       leaveTempo: { mutate: quickFeedbackLeaveTempoMutateMock },
@@ -38,6 +41,7 @@ describe('FeedbackVoteComponent', () => {
     localStorage.clear();
     document.documentElement.classList.remove('dark', 'light', 'preset-playful');
     getInfoQueryMock.mockRejectedValue(new Error('not found'));
+    quickFeedbackIsActiveQueryMock.mockResolvedValue({ active: true });
     quickFeedbackResultsQueryMock.mockResolvedValue({
       type: 'YESNO',
       locked: false,
@@ -66,20 +70,10 @@ describe('FeedbackVoteComponent', () => {
   });
 
   it('leitet standalone Feedback-Routen für laufende Quiz-Sessions in den Session-Vote-Flow um', async () => {
-    getInfoQueryMock.mockResolvedValueOnce({
-      id: 'session-1',
-      code: 'ABC123',
-      type: 'QUIZ',
-      status: 'ACTIVE',
-      serverTime: '2026-04-24T18:00:00.000Z',
-      quizName: 'Demo',
-      title: null,
-      channels: {
-        quiz: { enabled: true },
-        qa: { enabled: true, open: true, title: null, moderationMode: false },
-        quickFeedback: { enabled: true, open: true },
-      },
-      participantCount: 0,
+    quickFeedbackIsActiveQueryMock.mockResolvedValueOnce({
+      active: true,
+      sessionType: 'QUIZ',
+      sessionStatus: 'ACTIVE',
     });
 
     const fixture = TestBed.createComponent(FeedbackVoteComponent);
@@ -91,9 +85,10 @@ describe('FeedbackVoteComponent', () => {
     await fixture.whenStable();
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    expect(getInfoQueryMock).toHaveBeenCalledWith(
-      expect.objectContaining({ code: 'ABC123', anonymousClientId: expect.any(String) }),
+    expect(quickFeedbackIsActiveQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionCode: 'ABC123', anonymousClientId: expect.any(String) }),
     );
+    expect(getInfoQueryMock).not.toHaveBeenCalled();
     expect(quickFeedbackResultsQueryMock).not.toHaveBeenCalled();
     expect(navigateByUrlSpy).toHaveBeenCalledWith('/session/ABC123/vote?tab=quickFeedback', {
       replaceUrl: true,
@@ -112,9 +107,10 @@ describe('FeedbackVoteComponent', () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
     fixture.detectChanges();
 
-    expect(getInfoQueryMock).toHaveBeenCalledWith(
-      expect.objectContaining({ code: 'ABC123', anonymousClientId: expect.any(String) }),
+    expect(quickFeedbackIsActiveQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionCode: 'ABC123', anonymousClientId: expect.any(String) }),
     );
+    expect(getInfoQueryMock).not.toHaveBeenCalled();
     expect(quickFeedbackResultsQueryMock).toHaveBeenCalledWith({ sessionCode: 'ABC123' });
     expect(navigateByUrlSpy).not.toHaveBeenCalled();
     expect(fixture.nativeElement.textContent ?? '').toContain('Ja · Nein · Vielleicht');
@@ -123,20 +119,10 @@ describe('FeedbackVoteComponent', () => {
 
   it('zeigt bei beendeter Redis-Runde trotz gleichnamiger FINISHED-Quiz-Session keine Session-Bewertung', async () => {
     quickFeedbackResultsQueryMock.mockRejectedValueOnce(new Error('not found'));
-    getInfoQueryMock.mockResolvedValueOnce({
-      id: 'session-1',
-      code: 'ABC123',
-      type: 'QUIZ',
-      status: 'FINISHED',
-      serverTime: '2026-04-24T18:00:00.000Z',
-      quizName: 'Demo',
-      title: null,
-      channels: {
-        quiz: { enabled: true },
-        qa: { enabled: true, open: true, title: null, moderationMode: false },
-        quickFeedback: { enabled: true, open: false },
-      },
-      participantCount: 0,
+    quickFeedbackIsActiveQueryMock.mockResolvedValueOnce({
+      active: false,
+      sessionType: 'QUIZ',
+      sessionStatus: 'FINISHED',
     });
 
     const fixture = TestBed.createComponent(FeedbackVoteComponent);
@@ -150,9 +136,10 @@ describe('FeedbackVoteComponent', () => {
     fixture.detectChanges();
 
     const text = fixture.nativeElement.textContent ?? '';
-    expect(getInfoQueryMock).toHaveBeenCalledWith(
-      expect.objectContaining({ code: 'ABC123', anonymousClientId: expect.any(String) }),
+    expect(quickFeedbackIsActiveQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionCode: 'ABC123', anonymousClientId: expect.any(String) }),
     );
+    expect(getInfoQueryMock).not.toHaveBeenCalled();
     expect(navigateByUrlSpy).not.toHaveBeenCalled();
     expect(text).toContain('Feedback-Runde nicht gefunden oder abgelaufen.');
     expect(text).toContain('Zur Startseite');

--- a/apps/frontend/src/app/features/feedback/feedback-vote.component.spec.ts
+++ b/apps/frontend/src/app/features/feedback/feedback-vote.component.spec.ts
@@ -661,7 +661,9 @@ describe('FeedbackVoteComponent', () => {
   });
 
   it('zeigt bei abgelaufener Runde einen direkten Link zur Startseite', async () => {
-    quickFeedbackResultsQueryMock.mockRejectedValueOnce(new Error('not found'));
+    quickFeedbackResultsQueryMock.mockRejectedValueOnce(
+      new Error('NOT_FOUND: Feedback-Runde nicht gefunden oder abgelaufen.'),
+    );
 
     const fixture = TestBed.createComponent(FeedbackVoteComponent);
     fixture.componentRef.setInput('sessionCode', 'ABC123');
@@ -673,6 +675,11 @@ describe('FeedbackVoteComponent', () => {
     const text = fixture.nativeElement.textContent ?? '';
     expect(text).toContain('Feedback-Runde nicht gefunden oder abgelaufen.');
     expect(text).toContain('Zur Startseite');
+    expect(quickFeedbackOnResultsSubscribeMock).not.toHaveBeenCalled();
+    expect(
+      (fixture.componentInstance as unknown as { pollTimer: ReturnType<typeof setInterval> | null })
+        .pollTimer,
+    ).toBeNull();
     fixture.destroy();
   });
 
@@ -706,7 +713,9 @@ describe('FeedbackVoteComponent', () => {
         distribution: { YES: 0, NO: 0, MAYBE: 0 },
         currentRound: 1,
       })
-      .mockRejectedValueOnce(new Error('not found'));
+      .mockRejectedValueOnce(
+        new Error('NOT_FOUND: Feedback-Runde nicht gefunden oder abgelaufen.'),
+      );
 
     const fixture = TestBed.createComponent(FeedbackVoteComponent);
     fixture.componentRef.setInput('sessionCode', 'ABC123');
@@ -723,6 +732,10 @@ describe('FeedbackVoteComponent', () => {
     const text = fixture.nativeElement.textContent ?? '';
     expect(text).toContain('Feedback-Runde nicht gefunden oder abgelaufen.');
     expect(text).toContain('Zur Startseite');
+    expect(
+      (fixture.componentInstance as unknown as { pollTimer: ReturnType<typeof setInterval> | null })
+        .pollTimer,
+    ).toBeNull();
     fixture.destroy();
   });
 });

--- a/apps/frontend/src/app/features/feedback/feedback-vote.component.ts
+++ b/apps/frontend/src/app/features/feedback/feedback-vote.component.ts
@@ -253,11 +253,11 @@ export class FeedbackVoteComponent implements OnInit, OnDestroy {
 
   private async redirectStandaloneQuizSession(code: string): Promise<boolean> {
     try {
-      const session = await trpc.session.getInfo.query({
-        code,
+      const resolution = await trpc.quickFeedback.isActive.query({
+        sessionCode: code,
         anonymousClientId: getAnonymousClientId(),
       });
-      if (session.type === 'QUIZ' && session.status !== 'FINISHED') {
+      if (resolution.sessionType === 'QUIZ' && resolution.sessionStatus !== 'FINISHED') {
         await this.router.navigateByUrl(
           this.localizedPath(`/session/${code}/vote?tab=quickFeedback`),
           {
@@ -267,7 +267,7 @@ export class FeedbackVoteComponent implements OnInit, OnDestroy {
         return true;
       }
     } catch {
-      // Standalone-Blitzlicht oder abgelaufener Code: normale Feedback-Route weiter behandeln.
+      // Abgelaufener oder unbekannter Code: normale Feedback-Fehleransicht weiter behandeln.
     }
     return false;
   }

--- a/apps/frontend/src/app/features/feedback/feedback-vote.component.ts
+++ b/apps/frontend/src/app/features/feedback/feedback-vote.component.ts
@@ -92,6 +92,7 @@ export class FeedbackVoteComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private subscription: Unsubscribable | null = null;
+  private resultUpdatesStopped = false;
   private standaloneVoterId: string | null = null;
   private readonly tempoDefaultRegisteredKeys = new Set<string>();
   private readonly tempoDefaultRegistrations = new Map<string, Promise<void>>();
@@ -241,6 +242,10 @@ export class FeedbackVoteComponent implements OnInit, OnDestroy {
     }
 
     await this.pollStyle();
+    if (this.resultUpdatesStopped) {
+      this.loading.set(false);
+      return;
+    }
     this.subscribeToResults();
     this.loading.set(false);
     this.pollTimer = setInterval(() => void this.pollStyle(), 3000);
@@ -291,6 +296,9 @@ export class FeedbackVoteComponent implements OnInit, OnDestroy {
         this.clearEmbeddedState();
         this.error.set(null);
       } else {
+        if (this.isFeedbackRoundMissing(error)) {
+          this.stopResultUpdates();
+        }
         this.error.set(this.localizeFeedbackLoadError(error));
       }
       return false;
@@ -329,6 +337,24 @@ export class FeedbackVoteComponent implements OnInit, OnDestroy {
       return $localize`:@@sessionTabs.quickFeedbackClosedNotice:Der Blitzlicht-Kanal wurde von der Lehrperson geschlossen. Neue Abstimmungen sind gerade nicht möglich.`;
     }
     return $localize`:@@feedback.voteMissing:Feedback-Runde nicht gefunden oder abgelaufen.`;
+  }
+
+  private isFeedbackRoundMissing(error: unknown): boolean {
+    const message = (error as { message?: string } | null)?.message ?? '';
+    return (
+      message.includes('Feedback-Runde nicht gefunden oder abgelaufen.') ||
+      message.startsWith('NOT_FOUND:')
+    );
+  }
+
+  private stopResultUpdates(): void {
+    this.resultUpdatesStopped = true;
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.subscription?.unsubscribe();
+    this.subscription = null;
   }
 
   private applyResult(result: QuickFeedbackResult): void {

--- a/libs/shared-types/src/schemas.ts
+++ b/libs/shared-types/src/schemas.ts
@@ -4119,8 +4119,9 @@ export const QuickFeedbackIsActiveInputSchema = z.object({
 });
 export const QuickFeedbackIsActiveOutputSchema = z.object({
   active: z.boolean(),
-  /** Bei inaktivem Blitzlicht liefert der eine DB-Lookup direkt den Session-Status. */
+  /** Der kombinierte Resolver liefert Session-Metadaten ohne zweiten Client-Lookup. */
   sessionStatus: SessionStatusEnum.optional(),
+  sessionType: SessionTypeEnum.optional(),
 });
 export type QuickFeedbackIsActiveOutput = z.infer<typeof QuickFeedbackIsActiveOutputSchema>;
 


### PR DESCRIPTION
## Summary
- ersetzt den erwartbaren `session.getInfo`-Fehler für gültige Standalone-Blitzlichter durch den kombinierten Quick-Feedback-Resolver mit Session-Routing-Metadaten
- führt einen bekannten Blitzlicht-Code parallel zum Ergebnisdatensatz mit fünf Minuten längerer TTL und aktualisiert ihn bei jeder schreibenden TTL-Verlängerung
- stoppt HTTP-Polling und Subscription in der Standalone-Teilnehmeransicht dauerhaft, sobald die Runde als abgelaufen gemeldet wird
- behält den Schutz für tatsächlich unbekannte Codes bei und ergänzt Regressionstests für gültige Standalone-Codes, natürliches Ablaufen, Query, Subscription und Client-Polling

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint -- --no-cache`
- [x] Backend-Regressionstests für Quick Feedback
- [x] Frontend-Regressionstests für Feedback- und Home-Flows
- [x] vollständige Workspace-Tests über den Commit-Hook: 1.865 Tests grün