### PR TITLE
fix(ci): Vote-Timer-Fairness mit kontrolliertem Dispatcher und Karenz-Rest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1313,7 +1313,9 @@ jobs:
 
           run_status=0
           # Timer-Fairness zuerst (frisches Backend); Runner-Latenzgates lockerer als lokal (1000/2000 ms).
-          REPORT_FILE="$REPORT_DIR/vote-timer-fairness-600.json" JUNIT_FILE="$REPORT_DIR/vote-timer-fairness-600.junit.xml" VOTE_P95_LIMIT_MS=3000 VOTE_P99_LIMIT_MS=3000 PARTICIPANTS=600 npm run load:smoke:vote-timer-fairness || run_status=$?
+          # VOTE_HTTP_CONNECTIONS=600: Default-Fetch-Pool serialisiert sonst den Karenz-Burst und
+          # laesst spaete Requests ausserhalb der echten 2s-Backend-Karenz ankommen.
+          REPORT_FILE="$REPORT_DIR/vote-timer-fairness-600.json" JUNIT_FILE="$REPORT_DIR/vote-timer-fairness-600.junit.xml" VOTE_P95_LIMIT_MS=3000 VOTE_P99_LIMIT_MS=3000 VOTE_HTTP_CONNECTIONS=600 WITHIN_GRACE_REVEAL_OFFSET_MS=0 PARTICIPANTS=600 npm run load:smoke:vote-timer-fairness || run_status=$?
           REPORT_FILE="$REPORT_DIR/host-vote-progress-200.json" JUNIT_FILE="$REPORT_DIR/host-vote-progress-200.junit.xml" VOTE_P95_LIMIT_MS=2000 PARTICIPANTS=200 npm run load:smoke:host-vote-progress || run_status=$?
           REPORT_FILE="$REPORT_DIR/summary.json" JUNIT_FILE="$REPORT_DIR/summary.junit.xml" npm run load:artillery:500 || run_status=$?
           REPORT_FILE="$REPORT_DIR/yjs-sync.json" JUNIT_FILE="$REPORT_DIR/yjs-sync.junit.xml" CLIENTS=30 npm run load:yjs:sync || run_status=$?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1313,8 +1313,8 @@ jobs:
 
           run_status=0
           # Timer-Fairness zuerst (frisches Backend); Runner-Latenzgates lockerer als lokal (1000/2000 ms).
-          # VOTE_HTTP_CONNECTIONS=600: Default-Fetch-Pool serialisiert sonst den Karenz-Burst und
-          # laesst spaete Requests ausserhalb der echten 2s-Backend-Karenz ankommen.
+          # Eigener Undici-Dispatcher (VOTE_HTTP_CONNECTIONS=600) und WITHIN_GRACE_REVEAL_OFFSET_MS=0
+          # fuer kontrollierten Burst bzw. maximalen Karenz-Rest auf dem lokalen Runner.
           REPORT_FILE="$REPORT_DIR/vote-timer-fairness-600.json" JUNIT_FILE="$REPORT_DIR/vote-timer-fairness-600.junit.xml" VOTE_P95_LIMIT_MS=3000 VOTE_P99_LIMIT_MS=3000 VOTE_HTTP_CONNECTIONS=600 WITHIN_GRACE_REVEAL_OFFSET_MS=0 PARTICIPANTS=600 npm run load:smoke:vote-timer-fairness || run_status=$?
           REPORT_FILE="$REPORT_DIR/host-vote-progress-200.json" JUNIT_FILE="$REPORT_DIR/host-vote-progress-200.junit.xml" VOTE_P95_LIMIT_MS=2000 PARTICIPANTS=200 npm run load:smoke:host-vote-progress || run_status=$?
           REPORT_FILE="$REPORT_DIR/summary.json" JUNIT_FILE="$REPORT_DIR/summary.junit.xml" npm run load:artillery:500 || run_status=$?

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -487,11 +487,12 @@ PARTICIPANTS=600 TIMER_SECONDS=8 TRPC_URL=http://127.0.0.1:3000/trpc npm run loa
 ```
 
 Für den parallelen 600er-Burst setzt der Smoke intern einen Undici-Agent mit
-`VOTE_HTTP_CONNECTIONS` (Default: `PARTICIPANTS`) und startet die Karenz-Freigabe mit
-`WITHIN_GRACE_REVEAL_OFFSET_MS=0`. Ohne ausreichend viele HTTP-Verbindungen serialisiert der
-Node-Default-Fetch-Pool den Burst; Requests kommen dann erst nach Ablauf der echten
-2‑Sekunden-Backend-Karenz an und der Smoke scheitert flaky trotz korrekter Serverlogik.
-In CI bleiben die Latenzgates bei `VOTE_P95_LIMIT_MS=3000` / `VOTE_P99_LIMIT_MS=3000`.
+`VOTE_HTTP_CONNECTIONS` (Default: `PARTICIPANTS`). Der Default-Reveal-Offset beträgt
+`WITHIN_GRACE_REVEAL_OFFSET_MS=100` (Clock-Skew-Puffer für Remote-Ziele); in CI wird er auf
+`0` gesetzt, damit der Burst maximalen Karenz-Rest auf dem lokalen Runner erhält.
+`undici` ist als Root-`devDependency` deklariert, damit `npm ci` den Import nicht nur über
+transitives Hoisting auflöst. In CI bleiben die Latenzgates bei
+`VOTE_P95_LIMIT_MS=3000` / `VOTE_P99_LIMIT_MS=3000`.
 
 Der Smoke ergänzt den Host-Progress-Smoke: Er misst nicht den WebSocket-Fan-out, sondern den
 serverseitigen Vote-Hotpath rund um Timerende, Karenz und Ergebnisfreigabe.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -486,13 +486,15 @@ Wichtige Parameter:
 PARTICIPANTS=600 TIMER_SECONDS=8 TRPC_URL=http://127.0.0.1:3000/trpc npm run load:smoke:vote-timer-fairness
 ```
 
