### PR TITLE
feat(landing): Custom Domain info.arsnova.eu vorbereiten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,8 +419,9 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         env:
           PUBLIC_GITHUB_REPO: ${{ github.repository }}
-          PUBLIC_SITE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
-          BASE_PATH: /${{ github.event.repository.name }}/
+          PUBLIC_SITE_URL: https://info.arsnova.eu/
+          PUBLIC_APP_URL_V3: https://arsnova.eu
+          BASE_PATH: /
         run: npm run build:landing
 
       - name: Landing accessibility gate
@@ -428,14 +429,13 @@ jobs:
         run: |
           set -euo pipefail
           node node_modules/playwright/cli.js install --with-deps chromium
-          landing_base="/${{ github.event.repository.name }}"
-          mkdir -p "$RUNNER_TEMP/landing-a11y${landing_base}"
-          cp -R apps/landing/dist/. "$RUNNER_TEMP/landing-a11y${landing_base}/"
+          mkdir -p "$RUNNER_TEMP/landing-a11y"
+          cp -R apps/landing/dist/. "$RUNNER_TEMP/landing-a11y/"
           node scripts/serve-static-compressed.mjs "$RUNNER_TEMP/landing-a11y" 4321 > "$RUNNER_TEMP/landing-static.log" 2>&1 &
           server_pid="$!"
           trap 'kill "$server_pid" 2>/dev/null || true' EXIT
           for attempt in {1..30}; do
-            if curl -fsS "http://localhost:4321${landing_base}/" >/dev/null; then
+            if curl -fsS "http://localhost:4321/" >/dev/null; then
               break
             fi
             if [ "$attempt" -eq 30 ]; then
@@ -444,7 +444,7 @@ jobs:
             fi
             sleep 1
           done
-          BASE_URL="http://localhost:4321${landing_base}" npm run test:a11y -w @arsnova/landing
+          BASE_URL="http://localhost:4321" npm run test:a11y -w @arsnova/landing
 
   # Explizites `npm run typecheck` (Backend + Frontend, --noEmit) — ergänzt die
   # tsc-Schritte im build-Job; eigener Check in der PR-Übersicht, parallel zu build.

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -48,27 +48,27 @@ jobs:
       - name: Expected Pages URL
         run: |
           echo "Repository: ${{ github.repository }}"
-          echo "Nach Deploy erreichbar unter: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+          echo "Nach Aktivierung der Pages-Custom-Domain erreichbar unter: https://info.arsnova.eu/"
 
       - name: Build landing
         env:
           PUBLIC_GITHUB_REPO: ${{ github.repository }}
-          PUBLIC_SITE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
-          BASE_PATH: /${{ github.event.repository.name }}/
+          PUBLIC_SITE_URL: https://info.arsnova.eu/
+          PUBLIC_APP_URL_V3: https://arsnova.eu
+          BASE_PATH: /
         run: npm run build:landing
 
       - name: Accessibility gate
         run: |
           set -euo pipefail
           node node_modules/playwright/cli.js install --with-deps chromium
-          landing_base="/${{ github.event.repository.name }}"
-          mkdir -p "$RUNNER_TEMP/landing-a11y${landing_base}"
-          cp -R apps/landing/dist/. "$RUNNER_TEMP/landing-a11y${landing_base}/"
+          mkdir -p "$RUNNER_TEMP/landing-a11y"
+          cp -R apps/landing/dist/. "$RUNNER_TEMP/landing-a11y/"
           node scripts/serve-static-compressed.mjs "$RUNNER_TEMP/landing-a11y" 4321 > "$RUNNER_TEMP/landing-static.log" 2>&1 &
           server_pid="$!"
           trap 'kill "$server_pid" 2>/dev/null || true' EXIT
           for attempt in {1..30}; do
-            if curl -fsS "http://localhost:4321${landing_base}/" >/dev/null; then
+            if curl -fsS "http://localhost:4321/" >/dev/null; then
               break
             fi
             if [ "$attempt" -eq 30 ]; then
@@ -77,7 +77,7 @@ jobs:
             fi
             sleep 1
           done
-          BASE_URL="http://localhost:4321${landing_base}" npm run test:a11y -w @arsnova/landing
+          BASE_URL="http://localhost:4321" npm run test:a11y -w @arsnova/landing
 
       - name: List artifact root (Debug)
         run: ls -la apps/landing/dist/

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -42,6 +42,36 @@ jobs:
           node-version: 24
           cache: npm
 
