### PR TITLE
fix(ci): MOTD-Dismiss-Flake in a11y:layout

### DIFF
--- a/apps/frontend/scripts/check-a11y-static.mjs
+++ b/apps/frontend/scripts/check-a11y-static.mjs
@@ -41,11 +41,16 @@ async function dismissOptionalOverlay(page) {
   // Nur echte Startseiten-Overlays schließen — nicht Content-Pages (Hilfe/Legal/News),
   // die ebenfalls role=dialog nutzen; deren „Zurück“ würde history.back() auf about:blank auslösen.
   const closeButton = page
-    .locator('.home-motd-sheet button[aria-label], .preset-toast button[aria-label]')
+    .locator(
+      '.home-motd-sheet__head button[aria-label], .home-motd-sheet button[aria-label="Meldung schließen"], .preset-toast button[aria-label]',
+    )
     .first();
   if (await closeButton.isVisible().catch(() => false)) {
     await closeButton.click();
-    await page.waitForTimeout(200);
+    await page
+      .locator('.home-motd-sheet')
+      .waitFor({ state: 'hidden', timeout: 5_000 })
+      .catch(() => undefined);
   }
 }
 

--- a/apps/frontend/scripts/check-viewport-320.mjs
+++ b/apps/frontend/scripts/check-viewport-320.mjs
@@ -44,13 +44,21 @@ async function dismissOptionalOverlay(page, waitForMotd = false) {
         { timeout: 3_000 },
       )
       .catch(() => undefined);
+    // Idle-MOTD kann nach getCurrent noch kurz verzögert gerendert werden.
+    await page
+      .locator('.home-motd-sheet')
+      .waitFor({ state: 'visible', timeout: 2_500 })
+      .catch(() => undefined);
   }
-  // Nur MOTD schließen — Content-Pages (Hilfe/Legal/News) sind ebenfalls role=dialog;
-  // deren Zurück-Button darf hier nicht history.back() auf about:blank auslösen.
-  const closeButton = page.locator('.home-motd-sheet button[aria-label]').first();
+  // Nur MOTD-Schließen — nicht Thumb-Buttons und nicht Content-Page-Dialoge.
+  const closeButton = page
+    .locator(
+      '.home-motd-sheet__head button[aria-label], .home-motd-sheet button[aria-label="Meldung schließen"]',
+    )
+    .first();
   if (await closeButton.isVisible().catch(() => false)) {
     await closeButton.click();
-    await page.locator('.home-motd-sheet').waitFor({ state: 'hidden', timeout: 1_000 });
+    await page.locator('.home-motd-sheet').waitFor({ state: 'hidden', timeout: 5_000 });
   }
 }
 

--- a/apps/frontend/src/app/features/home/home.component.spec.ts
+++ b/apps/frontend/src/app/features/home/home.component.spec.ts
@@ -1142,6 +1142,38 @@ describe('HomeComponent', () => {
       expect(comp.motd()).toBeNull();
     });
 
+    it('schließt das MOTD-Overlay sofort, auch wenn recordInteraction noch hängt', async () => {
+      const { trpc } = await import('../../core/trpc.client');
+      let resolveRecord!: (value: { ok: boolean }) => void;
+      vi.mocked(trpc.motd.recordInteraction.mutate).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRecord = resolve;
+          }),
+      );
+
+      const fixture = createHomeFixture();
+      const comp = fixture.componentInstance;
+      comp.motd.set({
+        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        contentVersion: 7,
+        markdown: 'Meldung',
+        endsAt: '2099-12-31T12:00:00.000Z',
+      });
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('.home-motd-sheet')).not.toBeNull();
+
+      const dismissPromise = comp.dismissMotdOverlay('DISMISS_CLOSE');
+      await Promise.resolve();
+      fixture.detectChanges();
+
+      expect(comp.motd()).toBeNull();
+      expect(fixture.nativeElement.querySelector('.home-motd-sheet')).toBeNull();
+
+      resolveRecord({ ok: true });
+      await dismissPromise;
+    });
+
     it('unterdrückt MOTD-Overlay nach Locale-Reload (Sprachwechsel)', async () => {
       const { trpc } = await import('../../core/trpc.client');
       const { markMotdOverlayReloadSuppress } = await import('../../core/motd-storage');

--- a/apps/frontend/src/app/features/home/home.component.ts
+++ b/apps/frontend/src/app/features/home/home.component.ts
@@ -1022,19 +1022,21 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   ): Promise<void> {
     const m = this.motd();
     if (!m) return;
-    await this.tryRecordMotdInteraction(kind);
+    // Overlay sofort schließen — recordInteraction darf die UI nicht blockieren
+    // (sonst flake in a11y:layout bei langsamem CI / >1s API).
     markMotdDismissed(m.id, m.contentVersion);
     this.clearMotdOverlay();
     this.motdCurrent.invalidate();
+    await this.tryRecordMotdInteractionFor(m.id, m.contentVersion, kind);
   }
 
   async ackMotd(): Promise<void> {
     const m = this.motd();
     if (!m) return;
-    await this.tryRecordMotdInteraction('ACK');
     markMotdDismissed(m.id, m.contentVersion);
     this.clearMotdOverlay();
     this.motdCurrent.invalidate();
+    await this.tryRecordMotdInteractionFor(m.id, m.contentVersion, 'ACK');
   }
 
   async thumbMotd(up: boolean): Promise<void> {
@@ -1096,14 +1098,22 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   private async tryRecordMotdInteraction(kind: MotdInteractionKind): Promise<void> {
     const m = this.motd();
     if (!m) return;
-    if (hasMotdInteractionRecorded(m.id, m.contentVersion, kind)) return;
+    await this.tryRecordMotdInteractionFor(m.id, m.contentVersion, kind);
+  }
+
+  private async tryRecordMotdInteractionFor(
+    motdId: string,
+    contentVersion: number,
+    kind: MotdInteractionKind,
+  ): Promise<void> {
+    if (hasMotdInteractionRecorded(motdId, contentVersion, kind)) return;
     try {
       await trpc.motd.recordInteraction.mutate({
-        motdId: m.id,
-        contentVersion: m.contentVersion,
+        motdId,
+        contentVersion,
         kind,
       });
-      markMotdInteractionRecorded(m.id, m.contentVersion, kind);
+      markMotdInteractionRecorded(motdId, contentVersion, kind);
       this.motdInteractionRev.update((n) => n + 1);
     } catch {
       /* optional: still allow dismiss */


### PR DESCRIPTION
## Summary
- Main-CI (#183) flakte in Playwright Smoke: `a11y:layout` timeout beim Warten auf verstecktes `.home-motd-sheet` nach Klick auf Schließen.
- Ursache: `dismissMotdOverlay`/`ackMotd` warteten auf `motd.recordInteraction`, bevor das Overlay aus dem DOM entfernt wurde; bei >1 s API-Latenz schlug der Smoke fehl.
- Fix: Overlay sofort schließen, Interaction asynchron nachmelden; Smoke-Selector auf den Kopf-Schließen-Button + längerer Hidden-Timeout.

## Test plan
- [x] Unit: Overlay verschwindet, während `recordInteraction` noch pending ist
- [ ] CI: Playwright Smoke E2E / `a11y:layout` auf diesem Branch
- [ ] Manuell: MOTD schließen bleibt sofortig, Interaction wird weiterhin gesendet


Made with [Cursor](https://cursor.com)