### PR TITLE
[codex] MC-Test-Selbstprüfung im Cloud-Computing-Kurs ergänzen

### DIFF
--- a/docs/didaktik/BACHELOR-VORLESUNG-CLOUD-COMPUTING-36-UE-PRAKTIKUM.md
+++ b/docs/didaktik/BACHELOR-VORLESUNG-CLOUD-COMPUTING-36-UE-PRAKTIKUM.md
@@ -233,7 +233,8 @@ Die integrierte Vorlesung vermittelt Grundlagen, technologische Voraussetzungen,
 - [ ] identische Lernziele, Materialien, Lernprodukte und Prüfungsinformationen für Präsenz und Zoom bereitgestellt
 - [ ] identische Agenten, Modelle, Zielserver, Rechte, Budgets und Abnahmetests für Präsenz und Zoom bereitgestellt
 - [ ] Agentenvertrag, Freigabegates, Evidenzschema und Cleanup für Lehrende und Studierende getestet
-- [ ] für jeden Termin Themen und Keywords für 30 agentisch erzeugte MC-Test-Fragen gepflegt
+- [ ] für jeden Termin Themen/Keywords zur Abdeckungssteuerung und eine versionierte autoritative Materialbasis für 30 agentisch erzeugte MC-Test-Fragen gepflegt
+- [ ] festgeschriebener MC-Test-Commit, vierstufige Artefaktpipeline, Validator, Generierungsmanifest und menschliches Freigabegate getestet
 - [ ] Serverinstallation/Härtung sowie Security-, Privacy-, Performance- und FinOps-Agentenlabor lauffähig
 - [ ] gemischte Informatik-/Wirtschaftsinformatikrollen und gemeinsame Ergebnisverantwortung festgelegt
 - [ ] zulässige Agentennutzung und Offenlegung für die Referatsprüfung formal geklärt

--- a/docs/didaktik/BACHELOR-VORLESUNG-CLOUD-COMPUTING-36-UE-PRAKTIKUM.md
+++ b/docs/didaktik/BACHELOR-VORLESUNG-CLOUD-COMPUTING-36-UE-PRAKTIKUM.md
@@ -22,6 +22,7 @@
 | Praxisanteil laut Modulhandbuch | 0 Stunden; Anwendungsaufgaben bleiben Lehrmethode                                 |
 | Prüfungsbasis                   | Referat, 15 Minuten je Prüfling; Einreichung, Vortrag und Diskussion              |
 | Didaktisches Arbeitsmodell      | ausschließlich agent-first auf Lehrenden- und Studierendenseite                   |
+| Formative Selbstüberprüfung     | nach jedem Termin 30 durch einen KI-Agenten erzeugte MC-Test-Fragen               |
 
 Die 36 UE sind nicht frei zusätzlich zum Tutorium verfügbar. Sie bilden zusammen exakt die 27 betreuten Stunden aus Präsenz/synchroner Lehre und Tutorieller Betreuung ab.
 
@@ -220,7 +221,7 @@ Falls myCampus Workbook ausweist, gelten Einzelarbeit, zentrale Aufgabenstruktur
 
 ## 11. Kurzfassung für die Modulplanung
 
-Die integrierte Vorlesung vermittelt Grundlagen, technologische Voraussetzungen, Serverless Computing, etablierte Cloud-Plattformen und Datenwissenschaft/ML in der Cloud. Lehrende und Studierende steuern dafür ausschließlich KI-Agenten: Sie stellen isolierte Server bereit, installieren und härten `arsnova.eu`, prüfen Security, Datenschutz, Performance und Resilienz und verbinden die Evidenz mit TCO, FinOps, Unit Economics, Risiko und Exit. Informatik und Wirtschaftsinformatik arbeiten in gemischten Rollen. Sechs Präsenz-/synchrone Termine und sechs Tutorien bilden die 36 UE; 123 Stunden Selbststudium dienen Agentic-Dossier, Lektüre und Referatsvorbereitung. Präsenz- und Zoom-Lauf nutzen denselben Agenten- und Laborplan. Formale Prüfungsbasis ist ein 15-minütiges Referat je Prüfling aus Einreichung, Vortrag und Diskussion.
+Die integrierte Vorlesung vermittelt Grundlagen, technologische Voraussetzungen, Serverless Computing, etablierte Cloud-Plattformen und Datenwissenschaft/ML in der Cloud. Lehrende und Studierende steuern dafür ausschließlich KI-Agenten: Sie stellen isolierte Server bereit, installieren und härten `arsnova.eu`, prüfen Security, Datenschutz, Performance und Resilienz und verbinden die Evidenz mit TCO, FinOps, Unit Economics, Risiko und Exit. Informatik und Wirtschaftsinformatik arbeiten in gemischten Rollen. Sechs Präsenz-/synchrone Termine und sechs Tutorien bilden die 36 UE; 123 Stunden Selbststudium dienen Agentic-Dossier, Lektüre und Referatsvorbereitung. Nach jedem Termin stehen 30 agentisch erzeugte MC-Test-Fragen zur freiwilligen Selbstüberprüfung bereit. Präsenz- und Zoom-Lauf nutzen denselben Agenten- und Laborplan. Formale Prüfungsbasis ist ein 15-minütiges Referat je Prüfling aus Einreichung, Vortrag und Diskussion.
 
 ## 12. Freigabecheck
 
@@ -232,6 +233,7 @@ Die integrierte Vorlesung vermittelt Grundlagen, technologische Voraussetzungen,
 - [ ] identische Lernziele, Materialien, Lernprodukte und Prüfungsinformationen für Präsenz und Zoom bereitgestellt
 - [ ] identische Agenten, Modelle, Zielserver, Rechte, Budgets und Abnahmetests für Präsenz und Zoom bereitgestellt
 - [ ] Agentenvertrag, Freigabegates, Evidenzschema und Cleanup für Lehrende und Studierende getestet
+- [ ] für jeden Termin Themen und Keywords für 30 agentisch erzeugte MC-Test-Fragen gepflegt
 - [ ] Serverinstallation/Härtung sowie Security-, Privacy-, Performance- und FinOps-Agentenlabor lauffähig
 - [ ] gemischte Informatik-/Wirtschaftsinformatikrollen und gemeinsame Ergebnisverantwortung festgelegt
 - [ ] zulässige Agentennutzung und Offenlegung für die Referatsprüfung formal geklärt

--- a/docs/didaktik/CLOUD-COMPUTING-AGENTIC-LEHRLABOR.md
+++ b/docs/didaktik/CLOUD-COMPUTING-AGENTIC-LEHRLABOR.md
@@ -149,7 +149,7 @@ Lehrende nutzen Agenten für:
 - Erzeugung absichtlich fehlerhafter, aber sicher isolierter Ausgangszustände;
 - Vergleich von Studierendenevidenz mit Akzeptanzkriterien;
 - formative Feedbackvorschläge und Erkennung fehlender Nachweise;