+      - name: Verify custom-domain cutover
+        env:
+          CUSTOM_DOMAIN: info.arsnova.eu
+          PAGES_CNAME: kqc-real.github.io
+          PROJECT_URL: https://kqc-real.github.io/arsnova.eu/
+        run: |
+          set -euo pipefail
+
+          cname="$(node --input-type=module -e \
+            "import { resolveCname } from 'node:dns/promises'; console.log((await resolveCname(process.env.CUSTOM_DOMAIN))[0])")"
+          test "${cname%.}" = "$PAGES_CNAME"
+
+          http_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --max-time 20 --retry 3 --retry-all-errors "http://$CUSTOM_DOMAIN/")"
+          test "$http_status" = "301"
+
+          custom_url="$(curl --fail --silent --show-error --location --output /dev/null \
+            --write-out '%{url_effective}' --max-time 20 --retry 3 --retry-all-errors \
+            "http://$CUSTOM_DOMAIN/")"
+          test "$custom_url" = "https://$CUSTOM_DOMAIN/"
+
+          project_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --max-time 20 --retry 3 --retry-all-errors "$PROJECT_URL")"
+          test "$project_status" = "301"
+
+          project_url="$(curl --fail --silent --show-error --location --output /dev/null \
+            --write-out '%{url_effective}' --max-time 20 --retry 3 --retry-all-errors \
+            "$PROJECT_URL")"
+          test "$project_url" = "https://$CUSTOM_DOMAIN/"
+
       - name: Install dependencies
         run: npm ci
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **arsnova.eu** ist eine moderne Web-App für Live-Interaktion in Lehre, Weiterbildung, Workshops und Veranstaltungen. Lehrende erstellen Quiz-Inhalte lokal im Browser, starten Sessions per Code oder QR-Link und kombinieren dabei Quiz, Q&A und Blitzlicht-Feedback in einer einheitlichen Live-Session. Die Anwendung ist accountarm, mehrsprachig, PWA-fähig und auf einen DSGVO-orientierten Eigenbetrieb ausgelegt.
 
-Die öffentliche Referenzinstanz läuft unter **https://arsnova.eu**; der externe Betriebsstatus ist unter **https://arsnova.betteruptime.com/** einsehbar. Dieses Repository richtet sich an Organisationen, die arsnova.eu evaluieren, forken, anpassen oder auf eigener Infrastruktur produktiv betreiben möchten.
+Die öffentliche Referenzinstanz läuft unter **https://arsnova.eu**; die getrennte Marketing- und Informationsseite unter **https://info.arsnova.eu/**. Der externe Betriebsstatus ist unter **https://arsnova.betteruptime.com/** einsehbar. Dieses Repository richtet sich an Organisationen, die arsnova.eu evaluieren, forken, anpassen oder auf eigener Infrastruktur produktiv betreiben möchten.
 
 ## Für wen ist dieses Repository relevant?
 

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -31,8 +31,19 @@ Output: `apps/landing/dist/`
 ## GitHub Pages
 
 1. **Repo-Einstellung:** Settings → Pages → Build and deployment → Source: **GitHub Actions**.
-2. Beim Push auf `main` (bei Änderungen in `apps/landing/`) baut das Workflow `.github/workflows/deploy-landing.yml` die Landing und deployt sie.
-3. Nach Merge, GitHub-Domain-Verifikation und DNS-Konfiguration die Custom Domain `info.arsnova.eu` unter Settings → Pages aktivieren.
+2. **Vor einem Root-Build oder Merge:** GitHub-Domain-Verifikation,
+   DNS-CNAME, Custom Domain, Zertifikat und **Enforce HTTPS** vollständig
+   aktivieren und die Weiterleitung der bisherigen Projekt-URL prüfen.
+3. Erst danach die Konfiguration mit `PUBLIC_SITE_URL=https://info.arsnova.eu/`
+   und `BASE_PATH=/` nach `main` mergen. Beim Push baut und deployt
+   `.github/workflows/deploy-landing.yml` die Landing; ein Preflight bricht
+   ab, falls die Cutover-Voraussetzungen nicht mehr erfüllt sind.
+
+Der Cutover ist seit dem 27. Juli 2026 vollständig aktiv:
+`info.arsnova.eu` ist als Pages-Custom-Domain verifiziert, CNAME und
+HTTPS-Zertifikat sind aktiv, HTTPS wird erzwungen und
+`https://kqc-real.github.io/arsnova.eu/` leitet mit `301` auf die Custom Domain
+weiter.
 
 **Hinweis:** Du brauchst Schreibrechte auf das Repo und die Berechtigung, Pages auf „GitHub Actions“ umzustellen. Der Workflow selbst liegt im Repo; nach dem Push und nach Aktivierung von Pages läuft alles automatisch.
 
@@ -55,7 +66,7 @@ Für Builds auf GitHub Pages setzt der Workflow `PUBLIC_SITE_URL=https://info.ar
 
 ## Impressum & Datenschutz (DSGVO)
 
-Die Seiten `/impressum` und `/datenschutz` sind mit DSGVO-tauglichen Inhalten vorstrukturiert. **Vor Go-Live** die Platzhalter in **`src/config/legal.ts`** durch echte Angaben ersetzen (Anbieter, Anschrift, E-Mail, ggf. USt-ID, Verantwortliche Person, Datenschutz-E-Mail). Die Texte (Haftung, Urheberrecht, Betroffenenrechte etc.) sind rechtlich üblich formuliert; bei Bedarf durch einen Anwalt prüfen lassen.
+Die Seiten `/impressum/` und `/datenschutz/` sind mit DSGVO-tauglichen Inhalten vorstrukturiert. **Vor Go-Live** die Platzhalter in **`src/config/legal.ts`** durch echte Angaben ersetzen (Anbieter, Anschrift, E-Mail, ggf. USt-ID, Verantwortliche Person, Datenschutz-E-Mail). Die Texte (Haftung, Urheberrecht, Betroffenenrechte etc.) sind rechtlich üblich formuliert; bei Bedarf durch einen Anwalt prüfen lassen.
 
 ## OG-Bild
 

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -1,8 +1,8 @@
 # arsnova.eu – Landing
 
-> **Produktion:** Die App liegt unter **https://arsnova.eu**. Die Marketing‑Landing
-> kann z. B. über GitHub Pages mit Custom Domain (z. B. `arsnova.eu` oder
-> Subdomain) ausgeliefert werden.
+> **Produktion:** Die App liegt unter **https://arsnova.eu**. Die getrennte
+> Marketing- und Informationsseite wird über GitHub Pages unter
+> **https://info.arsnova.eu/** ausgeliefert.
 
 Marketing- und Informationsseite für arsnova.eu. Astro 6 + Tailwind 3 (PostCSS), SEO-optimiert, für GitHub Pages oder beliebigen Static Host.
 
@@ -20,6 +20,9 @@ npm run dev:landing
 ## Build
 
 ```bash
