### PR TITLE
fix(landing): Kurzinfo-Rechtschreibung Impressum/Datenschutz

### DIFF
--- a/apps/landing/src/pages/datenschutz.astro
+++ b/apps/landing/src/pages/datenschutz.astro
@@ -15,9 +15,12 @@ import { legal, site } from '../config/legal';
     <section class="mt-6 rounded-2xl border border-slate-700 bg-slate-800/60 p-5 text-slate-300">
       <p class="text-sm font-semibold uppercase tracking-[0.2em] text-brand-400">Kurzinfo</p>
       <ul class="mt-3 list-inside list-disc space-y-1 leading-7">
-        <li>Diese Hinweise betreffen primär die {site.landingLabel.toLowerCase()} unter {site.landingUrl}.</li>
+        <li>Diese Hinweise betreffen primär die Landing- und Informationsseite unter {site.landingUrl}.</li>
         <li>Die Landing setzt selbst keine Cookies und keine Analyse-Tools ein.</li>
-        <li>Die {site.appLabel.toLowerCase()} liegt getrennt unter {site.appUrl}; für sie und für Self-Hosting können ergänzende oder abweichende Hinweise gelten.</li>
+        <li>
+          Die Live-Anwendung für Quiz, Abstimmungen und Q&amp;A liegt getrennt unter {site.appUrl}; für sie
+          und für Self-Hosting können ergänzende oder abweichende Hinweise gelten.
+        </li>
       </ul>
     </section>
 
@@ -38,10 +41,10 @@ import { legal, site } from '../config/legal';
       <div>
         <h2 class="font-display text-lg font-semibold text-white">2. Geltungsbereich</h2>
         <p class="mt-2">
-          Diese Datenschutzerklärung gilt in erster Linie für die statische {site.landingLabel.toLowerCase()} unter <strong>{site.landingUrl}</strong>. Sie erläutert insbesondere die Verarbeitung beim Aufruf dieser Seiten, beim Nutzen externer Links und beim Hosting der Landing.
+          Diese Datenschutzerklärung gilt in erster Linie für die statische {site.landingLabel} unter <strong>{site.landingUrl}</strong>. Sie erläutert insbesondere die Verarbeitung beim Aufruf dieser Seiten, beim Nutzen externer Links und beim Hosting der Landing.
         </p>
         <p class="mt-2">
-          Für die eigentliche {site.appLabel.toLowerCase()} unter <strong>{site.appUrl}</strong> sowie für selbst gehostete Installationen können ergänzende oder abweichende Datenschutzhinweise gelten. Dort ist der jeweilige Betreiber bzw. die jeweilige Institution selbst verantwortlich.
+          Für die eigentliche {site.appLabel} unter <strong>{site.appUrl}</strong> sowie für selbst gehostete Installationen können ergänzende oder abweichende Datenschutzhinweise gelten. Dort ist der jeweilige Betreiber bzw. die jeweilige Institution selbst verantwortlich.
         </p>
       </div>
 

--- a/apps/landing/src/pages/impressum.astro
+++ b/apps/landing/src/pages/impressum.astro
@@ -15,7 +15,7 @@ import { legal, site } from '../config/legal';
     <section class="mt-6 rounded-2xl border border-slate-700 bg-slate-800/60 p-5 text-slate-300">
       <p class="text-sm font-semibold uppercase tracking-[0.2em] text-brand-400">Kurzinfo</p>
       <p class="mt-3 leading-7">
-        Diese Seite enthält die Anbieter- und Kontaktangaben für die {site.landingLabel.toLowerCase()} unter <strong>{site.landingUrl}</strong>. Die Live-Anwendung wird getrennt unter <strong>{site.appUrl}</strong> bereitgestellt.
+        Diese Seite enthält die Anbieter- und Kontaktangaben für die Landing- und Informationsseite unter <strong>{site.landingUrl}</strong>. Die Live-Anwendung wird getrennt unter <strong>{site.appUrl}</strong> bereitgestellt.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary
- Entfernt fehlerhaftes `.toLowerCase()` auf deutschen Labels in Impressum/Datenschutz-Kurzinfo
- Stellt korrekte Schreibweise wieder her („Landing- und Informationsseite“, „Live-Anwendung …“)

## Test plan
- [ ] Impressum-Kurzinfo auf korrekte Großschreibung prüfen
- [ ] Datenschutz-Kurzinfo und Abschnitt „Geltungsbereich“ prüfen
- [ ] Landing-Build grün


Made with [Cursor](https://cursor.com)