### PR TITLE
feat(landing): Änderungsdaten in Sitemap ergänzen

### DIFF
--- a/apps/landing/src/pages/sitemap.xml.ts
+++ b/apps/landing/src/pages/sitemap.xml.ts
@@ -5,16 +5,16 @@ import { toAbsoluteUrl } from '@/config/site';
 export const prerender = true;
 
 const pages = [
-  { path: '', changefreq: 'weekly', priority: '1.0' },
-  { path: 'impressum/', changefreq: 'monthly', priority: '0.5' },
-  { path: 'datenschutz/', changefreq: 'monthly', priority: '0.5' },
+  { path: '', lastmod: '2026-07-27', changefreq: 'weekly', priority: '1.0' },
+  { path: 'impressum/', lastmod: '2026-07-19', changefreq: 'monthly', priority: '0.5' },
+  { path: 'datenschutz/', lastmod: '2026-07-19', changefreq: 'monthly', priority: '0.5' },
 ];
 
 export const GET: APIRoute = () => {
   const urls = pages
     .map(
       (page) =>
-        `<url><loc>${toAbsoluteUrl(page.path)}</loc><changefreq>${page.changefreq}</changefreq><priority>${page.priority}</priority></url>`,
+        `<url><loc>${toAbsoluteUrl(page.path)}</loc><lastmod>${page.lastmod}</lastmod><changefreq>${page.changefreq}</changefreq><priority>${page.priority}</priority></url>`,
     )
     .join('');
 


### PR DESCRIPTION
## Summary
- ergänzt `lastmod` für Startseite, Impressum und Datenschutz
- verwendet die jeweiligen letzten Inhaltsänderungsdaten
- hält bestehende `changefreq`- und `priority`-Angaben bei

## Test plan
- [x] Prettier-Check
- [x] Landing-Build mit Node 24.18.0
- [x] generierte Sitemap mit `xmllint` validiert
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)