+PUBLIC_SITE_URL=https://info.arsnova.eu/ \
+PUBLIC_APP_URL_V3=https://arsnova.eu \
+BASE_PATH=/ \
 npm run build:landing
 ```
 
@@ -27,21 +30,19 @@ Output: `apps/landing/dist/`
 
 ## GitHub Pages
 
-> Hinweis: Die Custom‑Domain in den GitHub‑Pages‑Einstellungen muss zu eurer
-> gewünschten öffentlichen Landing‑URL passen (z. B. `arsnova.eu`).
-
 1. **Repo-Einstellung:** Settings → Pages → Build and deployment → Source: **GitHub Actions**.
 2. Beim Push auf `main` (bei Änderungen in `apps/landing/`) baut das Workflow `.github/workflows/deploy-landing.yml` die Landing und deployt sie.
-3. Optional: Eigene Domain unter Pages → Custom domain eintragen (z. B. `arsnova.eu`).
+3. Nach Merge, GitHub-Domain-Verifikation und DNS-Konfiguration die Custom Domain `info.arsnova.eu` unter Settings → Pages aktivieren.
 
 **Hinweis:** Du brauchst Schreibrechte auf das Repo und die Berechtigung, Pages auf „GitHub Actions“ umzustellen. Der Workflow selbst liegt im Repo; nach dem Push und nach Aktivierung von Pages läuft alles automatisch.
 
-### 404 auf \`username.github.io/arsnova.eu/\`?
+Die vollständige Aktivierungs-, DNS-, HTTPS- und Rollback-Reihenfolge steht im
+[GitHub-Pages-Runbook](../../docs/operations/LANDING-GITHUB-PAGES-RUNBOOK.md).
 
-- **Pages-Quelle:** Settings → Pages → Source muss **„GitHub Actions“** sein (nicht „Deploy from a branch“).
-- **Workflow ausführen:** Actions → „Deploy Landing (GitHub Pages)“ → „Run workflow“ (Branch: main). Prüfen, ob beide Jobs (Build, Deploy) grün sind.
-- **URL exakt:** Repo-Name muss genau `arsnova.eu` heißen; die URL ist `https://<owner>.github.io/arsnova.eu/`.
-- **Default-Branch:** Der Workflow läuft nur bei Push auf `main`; bei Fork prüfen, ob der Default-Branch `main` ist.
+Da über einen eigenen GitHub-Actions-Workflow veröffentlicht wird, ist keine
+`CNAME`-Datei im Artifact oder Repository erforderlich; GitHub ignoriert eine
+solche Datei bei diesem Veröffentlichungsweg. Die Domain-Zuordnung erfolgt in
+den Pages-Einstellungen.
 
 ## SEO
 
@@ -50,7 +51,7 @@ Output: `apps/landing/dist/`
 - generierte Sitemap unter `/sitemap.xml`
 - generierte `robots.txt` unter `/robots.txt`
 
-Für Builds auf GitHub Pages wird die öffentliche Site-URL im Workflow gesetzt. Falls die Landing über eine Custom Domain ausgeliefert wird, muss `PUBLIC_SITE_URL` auf diese Ziel-URL zeigen, damit Canonical, OG, Sitemap und `robots.txt` auf die tatsächlich gecrawlte Domain verweisen.
+Für Builds auf GitHub Pages setzt der Workflow `PUBLIC_SITE_URL=https://info.arsnova.eu/` und `BASE_PATH=/`. Dadurch verweisen Canonical, Open Graph, Sitemap und `robots.txt` auf die Landing-Domain. App-CTAs und das JSON-LD-Objekt `WebApplication` verwenden dagegen weiterhin `https://arsnova.eu`.
 
 ## Impressum & Datenschutz (DSGVO)
 

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -1,8 +1,9 @@
 import { defineConfig } from 'astro/config';
 
-// base: bei GitHub Pages = /<repo-name>/ (Projekt-Site), sonst / (eigene Domain)
+// Custom-Domain-Deployments liegen am Domain-Root. Für Projekt-Sites können
+// beide Werte beim Build weiterhin explizit überschrieben werden.
 const base = process.env.BASE_PATH || '/';