-- Erzeugung und Vorprüfung von jeweils 30 MC-Test-Fragen aus den Themen und Keywords jedes Termins.
+- Erzeugung und Vorprüfung von jeweils 30 MC-Test-Fragen nach dem festgeschriebenen vierstufigen [Generatorvertrag](./vorlesungen-cloud-computing-termine.md#verbindlicher-mc-test-generatorvertrag); Themen und Keywords steuern die Abdeckung, die freigegebene Materialbasis liefert das Fachwissen.
 
 Lehrendenagenten erhalten keine autonome Notenhoheit und verändern keine studentischen Abgaben. Aufgabe, Agentenkonfiguration, verwendete Prüfroutinen und wesentliche Modellgrenzen werden transparent gemacht.
 
@@ -242,6 +242,6 @@ Bei erlaubter Agentennutzung gilt:
 - [ ] Serverbereitstellung, Härtung, Security, Datenschutz, Performance und FinOps agentisch abgedeckt
 - [ ] gemischte Informatik-/Wirtschaftsinformatikrollen und gemeinsame Ergebnisverantwortung erklärt
 - [ ] Lehrendenagenten für Labor, Vorprüfung und formatives Feedback getestet
-- [ ] MC-Test-Generator für 30 Fragen je Termin mit den gepflegten Themen und Keywords getestet
+- [ ] festgeschriebener MC-Test-Commit, vierstufige Artefaktpipeline, Validator, Generierungsmanifest und menschliches Freigabegate für 30 Fragen je Termin getestet
 - [ ] keine autonome Notengebung oder ungeprüfte Übernahme von Agentenaussagen vorgesehen
 - [ ] erlaubter KI-Einsatz in der Referatsprüfung formal geklärt und veröffentlicht

--- a/docs/didaktik/CLOUD-COMPUTING-AGENTIC-LEHRLABOR.md
+++ b/docs/didaktik/CLOUD-COMPUTING-AGENTIC-LEHRLABOR.md
@@ -148,7 +148,8 @@ Lehrende nutzen Agenten für:
 - Vorprüfung von IaC, Härtung, Datenschutz, Lasttests und Kostenmodellen;
 - Erzeugung absichtlich fehlerhafter, aber sicher isolierter Ausgangszustände;
 - Vergleich von Studierendenevidenz mit Akzeptanzkriterien;
-- formative Feedbackvorschläge und Erkennung fehlender Nachweise.
+- formative Feedbackvorschläge und Erkennung fehlender Nachweise;
+- Erzeugung und Vorprüfung von jeweils 30 MC-Test-Fragen aus den Themen und Keywords jedes Termins.
 
 Lehrendenagenten erhalten keine autonome Notenhoheit und verändern keine studentischen Abgaben. Aufgabe, Agentenkonfiguration, verwendete Prüfroutinen und wesentliche Modellgrenzen werden transparent gemacht.
 
@@ -215,6 +216,8 @@ Das Dossier ist die Arbeits- und Quellenbasis des Referats, aber kein zusätzlic
 
 Beide Kursläufe nutzen dieselbe remote erreichbare oder identisch reproduzierbare Laborplattform, dieselben Agentenkonfigurationen, Aufgaben, Berechtigungen, Budgets und Abnahmetests. Im Präsenzlauf arbeiten Teams am Tisch mit dem Agenten; im Zoom-Lauf steuern sie denselben Prozess in Breakouts mit geteilter Evidenzansicht. Lokale Rechner dienen nur als Zugang, nicht als unterschiedlich leistungsfähige Zielumgebungen.
 
+Für die freiwillige Selbstüberprüfung wird nach jedem Termin in beiden Kursläufen derselbe Satz von 30 agentisch erzeugten MC-Test-Fragen bereitgestellt.
+
 Bildschirmfreigabe oder Projektion zeigt bevorzugt Auftrag, Plan, Diff, Test und Entscheidung – nicht lange unkommentierte Agentenläufe. Asynchrone Agentenausführung muss einen definierten Rückkehrpunkt, Statuskanal und Abbruchweg besitzen.
 
 ## 11. Prüfungs- und Integritätsregel
@@ -239,5 +242,6 @@ Bei erlaubter Agentennutzung gilt:
 - [ ] Serverbereitstellung, Härtung, Security, Datenschutz, Performance und FinOps agentisch abgedeckt
 - [ ] gemischte Informatik-/Wirtschaftsinformatikrollen und gemeinsame Ergebnisverantwortung erklärt
 - [ ] Lehrendenagenten für Labor, Vorprüfung und formatives Feedback getestet
+- [ ] MC-Test-Generator für 30 Fragen je Termin mit den gepflegten Themen und Keywords getestet
 - [ ] keine autonome Notengebung oder ungeprüfte Übernahme von Agentenaussagen vorgesehen
 - [ ] erlaubter KI-Einsatz in der Referatsprüfung formal geklärt und veröffentlicht

--- a/docs/didaktik/CLOUD-COMPUTING-DURCHFUEHRUNG-PRAESENZ-ZOOM.md
+++ b/docs/didaktik/CLOUD-COMPUTING-DURCHFUEHRUNG-PRAESENZ-ZOOM.md
@@ -15,6 +15,7 @@ Es gibt **keinen fachlich unterschiedlichen Präsenz- und Onlinekurs**. Beide Ku
 - dieselben Qualitäts-, Quellen- und Bewertungskriterien;
 - dieselben freigegebenen Agenten, Modelle, Systemaufträge, Werkzeugprofile und Versionen;
 - dieselben isolierten Zielserver, Rechte, Budgets, Freigabegates und Abnahmetests;
+- dieselben 30 agentisch erzeugten MC-Test-Fragen zur Selbstüberprüfung nach jedem Termin;
 - denselben dokumentierten Stand der Fallstudie `arsnova.eu`.
 
 Unterschiedlich sind **Sozialform, Moderation, Medien, technische Vorbereitung und Ausfallplan**. Der Ausdruck `Präsenz/synchron` in den Kursdokumenten bezeichnet die gemeinsame Workload-Kategorie des Modulhandbuchs: Im Präsenzlauf findet sie im Raum statt, im Onlinelauf synchron in Zoom.

--- a/docs/didaktik/CLOUD-COMPUTING-KURSREADME.md
+++ b/docs/didaktik/CLOUD-COMPUTING-KURSREADME.md
@@ -26,20 +26,20 @@ Offizielle Orientierung: [IU Bachelor Informatik – Kursübersicht](https://www
 
 ## 2. Beschlossener Konzeptkern
 
-| Entscheidung      | Konzeptstand                                                                                             |
-| ----------------- | -------------------------------------------------------------------------------------------------------- |
-| Format            | zwei Kursläufe, einmal Präsenz und einmal Zoom; jeweils 12 Termine × 3 UE                                |
-| Modalitätsregel   | gleiche Ziele, Inhalte, Zeiten, Agenten, Laborumgebungen, Lernprodukte und Prüfung                       |
-| Arbeitsmodell     | ausschließlich KI-Agenten im Sinne des Agentic Software Engineering auf Lehrenden- und Studierendenseite |
-| Lehrvehikel       | `arsnova.eu` als durchgehende reale Fallstudie, nicht als bloße Demo                                     |
-| Pflichtabdeckung  | Grundlagen, technologische Voraussetzungen, Serverless, GCP/AWS/Azure sowie Datenwissenschaft/ML         |
-| Lernlogik         | Cloud-Grundlagen → agentischer Serveraufbau → Härtung/Messung → wirtschaftliche Entscheidung             |
-| Praxis            | isolierte Zielserver werden durch kontrollierte Agenten installiert, gehärtet, geprüft und zurückgebaut  |
-| Selbstüberprüfung | nach jedem Termin 30 agentisch erzeugte MC-Test-Fragen aus den ausgewiesenen Themen und Keywords         |
-| Lernprodukt       | Formatives Agentic Cloud Engineering Dossier als Arbeitsgrundlage für das Referat                        |
-| Prüfungsbasis     | 15 Minuten je Prüfling; Einreichung, Vortrag und Diskussion; Workbook nur nach bestätigter Zuordnung     |
-| Providerbezug     | GCP, AWS und Azure verbindlich; Hetzner und OpenStack/Kubernetes als Fall- und Vergleichsoptionen        |
-| WI-Integration    | TCO, FinOps, Unit Economics, Sensitivität, Risiko, Build/Buy und Exit beruhen auf technischer Evidenz    |
+| Entscheidung      | Konzeptstand                                                                                                |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| Format            | zwei Kursläufe, einmal Präsenz und einmal Zoom; jeweils 12 Termine × 3 UE                                   |
+| Modalitätsregel   | gleiche Ziele, Inhalte, Zeiten, Agenten, Laborumgebungen, Lernprodukte und Prüfung                          |
+| Arbeitsmodell     | ausschließlich KI-Agenten im Sinne des Agentic Software Engineering auf Lehrenden- und Studierendenseite    |
+| Lehrvehikel       | `arsnova.eu` als durchgehende reale Fallstudie, nicht als bloße Demo                                        |
+| Pflichtabdeckung  | Grundlagen, technologische Voraussetzungen, Serverless, GCP/AWS/Azure sowie Datenwissenschaft/ML            |
+| Lernlogik         | Cloud-Grundlagen → agentischer Serveraufbau → Härtung/Messung → wirtschaftliche Entscheidung                |
+| Praxis            | isolierte Zielserver werden durch kontrollierte Agenten installiert, gehärtet, geprüft und zurückgebaut     |
+| Selbstüberprüfung | nach jedem Termin 30 agentisch erzeugte MC-Test-Fragen aus einer versionierten, autoritativen Materialbasis |
+| Lernprodukt       | Formatives Agentic Cloud Engineering Dossier als Arbeitsgrundlage für das Referat                           |
+| Prüfungsbasis     | 15 Minuten je Prüfling; Einreichung, Vortrag und Diskussion; Workbook nur nach bestätigter Zuordnung        |
+| Providerbezug     | GCP, AWS und Azure verbindlich; Hetzner und OpenStack/Kubernetes als Fall- und Vergleichsoptionen           |
+| WI-Integration    | TCO, FinOps, Unit Economics, Sensitivität, Risiko, Build/Buy und Exit beruhen auf technischer Evidenz       |
 
 Zwei **Lehr- und Architekturzielbilder** strukturieren die Fallarbeit:
 

--- a/docs/didaktik/CLOUD-COMPUTING-KURSREADME.md
+++ b/docs/didaktik/CLOUD-COMPUTING-KURSREADME.md
@@ -26,19 +26,20 @@ Offizielle Orientierung: [IU Bachelor Informatik – Kursübersicht](https://www
 
 ## 2. Beschlossener Konzeptkern
 
-| Entscheidung     | Konzeptstand                                                                                             |
-| ---------------- | -------------------------------------------------------------------------------------------------------- |
-| Format           | zwei Kursläufe, einmal Präsenz und einmal Zoom; jeweils 12 Termine × 3 UE                                |
-| Modalitätsregel  | gleiche Ziele, Inhalte, Zeiten, Agenten, Laborumgebungen, Lernprodukte und Prüfung                       |
-| Arbeitsmodell    | ausschließlich KI-Agenten im Sinne des Agentic Software Engineering auf Lehrenden- und Studierendenseite |
-| Lehrvehikel      | `arsnova.eu` als durchgehende reale Fallstudie, nicht als bloße Demo                                     |
-| Pflichtabdeckung | Grundlagen, technologische Voraussetzungen, Serverless, GCP/AWS/Azure sowie Datenwissenschaft/ML         |
-| Lernlogik        | Cloud-Grundlagen → agentischer Serveraufbau → Härtung/Messung → wirtschaftliche Entscheidung             |
-| Praxis           | isolierte Zielserver werden durch kontrollierte Agenten installiert, gehärtet, geprüft und zurückgebaut  |
-| Lernprodukt      | Formatives Agentic Cloud Engineering Dossier als Arbeitsgrundlage für das Referat                        |
-| Prüfungsbasis    | 15 Minuten je Prüfling; Einreichung, Vortrag und Diskussion; Workbook nur nach bestätigter Zuordnung     |
-| Providerbezug    | GCP, AWS und Azure verbindlich; Hetzner und OpenStack/Kubernetes als Fall- und Vergleichsoptionen        |
-| WI-Integration   | TCO, FinOps, Unit Economics, Sensitivität, Risiko, Build/Buy und Exit beruhen auf technischer Evidenz    |
+| Entscheidung      | Konzeptstand                                                                                             |
+| ----------------- | -------------------------------------------------------------------------------------------------------- |
+| Format            | zwei Kursläufe, einmal Präsenz und einmal Zoom; jeweils 12 Termine × 3 UE                                |
+| Modalitätsregel   | gleiche Ziele, Inhalte, Zeiten, Agenten, Laborumgebungen, Lernprodukte und Prüfung                       |
+| Arbeitsmodell     | ausschließlich KI-Agenten im Sinne des Agentic Software Engineering auf Lehrenden- und Studierendenseite |
+| Lehrvehikel       | `arsnova.eu` als durchgehende reale Fallstudie, nicht als bloße Demo                                     |
+| Pflichtabdeckung  | Grundlagen, technologische Voraussetzungen, Serverless, GCP/AWS/Azure sowie Datenwissenschaft/ML         |
+| Lernlogik         | Cloud-Grundlagen → agentischer Serveraufbau → Härtung/Messung → wirtschaftliche Entscheidung             |
+| Praxis            | isolierte Zielserver werden durch kontrollierte Agenten installiert, gehärtet, geprüft und zurückgebaut  |
+| Selbstüberprüfung | nach jedem Termin 30 agentisch erzeugte MC-Test-Fragen aus den ausgewiesenen Themen und Keywords         |
+| Lernprodukt       | Formatives Agentic Cloud Engineering Dossier als Arbeitsgrundlage für das Referat                        |
+| Prüfungsbasis     | 15 Minuten je Prüfling; Einreichung, Vortrag und Diskussion; Workbook nur nach bestätigter Zuordnung     |
+| Providerbezug     | GCP, AWS und Azure verbindlich; Hetzner und OpenStack/Kubernetes als Fall- und Vergleichsoptionen        |
+| WI-Integration    | TCO, FinOps, Unit Economics, Sensitivität, Risiko, Build/Buy und Exit beruhen auf technischer Evidenz    |
 
 Zwei **Lehr- und Architekturzielbilder** strukturieren die Fallarbeit:
 
@@ -89,7 +90,7 @@ Verbindliche Evidenzquellen:
 5. **Modul und Constructive Alignment:** [Bachelor-Konzept 36 UE](./BACHELOR-VORLESUNG-CLOUD-COMPUTING-36-UE-PRAKTIKUM.md)
 6. **Präsenz und Zoom gleichwertig umsetzen:** [Durchführungskonzept](./CLOUD-COMPUTING-DURCHFUEHRUNG-PRAESENZ-ZOOM.md)
 7. **Semesterstart in 30 Minuten:** [Dozenten-Quickstart](./dozenten-quickstart-cloud-computing.md)
-8. **Durchführung:** [12 Terminpläne](./vorlesungen-cloud-computing-termine.md)
+8. **Durchführung und MC-Test-Vorgaben:** [12 Terminpläne](./vorlesungen-cloud-computing-termine.md)
 
 ### Für die Fallstudie
 

--- a/docs/didaktik/dozenten-quickstart-cloud-computing.md
+++ b/docs/didaktik/dozenten-quickstart-cloud-computing.md
@@ -11,26 +11,26 @@
 3. Richte Agenten, Zielserver, Rechte, Budgets und Evidenz nach dem [Agentic-Lehrlabor](./CLOUD-COMPUTING-AGENTIC-LEHRLABOR.md) ein.
 4. Übernimm Dauer, Bestandteile, Fristen und Bewertung aus der [Referatsumsetzung](./CLOUD-COMPUTING-REFERAT-PRUEFUNG.md).
 5. Prüfe das [Lehrkonzept](./BACHELOR-VORLESUNG-CLOUD-COMPUTING-36-UE-PRAKTIKUM.md).
-6. Nutze die [12 Terminpläne](./vorlesungen-cloud-computing-termine.md) einschließlich der Themen und Keywords für jeweils 30 MC-Test-Fragen.
+6. Nutze die [12 Terminpläne](./vorlesungen-cloud-computing-termine.md) einschließlich [MC-Test-Generatorvertrag](./vorlesungen-cloud-computing-termine.md#verbindlicher-mc-test-generatorvertrag), Themen/Keywords und autoritativer Materialbasis für jeweils 30 Fragen.
 7. Übertrage die Aktivitäten mit dem [Präsenz-/Zoom-Konzept](./CLOUD-COMPUTING-DURCHFUEHRUNG-PRAESENZ-ZOOM.md) auf den jeweiligen Kurslauf.
 8. Bestätige vor Veröffentlichung der Prüfung in myCampus, ob Referat oder abweichend Workbook und welcher Agenteneinsatz zulässig ist.
 
 ## Zwölf Entscheidungen vor Semesterstart
 
-| Frage             | Empfohlener Startpunkt                                                                            |
-| ----------------- | ------------------------------------------------------------------------------------------------- |
-| Zeitraster        | 12 Termine × 3 UE: sechs Präsenz/synchron, sechs Tutorium                                         |
-| Kursmodus         | gleicher fachlicher Plan; Tisch-/Raumform in Präsenz, Breakout-/Dokumentform in Zoom              |
-| Selbststudium     | 123 h für Lektüre, Agentic-Dossier, Plattform-/Wirtschaftsvergleich und Referatsvorbereitung      |
-| Fallauftrag       | Formatives Agentic Cloud Engineering Dossier für `arsnova.eu`, keine zusätzliche Prüfungsleistung |
-| Arbeitsmodell     | ausschließlich werkzeugnutzende KI-Agenten auf Lehrenden- und Studierendenseite                   |
-| Agentenplattform  | institutionell freigegebenes Modell, Werkzeugprofil, Datenschutz, Version und Ersatzkonfiguration |
-| Pflichtabdeckung  | Grundlagen, Technologie, Serverless, GCP/AWS/Azure und Datenwissenschaft/ML sichtbar zuordnen     |
-| Leistungsnachweis | Referat, 15 Minuten je Prüfling; Einreichung 30 %, Vortrag 30 %, Diskussion 40 %                  |
-| Referatsformat    | Einzel/Gruppe und Präsentation mit Handout/Poster aus Prüfungsauftrag oder myCampus übernehmen    |
-| Labortiefe        | isolierte Zielserver agentisch installieren, härten, prüfen und zurückbauen; Produktion gesperrt  |
-| Kohortenrollen    | Informatik/Wirtschaftsinformatik mischen; Technik, Privacy, Performance und FinOps koppeln        |
-| Selbstüberprüfung | nach jedem Termin 30 agentisch erzeugte MC-Test-Fragen aus den festgelegten Themen und Keywords   |
+| Frage             | Empfohlener Startpunkt                                                                                |
+| ----------------- | ----------------------------------------------------------------------------------------------------- |
+| Zeitraster        | 12 Termine × 3 UE: sechs Präsenz/synchron, sechs Tutorium                                             |
+| Kursmodus         | gleicher fachlicher Plan; Tisch-/Raumform in Präsenz, Breakout-/Dokumentform in Zoom                  |
+| Selbststudium     | 123 h für Lektüre, Agentic-Dossier, Plattform-/Wirtschaftsvergleich und Referatsvorbereitung          |
+| Fallauftrag       | Formatives Agentic Cloud Engineering Dossier für `arsnova.eu`, keine zusätzliche Prüfungsleistung     |
+| Arbeitsmodell     | ausschließlich werkzeugnutzende KI-Agenten auf Lehrenden- und Studierendenseite                       |
+| Agentenplattform  | institutionell freigegebenes Modell, Werkzeugprofil, Datenschutz, Version und Ersatzkonfiguration     |
+| Pflichtabdeckung  | Grundlagen, Technologie, Serverless, GCP/AWS/Azure und Datenwissenschaft/ML sichtbar zuordnen         |
+| Leistungsnachweis | Referat, 15 Minuten je Prüfling; Einreichung 30 %, Vortrag 30 %, Diskussion 40 %                      |
+| Referatsformat    | Einzel/Gruppe und Präsentation mit Handout/Poster aus Prüfungsauftrag oder myCampus übernehmen        |
+| Labortiefe        | isolierte Zielserver agentisch installieren, härten, prüfen und zurückbauen; Produktion gesperrt      |
+| Kohortenrollen    | Informatik/Wirtschaftsinformatik mischen; Technik, Privacy, Performance und FinOps koppeln            |
+| Selbstüberprüfung | nach jedem Termin 30 agentisch erzeugte MC-Test-Fragen aus freigegebener, versionierter Materialbasis |
 
 ## Formaler Kern auf einen Blick
 
@@ -78,7 +78,8 @@ Providerpreise, SKU-Stücklisten und OpenStack-/Kubernetes-Optionen sind Vertief
 - isolierten Zielserver, Snapshot/Neuaufbau, kurzlebige Credentials und automatischen Cleanup bereithalten.
 - Für den Kursmodus Gruppenbildung, Ergebnissicherung und Technikfallback aus dem Präsenz-/Zoom-Konzept auswählen.
 - Volatile Preise oder Providerfunktionen am Tag der Verwendung gegen Primärquellen prüfen.
-- Aus den im Terminplan genannten Themen und Keywords 30 MC-Test-Fragen erzeugen und Lösungsschlüssel, Eindeutigkeit, Quellenbezug sowie Importformat prüfen.
+- Für MC-Test die freigegebene Folien-/Skriptversion, Repo-Anker und datierten Primärquellen im Generierungsmanifest festhalten; Themen und Keywords nur zur Abdeckungssteuerung verwenden.
+- Mit dem festgeschriebenen MC-Test-Commit die vier Stufen Fragensatz, Micro Learning Objectives, Fragen-QA und Lernziel-QA ausführen; das bereinigte JSON validieren und erst nach menschlicher Inhaltsprüfung importieren beziehungsweise veröffentlichen.
 
 ## Semesterstart-Checkliste
 
@@ -100,7 +101,7 @@ Providerpreise, SKU-Stücklisten und OpenStack-/Kubernetes-Optionen sind Vertief
 - [ ] Repository-Commit oder Stichtag für die Fallstudie festgelegt
 - [ ] agentische Serverbereitstellung und Härtung auf rücksetzbarer Nichtproduktionsumgebung getestet
 - [ ] Security-, Privacy-, Performance-, Recovery- und FinOps-Agentenaufträge getestet
-- [ ] Generator und Freigabeprüfung für 30 MC-Test-Fragen je Termin getestet
+- [ ] festgeschriebener MC-Test-Commit, vierstufige Artefaktpipeline, Validator, Generierungsmanifest und menschliche Freigabe für 30 Fragen je Termin getestet
 - [ ] Modell-/Cloud-Konten, Quotas, Budgets, Datenschutz und Secret-Behandlung geklärt
 - [ ] gemischte Informatik-/Wirtschaftsinformatikrollen festgelegt
 - [ ] Produktionslasttests und Echtdaten ausdrücklich ausgeschlossen

--- a/docs/didaktik/dozenten-quickstart-cloud-computing.md
+++ b/docs/didaktik/dozenten-quickstart-cloud-computing.md
@@ -11,11 +11,11 @@
 3. Richte Agenten, Zielserver, Rechte, Budgets und Evidenz nach dem [Agentic-Lehrlabor](./CLOUD-COMPUTING-AGENTIC-LEHRLABOR.md) ein.
 4. Übernimm Dauer, Bestandteile, Fristen und Bewertung aus der [Referatsumsetzung](./CLOUD-COMPUTING-REFERAT-PRUEFUNG.md).
 5. Prüfe das [Lehrkonzept](./BACHELOR-VORLESUNG-CLOUD-COMPUTING-36-UE-PRAKTIKUM.md).
-6. Nutze die [12 Terminpläne](./vorlesungen-cloud-computing-termine.md) für die Durchführung.
+6. Nutze die [12 Terminpläne](./vorlesungen-cloud-computing-termine.md) einschließlich der Themen und Keywords für jeweils 30 MC-Test-Fragen.
 7. Übertrage die Aktivitäten mit dem [Präsenz-/Zoom-Konzept](./CLOUD-COMPUTING-DURCHFUEHRUNG-PRAESENZ-ZOOM.md) auf den jeweiligen Kurslauf.
 8. Bestätige vor Veröffentlichung der Prüfung in myCampus, ob Referat oder abweichend Workbook und welcher Agenteneinsatz zulässig ist.
 
-## Elf Entscheidungen vor Semesterstart
+## Zwölf Entscheidungen vor Semesterstart
 
 | Frage             | Empfohlener Startpunkt                                                                            |
 | ----------------- | ------------------------------------------------------------------------------------------------- |
@@ -30,6 +30,7 @@
 | Referatsformat    | Einzel/Gruppe und Präsentation mit Handout/Poster aus Prüfungsauftrag oder myCampus übernehmen    |
 | Labortiefe        | isolierte Zielserver agentisch installieren, härten, prüfen und zurückbauen; Produktion gesperrt  |
 | Kohortenrollen    | Informatik/Wirtschaftsinformatik mischen; Technik, Privacy, Performance und FinOps koppeln        |
+| Selbstüberprüfung | nach jedem Termin 30 agentisch erzeugte MC-Test-Fragen aus den festgelegten Themen und Keywords   |
 
 ## Formaler Kern auf einen Blick
 
@@ -45,6 +46,7 @@
 - agent-first: Agenten führen Labor-, Analyse- und Bewertungsaufträge aus; Menschen setzen Grenzen, genehmigen Risiko/Kosten, verifizieren und verantworten
 - Serverlabor: reproduzierbare Bereitstellung und Härtung, Security, Datenschutz, Performance, Recovery und Cleanup auf isolierten Zielservern
 - Wirtschaftsinformatik: TCO, Unit Economics, Sensitivität, Build/Buy, Risiko und Exit aus derselben technischen Evidenz
+- MC-Test: nach jedem Termin 30 agentisch erzeugte, lehrendengeprüfte Fragen zur freiwilligen Selbstüberprüfung; in Präsenz und Zoom identisch
 
 ## Was Lehrende fachlich nicht verkürzen dürfen
 
@@ -76,6 +78,7 @@ Providerpreise, SKU-Stücklisten und OpenStack-/Kubernetes-Optionen sind Vertief
 - isolierten Zielserver, Snapshot/Neuaufbau, kurzlebige Credentials und automatischen Cleanup bereithalten.
 - Für den Kursmodus Gruppenbildung, Ergebnissicherung und Technikfallback aus dem Präsenz-/Zoom-Konzept auswählen.
 - Volatile Preise oder Providerfunktionen am Tag der Verwendung gegen Primärquellen prüfen.
+- Aus den im Terminplan genannten Themen und Keywords 30 MC-Test-Fragen erzeugen und Lösungsschlüssel, Eindeutigkeit, Quellenbezug sowie Importformat prüfen.
 
 ## Semesterstart-Checkliste
 
@@ -97,6 +100,7 @@ Providerpreise, SKU-Stücklisten und OpenStack-/Kubernetes-Optionen sind Vertief
 - [ ] Repository-Commit oder Stichtag für die Fallstudie festgelegt
 - [ ] agentische Serverbereitstellung und Härtung auf rücksetzbarer Nichtproduktionsumgebung getestet
 - [ ] Security-, Privacy-, Performance-, Recovery- und FinOps-Agentenaufträge getestet
+- [ ] Generator und Freigabeprüfung für 30 MC-Test-Fragen je Termin getestet
 - [ ] Modell-/Cloud-Konten, Quotas, Budgets, Datenschutz und Secret-Behandlung geklärt
 - [ ] gemischte Informatik-/Wirtschaftsinformatikrollen festgelegt
 - [ ] Produktionslasttests und Echtdaten ausdrücklich ausgeschlossen

--- a/docs/didaktik/vorlesungen-cloud-computing-termine.md
+++ b/docs/didaktik/vorlesungen-cloud-computing-termine.md
@@ -17,7 +17,32 @@ Pausen und institutionelle Zeitfenster sind vor Semesterstart einzurechnen. Die 
 
 Alle substanziellen Aktivitäten werden auf Lehrenden- und Studierendenseite mit KI-Agenten ausgeführt. Jeder Termin folgt `Auftrag → Plan → Freigabe → Ausführung → Verifikation → Evidenz → Entscheidung`; reine Chatantworten oder manuell nachgeklickte Cloud-Schritte erfüllen den Arbeitsauftrag nicht. Menschen setzen Grenzen, genehmigen Risiko/Kosten und verantworten das Ergebnis.
 
-Nach **jedem** der zwölf Termine erstellt ein Lehrendenagent aus den jeweils ausgewiesenen Themen und Keywords genau **30 [MC-Test](https://github.com/kqc-real/streamlit)-Fragen** zur freiwilligen Selbstüberprüfung. Entsprechend dem EDULEARN26-Konzept erhält jedes Item ein Lernziel, ein Thema, eine Gewichtung beziehungsweise Schwierigkeit, eines der Niveaus Reproduktion/Anwendung/Analyse sowie eine Begründung zu den Antwortoptionen. Der Agent liefert schema-konforme, technisch importierbare Fragen; die Lehrperson prüft Lösungsschlüssel, Eindeutigkeit, Quellenbezug und unbeabsichtigte Lösungshinweise vor der Freigabe. Präsenz- und Zoom-Lauf erhalten denselben freigegebenen Fragensatz. MC-Test ist formativ und weder Prüfungsleistung noch Prüfungszulassung.
+Nach **jedem** der zwölf Termine erstellt ein Lehrendenagent genau **30 MC-Test-Fragen** zur freiwilligen Selbstüberprüfung. Die ausgewiesenen Themen und Keywords steuern ausschließlich die inhaltliche Abdeckung; fachliche Wissensbasis sind die je Termin freigegebenen Materialien und Primärquellen. Präsenz- und Zoom-Lauf erhalten denselben freigegebenen Fragensatz. MC-Test ist formativ und weder Prüfungsleistung noch Prüfungszulassung.
+
+## Verbindlicher MC-Test-Generatorvertrag
+
+Für den Kurslauf ist [MC-Test](https://github.com/kqc-real/streamlit/tree/b6b159555e8a228dad73dd75fd66c154a1088e28) auf Commit `b6b159555e8a228dad73dd75fd66c154a1088e28` festgeschrieben. Maßgeblich sind genau diese Versionen von:
+
+- [Stage 1: Fragensatz erzeugen](https://github.com/kqc-real/streamlit/blob/b6b159555e8a228dad73dd75fd66c154a1088e28/prompts/KI_PROMPT.md)
+- [Stage 2: Micro Learning Objectives erzeugen](https://github.com/kqc-real/streamlit/blob/b6b159555e8a228dad73dd75fd66c154a1088e28/prompts/KI_PROMPT_MICRO_LEARNING_OBJECTIVES.md)
+- [Stage 3: Fragensatz-Postproduktion](https://github.com/kqc-real/streamlit/blob/b6b159555e8a228dad73dd75fd66c154a1088e28/prompts/KI_PROMPT_POSTPRODUCTION_QA.md)
+- [Stage 4: Lernziel-Postproduktion](https://github.com/kqc-real/streamlit/blob/b6b159555e8a228dad73dd75fd66c154a1088e28/prompts/KI_PROMPT_POSTPRODUCTION_QA_LEARNING_OBJECTIVES.md)
+- [Validator `validate_sets.py`](https://github.com/kqc-real/streamlit/blob/b6b159555e8a228dad73dd75fd66c154a1088e28/validate_sets.py)
+
+Der Lehrendenagent führt die vier Artefaktstufen in derselben Sitzung strikt nacheinander aus und speichert nach jeder Stufe genau ein prüfbares Artefakt:
+
+1. Aus Konfiguration und freigegebener Materialbasis entsteht ein kanonisches Fragen-JSON.
+2. Aus dem Stage-1-JSON entsteht ein separates Markdown-Dokument mit genau einem Micro Learning Objective je Frage. Lernziele sind **kein** Feld des Fragen-JSON.
+3. Ausschließlich das Stage-1-JSON wird postproduziert; Ergebnis ist ein bereinigtes kanonisches Fragen-JSON.
+4. Das Stage-2-Markdown wird gegen das bereinigte Stage-3-JSON neu ausgerichtet; Ergebnis ist das finale Lernziel-Markdown.
+
+Das verbindliche Standardprofil je Termin umfasst 30 deutschsprachige Fragen mit genau vier Antwortoptionen: 10 Fragen mit `weight = 1` / `Reproduktion`, 12 mit `weight = 2` / `Anwendung` und 8 mit `weight = 3` / `Strukturelle Analyse`. Eine didaktisch begründete Abweichung wird vor der Generierung im Manifest festgehalten; sie darf nicht stillschweigend durch den Agenten entstehen.
+
+Das kanonische JSON besteht ausschließlich aus `meta` und `questions`. `meta` enthält mindestens `title`, `created`, `language`, `target_audience`, `question_count`, `difficulty_profile`, `time_per_weight_minutes`, `additional_buffer_minutes` und `test_duration_minutes`. Jedes Element von `questions` enthält `question`, vier Einträge in `options`, den nullbasierten Lösungsindex `answer`, `explanation`, `weight`, `topic`, `concept`, `cognitive_level`, ein `mini_glossary` mit zwei bis sechs Begriffen sowie `extended_explanation`; bei Gewicht 1 ist `extended_explanation` `null`, bei Gewicht 2 oder 3 enthält es `title`, zwei bis sechs `steps` und `content`.
+
+Zu jedem Fragensatz wird außerhalb des kanonischen JSON ein Generierungsmanifest geführt. Es nennt Termin, Sprache, `arsnova.eu`-Commit, MC-Test-Commit, freigegebene Folien-/Skriptversion, alle weiteren Quellen mit Version oder Abrufdatum, Profil und Optionszahl sowie die vier erzeugten Artefakte. Volatile Providerfunktionen, Preise, Security-, Datenschutz- und Prüfungsangaben werden am Generierungstag gegen datierte Primärquellen geprüft. Dateinamen oder Quellenmarker werden nicht in die Fragenfelder geschrieben.
+
+Ein Satz wird erst veröffentlicht, wenn Stage 1 bis 4 vollständig vorliegen, das Stage-3-JSON mit dem festgeschriebenen `validate_sets.py` ohne Fehler validiert wurde und die Lehrperson alle Lösungsschlüssel, Eindeutigkeit, fachliche Deckung durch die Materialbasis, plausible Distraktoren und unbeabsichtigte Lösungshinweise geprüft hat. Erst danach erfolgt ein gegebenenfalls erforderlicher Importexport aus dem kanonischen JSON. Das Manifest und die freigegebenen Artefakte werden für Präsenz und Zoom identisch versioniert.
 
 Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für das 15-minütige Referat je Prüfling. Falls myCampus stattdessen Workbook vorgibt, werden ausschließlich die zentralen Workbookaufgaben und [Workbook-Regeln](./CLOUD-COMPUTING-IU-FORMALIA.md#7-alternativpfad-workbook-nur-nach-bestätigung) verwendet.
 
@@ -26,6 +51,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 **Typ:** Präsenz/synchron · **Modulhandbuch:** Inhaltsblock 1 · **Leitfrage:** Wann ist ein Dienst Cloud Computing und wie wird ein Agent dafür sicher beauftragt?
 
 **MC-Test (30 Fragen):** Themen: Cloud-Merkmale, Service- und Deployment-Modelle, Shared Responsibility, sicherer Agentenauftrag · Keywords: On-demand Self-service, Broad Network Access, Resource Pooling, Rapid Elasticity, Measured Service, IaaS, PaaS, SaaS, Public Cloud, Private Cloud, Hybrid Cloud, Multi-Cloud, Hosting, Outsourcing, Virtualisierung, Shared Responsibility, Agentenvertrag, Least Privilege, Budget, Akzeptanzkriterium, Abbruchkriterium
+
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; NIST SP 800-145; [Kurslandkarte](./CLOUD-COMPUTING-KURSREADME.md) und [akademische Einordnung](../implementation/CLOUD-COMPUTING-EINORDNUNG-AKADEMISCH.md) am im Manifest genannten `arsnova.eu`-Commit
 
 ### UE 1 (0–45)
 
@@ -53,6 +80,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **MC-Test (30 Fragen):** Themen: Virtualisierung, Containerisierung, Infrastructure as Code, Speicher, Netzwerk und API-Kommunikation · Keywords: Hypervisor, virtuelle Maschine, Image, Container, Isolation, Docker Compose, Orchestrierung, Infrastructure as Code, Compute, Block Storage, File Storage, Object Storage, DNS, TLS, Load Balancer, Firewall, HTTP, REST, WebSocket, Egress, Quota, Cleanup
 
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; [Dockerfile](../../Dockerfile), [Produktions-Compose](../../docker-compose.prod.yml) und [Deployment](../deployment-debian-root-server.md) am im Manifest genannten `arsnova.eu`-Commit; verwendete Docker-/Providerdokumentation mit Abrufdatum
+
 ### UE 1 (0–45)
 
 - Architekturagent modelliert Virtualisierung, Hypervisor, VM, Container, Images, Isolation und Ressourcensteuerung
@@ -78,6 +107,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 **Typ:** Tutorium · **Modulhandbuch:** Vertiefung Inhaltsblock 2 · **Leitfrage:** Kann der Agent einen isolierten Server reproduzierbar installieren und nachweisbar härten?
 
 **MC-Test (30 Fragen):** Themen: agentische Serverbereitstellung, Installation, Härtung, Zustands- und Vertrauensgrenzen, Wiederherstellung · Keywords: Provisioning, Idempotenz, Patchmanagement, unprivilegiertes Dienstkonto, SSH-Schlüssel, Firewall, minimale Ports, Dateirechte, Secrets, Nginx, PostgreSQL, Redis, Yjs, WebSocket, PDF-Worker, Trust Boundary, State, Hardening-Scan, Rollback, Destroy, Rebuild
+
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; [Architektur-Handbuch](../architecture/handbook.md), [`session.ts`](../../apps/backend/src/routers/session.ts) und [`redis.ts`](../../apps/backend/src/redis.ts) am im Manifest genannten `arsnova.eu`-Commit; freigegebenes Zielserverinventar und Härtungs-/Restore-Nachweise des Kurslaufs
 
 ### UE 1 (0–45)
 
@@ -106,6 +137,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **MC-Test (30 Fragen):** Themen: Serverless Computing, Funktions- und Dienstmodelle, Eignung, Grenzen und Kosten · Keywords: FaaS, BaaS, Trigger, Statelessness, Cold Start, Laufzeitgrenze, Autoscaling, Pay-per-use, Function, Container, Job, Queue, Worker, Managed Service, Observability, Datenlokalität, Vendor Lock-in, Break-even, PDF-Erzeugung, Webhook, Yjs
 
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; [`pdfWorkerTransport.ts`](../../apps/backend/src/lib/pdfWorkerTransport.ts) und [6R-Einordnung](../implementation/CLOUD-COMPUTING-6R-EINORDNUNG.md) am im Manifest genannten `arsnova.eu`-Commit; offizielle Funktions-, Limit- und Preisunterlagen von GCP, AWS und Azure mit Abrufdatum
+
 ### UE 1 (0–45)
 
 - Serverless-Agent erschließt Function as a Service, Backend as a Service, Trigger, kurze Ausführung und zustandslose Instanz
@@ -133,6 +166,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **MC-Test (30 Fragen):** Themen: Google Cloud, AWS und Azure, Providerfähigkeiten, Verantwortungsgrenzen, Regionen und Kosten · Keywords: Projekt, Account, Subscription, Region, Availability Zone, IAM, VPC, VNet, Compute, Container Service, Functions, Object Storage, Managed Database, Monitoring, Shared Responsibility, Pricing, Egress, Data Residency, Lock-in, Exit, Primärquelle
 
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; [Provider-Vergleich](../implementation/CLOUD-PROVIDER-VERGLEICH-ARSNOVA-EU.md) am im Manifest genannten `arsnova.eu`-Commit; offizielle Service-, Regionen-, Shared-Responsibility- und Preisunterlagen von GCP, AWS und Azure mit Abrufdatum, Region, Währung und Steuerbasis
+
 ### UE 1 (0–45)
 
 - Provider-Agent erhebt Konto-/Projektmodell, Regionen, Availability Zones, Identität, Netzwerk und Abrechnung
@@ -158,6 +193,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 **Typ:** Präsenz/synchron · **Modulhandbuch:** Inhaltsblock 5 · **Leitfrage:** Welche Cloud-Fähigkeit empfiehlt ein Daten-/ML-Agent und besteht sie die Privacy- und Wirtschaftlichkeitsgates?
 
 **MC-Test (30 Fragen):** Themen: Datenwissenschaft und maschinelles Lernen in der Cloud, Datenpipeline, Managed ML, Datenschutz und Wirtschaftlichkeit · Keywords: Batch, Streaming, ETL, ELT, Data Lake, Data Warehouse, Notebook, Pipeline, Training, Inferenz, MLOps, Managed ML, Datenqualität, Reproduzierbarkeit, Datenminimierung, Zweckbindung, Datenresidenz, Aufbewahrung, Löschung, Modell-/Datenexport, synthetische Daten, Egress
+
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; freigegebener Datenfluss und Privacy-/FinOps-Artefakte des Kurslaufs; offizielle Produkt-, Datenverarbeitungs-, Regionen-, Export- und Preisunterlagen zu Vertex AI, Amazon SageMaker und Azure Machine Learning mit Abrufdatum
 
 ### UE 1 (0–45)
 
@@ -185,6 +222,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **MC-Test (30 Fragen):** Themen: Persistenz, Speicherklassen, Backup, Restore und Disaster Recovery · Keywords: Persistenz, Cache, flüchtiger Zustand, PostgreSQL, Redis, Yjs, Object Storage, Backup, Snapshot, Offsite Backup, RPO, RTO, Konsistenz, Idempotenz, Restore, Integrität, Datenverlust, Recovery-Test, Disaster Recovery, Owner, Kosten
 
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; [Prisma-Schema](../../prisma/schema.prisma) und [Backup-/Restore-Runbook](../operations/BACKUP-RESTORE-RUNBOOK.md) am im Manifest genannten `arsnova.eu`-Commit; freigegebene Backup-, Fehlerfall- und Restore-Nachweise des Kurslaufs
+
 ### UE 1 (0–45)
 
 - Recovery-Agent inventarisiert Persistenz, Cache, flüchtigen Zustand und Object Storage auf dem Zielserver
@@ -210,6 +249,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 **Typ:** Tutorium · **Modulhandbuch:** Fallvertiefung zu Nutzen/Risiken und technischer Grundlage · **Leitfrage:** Welche agentisch ausgeführte Messung kann eine Skalierungs- oder Wirtschaftlichkeitsannahme widerlegen?
 
 **MC-Test (30 Fragen):** Themen: Skalierung, Elastizität, Last- und Performance Engineering, Resilienz und Unit Costs · Keywords: vertikale Skalierung, horizontale Skalierung, Elastizität, Load Balancing, Queueing, Backpressure, p50, p95, p99, Durchsatz, Fehlerrate, Sättigung, SLI, SLO, Lasttest, Baseline, WebSocket, Yjs, Scale-out, Hotspot, Abbruchkriterium, Unit Cost
+
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; [Produktions-Join](../implementation/LASTTEST-500-PRODUKTION-6LTFZF-2026-05-09.md), [lokale Baseline](../implementation/LOCAL-BASELINE-FREIGABE-2026-07-12.md) und [§6.5-Abnahme](../implementation/S6.5-SECURITY-LOAD-ACCEPTANCE.md) am im Manifest genannten `arsnova.eu`-Commit; freigegebene Lastreports des Kurslaufs mit Umgebung und Messdatum
 
 ### UE 1 (0–45)
 
@@ -238,6 +279,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **MC-Test (30 Fragen):** Themen: Cloud-Sicherheit, Datenschutz, Observability und Resilienz · Keywords: IAM, Least Privilege, Secrets, Netzwerksegmentierung, Supply Chain, Tenant-Isolation, Session-Isolation, Verschlüsselung, Datenminimierung, Logs, Metriken, Traces, Alerting, Runbook, Redundanz, Graceful Degradation, Vulnerability Scan, Remediation, Negativtest, False Positive, Restrisiko
 
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; [Security Overview](../SECURITY-OVERVIEW.md), [Monitoring-Runbook](../operations/MONITORING-RUNBOOK.md) und [W3.7-Abnahme](../implementation/W3.7-MONITORING-ALARMS-ABNAHME.md) am im Manifest genannten `arsnova.eu`-Commit; freigegebene Scan-, Negativtest- und Datenschutzartefakte des Kurslaufs sowie datierte Primärquellen für volatile Sicherheitsvorgaben
+
 ### UE 1 (0–45)
 
 - Security-Agent modelliert IAM, Least Privilege, Secrets, Netzwerkgrenzen, Supply Chain und Tenant-/Session-Isolation
@@ -265,6 +308,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **MC-Test (30 Fragen):** Themen: Providerentscheidung, FinOps, TCO, Unit Economics und 6R-Migration · Keywords: Rehost, Replatform, Repurchase, Refactor, Retire, Retain, TCO, Unit Economics, CapEx, OpEx, Personalaufwand, Support, Observability-Kosten, Compliance-Kosten, Egress, Build-or-Buy, Best Case, Base Case, Worst Case, Sensitivitätsanalyse, Lock-in, Exit, ADR
 
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; [6R-Einordnung](../implementation/CLOUD-COMPUTING-6R-EINORDNUNG.md), [Provider-Vergleich](../implementation/CLOUD-PROVIDER-VERGLEICH-ARSNOVA-EU.md) und [Kostenrechenblatt](../implementation/CLOUD-COMPUTING-HETZNER-KOSTENVORSCHLAG.md) am im Manifest genannten `arsnova.eu`-Commit; offizielle Preisrechner/-listen mit Abrufdatum, Region, Währung und Steuerbasis
+
 ### UE 1 (0–45)
 
 - Economics-/FinOps-Agent prüft den GCP-/AWS-/Azure-Vergleich aus Termin 5 auf gleiche Systemgrenze und Leistungsbasis
@@ -290,6 +335,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 **Typ:** Tutorium · **Prüfungsbezug:** Referat, 15 Minuten je Prüfling · **Leitfrage:** Wie bilden Einreichung, Vortrag und Diskussion gemeinsam eine akademisch belastbare Prüfungsleistung?
 
 **MC-Test (30 Fragen):** Themen: wissenschaftliche Argumentation, Referatsstruktur, Evidenz, Quellen, Visualisierung und Agentenoffenlegung · Keywords: Forschungsfrage, These, Argumentationslinie, Primärquelle, Quellenkritik, Fakt, Evidenz, Annahme, Entscheidung, Zitation, Literaturverzeichnis, Handout, Poster, Abbildung, individuelle Kennzeichnung, Agentenbeitrag, akademische Integrität, Zeitbudget, Einreichung, Vortrag, Diskussion, 30/30/40-Gewichtung
+
+**MC-Test-Materialbasis:** freigegebene Folien-/Skriptversion des Termins; [IU-Formalia](./CLOUD-COMPUTING-IU-FORMALIA.md), [Referatsumsetzung](./CLOUD-COMPUTING-REFERAT-PRUEFUNG.md) und [Agentic-Lehrlabor](./CLOUD-COMPUTING-AGENTIC-LEHRLABOR.md) am im Manifest genannten `arsnova.eu`-Commit; veröffentlichter Prüfungsauftrag, Hilfsmittelregel und Bewertungsbogen des Kurslaufs mit Gültigkeitsdatum
 
 ### UE 1 (0–45)
 
@@ -324,6 +371,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **MC-Test (30 Fragen):** Themen: kumulative Cloud-Computing-Synthese, Referatsverteidigung, Agentenkritik und Grenzen der Evidenz · Keywords: Cloud-Merkmale, Service-Modell, technologische Voraussetzung, Serverless, Google Cloud, AWS, Azure, Datenwissenschaft, maschinelles Lernen, Security, Datenschutz, Performance, Resilienz, FinOps, Evidenzstufe, Gültigkeitsgrenze, Restrisiko, Sensitivität, Agentenfehler, Quellenprüfung, Zeitmanagement, Diskussion, akademische Integrität
 
+**MC-Test-Materialbasis:** vollständige freigegebene Folien-/Skriptversion des Kurslaufs; die im Manifest festgeschriebenen Materialbasen der Termine 1 bis 10; [IU-Formalia](./CLOUD-COMPUTING-IU-FORMALIA.md), [Referatsumsetzung](./CLOUD-COMPUTING-REFERAT-PRUEFUNG.md) und [Agentic-Lehrlabor](./CLOUD-COMPUTING-AGENTIC-LEHRLABOR.md) am genannten `arsnova.eu`-Commit; gültiger Prüfungsauftrag und Bewertungsbogen
+
 ### UE 1 (0–45)
 
 - Einreichung gegen Umfang, Namen/Matrikelnummern, Literatur, Abbildungen und individuelle Kennzeichnung prüfen
@@ -356,5 +405,5 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 - **Wirtschaftsinformatik:** TCO, Unit Economics, Sensitivität, Risiko, Build/Buy und Exit nie von technischer Mess- und Architekturevidenz trennen.
 - **Prüfungsform Referat:** Die vollständigen Vorgaben der [Referatsumsetzung](./CLOUD-COMPUTING-REFERAT-PRUEFUNG.md) anwenden; keine zusätzliche Dossierbewertung einführen.
 - **Prüfungsform Workbook bestätigt:** Termine 11 und 12 auf die zentralen fünf Aufgaben und Einzelarbeitsregeln ausrichten; keine selbst erfundene Gruppenabgabe.
-- **Repo ändert sich:** Kurslandkarte aktualisieren und pro Termin den verwendeten Commit dokumentieren.
+- **Repo oder MC-Test ändert sich:** Kurslandkarte aktualisieren; pro Fragensatz `arsnova.eu`- und MC-Test-Commit im Generierungsmanifest dokumentieren. Ein Versionswechsel der Prompts oder des Validators erfordert einen erneuten Pipeline-Test und eine bewusste Kursfreigabe.
 - **Zu wenig Zeit:** Fallvertiefungen kürzen, niemals die fünf offiziellen Inhaltsblöcke oder die Präsenz-/Tutoriumsbilanz streichen.

--- a/docs/didaktik/vorlesungen-cloud-computing-termine.md
+++ b/docs/didaktik/vorlesungen-cloud-computing-termine.md
@@ -17,11 +17,15 @@ Pausen und institutionelle Zeitfenster sind vor Semesterstart einzurechnen. Die 
 
 Alle substanziellen Aktivitäten werden auf Lehrenden- und Studierendenseite mit KI-Agenten ausgeführt. Jeder Termin folgt `Auftrag → Plan → Freigabe → Ausführung → Verifikation → Evidenz → Entscheidung`; reine Chatantworten oder manuell nachgeklickte Cloud-Schritte erfüllen den Arbeitsauftrag nicht. Menschen setzen Grenzen, genehmigen Risiko/Kosten und verantworten das Ergebnis.
 
+Nach **jedem** der zwölf Termine erstellt ein Lehrendenagent aus den jeweils ausgewiesenen Themen und Keywords genau **30 [MC-Test](https://github.com/kqc-real/streamlit)-Fragen** zur freiwilligen Selbstüberprüfung. Entsprechend dem EDULEARN26-Konzept erhält jedes Item ein Lernziel, ein Thema, eine Gewichtung beziehungsweise Schwierigkeit, eines der Niveaus Reproduktion/Anwendung/Analyse sowie eine Begründung zu den Antwortoptionen. Der Agent liefert schema-konforme, technisch importierbare Fragen; die Lehrperson prüft Lösungsschlüssel, Eindeutigkeit, Quellenbezug und unbeabsichtigte Lösungshinweise vor der Freigabe. Präsenz- und Zoom-Lauf erhalten denselben freigegebenen Fragensatz. MC-Test ist formativ und weder Prüfungsleistung noch Prüfungszulassung.
+
 Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für das 15-minütige Referat je Prüfling. Falls myCampus stattdessen Workbook vorgibt, werden ausschließlich die zentralen Workbookaufgaben und [Workbook-Regeln](./CLOUD-COMPUTING-IU-FORMALIA.md#7-alternativpfad-workbook-nur-nach-bestätigung) verwendet.
 
 ## Termin 1: Grundlagen und Agentenvertrag
 
 **Typ:** Präsenz/synchron · **Modulhandbuch:** Inhaltsblock 1 · **Leitfrage:** Wann ist ein Dienst Cloud Computing und wie wird ein Agent dafür sicher beauftragt?
+
+**MC-Test (30 Fragen):** Themen: Cloud-Merkmale, Service- und Deployment-Modelle, Shared Responsibility, sicherer Agentenauftrag · Keywords: On-demand Self-service, Broad Network Access, Resource Pooling, Rapid Elasticity, Measured Service, IaaS, PaaS, SaaS, Public Cloud, Private Cloud, Hybrid Cloud, Multi-Cloud, Hosting, Outsourcing, Virtualisierung, Shared Responsibility, Agentenvertrag, Least Privilege, Budget, Akzeptanzkriterium, Abbruchkriterium
 
 ### UE 1 (0–45)
 
@@ -47,6 +51,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **Typ:** Präsenz/synchron · **Modulhandbuch:** Inhaltsblock 2 · **Leitfrage:** Welche Abstraktionen und Agentengrenzen machen einen reproduzierbaren Cloud-Zielserver möglich?
 
+**MC-Test (30 Fragen):** Themen: Virtualisierung, Containerisierung, Infrastructure as Code, Speicher, Netzwerk und API-Kommunikation · Keywords: Hypervisor, virtuelle Maschine, Image, Container, Isolation, Docker Compose, Orchestrierung, Infrastructure as Code, Compute, Block Storage, File Storage, Object Storage, DNS, TLS, Load Balancer, Firewall, HTTP, REST, WebSocket, Egress, Quota, Cleanup
+
 ### UE 1 (0–45)
 
 - Architekturagent modelliert Virtualisierung, Hypervisor, VM, Container, Images, Isolation und Ressourcensteuerung
@@ -70,6 +76,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 ## Termin 3: Agentische Serverinstallation, Härtung und Zustandsgrenzen
 
 **Typ:** Tutorium · **Modulhandbuch:** Vertiefung Inhaltsblock 2 · **Leitfrage:** Kann der Agent einen isolierten Server reproduzierbar installieren und nachweisbar härten?
+
+**MC-Test (30 Fragen):** Themen: agentische Serverbereitstellung, Installation, Härtung, Zustands- und Vertrauensgrenzen, Wiederherstellung · Keywords: Provisioning, Idempotenz, Patchmanagement, unprivilegiertes Dienstkonto, SSH-Schlüssel, Firewall, minimale Ports, Dateirechte, Secrets, Nginx, PostgreSQL, Redis, Yjs, WebSocket, PDF-Worker, Trust Boundary, State, Hardening-Scan, Rollback, Destroy, Rebuild
 
 ### UE 1 (0–45)
 
@@ -96,6 +104,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **Typ:** Präsenz/synchron · **Modulhandbuch:** Inhaltsblock 3 · **Leitfrage:** Welche Aufgaben empfiehlt ein Agent für Serverless und hält die Empfehlung einem isolierten Gegenversuch stand?
 
+**MC-Test (30 Fragen):** Themen: Serverless Computing, Funktions- und Dienstmodelle, Eignung, Grenzen und Kosten · Keywords: FaaS, BaaS, Trigger, Statelessness, Cold Start, Laufzeitgrenze, Autoscaling, Pay-per-use, Function, Container, Job, Queue, Worker, Managed Service, Observability, Datenlokalität, Vendor Lock-in, Break-even, PDF-Erzeugung, Webhook, Yjs
+
 ### UE 1 (0–45)
 
 - Serverless-Agent erschließt Function as a Service, Backend as a Service, Trigger, kurze Ausführung und zustandslose Instanz
@@ -121,6 +131,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **Typ:** Präsenz/synchron · **Modulhandbuch:** Inhaltsblock 4 · **Leitfrage:** Wie vergleicht ein Provider-Agent Google Cloud, AWS und Azure ohne Produktkatalog- oder Preisillusion?
 
+**MC-Test (30 Fragen):** Themen: Google Cloud, AWS und Azure, Providerfähigkeiten, Verantwortungsgrenzen, Regionen und Kosten · Keywords: Projekt, Account, Subscription, Region, Availability Zone, IAM, VPC, VNet, Compute, Container Service, Functions, Object Storage, Managed Database, Monitoring, Shared Responsibility, Pricing, Egress, Data Residency, Lock-in, Exit, Primärquelle
+
 ### UE 1 (0–45)
 
 - Provider-Agent erhebt Konto-/Projektmodell, Regionen, Availability Zones, Identität, Netzwerk und Abrechnung
@@ -144,6 +156,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 ## Termin 6: Datenwissenschaft und maschinelles Lernen in der Cloud
 
 **Typ:** Präsenz/synchron · **Modulhandbuch:** Inhaltsblock 5 · **Leitfrage:** Welche Cloud-Fähigkeit empfiehlt ein Daten-/ML-Agent und besteht sie die Privacy- und Wirtschaftlichkeitsgates?
+
+**MC-Test (30 Fragen):** Themen: Datenwissenschaft und maschinelles Lernen in der Cloud, Datenpipeline, Managed ML, Datenschutz und Wirtschaftlichkeit · Keywords: Batch, Streaming, ETL, ELT, Data Lake, Data Warehouse, Notebook, Pipeline, Training, Inferenz, MLOps, Managed ML, Datenqualität, Reproduzierbarkeit, Datenminimierung, Zweckbindung, Datenresidenz, Aufbewahrung, Löschung, Modell-/Datenexport, synthetische Daten, Egress
 
 ### UE 1 (0–45)
 
@@ -169,6 +183,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **Typ:** Tutorium · **Modulhandbuch:** Vertiefung Inhaltsblock 2 · **Leitfrage:** Kann ein Recovery-Agent die geforderte Wiederherstellung tatsächlich und reproduzierbar ausführen?
 
+**MC-Test (30 Fragen):** Themen: Persistenz, Speicherklassen, Backup, Restore und Disaster Recovery · Keywords: Persistenz, Cache, flüchtiger Zustand, PostgreSQL, Redis, Yjs, Object Storage, Backup, Snapshot, Offsite Backup, RPO, RTO, Konsistenz, Idempotenz, Restore, Integrität, Datenverlust, Recovery-Test, Disaster Recovery, Owner, Kosten
+
 ### UE 1 (0–45)
 
 - Recovery-Agent inventarisiert Persistenz, Cache, flüchtigen Zustand und Object Storage auf dem Zielserver
@@ -192,6 +208,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 ## Termin 8: Skalierung und Performance Engineering
 
 **Typ:** Tutorium · **Modulhandbuch:** Fallvertiefung zu Nutzen/Risiken und technischer Grundlage · **Leitfrage:** Welche agentisch ausgeführte Messung kann eine Skalierungs- oder Wirtschaftlichkeitsannahme widerlegen?
+
+**MC-Test (30 Fragen):** Themen: Skalierung, Elastizität, Last- und Performance Engineering, Resilienz und Unit Costs · Keywords: vertikale Skalierung, horizontale Skalierung, Elastizität, Load Balancing, Queueing, Backpressure, p50, p95, p99, Durchsatz, Fehlerrate, Sättigung, SLI, SLO, Lasttest, Baseline, WebSocket, Yjs, Scale-out, Hotspot, Abbruchkriterium, Unit Cost
 
 ### UE 1 (0–45)
 
@@ -218,6 +236,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **Typ:** Präsenz/synchron · **Modulhandbuch:** Nutzen/Risiken und Plattformanalyse · **Leitfrage:** Können Security- und Privacy-Agenten Befunde sicher beheben und mit unabhängiger Evidenz schließen?
 
+**MC-Test (30 Fragen):** Themen: Cloud-Sicherheit, Datenschutz, Observability und Resilienz · Keywords: IAM, Least Privilege, Secrets, Netzwerksegmentierung, Supply Chain, Tenant-Isolation, Session-Isolation, Verschlüsselung, Datenminimierung, Logs, Metriken, Traces, Alerting, Runbook, Redundanz, Graceful Degradation, Vulnerability Scan, Remediation, Negativtest, False Positive, Restrisiko
+
 ### UE 1 (0–45)
 
 - Security-Agent modelliert IAM, Least Privilege, Secrets, Netzwerkgrenzen, Supply Chain und Tenant-/Session-Isolation
@@ -243,6 +263,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 
 **Typ:** Tutorium · **Modulhandbuch:** Analyse etablierter Plattformen · **Leitfrage:** Welche technisch belegte Cloud-Option ist unter Kosten, Risiko und Exit wirtschaftlich vertretbar?
 
+**MC-Test (30 Fragen):** Themen: Providerentscheidung, FinOps, TCO, Unit Economics und 6R-Migration · Keywords: Rehost, Replatform, Repurchase, Refactor, Retire, Retain, TCO, Unit Economics, CapEx, OpEx, Personalaufwand, Support, Observability-Kosten, Compliance-Kosten, Egress, Build-or-Buy, Best Case, Base Case, Worst Case, Sensitivitätsanalyse, Lock-in, Exit, ADR
+
 ### UE 1 (0–45)
 
 - Economics-/FinOps-Agent prüft den GCP-/AWS-/Azure-Vergleich aus Termin 5 auf gleiche Systemgrenze und Leistungsbasis
@@ -266,6 +288,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 ## Termin 11: Referatswerkstatt
 
 **Typ:** Tutorium · **Prüfungsbezug:** Referat, 15 Minuten je Prüfling · **Leitfrage:** Wie bilden Einreichung, Vortrag und Diskussion gemeinsam eine akademisch belastbare Prüfungsleistung?
+
+**MC-Test (30 Fragen):** Themen: wissenschaftliche Argumentation, Referatsstruktur, Evidenz, Quellen, Visualisierung und Agentenoffenlegung · Keywords: Forschungsfrage, These, Argumentationslinie, Primärquelle, Quellenkritik, Fakt, Evidenz, Annahme, Entscheidung, Zitation, Literaturverzeichnis, Handout, Poster, Abbildung, individuelle Kennzeichnung, Agentenbeitrag, akademische Integrität, Zeitbudget, Einreichung, Vortrag, Diskussion, 30/30/40-Gewichtung
 
 ### UE 1 (0–45)
 
@@ -297,6 +321,8 @@ Das Agentic Cloud Engineering Dossier ist eine formative Arbeitsgrundlage für d
 ## Termin 12: Probeprüfung und Synthese
 
 **Typ:** Tutorium · **Prüfungsbezug:** Referat, 15 Minuten je Prüfling · **Leitfrage:** Deckt die individuelle Leistung das Modulziel ab und hält sie einer dialogischen Befragung stand?
+
+**MC-Test (30 Fragen):** Themen: kumulative Cloud-Computing-Synthese, Referatsverteidigung, Agentenkritik und Grenzen der Evidenz · Keywords: Cloud-Merkmale, Service-Modell, technologische Voraussetzung, Serverless, Google Cloud, AWS, Azure, Datenwissenschaft, maschinelles Lernen, Security, Datenschutz, Performance, Resilienz, FinOps, Evidenzstufe, Gültigkeitsgrenze, Restrisiko, Sensitivität, Agentenfehler, Quellenprüfung, Zeitmanagement, Diskussion, akademische Integrität
 
 ### UE 1 (0–45)
 


### PR DESCRIPTION
## Was geändert wurde

- Für jeden der zwölf Cloud-Computing-Termine sind Themen und Keywords für genau 30 MC-Test-Fragen dokumentiert.
- Der Lehrendenagent erzeugt daraus schema-konforme Items mit Lernziel, Thema, Schwierigkeit, kognitivem Niveau und Begründungen.
- Kurslandkarte, Lehrkonzept, Agentic-Lehrlabor, Präsenz-/Zoom-Konzept und Dozenten-Quickstart sind konsistent angepasst.

## Warum

MC-Test soll entsprechend dem EDULEARN26-Konzept nach jeder Sitzung zur Selbstüberprüfung des vermittelten Stoffes eingesetzt werden. MC-Test wird dabei nicht als zusätzliche Fallstudie behandelt.

## Auswirkungen

- Präsenz- und Zoom-Lauf erhalten denselben freigegebenen Fragensatz.
- MC-Test bleibt formativ und ist weder Prüfungsleistung noch Prüfungszulassung.
- Die Lehrperson prüft Lösungsschlüssel, Eindeutigkeit, Quellenbezug und unbeabsichtigte Lösungshinweise.

## Validierung

- alle 12 Termine besitzen genau einen Themen-/Keyword-Block für 30 Fragen
- git diff --check
- Commit-Hooks: Prettier, Typechecks und Tests aller Workspaces