### PR TITLE
fix(a11y): Absende-Bestätigung im Vote-Client für Screenreader

### DIFF
--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
@@ -1119,7 +1119,7 @@
           }
 
           @if (voteError()) {
-            <p class="vote-error" id="vote-error" role="alert">
+            <p class="vote-error" id="vote-error" role="alert" tabindex="-1">
               <mat-icon class="vote-error__icon" aria-hidden="true">warning</mat-icon>
               <span class="vote-error__text">{{ voteError() }}</span>
             </p>

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.html
@@ -1532,7 +1532,14 @@
 
           @if (voteSent()) {
             @if (isActive()) {
-              <div class="vote-sent" role="status" aria-live="polite">
+              <div
+                id="vote-sent"
+                class="vote-sent"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                tabindex="-1"
+              >
                 <mat-icon aria-hidden="true">check_circle</mat-icon>
                 <span class="vote-sent__copy">
                   <span class="vote-sent__title">{{ vpc.voteSentLabel(isPlayfulPreset()) }}</span>

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.scss
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.scss
@@ -1819,6 +1819,15 @@
   border: 1px solid color-mix(in srgb, var(--mat-sys-primary) 25%, transparent);
 }
 
+.vote-sent:focus {
+  outline: 2px solid var(--mat-sys-primary);
+  outline-offset: 2px;
+}
+
+.vote-sent:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .vote-sent > mat-icon {
   flex-shrink: 0;
   margin-top: 0.1rem;

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.spec.ts
@@ -2268,6 +2268,18 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
     voteSubmitMutateMock.mockRejectedValueOnce(new Error('Netzwerkfehler'));
 
     const fixture = TestBed.createComponent(SessionVoteComponent);
+    const scrollRoot = document.createElement('div');
+    scrollRoot.className = 'app-main';
+    Object.defineProperty(scrollRoot, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 640,
+    });
+    const scrollToSpy = vi.fn();
+    scrollRoot.scrollTo = scrollToSpy as unknown as typeof scrollRoot.scrollTo;
+    document.body.append(scrollRoot);
+    scrollRoot.append(fixture.nativeElement);
+
     fixture.detectChanges();
     await flushComponentAfterStable(fixture, 50);
 
@@ -2277,6 +2289,39 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
 
     const submitButton = fixture.nativeElement.querySelector('#vote-submit') as HTMLButtonElement;
     submitButton.focus();
+
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    const getBoundingClientRectSpy = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) {
+        if (this.id === 'vote-error') {
+          return {
+            x: 0,
+            y: -220,
+            top: -220,
+            bottom: -140,
+            left: 0,
+            right: 360,
+            width: 360,
+            height: 80,
+            toJSON: () => ({}),
+          } as DOMRect;
+        }
+        if (this === scrollRoot) {
+          return {
+            x: 0,
+            y: 0,
+            top: 0,
+            bottom: 700,
+            left: 0,
+            right: 390,
+            width: 390,
+            height: 700,
+            toJSON: () => ({}),
+          } as DOMRect;
+        }
+        return originalGetBoundingClientRect.call(this);
+      });
 
     await component.submitVote();
     fixture.detectChanges();
@@ -2289,7 +2334,17 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
     expect(error.textContent).toContain('Netzwerkfehler');
     expect(document.activeElement).toBe(error);
     expect(fixture.nativeElement.querySelector('#vote-submit')).not.toBeNull();
+    expect(scrollToSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        top: expect.any(Number),
+        behavior: expect.stringMatching(/^(auto|smooth)$/),
+      }),
+    );
+    const scrollArg = scrollToSpy.mock.calls[0]?.[0] as ScrollToOptions;
+    expect(scrollArg.top).toBeGreaterThanOrEqual(0);
 
+    getBoundingClientRectSpy.mockRestore();
+    scrollRoot.remove();
     fixture.destroy();
   });
 

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.spec.ts
@@ -2162,6 +2162,72 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
     fixture.destroy();
   });
 