-Für den parallelen 600er-Burst setzt der Smoke intern einen Undici-Agent mit
+Für den parallelen 600er-Burst setzt der Smoke einen eigenen Undici-Dispatcher mit
 `VOTE_HTTP_CONNECTIONS` (Default: `PARTICIPANTS`). Der Default-Reveal-Offset beträgt
 `WITHIN_GRACE_REVEAL_OFFSET_MS=100` (Clock-Skew-Puffer für Remote-Ziele); in CI wird er auf
 `0` gesetzt, damit der Burst maximalen Karenz-Rest auf dem lokalen Runner erhält.
 `undici` ist als Root-`devDependency` deklariert, damit `npm ci` den Import nicht nur über
 transitives Hoisting auflöst. In CI bleiben die Latenzgates bei
-`VOTE_P95_LIMIT_MS=3000` / `VOTE_P99_LIMIT_MS=3000`.
+`VOTE_P95_LIMIT_MS=3000` / `VOTE_P99_LIMIT_MS=3000`. Der erfolgreiche CI-Lauf belegt die
+Gesamtkonfiguration; ein verbleibendes Runner-/Backend-Timing-Flake-Risiko im engen
+2‑Sekunden-Karenzfenster bleibt bestehen.
 
 Der Smoke ergänzt den Host-Progress-Smoke: Er misst nicht den WebSocket-Fan-out, sondern den
 serverseitigen Vote-Hotpath rund um Timerende, Karenz und Ergebnisfreigabe.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -486,6 +486,13 @@ Wichtige Parameter:
 PARTICIPANTS=600 TIMER_SECONDS=8 TRPC_URL=http://127.0.0.1:3000/trpc npm run load:smoke:vote-timer-fairness
 ```
 
+Für den parallelen 600er-Burst setzt der Smoke intern einen Undici-Agent mit
+`VOTE_HTTP_CONNECTIONS` (Default: `PARTICIPANTS`) und startet die Karenz-Freigabe mit
+`WITHIN_GRACE_REVEAL_OFFSET_MS=0`. Ohne ausreichend viele HTTP-Verbindungen serialisiert der
+Node-Default-Fetch-Pool den Burst; Requests kommen dann erst nach Ablauf der echten
+2‑Sekunden-Backend-Karenz an und der Smoke scheitert flaky trotz korrekter Serverlogik.
+In CI bleiben die Latenzgates bei `VOTE_P95_LIMIT_MS=3000` / `VOTE_P99_LIMIT_MS=3000`.
+
 Der Smoke ergänzt den Host-Progress-Smoke: Er misst nicht den WebSocket-Fan-out, sondern den
 serverseitigen Vote-Hotpath rund um Timerende, Karenz und Ergebnisfreigabe.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
         "lint-staged": "^17.0.8",
         "prettier": "^3.2.0",
         "typescript": "~5.9.0",
-        "typescript-eslint": "^8.56.0"
+        "typescript-eslint": "^8.56.0",
+        "undici": "^7.29.0"
       },
       "engines": {
         "node": ">=22.12.0 <23 || >=24.0.0 <25"
@@ -1266,6 +1267,16 @@
         "vitest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/build/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@angular/cdk": {
@@ -28409,9 +28420,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "lint-staged": "^17.0.8",
     "prettier": "^3.2.0",
     "typescript": "~5.9.0",
-    "typescript-eslint": "^8.56.0"
+    "typescript-eslint": "^8.56.0",
+    "undici": "^7.29.0"
   },
   "dependencies": {
     "@prisma/client": "^7.9.0",

--- a/scripts/load/run-security-acceptance.mjs
+++ b/scripts/load/run-security-acceptance.mjs
@@ -247,6 +247,7 @@ function runnerEnvironment(id, slos, target) {
         PARTICIPANTS: '500',
         TIMER_SECONDS: '8',
         JOIN_CONCURRENCY: '60',
+        VOTE_HTTP_CONNECTIONS: '500',
         GRACE_MS: '2000',
         WITHIN_GRACE_REVEAL_OFFSET_MS: '100',
         OUTSIDE_GRACE_REVEAL_OFFSET_MS: '2300',

--- a/scripts/load/vote-timer-fairness-600.mjs
+++ b/scripts/load/vote-timer-fairness-600.mjs
@@ -14,6 +14,9 @@
  *
  * Optional:
  *   VOTE_HTTP_CONNECTIONS=600 WITHIN_GRACE_REVEAL_OFFSET_MS=0
+ *
+ * Nutzt einen eigenen Undici-Dispatcher fuer den Burst. CI setzt Offset 0 fuer
+ * maximalen Karenz-Rest auf dem lokalen Runner; ein Timing-Flake-Risiko bleibt.
  */
 import { Agent, fetch as undiciFetch } from 'undici';
 import { waitForBackend } from './lib/wait-for-backend.mjs';

--- a/scripts/load/vote-timer-fairness-600.mjs
+++ b/scripts/load/vote-timer-fairness-600.mjs
@@ -40,11 +40,11 @@ const VOTE_HTTP_CONNECTIONS = Math.max(
 const VOTE_P95_LIMIT_MS = Math.max(100, Number(process.env.VOTE_P95_LIMIT_MS || 1_000));
 const VOTE_P99_LIMIT_MS = Math.max(100, Number(process.env.VOTE_P99_LIMIT_MS || 2_000));
 const GRACE_MS = Math.max(0, Number(process.env.GRACE_MS || 2_000));
-// Reveal unmittelbar nach Deadline, damit der 600er-Burst noch im 2s-Karenzfenster
-// serverseitig ankommt (Runner-Default-Fetch-Pool sonst serialisiert zu spaet).
+// Kleiner Offset schuetzt Remote-Laeufe mit Clock-Skew; CI setzt 0 fuer maximalen
+// Karenz-Rest nach der Freigabe auf dem lokalen Runner.
 const WITHIN_GRACE_REVEAL_OFFSET_MS = Math.max(
   0,
-  Number(process.env.WITHIN_GRACE_REVEAL_OFFSET_MS || 0),
+  Number(process.env.WITHIN_GRACE_REVEAL_OFFSET_MS || 100),
 );
 const OUTSIDE_GRACE_REVEAL_OFFSET_MS = Math.max(
   GRACE_MS + 1,

--- a/scripts/load/vote-timer-fairness-600.mjs
+++ b/scripts/load/vote-timer-fairness-600.mjs
@@ -11,7 +11,11 @@
  * Run:
  *   node scripts/load/vote-timer-fairness-600.mjs
  *   PARTICIPANTS=600 TIMER_SECONDS=8 TRPC_URL=http://127.0.0.1:3000/trpc node scripts/load/vote-timer-fairness-600.mjs
+ *
+ * Optional:
+ *   VOTE_HTTP_CONNECTIONS=600 WITHIN_GRACE_REVEAL_OFFSET_MS=0
  */
+import { Agent, fetch as undiciFetch } from 'undici';
 import { waitForBackend } from './lib/wait-for-backend.mjs';
 import { writeScenarioReport } from './lib/reporting.mjs';
 import { summarizeDurations, violatesExclusiveUpperBound } from './lib/percentiles.mjs';
@@ -29,12 +33,18 @@ const TRPC_URL = String(process.env.TRPC_URL || 'http://127.0.0.1:3000/trpc').tr
 const PARTICIPANTS = Math.max(1, Number(process.env.PARTICIPANTS || 600));
 const TIMER_SECONDS = Math.max(2, Number(process.env.TIMER_SECONDS || 8));
 const JOIN_CONCURRENCY = Math.max(1, Number(process.env.JOIN_CONCURRENCY || 60));
+const VOTE_HTTP_CONNECTIONS = Math.max(
+  1,
+  Number(process.env.VOTE_HTTP_CONNECTIONS || PARTICIPANTS),
+);
 const VOTE_P95_LIMIT_MS = Math.max(100, Number(process.env.VOTE_P95_LIMIT_MS || 1_000));
 const VOTE_P99_LIMIT_MS = Math.max(100, Number(process.env.VOTE_P99_LIMIT_MS || 2_000));
 const GRACE_MS = Math.max(0, Number(process.env.GRACE_MS || 2_000));
+// Reveal unmittelbar nach Deadline, damit der 600er-Burst noch im 2s-Karenzfenster
+// serverseitig ankommt (Runner-Default-Fetch-Pool sonst serialisiert zu spaet).
 const WITHIN_GRACE_REVEAL_OFFSET_MS = Math.max(
   0,
-  Number(process.env.WITHIN_GRACE_REVEAL_OFFSET_MS || 100),
+  Number(process.env.WITHIN_GRACE_REVEAL_OFFSET_MS || 0),
 );
 const OUTSIDE_GRACE_REVEAL_OFFSET_MS = Math.max(
   GRACE_MS + 1,
@@ -42,12 +52,22 @@ const OUTSIDE_GRACE_REVEAL_OFFSET_MS = Math.max(
 );
 const SETTLE_AFTER_VOTES_MS = Math.max(0, Number(process.env.SETTLE_AFTER_VOTES_MS || 500));
 
+const httpAgent = new Agent({
+  connections: VOTE_HTTP_CONNECTIONS,
+  pipelining: 1,
+  keepAliveTimeout: 10_000,
+  keepAliveMaxTimeout: 10_000,
+});
+
 function createHttpClient(hostToken) {
   return createTRPCProxyClient({
     links: [
       httpLink({
         url: TRPC_URL,
         headers: hostToken ? () => ({ 'x-host-token': hostToken }) : undefined,
+        fetch(url, init) {
+          return undiciFetch(url, { ...init, dispatcher: httpAgent });
+        },
       }),
     ],
   });
@@ -298,6 +318,7 @@ async function run() {
     participants: PARTICIPANTS,
     timerSeconds: TIMER_SECONDS,
     graceMs: GRACE_MS,
+    voteHttpConnections: VOTE_HTTP_CONNECTIONS,
     withinGraceRevealOffsetMs: WITHIN_GRACE_REVEAL_OFFSET_MS,
     outsideGraceRevealOffsetMs: OUTSIDE_GRACE_REVEAL_OFFSET_MS,
     scenarios,
@@ -361,6 +382,8 @@ async function run() {
       participants: PARTICIPANTS,
       timerSeconds: TIMER_SECONDS,
       graceMs: GRACE_MS,
+      voteHttpConnections: VOTE_HTTP_CONNECTIONS,
+      withinGraceRevealOffsetMs: WITHIN_GRACE_REVEAL_OFFSET_MS,
       voteP95LimitMs: VOTE_P95_LIMIT_MS,
       voteP99LimitMs: VOTE_P99_LIMIT_MS,
     },
@@ -380,7 +403,9 @@ async function run() {
   console.log('\nOK Vote-Timer-Fairness-Last-Smoke bestanden.');
 }
 
-run().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+run()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => httpAgent.close().catch(() => undefined));


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Der Nightly-Job `Artillery 500 Live Session` scheiterte wiederholt am vorgelagerten Smoke `vote-timer-fairness-600`: im Karenz-Szenario wurden nur ~560–570/600 Votes akzeptiert, obwohl Artillery-500, Yjs, Wordcloud und Soak anschließend grün waren. Die 2s-Backend-Karenz und das bereits auf 3000 ms gelockerte p95-Gate waren nicht der Fehler; der CI-Burst brauchte eine kontrolliertere Client-Konfiguration, und `undici` hing nur am transitiven Hoisting.
- **Lösung:** Der Smoke nutzt einen als Root-`devDependency` deklarierten eigenen Undici-Dispatcher mit `VOTE_HTTP_CONNECTIONS` (CI: 600). CI setzt `WITHIN_GRACE_REVEAL_OFFSET_MS=0` für maximalen Karenz-Rest auf dem lokalen Runner; der Script-Default bleibt 100 ms als Clock-Skew-Puffer für Remote-Ziele. Die formale Abnahme pinnt `VOTE_HTTP_CONNECTIONS=500`. Nachweislauf per `workflow_dispatch` auf diesem Head. Die frühere Behauptung einer Default-Fetch-Pool-Serialisierung wird nicht aufrechterhalten.
- **Bewusste Nicht-Ziele:** Keine Verlängerung der Produktions-Karenz, keine Aufweichung von `accepted === 600`, keine weiteren p95-Limit-Erhöhungen.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

`apps/backend/src/routers/vote.ts` (2s-Timer-Karenz nach Deadline; RESULTS-Late-Votes nur bei Freigabe nach Deadline). Load-Smoke-Vertrag in `docs/TESTING.md`: ACTIVE 600/600, Karenz 600/600, außerhalb Karenz 0/600.

**Betroffene externe Verträge:**

Keine. Nur CI-/Load-Smoke-Clientverhalten (eigener Undici-Dispatcher) und Root-`devDependency`.

## Implementierung

- `scripts/load/vote-timer-fairness-600.mjs`: Undici-Agent; Default-Reveal-Offset 100 ms; Report-Felder für Connections/Offset.
- `.github/workflows/ci.yml`: `VOTE_HTTP_CONNECTIONS=600`, `WITHIN_GRACE_REVEAL_OFFSET_MS=0`.
- `package.json` / Lockfile: `undici` als Root-`devDependency`.
- `scripts/load/run-security-acceptance.mjs`: `VOTE_HTTP_CONNECTIONS=500` für `vote-burst-500` gepinnt.
- `docs/TESTING.md`: Flake-Hintergrund und Parameter dokumentiert.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [x] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [x] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [ ] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` (pre-commit) | bestanden |
| `npm test` (pre-commit) | bestanden (shared-types, session-export-report, backend, frontend) |
| `npx prettier --check` für geänderte Dateien | bestanden |
| `workflow_dispatch` CI auf `1817e376` (`Artillery 500 Live Session`) | bestanden: https://github.com/kqc-real/arsnova.eu/actions/runs/30686721017/job/91333891304 — ACTIVE 600/600 (p95 1621 / p99 1685), Karenz 600/600 (p95 2171 / p99 2179), außerhalb 0/600; Gates 3000 ms |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