-const site = process.env.PUBLIC_SITE_URL || 'https://arsnova.eu/';
+const site = process.env.PUBLIC_SITE_URL || 'https://info.arsnova.eu/';
 
 // https://astro.build/config
 export default defineConfig({

--- a/apps/landing/src/config/legal.ts
+++ b/apps/landing/src/config/legal.ts
@@ -47,7 +47,8 @@ export const legal = {
 
 export const site = {
   name: 'arsnova.eu',
-  url: 'https://arsnova.eu',
+  landingUrl: 'https://info.arsnova.eu',
+  appUrl: 'https://arsnova.eu',
   landingLabel: 'Landing- und Informationsseite',
   appLabel: 'Live-Anwendung für Quiz, Abstimmungen und Q&A',
 } as const;

--- a/apps/landing/src/config/site.ts
+++ b/apps/landing/src/config/site.ts
@@ -1,4 +1,4 @@
-const DEFAULT_SITE_URL = 'https://arsnova.eu/';
+const DEFAULT_SITE_URL = 'https://info.arsnova.eu/';
 
 function ensureTrailingSlash(url: string): string {
   return url.endsWith('/') ? url : `${url}/`;

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -1,6 +1,6 @@
 ---
 import '@/styles/global.css';
-import { APP_ACCESSIBILITY_URL, GITHUB_URL } from '@/config/github';
+import { APP_ACCESSIBILITY_URL, APP_URL_V3, GITHUB_URL } from '@/config/github';
 import { homeMetaDescription, homeMetaTitle } from '@/config/seo';
 import { SITE_URL, toAbsoluteUrl } from '@/config/site';
 
@@ -12,7 +12,7 @@ export interface Props {
 }
 
 const { title, description, canonical, noindex = false } = Astro.props;
-/** Base path für Links (z. B. /arsnova.eu/ bei GitHub Pages) */
+/** Base path für interne Links; auf der Custom Domain ist dies `/`. */
 const base = (typeof import.meta.env.BASE_URL === 'string' && import.meta.env.BASE_URL) || '/';
 const fullTitle = title === 'Start' ? homeMetaTitle : `${title} · arsnova.eu`;
 const url = canonical ? toAbsoluteUrl(canonical) : SITE_URL;
@@ -48,36 +48,46 @@ const ogImage = toAbsoluteUrl('og.png');
 
     <!-- Keine Google Fonts – System-Schriften, kein Tracking. -->
 
-    <!-- JSON-LD: WebApplication -->
+    <!-- JSON-LD: Landing-Website und Live-Anwendung haben getrennte URLs. -->
     <script is:inline type="application/ld+json" set:html={JSON.stringify({
       '@context': 'https://schema.org',
-      '@type': 'WebApplication',
-      name: 'arsnova.eu',
-      description: title === 'Start' ? homeMetaDescription : description,
-      url: SITE_URL,
-      applicationCategory: 'EducationalApplication',
-      operatingSystem: 'Web',
-      offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
-      featureList: [
-        'Live-Quiz und Abstimmungen',
-        'Selbsteinschätzung bei bewertbaren Fragen',
-        'Ergebnisbericht (PDF) und Nachbesprechung nach Session-Ende',
-        'Numerische Schätzfragen mit zwei Runden und Statistik',
-        'Q&A-Fragenwand mit Moderation, Up- und Downvoting',
-        'Lobby, Presenter, QR/Code',
-        'Fragetypen MC/SC/Kurzantwort/Freitext/Umfrage/Rating/Schätzfrage',
-        'Markdown und KaTeX',
-        'Lesephase und Peer Instruction',
-        'Q&A- und Freitext-Word-Cloud mit Phrasen und Gewichtung',
-        'Sortierung nach Unterstützung, belastbarer Zustimmung und Kontroverse',
-        'Team-Modus und Presets',
-        'Leaderboard, Streak, Bonus-Code',
-        'Import/Export und Yjs-Sync',
-        'KI-Import extern, Zod-validiert',
-        'UI in fünf Sprachen',
-        'Barrierefreiheit nach WCAG 2.2 AA',
-        'Docker Self-Host und Admin-Audit',
-        'Local-First und DSGVO-orientierter Betrieb',
+      '@graph': [
+        {
+          '@type': 'WebSite',
+          name: 'arsnova.eu – Informationen',
+          url: SITE_URL,
+          description: title === 'Start' ? homeMetaDescription : description,
+        },
+        {
+          '@type': 'WebApplication',
+          name: 'arsnova.eu',
+          description: homeMetaDescription,
+          url: APP_URL_V3,
+          applicationCategory: 'EducationalApplication',
+          operatingSystem: 'Web',
+          offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+          featureList: [
+            'Live-Quiz und Abstimmungen',
+            'Selbsteinschätzung bei bewertbaren Fragen',
+            'Ergebnisbericht (PDF) und Nachbesprechung nach Session-Ende',
+            'Numerische Schätzfragen mit zwei Runden und Statistik',
+            'Q&A-Fragenwand mit Moderation, Up- und Downvoting',
+            'Lobby, Presenter, QR/Code',
+            'Fragetypen MC/SC/Kurzantwort/Freitext/Umfrage/Rating/Schätzfrage',
+            'Markdown und KaTeX',
+            'Lesephase und Peer Instruction',
+            'Q&A- und Freitext-Word-Cloud mit Phrasen und Gewichtung',
+            'Sortierung nach Unterstützung, belastbarer Zustimmung und Kontroverse',
+            'Team-Modus und Presets',
+            'Leaderboard, Streak, Bonus-Code',
+            'Import/Export und Yjs-Sync',
+            'KI-Import extern, Zod-validiert',
+            'UI in fünf Sprachen',
+            'Barrierefreiheit nach WCAG 2.2 AA',
+            'Docker Self-Host und Admin-Audit',
+            'Local-First und DSGVO-orientierter Betrieb',
+          ],
+        },
       ],
     })} />
   </head>

--- a/apps/landing/src/pages/datenschutz.astro
+++ b/apps/landing/src/pages/datenschutz.astro
@@ -6,7 +6,7 @@ import { legal, site } from '../config/legal';
 <BaseLayout
   title="Datenschutz"
   description="Datenschutzerklärung für arsnova.eu – Informationen zur Verarbeitung personenbezogener Daten."
-  canonical="/datenschutz"
+  canonical="/datenschutz/"
 >
   <article class="mx-auto max-w-3xl px-4 py-16 sm:px-6">
     <h1 class="font-display text-3xl font-bold text-white">Datenschutzerklärung</h1>

--- a/apps/landing/src/pages/datenschutz.astro
+++ b/apps/landing/src/pages/datenschutz.astro
@@ -15,9 +15,9 @@ import { legal, site } from '../config/legal';
     <section class="mt-6 rounded-2xl border border-slate-700 bg-slate-800/60 p-5 text-slate-300">
       <p class="text-sm font-semibold uppercase tracking-[0.2em] text-brand-400">Kurzinfo</p>
       <ul class="mt-3 list-inside list-disc space-y-1 leading-7">
-        <li>Diese Hinweise betreffen primär die {site.landingLabel.toLowerCase()} unter {site.url}.</li>
+        <li>Diese Hinweise betreffen primär die {site.landingLabel.toLowerCase()} unter {site.landingUrl}.</li>
         <li>Die Landing setzt selbst keine Cookies und keine Analyse-Tools ein.</li>
-        <li>Für die {site.appLabel.toLowerCase()} und für Self-Hosting können ergänzende oder abweichende Hinweise gelten.</li>
+        <li>Die {site.appLabel.toLowerCase()} liegt getrennt unter {site.appUrl}; für sie und für Self-Hosting können ergänzende oder abweichende Hinweise gelten.</li>
       </ul>
     </section>
 
@@ -38,10 +38,10 @@ import { legal, site } from '../config/legal';
       <div>
         <h2 class="font-display text-lg font-semibold text-white">2. Geltungsbereich</h2>
         <p class="mt-2">
-          Diese Datenschutzerklärung gilt in erster Linie für die statische {site.landingLabel.toLowerCase()} unter <strong>{site.url}</strong>. Sie erläutert insbesondere die Verarbeitung beim Aufruf dieser Seiten, beim Nutzen externer Links und beim Hosting der Landing.
+          Diese Datenschutzerklärung gilt in erster Linie für die statische {site.landingLabel.toLowerCase()} unter <strong>{site.landingUrl}</strong>. Sie erläutert insbesondere die Verarbeitung beim Aufruf dieser Seiten, beim Nutzen externer Links und beim Hosting der Landing.
         </p>
         <p class="mt-2">
-          Für die eigentliche {site.appLabel.toLowerCase()} sowie für selbst gehostete Installationen können ergänzende oder abweichende Datenschutzhinweise gelten. Dort ist der jeweilige Betreiber bzw. die jeweilige Institution selbst verantwortlich.
+          Für die eigentliche {site.appLabel.toLowerCase()} unter <strong>{site.appUrl}</strong> sowie für selbst gehostete Installationen können ergänzende oder abweichende Datenschutzhinweise gelten. Dort ist der jeweilige Betreiber bzw. die jeweilige Institution selbst verantwortlich.
         </p>
       </div>
 
@@ -99,7 +99,7 @@ import { legal, site } from '../config/legal';
       <div>
         <h2 class="font-display text-lg font-semibold text-white">8. Hinweis zur Anwendung arsnova.eu</h2>
         <p class="mt-2">
-          Die Anwendung arsnova.eu ist datenschutzfreundlich konzipiert und verfolgt einen Local-First-Ansatz. Welche Daten beim Betrieb der Anwendung, bei Sessions oder bei Self-Hosting konkret verarbeitet werden, richtet sich jedoch nach dem jeweiligen Betreiber der Instanz. Bitte beachten Sie deshalb für die Live-Anwendung die dort jeweils bereitgestellten Datenschutzhinweise.
+          Die Anwendung unter <strong>{site.appUrl}</strong> ist datenschutzfreundlich konzipiert und verfolgt einen Local-First-Ansatz. Welche Daten beim Betrieb der Anwendung, bei Sessions oder bei Self-Hosting konkret verarbeitet werden, richtet sich jedoch nach dem jeweiligen Betreiber der Instanz. Bitte beachten Sie deshalb für die Live-Anwendung die dort jeweils bereitgestellten Datenschutzhinweise.
         </p>
       </div>
 

--- a/apps/landing/src/pages/impressum.astro
+++ b/apps/landing/src/pages/impressum.astro
@@ -6,7 +6,7 @@ import { legal, site } from '../config/legal';
 <BaseLayout
   title="Impressum"
   description="Impressum und Anbieterkennzeichnung für arsnova.eu."
-  canonical="/impressum"
+  canonical="/impressum/"
 >
   <article class="mx-auto max-w-3xl px-4 py-16 sm:px-6">
     <h1 class="font-display text-3xl font-bold text-white">Impressum</h1>

--- a/apps/landing/src/pages/impressum.astro
+++ b/apps/landing/src/pages/impressum.astro
@@ -15,7 +15,7 @@ import { legal, site } from '../config/legal';
     <section class="mt-6 rounded-2xl border border-slate-700 bg-slate-800/60 p-5 text-slate-300">
       <p class="text-sm font-semibold uppercase tracking-[0.2em] text-brand-400">Kurzinfo</p>
       <p class="mt-3 leading-7">
-        Diese Seite enthält die Anbieter- und Kontaktangaben für die {site.landingLabel.toLowerCase()} von {site.name}.
+        Diese Seite enthält die Anbieter- und Kontaktangaben für die {site.landingLabel.toLowerCase()} unter <strong>{site.landingUrl}</strong>. Die Live-Anwendung wird getrennt unter <strong>{site.appUrl}</strong> bereitgestellt.
       </p>
     </section>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ Formale A11y-Abnahmedokumentation (2026-07-27):
 
 - **Datenmodell:** [`prisma/schema.prisma`](../prisma/schema.prisma)
 - **Geteilte API-Typen:** [`libs/shared-types`](../libs/shared-types/)
+- **Landing auf GitHub Pages:** [Custom-Domain-Runbook](operations/LANDING-GITHUB-PAGES-RUNBOOK.md)
 - **Diagramm-Index:** [diagrams/diagrams.md](diagrams/diagrams.md), [diagrams/architecture-overview.md](diagrams/architecture-overview.md)
 - **Status-Ampel (SLO vs Last):** [ADR-0021](architecture/decisions/0021-separate-service-status-from-load-status-with-live-slo-telemetry.md)
 - **Projektglossar:** [GLOSSAR.md](GLOSSAR.md)

--- a/docs/operations/LANDING-GITHUB-PAGES-RUNBOOK.md
+++ b/docs/operations/LANDING-GITHUB-PAGES-RUNBOOK.md
@@ -1,0 +1,118 @@
+# Landing unter `info.arsnova.eu`
+
+Dieses Runbook aktiviert die Astro-Landing als GitHub-Pages-Custom-Domain. Die
+Live-Anwendung unter `https://arsnova.eu` und die DNS-Einträge der Apex-Domain
+bleiben unverändert.
+
+## Voraussetzungen
+
+- Der Landing-Workflow ist auf `main` gemergt und erfolgreich durchgelaufen.
+- Unter Repository → Settings → Pages ist **GitHub Actions** als Quelle gewählt.
+- Die ausführende Person kann DNS-Einträge für `arsnova.eu` und GitHub-Pages-
+  Einstellungen verwalten.
+
+## Aktivierungsreihenfolge
+
+### 1. Apex-Domain bei GitHub verifizieren
+
+1. GitHub-Profil → Settings → Pages → **Add a domain** öffnen.
+2. `arsnova.eu` eintragen. GitHub zeigt einen individuellen TXT-Wert an.
+3. Beim DNS-Provider den von GitHub angezeigten Eintrag anlegen:
+   - Typ: `TXT`
+   - Host/Name: `_github-pages-challenge-kqc-real`
+   - Value/Ziel: der **individuelle GitHub-Verifizierungscode**
+   - TTL: Provider-Standard oder `3600`
+4. Falls der Provider einen vollständigen Namen erwartet, stattdessen
+   `_github-pages-challenge-kqc-real.arsnova.eu` verwenden. Die Domain darf
+   nicht doppelt angehängt werden.
+5. Auflösung prüfen:
+
+   ```bash
+   dig TXT _github-pages-challenge-kqc-real.arsnova.eu +short
+   ```
+
+6. In GitHub **Verify** wählen. Den TXT-Eintrag danach als Takeover-Schutz
+   dauerhaft beibehalten.
+
+### 2. CAA für das Pages-Zertifikat prüfen
+
+```bash
+dig CAA arsnova.eu +short
+```
+
+Existieren keine CAA-Einträge, ist keine Änderung nötig. Existieren CAA-
+Einträge, muss mindestens einer Let's Encrypt erlauben. Fehlt diese Erlaubnis,
+beim Provider ergänzen:
+
+- Typ: `CAA`
+- Host/Name: `@`
+- Flag: `0`
+- Tag: `issue`
+- Value: `letsencrypt.org`
+- TTL: Provider-Standard oder `3600`
+
+Je nach Provider wird der Inhalt zusammengefasst als
+`0 issue "letsencrypt.org"` eingegeben. Bestehende CAA-Einträge nicht
+ungeprüft ersetzen.
+
+### 3. Landing-Subdomain im DNS setzen
+
+Beim DNS-Provider genau diesen Record anlegen:
+
+- Typ: `CNAME`
+- Host/Name: `info`
+- Ziel/Value: `kqc-real.github.io`
+- TTL: Provider-Standard oder `3600`
+
+Nicht eintragen:
+
+- kein `https://`
+- keinen Pfad wie `/arsnova.eu`
+- keinen abschließenden URL-Slash
+- keine A- oder AAAA-Records für `info`
+- keine Änderung am Apex/Root `arsnova.eu`
+
+Vorhandene, widersprüchliche Records für `info` müssen entfernt werden. Danach
+die öffentliche Auflösung prüfen:
+
+```bash
+dig CNAME info.arsnova.eu +short
+```
+
+Das Ergebnis muss auf `kqc-real.github.io.` zeigen.
+
+### 4. Custom Domain in GitHub Pages aktivieren
+
+Erst nach erfolgreicher Domain-Verifikation und auflösbarem CNAME:
+
+1. Repository → Settings → Pages öffnen.
+2. Unter **Custom domain** `info.arsnova.eu` eintragen und **Save** wählen.
+3. Den DNS-Check abwarten.
+4. `https://info.arsnova.eu/`, `/robots.txt` und `/sitemap.xml` prüfen.
+5. Sobald GitHub das Let's-Encrypt-Zertifikat bereitgestellt hat,
+   **Enforce HTTPS** aktivieren.
+
+Die Aktivierung erfolgt bewusst manuell und nicht vorab per API. Bei dem
+Actions-basierten Pages-Deploy ist keine `CNAME`-Datei nötig; GitHub ignoriert
+sie bei eigenen Actions-Workflows. Die Zuordnung wird in den Pages-
+Einstellungen gespeichert.
+
+### 5. Suchmaschinen umstellen
+
+1. In der Google Search Console eine URL-Präfix-Property für
+   `https://info.arsnova.eu/` hinzufügen und verifizieren.
+2. `https://info.arsnova.eu/sitemap.xml` einreichen.
+3. Stichprobenartig Canonical, Open Graph, `robots.txt` und indexierte URLs
+   kontrollieren.
+
+## Rollback und Takeover-Schutz
+
+Wenn die Pages-Zuordnung entfernt oder das Pages-Site deaktiviert wird, den
+DNS-CNAME `info` unmittelbar vorher oder gleichzeitig entfernen. Ein
+verwaister CNAME darf nicht auf `kqc-real.github.io` zeigen, weil er eine
+Domainübernahme begünstigen kann.
+
+Den GitHub-Verifizierungs-TXT-Record beibehalten. Soll die Landing wieder über
+die Projekt-Site `kqc-real.github.io/arsnova.eu/` laufen, müssen zusätzlich
+`PUBLIC_SITE_URL` und `BASE_PATH` im Build auf diese Projekt-URL bzw.
+`/arsnova.eu/` zurückgestellt und neu deployt werden.

--- a/docs/operations/LANDING-GITHUB-PAGES-RUNBOOK.md
+++ b/docs/operations/LANDING-GITHUB-PAGES-RUNBOOK.md
@@ -4,14 +4,31 @@ Dieses Runbook aktiviert die Astro-Landing als GitHub-Pages-Custom-Domain. Die
 Live-Anwendung unter `https://arsnova.eu` und die DNS-Einträge der Apex-Domain
 bleiben unverändert.
 
+> **Cutover-Status vom 27. Juli 2026:** Die GitHub-Pages-Custom-Domain
+> `info.arsnova.eu` ist aktiv und verifiziert, der CNAME löst auf
+> `kqc-real.github.io` auf, das Zertifikat ist freigegeben und HTTPS wird
+> erzwungen. Die bisherige Projekt-URL
+> `https://kqc-real.github.io/arsnova.eu/` antwortet mit `301` und leitet auf
+> `https://info.arsnova.eu/` weiter. Damit sind die Voraussetzungen für den
+> Root-Build dieses PRs bereits erfüllt.
+
 ## Voraussetzungen
 
-- Der Landing-Workflow ist auf `main` gemergt und erfolgreich durchgelaufen.
 - Unter Repository → Settings → Pages ist **GitHub Actions** als Quelle gewählt.
 - Die ausführende Person kann DNS-Einträge für `arsnova.eu` und GitHub-Pages-
   Einstellungen verwalten.
+- **Vor** einem Merge oder produktiven Deploy mit
+  `PUBLIC_SITE_URL=https://info.arsnova.eu/` und `BASE_PATH=/` müssen
+  Domain-Verifikation, CNAME, Pages-Custom-Domain, Zertifikat und
+  HTTPS-Erzwingung vollständig aktiv und mit den Prüfungen in Schritt 5
+  bestätigt sein.
 
 ## Aktivierungsreihenfolge
+
+Die Schritte 1 bis 5 werden noch mit dem bestehenden Projektseiten-Build
+abgeschlossen. Erst Schritt 6 stellt den Build auf Root-Pfade um. Diese
+Reihenfolge verhindert, dass absolute Pfade wie `/_astro/…` vor dem
+Domain-Cutover unter `kqc-real.github.io/arsnova.eu/` veröffentlicht werden.
 
 ### 1. Apex-Domain bei GitHub verifizieren
 
@@ -88,16 +105,56 @@ Erst nach erfolgreicher Domain-Verifikation und auflösbarem CNAME:
 1. Repository → Settings → Pages öffnen.
 2. Unter **Custom domain** `info.arsnova.eu` eintragen und **Save** wählen.
 3. Den DNS-Check abwarten.
-4. `https://info.arsnova.eu/`, `/robots.txt` und `/sitemap.xml` prüfen.
-5. Sobald GitHub das Let's-Encrypt-Zertifikat bereitgestellt hat,
+4. Sobald GitHub das Let's-Encrypt-Zertifikat bereitgestellt hat,
    **Enforce HTTPS** aktivieren.
+5. Noch keinen Root-Build deployen, bevor die Prüfungen in Schritt 5
+   erfolgreich sind.
 
 Die Aktivierung erfolgt bewusst manuell und nicht vorab per API. Bei dem
 Actions-basierten Pages-Deploy ist keine `CNAME`-Datei nötig; GitHub ignoriert
 sie bei eigenen Actions-Workflows. Die Zuordnung wird in den Pages-
 Einstellungen gespeichert.
 
-### 5. Suchmaschinen umstellen
+### 5. Cutover vor Root-Build und Merge verifizieren
+
+```bash
+node --input-type=module -e \
+  "import { resolveCname } from 'node:dns/promises'; console.log(await resolveCname('info.arsnova.eu'))"
+curl -I http://info.arsnova.eu/
+curl -I https://info.arsnova.eu/
+curl -I https://kqc-real.github.io/arsnova.eu/
+```
+
+Erwartet werden:
+
+- der CNAME `kqc-real.github.io`,
+- eine HTTP-Weiterleitung auf `https://info.arsnova.eu/`,
+- ein gültiges HTTPS-Zertifikat und eine erfolgreiche HTTPS-Antwort,
+- eine `301`-Weiterleitung der bisherigen Projekt-URL auf die Custom Domain.
+
+Zusätzlich unter Settings → Pages prüfen, dass die Domain als verifiziert
+angezeigt wird und **Enforce HTTPS** aktiv ist. Der Deploy-Workflow wiederholt
+diese Prüfungen als Preflight und bricht vor Installation und Root-Build ab,
+wenn eine Cutover-Annahme nicht mehr gilt.
+
+### 6. Root-Build mergen und deployen
+
+Erst jetzt die Workflow-Konfiguration mit
+`PUBLIC_SITE_URL=https://info.arsnova.eu/` und `BASE_PATH=/` nach `main`
+mergen beziehungsweise produktiv auslösen. Nach dem Deploy prüfen:
+
+```bash
+curl -I https://info.arsnova.eu/
+curl -I https://info.arsnova.eu/impressum/
+curl -I https://info.arsnova.eu/datenschutz/
+curl -I https://info.arsnova.eu/robots.txt
+curl -I https://info.arsnova.eu/sitemap.xml
+```
+
+Im HTML müssen Canonicals und Asset-URLs auf `https://info.arsnova.eu/`
+beziehungsweise Root-Pfade zeigen.
+
+### 7. Suchmaschinen umstellen
 
 1. In der Google Search Console eine URL-Präfix-Property für
    `https://info.arsnova.eu/` hinzufügen und verifizieren.


### PR DESCRIPTION
## Summary
- Landing-Build und GitHub-Pages-Workflows auf `https://info.arsnova.eu/` mit Root-Pfad `/` umgestellt
- Canonical, Open Graph, Twitter-Bild, robots.txt und Sitemap an die Landing-Domain gebunden; App-CTAs und `WebApplication`-JSON-LD bleiben auf `https://arsnova.eu`
- Canonicals der Verzeichnisse verwenden konsistent `/impressum/` und `/datenschutz/`
- Runbook auf die sichere Reihenfolge korrigiert: Domain-Verifikation, DNS, Pages-Custom-Domain, Zertifikat und HTTPS müssen vor Root-Build und Merge aktiv und geprüft sein
- Deploy-Workflow mit schlankem Preflight für CNAME, HTTPS-Erzwingung und Weiterleitung der bisherigen Projekt-URL abgesichert

## Cutover-Status
- [x] Pages-Custom-Domain `info.arsnova.eu` aktiv und verifiziert
- [x] DNS-CNAME zeigt auf `kqc-real.github.io`
- [x] Zertifikat freigegeben und `Enforce HTTPS` aktiv
- [x] `https://kqc-real.github.io/arsnova.eu/` antwortet mit `301` und leitet auf `https://info.arsnova.eu/`

Der operative Cutover wurde vorgezogen und ist bereits vollständig abgeschlossen. Damit ist die Voraussetzung für den Root-Build vor dem Merge erfüllt; das Runbook dokumentiert diese Reihenfolge nun auch für Wiederholungen.

## Testplan
- [x] Node `24.18.0` aus `.nvmrc`
- [x] Landing mit `PUBLIC_SITE_URL=https://info.arsnova.eu/`, `PUBLIC_APP_URL_V3=https://arsnova.eu`, `BASE_PATH=/` gebaut
- [x] Generierte Canonicals `/impressum/` und `/datenschutz/`, Sitemap, Root-Assets und Landing-/App-URLs geprüft
- [x] Cutover-Preflight lokal gegen DNS, HTTP→HTTPS und Projektseiten-Weiterleitung ausgeführt
- [x] `npm run check -w @arsnova/landing` — 0 Fehler/Warnungen/Hinweise
- [x] fokussiertes ESLint für `apps/landing`
- [x] Landing-A11y-Gate — 3 Zustände, 0 WCAG-Verstöße
- [x] Prettier für Workflow/Markdown und `git diff --check`
- [x] Commit-Hooks: vollständiger Typecheck und Tests — 166 Testdateien erfolgreich, 7 übersprungen

## Nach Merge
- Root-Deploy auf `https://info.arsnova.eu/` und Legal-/robots-/Sitemap-URLs prüfen
- Search-Console-Property und Sitemap einrichten

Made with [Cursor](https://cursor.com)