+  it('kuendigt nach Absenden die Bestaetigung an und setzt den Fokus darauf', async () => {
+    getInfoQueryMock.mockResolvedValue({
+      id: '6a8edced-5f8f-4cfa-9176-454fac9570ad',
+      serverTime: MOCK_SERVER_TIME,
+      code: 'ABC123',
+      type: 'QUIZ',
+      status: 'ACTIVE',
+      quizName: 'Q',
+      title: null,
+      participantCount: 2,
+      teamMode: false,
+      enableRewardEffects: false,
+      preset: 'SERIOUS',
+      enableEmojiReactions: false,
+      channels: {
+        quiz: { enabled: true },
+        qa: { enabled: false, open: false, title: null, moderationMode: false },
+        quickFeedback: { enabled: false, open: false },
+      },
+    });
+    currentQuestionQueryMock.mockResolvedValue({
+      id: 'single-choice-sent-a11y',
+      text: 'Welche Antwort ist richtig?',
+      type: 'SINGLE_CHOICE',
+      difficulty: 'MEDIUM',
+      order: 0,
+      totalQuestions: 1,
+      answers: [
+        { id: 'a1', text: 'A', isCorrect: true },
+        { id: 'a2', text: 'B', isCorrect: false },
+      ],
+      activeAt: new Date().toISOString(),
+      timer: 30,
+      currentRound: 1,
+      totalVotes: 0,
+      participantCount: 2,
+    });
+    voteSubmitMutateMock.mockResolvedValue({ ok: true });
+
+    const fixture = TestBed.createComponent(SessionVoteComponent);
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+
+    const component = fixture.componentInstance;
+    component.toggleAnswer('a1');
+    fixture.detectChanges();
+
+    const submitButton = fixture.nativeElement.querySelector('#vote-submit') as HTMLButtonElement;
+    submitButton.focus();
+    expect(document.activeElement).toBe(submitButton);
+
+    await component.submitVote();
+    fixture.detectChanges();
+
+    const sent = fixture.nativeElement.querySelector('#vote-sent') as HTMLElement;
+    expect(sent).not.toBeNull();
+    expect(sent.getAttribute('role')).toBe('status');
+    expect(sent.getAttribute('aria-live')).toBe('polite');
+    expect(sent.getAttribute('aria-atomic')).toBe('true');
+    expect(sent.textContent).toContain('Antwort gesendet');
+    expect(document.activeElement).toBe(sent);
+    expect(fixture.nativeElement.querySelector('#vote-submit')).toBeNull();
+
+    fixture.destroy();
+  });
+
   it('sendet erst beim Click und nicht bereits beim Pointer-Down', async () => {
     getInfoQueryMock.mockResolvedValue({
       id: '6a8edced-5f8f-4cfa-9176-454fac9570ad',

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.spec.ts
@@ -2228,6 +2228,71 @@ describe('SessionVoteComponent', { timeout: 30_000 }, () => {
     fixture.destroy();
   });
 
+  it('fokussiert bei Submit-Fehler die Fehlermeldung und nicht die Erfolgsbestaetigung', async () => {
+    getInfoQueryMock.mockResolvedValue({
+      id: '6a8edced-5f8f-4cfa-9176-454fac9570ad',
+      serverTime: MOCK_SERVER_TIME,
+      code: 'ABC123',
+      type: 'QUIZ',
+      status: 'ACTIVE',
+      quizName: 'Q',
+      title: null,
+      participantCount: 2,
+      teamMode: false,
+      enableRewardEffects: false,
+      preset: 'SERIOUS',
+      enableEmojiReactions: false,
+      channels: {
+        quiz: { enabled: true },
+        qa: { enabled: false, open: false, title: null, moderationMode: false },
+        quickFeedback: { enabled: false, open: false },
+      },
+    });
+    currentQuestionQueryMock.mockResolvedValue({
+      id: 'single-choice-submit-error-a11y',
+      text: 'Welche Antwort ist richtig?',
+      type: 'SINGLE_CHOICE',
+      difficulty: 'MEDIUM',
+      order: 0,
+      totalQuestions: 1,
+      answers: [
+        { id: 'a1', text: 'A', isCorrect: true },
+        { id: 'a2', text: 'B', isCorrect: false },
+      ],
+      activeAt: new Date().toISOString(),
+      timer: 30,
+      currentRound: 1,
+      totalVotes: 0,
+      participantCount: 2,
+    });
+    voteSubmitMutateMock.mockRejectedValueOnce(new Error('Netzwerkfehler'));
+
+    const fixture = TestBed.createComponent(SessionVoteComponent);
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+
+    const component = fixture.componentInstance;
+    component.toggleAnswer('a1');
+    fixture.detectChanges();
+
+    const submitButton = fixture.nativeElement.querySelector('#vote-submit') as HTMLButtonElement;
+    submitButton.focus();
+
+    await component.submitVote();
+    fixture.detectChanges();
+
+    expect(component.voteSent()).toBe(false);
+    expect(fixture.nativeElement.querySelector('#vote-sent')).toBeNull();
+    const error = fixture.nativeElement.querySelector('#vote-error') as HTMLElement;
+    expect(error).not.toBeNull();
+    expect(error.getAttribute('role')).toBe('alert');
+    expect(error.textContent).toContain('Netzwerkfehler');
+    expect(document.activeElement).toBe(error);
+    expect(fixture.nativeElement.querySelector('#vote-submit')).not.toBeNull();
+
+    fixture.destroy();
+  });
+
   it('sendet erst beim Click und nicht bereits beim Pointer-Down', async () => {
     getInfoQueryMock.mockResolvedValue({
       id: '6a8edced-5f8f-4cfa-9176-454fac9570ad',

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
@@ -4294,32 +4294,35 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
    * aria-atomic liest Titel und Hinweis zusammen. Nur nach bestätigtem mutate aufrufen.
    */
   private focusVoteSentConfirmation(): void {
+    this.scrollAndFocusVoteStatusTarget('#vote-sent');
+  }
+
+  /**
+   * Nach fehlgeschlagenem Absenden Fokus auf die Alert-Fehlermeldung legen und
+   * sie in `.app-main` sichtbar scrollen (Floating-Submit liegt oft weit darunter).
+   */
+  private focusVoteError(): void {
+    this.scrollAndFocusVoteStatusTarget('#vote-error');
+  }
+
+  private scrollAndFocusVoteStatusTarget(selector: string): void {
     const host = this.el.nativeElement as HTMLElement;
-    const sent = host.querySelector('#vote-sent') as HTMLElement | null;
-    if (!sent) return;
-    this.ensureFocusable(sent);
+    const target = host.querySelector(selector) as HTMLElement | null;
+    if (!target) return;
+    this.ensureFocusable(target);
     const scrollRoot = host.closest('.app-main') as HTMLElement | null;
     if (scrollRoot) {
       const behavior = this.voteScrollBehavior();
       const rootRect = scrollRoot.getBoundingClientRect();
-      const sentRect = sent.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
       const toolbarClearancePx = parseFloat(getComputedStyle(scrollRoot).paddingTop) || 0;
       const gapPx = 8;
-      const y = sentRect.top - rootRect.top + scrollRoot.scrollTop - toolbarClearancePx - gapPx;
+      const y = targetRect.top - rootRect.top + scrollRoot.scrollTop - toolbarClearancePx - gapPx;
       scrollRoot.scrollTo({ top: Math.max(0, y), behavior });
-    } else if (typeof sent.scrollIntoView === 'function') {
-      sent.scrollIntoView({ behavior: this.voteScrollBehavior(), block: 'nearest' });
+    } else if (typeof target.scrollIntoView === 'function') {
+      target.scrollIntoView({ behavior: this.voteScrollBehavior(), block: 'nearest' });
     }
-    sent.focus({ preventScroll: true });
-  }
-
-  /** Nach fehlgeschlagenem Absenden Fokus auf die Alert-Fehlermeldung legen. */
-  private focusVoteError(): void {
-    const host = this.el.nativeElement as HTMLElement;
-    const error = host.querySelector('#vote-error') as HTMLElement | null;
-    if (!error) return;
-    this.ensureFocusable(error);
-    error.focus({ preventScroll: true });
+    target.focus({ preventScroll: true });
   }
 
   async sendEmoji(emoji: string): Promise<void> {

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
@@ -4244,6 +4244,7 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
     this.voteSent.set(true);
     this.stopScorePreviewTicker();
     this.cdr.detectChanges();
+    this.focusVoteSentConfirmation();
 
     try {
       await trpc.vote.submit.mutate({
@@ -4281,6 +4282,31 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
       this.voteSending.set(false);
       setTimeout(() => this.debounced.set(false), 300);
     }
+  }
+
+  /**
+   * Nach Absenden verschwindet der Floating-Submit (#vote-submit) — Fokus ginge sonst verloren
+   * und die Live-Region „Antwort gesendet“ würde von Screenreadern oft nicht angekündigt.
+   * Fokus + Scroll auf die sichtbare Bestätigung; aria-atomic liest Titel und Hinweis zusammen.
+   */
+  private focusVoteSentConfirmation(): void {
+    const host = this.el.nativeElement as HTMLElement;
+    const sent = host.querySelector('#vote-sent') as HTMLElement | null;
+    if (!sent) return;
+    this.ensureFocusable(sent);
+    const scrollRoot = host.closest('.app-main') as HTMLElement | null;
+    if (scrollRoot) {
+      const behavior = this.voteScrollBehavior();
+      const rootRect = scrollRoot.getBoundingClientRect();
+      const sentRect = sent.getBoundingClientRect();
+      const toolbarClearancePx = parseFloat(getComputedStyle(scrollRoot).paddingTop) || 0;
+      const gapPx = 8;
+      const y = sentRect.top - rootRect.top + scrollRoot.scrollTop - toolbarClearancePx - gapPx;
+      scrollRoot.scrollTo({ top: Math.max(0, y), behavior });
+    } else if (typeof sent.scrollIntoView === 'function') {
+      sent.scrollIntoView({ behavior: this.voteScrollBehavior(), block: 'nearest' });
+    }
+    sent.focus({ preventScroll: true });
   }
 
   async sendEmoji(emoji: string): Promise<void> {

--- a/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
+++ b/apps/frontend/src/app/features/session/session-vote/session-vote.component.ts
@@ -1165,7 +1165,7 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
     return s !== null && s <= 0;
   });
   readonly voteInteractionLocked = computed(
-    () => this.voteSent() || this.timerExpired() || this.voteClosed(),
+    () => this.voteSent() || this.voteSending() || this.timerExpired() || this.voteClosed(),
   );
   readonly voteSubmissionLocked = computed(() => this.voteSent() || this.voteClosed());
 
@@ -4241,10 +4241,8 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
     this.voteError.set(null);
     this.timeoutMessage.set(null);
     this.clearLateSubmitCloseTimeout();
-    this.voteSent.set(true);
     this.stopScorePreviewTicker();
     this.cdr.detectChanges();
-    this.focusVoteSentConfirmation();
 
     try {
       await trpc.vote.submit.mutate({
@@ -4258,12 +4256,15 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
         confidenceValue: confidence,
         round: this.currentRound(),
       });
+      this.voteSent.set(true);
       this.storeVoteResponse(q, answerIds, freeText, rating, numericValue, confidence);
       try {
         navigator.vibrate?.(10);
       } catch {
         /* unsupported */
       }
+      this.cdr.detectChanges();
+      this.focusVoteSentConfirmation();
     } catch (err: unknown) {
       const localizedError = localizeKnownServerError(err, 'Abstimmung fehlgeschlagen.');
       const voteClosedByServer = isClosedVoteServerMessage(localizedError);
@@ -4278,6 +4279,8 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
       } else if (!overrideIds) {
         this.selectedAnswerIds.set(new Set());
       }
+      this.cdr.detectChanges();
+      this.focusVoteError();
     } finally {
       this.voteSending.set(false);
       setTimeout(() => this.debounced.set(false), 300);
@@ -4285,9 +4288,10 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Nach Absenden verschwindet der Floating-Submit (#vote-submit) — Fokus ginge sonst verloren
-   * und die Live-Region „Antwort gesendet“ würde von Screenreadern oft nicht angekündigt.
-   * Fokus + Scroll auf die sichtbare Bestätigung; aria-atomic liest Titel und Hinweis zusammen.
+   * Nach erfolgreichem Absenden verschwindet der Floating-Submit (#vote-submit) —
+   * Fokus ginge sonst verloren und die Live-Region „Antwort gesendet“ würde von
+   * Screenreadern oft nicht angekündigt. Fokus + Scroll auf die sichtbare Bestätigung;
+   * aria-atomic liest Titel und Hinweis zusammen. Nur nach bestätigtem mutate aufrufen.
    */
   private focusVoteSentConfirmation(): void {
     const host = this.el.nativeElement as HTMLElement;
@@ -4307,6 +4311,15 @@ export class SessionVoteComponent implements OnInit, OnDestroy {
       sent.scrollIntoView({ behavior: this.voteScrollBehavior(), block: 'nearest' });
     }
     sent.focus({ preventScroll: true });
+  }
+
+  /** Nach fehlgeschlagenem Absenden Fokus auf die Alert-Fehlermeldung legen. */
+  private focusVoteError(): void {
+    const host = this.el.nativeElement as HTMLElement;
+    const error = host.querySelector('#vote-error') as HTMLElement | null;
+    if (!error) return;
+    this.ensureFocusable(error);
+    error.focus({ preventScroll: true });
   }
 
   async sendEmoji(emoji: string): Promise<void> {


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Nach dem Absenden einer Antwort verschwand der Floating-Submit-Button und damit der Tastaturfokus; die sichtbare Bestätigung „Antwort gesendet“ wurde von Screenreadern oft nicht angekündigt.
- **Lösung:** `#vote-sent` mit `aria-atomic="true"`, Fokus und Scroll dorthin erst nach erfolgreichem `vote.submit`; bei Fehlern Fokus auf `#vote-error` ohne falsche Erfolgsansage; Submit bleibt während der Übertragung disabled/pending.
- **Bewusste Nicht-Ziele:** Keine Änderungen an Scoring, Host-Logik, Token-Checks oder Backend-Verträgen; keine neuen i18n-Keys außerhalb der bestehenden Vote-Texte.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

WCAG 2.2 AA Fokus/Ankündigung; Teilnehmer-Payloads ohne Lösungsdaten; Fokus nur nach bestätigtem Mutate-Ergebnis (Erfolg → `#vote-sent`, Fehler → `#vote-error`).

**Betroffene externe Verträge:**

Keine. Nur Frontend-Vote-UI (ARIA/Fokus/Scroll).

## Implementierung

- `.vote-sent` erhält stabile `id`, `tabindex="-1"` und `aria-atomic="true"`.
- Nach erfolgreichem Submit: `scrollAndFocusVoteStatusTarget('#vote-sent')`.
- Bei Submit-Fehler: entsprechender Fokus auf `#vote-error`.
- Unit-Tests für Erfolgs- und Reject-Pfad ergänzt bzw. aktualisiert.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [ ] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run test -w @arsnova/frontend` (lokal/CI, Vote-Specs) | bestanden (`kuendigt nach Absenden`, `fokussiert bei Submit-Fehler`) |
| CI Build & Validate / Typecheck auf Branch | grün bzw. in Lauf |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Geändertes Fokus-/Ankündigungsverhalten im Teilnehmer-Vote-Client nach Absenden.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine; normaler Frontend-Deploy.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Metriken; bei Regressionen Fokusverlust nach Submit bzw. fehlende Screenreader-Ansage.
- **Rollback:** PR revertieren / vorherigen Frontend-Stand deployen.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Unit-Tests in `session-vote.component.spec.ts` (Erfolg + Reject)
- CI-Lauf dieses PRs nach Template-Update

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Keine Backend-/Schema-/Migrations-/Realtime-/Laständerungen. Manuelle Screenreader-Prüfung im echten Gerät/Browser steht noch aus (CI deckt DOM-Fokus ab). Prod-Build nicht separat lokal wiederholt, sofern CI ihn ausführt.
- **Verbleibende Risiken:** Vollständige Screenreader-Ansage hängt von AT/Browser ab; Unit-Tests prüfen Fokusziel und Sichtbarkeit, nicht VoiceOver/NVDA-Ausgabe.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