Nachweis Last-Smoke: manueller `workflow_dispatch`-Lauf auf diesem Head; die fachliche Karenz bleibt 2 s. Separates erneutes Hochsetzen von Latenzlimits wurde bewusst vermieden.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Keine. Nur CI-/Load-Smoke-Client, Root-`devDependency` und Doku.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Manual-/Nightly-Job `Artillery 500 Live Session`; Reportfelder `voteHttpConnections`, `withinGraceRevealOffsetMs`.
- **Rollback:** PR revert; alter Smoke, Workflow-Zeile und Dependency wiederherstellen.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Flaky Nightly: https://github.com/kqc-real/arsnova.eu/actions/runs/30677883447/job/91308722740 (`Karenz akzeptierte 561/600`; Artillery-500 selbst OK)
- Nachweislauf auf diesem Head (`workflow_dispatch`): https://github.com/kqc-real/arsnova.eu/actions/runs/30686721017/job/91333891304 — Vote-Timer-Fairness OK (600/600/0), Artillery-500 OK
- Nightly-Rerun des alten Commits war zwischenzeitlich grün (Flake bestätigt), ersetzt aber nicht den Branch-Nachweis

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Lint und `build:prod` sind für Load-Script-/Workflow-/Dependency-/Docs-Änderung nicht maßgebend; Pre-commit hat Typecheck und Unit-Tests ausgeführt. Separater lokaler Backend-600er-Smoke entfällt zugunsten des CI-`workflow_dispatch`.
- **Verbleibende Risiken:** Der erfolgreiche Branch-Lauf belegt die Gesamtkonfiguration, nicht die kausale Überlegenheit eines eigenen Agents gegenüber Default-`fetch`. Bei engem 2s-Karenzfenster und Runner-/Backend-Jitter kann der Smoke erneut flaken; dann bleibt er zu Recht rot. Die Produktions-Karenz wird nicht verlängert.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

## Reviewer-Hinweis

Bitte den `workflow_dispatch`-Job `Artillery 500 Live Session` auf Head `1817e376` als fachlichen Nachweis priorisieren.

