### PR TITLE
feat(help): Hilfeseite nach Rolle und Erfahrung neu strukturieren (#190)

### DIFF
--- a/apps/frontend/src/app/core/seo-route-meta.spec.ts
+++ b/apps/frontend/src/app/core/seo-route-meta.spec.ts
@@ -16,4 +16,12 @@ describe('resolveSeoForPath', () => {
       'arsnova.eu | Die europäische Alternative zu Mentimeter & Kahoot',
     );
   });
+
+  it('verwendet die rollenorientierten Help-Metadaten', () => {
+    expect(resolveSeoForPath('/help')).toEqual({
+      title: 'Hilfe & Einstieg – arsnova.eu',
+      description:
+        'Hilfe für Veranstaltungsleitungen und Teilnehmende: Session starten, abstimmen, Q&A und Blitzlicht nutzen, Ergebnisse auswerten und Funktionen nachschlagen.',
+    });
+  });
 });

--- a/apps/frontend/src/app/core/seo-route-meta.ts
+++ b/apps/frontend/src/app/core/seo-route-meta.ts
@@ -113,11 +113,11 @@ function seoDescQuizSync(): string {
 }
 
 function seoTitleHelp(): string {
-  return $localize`:@@seo.titleHelp:So funktioniert’s – arsnova.eu`;
+  return $localize`:@@seo.titleHelp:Hilfe & Einstieg – arsnova.eu`;
 }
 
 function seoDescHelp(): string {
-  return $localize`:@@seo.descHelp:Kurz erklärt: Live-Sessions, Quiz-Frageformate, Selbsteinschätzung, Blitzlicht, Q&A und Moderationsabläufe auf arsnova.eu.`;
+  return $localize`:@@seo.descHelp:Hilfe für Veranstaltungsleitungen und Teilnehmende: Session starten, abstimmen, Q&A und Blitzlicht nutzen, Ergebnisse auswerten und Funktionen nachschlagen.`;
 }
 
 function seoTitleNewsArchive(): string {

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -34,510 +34,387 @@
           </span>
           <span class="dialog-title-header__copy">
             <h1 id="help-page-title" class="dialog-title-header__heading" i18n="@@help.pageTitle">
-              So funktioniert’s
+              Hilfe &amp; Einstieg
             </h1>
           </span>
         </header>
         <p i18n="@@help.intro">
-          Diese Seite richtet sich an
-          <strong>Lehrende, Trainer:innen und Vortragende</strong>, die aus einer Präsentation eine
-          echte Live-Situation machen wollen: kurze Checks, Diskussionen, Q&amp;A, Blitzlicht und
-          Auswertung laufen in einer Session zusammen. <strong>Ohne Pflichtkonto</strong> für deine
-          Gruppe: Code oder QR zeigen, Smartphones raus, loslegen.
+          Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt
+          Funktionen nachschlagen.
         </p>
 
-        <section>
-          <h2 i18n="@@help.uspTitle">Was arsnova.eu anders macht</h2>
-          <p i18n="@@help.usp1">
-            arsnova.eu ist als <strong>Live-Regie für Unterricht, Training und Talks</strong>
-            gedacht: Du wechselst nicht zwischen Präsentation, Chat, Umfragetool und Quiz-App,
-            sondern steuerst Interaktion, Beamer-Ansicht und Ergebnisfreigabe an einem Ort.
-          </p>
-          <p i18n="@@help.usp2">
-            Der Fokus liegt auf <strong>didaktischer Kontrolle und Datenschutz</strong>: Inhalte
-            bleiben zunächst local-first im Browser, Teilnehmende brauchen kein Konto, das Projekt
-            ist Open Source und für EU-orientierten Betrieb ausgelegt. Markdown und KaTeX machen
-            fachliche Fragen präsentationstauglich, von MINT-Formeln bis zum kurzen Fallbeispiel.
-          </p>
+        <nav class="help-role-nav" i18n-aria-label="@@help.roleNavAria" aria-label="Rollenwahl">
+          <a class="help-role-card" href="#help-host">
+            <mat-icon class="help-role-card__icon" aria-hidden="true">co_present</mat-icon>
+            <span class="help-role-card__copy">
+              <span class="help-role-card__title" i18n="@@help.roleHostTitle"
+                >Ich leite eine Veranstaltung</span
+              >
+              <span class="help-role-card__hint" i18n="@@help.roleHostHint"
+                >Für Lehrende, Vortragende, Trainer:innen und Moderator:innen</span
+              >
+            </span>
+            <mat-icon class="help-role-card__chevron" aria-hidden="true">south</mat-icon>
+          </a>
+          <a class="help-role-card" href="#help-participant">
+            <mat-icon class="help-role-card__icon" aria-hidden="true">groups</mat-icon>
+            <span class="help-role-card__copy">
+              <span class="help-role-card__title" i18n="@@help.roleParticipantTitle"
+                >Ich nehme an einer Veranstaltung teil</span
+              >
+              <span class="help-role-card__hint" i18n="@@help.roleParticipantHint"
+                >Für alle, die abstimmen, Fragen stellen oder Feedback geben</span
+              >
+            </span>
+            <mat-icon class="help-role-card__chevron" aria-hidden="true">south</mat-icon>
+          </a>
+        </nav>
+
+        <section id="help-host" class="help-section" aria-labelledby="help-host-title">
+          <h2 id="help-host-title" i18n="@@help.roleHostTitle">Ich leite eine Veranstaltung</h2>
+
+          <h3 class="help-experience-title" i18n="@@help.newUserTitle">Neu bei arsnova.eu</h3>
+          <mat-accordion class="help-accordion" [multi]="true">
+            <mat-expansion-panel #hostCapabilitiesPanel class="help-panel" [expanded]="true">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.hostCapabilitiesTitle"
+                  >Was kann ich mit arsnova.eu machen?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="hostCapabilitiesPanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.hostCapabilitiesBody">
+                  Mit einem Quiz stellst du vorbereitete Wissens- oder Meinungsfragen. Im Q&amp;A
+                  sammelst und priorisierst du Fragen aus dem Publikum. Das Blitzlicht eignet sich
+                  für spontane Stimmungs-, Verständnis- und Tempoabfragen. Du kannst alle drei
+                  Bereiche in einer Live-Session verbinden.
+                </p>
+              </div>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #hostFirstSessionPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.hostFirstSessionTitle"
+                  >Wie starte ich meine erste Session?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="hostFirstSessionPanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.hostFirstSessionBody">
+                  Öffne die Quiz-Sammlung und nutze das Demo-Quiz oder erstelle ein eigenes Quiz.
+                  Wähle „Starten“, lege Stil und Optionen fest und teile anschließend den
+                  sechsstelligen Code oder QR-Code. In der Host-Ansicht zeigst du die nächste Frage,
+                  startest die Antwortphase und gibst das Ergebnis frei. Tipp: Teste die Vorschau
+                  vor dem ersten Einsatz einmal auf einem zweiten Gerät.
+                </p>
+              </div>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #hostFinishPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.hostFinishTitle"
+                  >Wie beende und werte ich eine Session aus?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div class="help-panel__body" [attr.inert]="hostFinishPanel.expanded ? null : ''">
+                <p i18n="@@help.hostFinishBody">
+                  Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten
+                  Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die
+                  didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der
+                  Nachbesprechungsplan bleibt über die Quizkarte erreichbar.
+                </p>
+              </div>
+            </mat-expansion-panel>
+          </mat-accordion>
+
+          <h3 class="help-experience-title" i18n="@@help.experiencedUserTitle">
+            Schon vertraut mit arsnova.eu
+          </h3>
+          <mat-accordion class="help-accordion" [multi]="true">
+            <mat-expansion-panel #hostFormatsPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.hostFormatsTitle"
+                  >Fragetypen und Selbsteinschätzung</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div class="help-panel__body" [attr.inert]="hostFormatsPanel.expanded ? null : ''">
+                <p i18n="@@help.hostFormatsBody">
+                  Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext,
+                  Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann
+                  anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie
+                  verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und
+                  mögliche Fehlkonzepte sichtbar.
+                </p>
+              </div>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #hostModerationPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.hostModerationTitle"
+                  >Live moderieren und Peer Instruction nutzen</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div class="help-panel__body" [attr.inert]="hostModerationPanel.expanded ? null : ''">
+                <p i18n="@@help.hostModerationBody">
+                  Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine
+                  verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen,
+                  startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung.
+                  Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.
+                </p>
+              </div>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #hostQaPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.hostQaTitle"
+                  >Die Q&amp;A-Fragenwand moderieren</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div class="help-panel__body" [attr.inert]="hostQaPanel.expanded ? null : ''">
+                <p i18n="@@help.hostQaBody">
+                  Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst
+                  Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes
+                  sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke
+                  verdichtet sichtbare Themen für die Präsentation.
+                </p>
+              </div>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #hostPulsePanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.hostPulseTitle"
+                  >Blitzlicht und Tempo-Feedback einsetzen</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div class="help-panel__body" [attr.inert]="hostPulsePanel.expanded ? null : ''">
+                <p i18n="@@help.hostPulseBody">
+                  Starte ein Blitzlicht aus der Live-Session oder über „Live mit einem Klick“ auf
+                  der Startseite. Du kannst die Abstimmung pausieren, fortsetzen, zurücksetzen oder
+                  als neue Runde starten. Beim Tempo-Feedback ändern Teilnehmende ihre Rückmeldung
+                  jederzeit; du siehst nur die aggregierte Tendenz.
+                </p>
+              </div>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #hostLibraryPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.hostLibraryTitle"
+                  >Quiz-Sammlung und Einstellungen verwalten</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div class="help-panel__body" [attr.inert]="hostLibraryPanel.expanded ? null : ''">
+                <p i18n="@@help.hostLibraryBody">
+                  In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und
+                  importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die
+                  Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen
+                  Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start
+                  konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und
+                  Bonus-Codes.
+                </p>
+              </div>
+            </mat-expansion-panel>
+          </mat-accordion>
         </section>
 
-        <section class="help-section--formats" aria-labelledby="help-formats-title">
-          <h2 id="help-formats-title" i18n="@@help.formatsTitle">
-            Frageformate: passend zum didaktischen Ziel
+        <section
+          id="help-participant"
+          class="help-section"
+          aria-labelledby="help-participant-title"
+        >
+          <h2 id="help-participant-title" i18n="@@help.roleParticipantTitle">
+            Ich nehme an einer Veranstaltung teil
           </h2>
-          <p class="help-section-lead" i18n="@@help.formatsLead">
-            Wähle das Format nach der Situation im Raum: Willst du Wissen prüfen, Haltungen sichtbar
-            machen, Begriffe einsammeln oder Schätzungen diskutieren? Die Formate sind bewusst
-            getrennt, damit Ergebnisanzeige, Bewertung und Moderation zum Einsatzzweck passen.
-          </p>
-          <ul
-            class="help-format-grid"
-            i18n-aria-label="@@help.formatsGridAria"
-            aria-label="Verfügbare Quiz-Frageformate"
-          >
-            <li class="help-format-card">
-              <mat-icon class="help-format-card__icon" aria-hidden="true">
-                radio_button_checked
-              </mat-icon>
-              <div class="help-format-card__body">
-                <h3 i18n="@@help.formatSingleChoiceTitle">Single Choice</h3>
-                <p class="help-format-card__tag" i18n="@@help.formatSingleChoiceTag">
-                  eine richtige Option
-                </p>
-                <p i18n="@@help.formatSingleChoiceBody">
-                  Für punktgenaue Verständnischecks: Eine Antwort ist korrekt, Ergebnis und Punkte
-                  sind sofort klar.
+
+          <h3 class="help-experience-title" i18n="@@help.newUserTitle">Neu bei arsnova.eu</h3>
+          <mat-accordion class="help-accordion" [multi]="true">
+            <mat-expansion-panel #participantJoinPanel class="help-panel" [expanded]="true">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.participantJoinTitle"
+                  >Wie trete ich einer Session bei?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="participantJoinPanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.participantJoinBody">
+                  Scanne den QR-Code oder öffne arsnova.eu und gib den sechsstelligen Code ein. Du
+                  brauchst kein Konto. Je nach Einstellung der Veranstaltungsleitung nimmst du
+                  anonym, mit einem vorgegebenen Nickname oder mit einem selbst gewählten Namen
+                  teil.
                 </p>
               </div>
-            </li>
-            <li class="help-format-card">
-              <mat-icon class="help-format-card__icon" aria-hidden="true">checklist</mat-icon>
-              <div class="help-format-card__body">
-                <h3 i18n="@@help.formatMultipleChoiceTitle">Multiple Choice</h3>
-                <p class="help-format-card__tag" i18n="@@help.formatMultipleChoiceTag">
-                  mehrere richtige Optionen
-                </p>
-                <p i18n="@@help.formatMultipleChoiceBody">
-                  Für komplexere Konzepte, typische Fehlannahmen oder Fragen wie „Welche Aussagen
-                  stimmen?“ – mehrere Lösungen können zählen.
-                </p>
-              </div>
-            </li>
-            <li class="help-format-card">
-              <mat-icon class="help-format-card__icon" aria-hidden="true">short_text</mat-icon>
-              <div class="help-format-card__body">
-                <h3 i18n="@@help.formatShortTextTitle">Kurzantwort</h3>
-                <p class="help-format-card__tag" i18n="@@help.formatShortTextTag">
-                  Musterlösung statt Auswahl
-                </p>
-                <p i18n="@@help.formatShortTextBody">
-                  Teilnehmende formulieren kurz selbst. Du hinterlegst Musterlösungen; arsnova.eu
-                  kann Schreibvarianten, Toleranz und bei Bedarf Zahlen oder Einheiten auswerten.
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #participantAnswerPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.participantAnswerTitle"
+                  >Wie beantworte ich eine Quizfrage?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="participantAnswerPanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.participantAnswerBody">
+                  Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung
+                  aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du
+                  dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das
+                  Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.
                 </p>
               </div>
-            </li>
-            <li class="help-format-card">
-              <mat-icon class="help-format-card__icon" aria-hidden="true">notes</mat-icon>
-              <div class="help-format-card__body">
-                <h3 i18n="@@help.formatFreeTextTitle">Freitext</h3>
-                <p class="help-format-card__tag" i18n="@@help.formatFreeTextTag">
-                  offene Antworten
-                </p>
-                <p i18n="@@help.formatFreeTextBody">
-                  Für Ideen, Reflexionen und Erwartungsabfragen. Keine automatische Bewertung;
-                  Antworten lassen sich sammeln und als Wortwolke sichtbar machen.
-                </p>
-              </div>
-            </li>
-            <li class="help-format-card">
-              <mat-icon class="help-format-card__icon" aria-hidden="true">poll</mat-icon>
-              <div class="help-format-card__body">
-                <h3 i18n="@@help.formatSurveyTitle">Umfrage</h3>
-                <p class="help-format-card__tag" i18n="@@help.formatSurveyTag">
-                  Meinungsbild ohne richtig/falsch
-                </p>
-                <p i18n="@@help.formatSurveyBody">
-                  Für Prioritäten, Vorwissen oder Entscheidungen im Raum. Optionen werden gezählt,
-                  ohne Scorelogik.
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #participantContributePanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.participantContributeTitle"
+                  >Wie stelle ich eine Frage oder gebe Feedback?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="participantContributePanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.participantContributeBody">
+                  Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch-
+                  oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe.
+                  Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein
+                  Tempo-Feedback kannst du während der laufenden Abfrage ändern.
                 </p>
               </div>
-            </li>
-            <li class="help-format-card">
-              <mat-icon class="help-format-card__icon" aria-hidden="true">linear_scale</mat-icon>
-              <div class="help-format-card__body">
-                <h3 i18n="@@help.formatRatingTitle">Bewertungsskala</h3>
-                <p class="help-format-card__tag" i18n="@@help.formatRatingTag">
-                  Skala mit eigenen Polen
-                </p>
-                <p i18n="@@help.formatRatingBody">
-                  Für Zustimmung, Sicherheit, Tempo oder Feedback von niedrig bis hoch; optional mit
-                  benannten Endpunkten.
-                </p>
-              </div>
-            </li>
-            <li class="help-format-card help-format-card--wide">
-              <mat-icon class="help-format-card__icon" aria-hidden="true">analytics</mat-icon>
-              <div class="help-format-card__body">
-                <h3 i18n="@@help.formatNumericEstimateTitle">Numerische Schätzfrage</h3>
-                <p class="help-format-card__tag" i18n="@@help.formatNumericEstimateTag">
-                  Zahlen schätzen, Streuung sehen
-                </p>
-                <p i18n="@@help.formatNumericEstimateBody">
-                  Für Jahreszahlen, Größenordnungen, Messwerte und Wahrscheinlichkeiten. Mit
-                  Referenzwert, Toleranzband, Histogramm, Statistik und optionaler zweiter Runde.
+            </mat-expansion-panel>
+          </mat-accordion>
+
+          <h3 class="help-experience-title" i18n="@@help.experiencedUserTitle">
+            Schon vertraut mit arsnova.eu
+          </h3>
+          <mat-accordion class="help-accordion" [multi]="true">
+            <mat-expansion-panel #participantChannelsPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.participantChannelsTitle"
+                  >Wie nutze ich Quiz, Q&amp;A und Blitzlicht in einer Session?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="participantChannelsPanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.participantChannelsBody">
+                  Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge
+                  der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein
+                  Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die
+                  Veranstaltungsleitung.
                 </p>
               </div>
-            </li>
-          </ul>
-          <p class="help-format-note" i18n="@@help.formatsBlitzNote">
-            Blitzlicht ist davon getrennt: Es ist für spontane Live-Rückmeldungen gedacht, wenn du
-            keine vollständige Quizfrage bauen willst.
-          </p>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #participantSecondRoundPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.participantSecondRoundTitle"
+                  >Was passiert bei einer zweiten Abstimmungsrunde?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="participantSecondRoundPanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.participantSecondRoundBody">
+                  Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend
+                  diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende
+                  deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten
+                  Antwort unterscheiden.
+                </p>
+              </div>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #participantResultsPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.participantResultsTitle"
+                  >Wie sind Ergebnisse, Rangliste und Teamwertung zu verstehen?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="participantResultsPanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.participantResultsBody">
+                  Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste,
+                  Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert
+                  wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung.
+                </p>
+              </div>
+            </mat-expansion-panel>
+          </mat-accordion>
         </section>
 
-        <section class="help-section--confidence" aria-labelledby="help-confidence-title">
-          <h2 id="help-confidence-title" i18n="@@help.confidenceTitle">
-            Selbsteinschätzung bei bewertbaren Fragen
-          </h2>
-          <p class="help-section-lead" i18n="@@help.confidenceLead">
-            Die Selbsteinschätzung ist kein eigener Fragetyp, sondern eine optionale Zusatzabfrage
-            nach Single Choice, Multiple Choice, Kurzantwort und numerischer Schätzfrage:
-            Teilnehmende geben an, wie sicher sie bei ihrer Antwort sind (Skala 1–5). Das
-            beeinflusst keine Punkte – hilft dir aber, Lernstand und Fehlkonzepte zu erkennen.
-          </p>
-          <ul
-            class="help-qa-feature-list"
-            i18n-aria-label="@@help.confidenceListAria"
-            aria-label="Didaktische Funktionen der Selbsteinschätzung"
-          >
-            <li class="help-qa-feature">
-              <mat-icon class="help-qa-feature__icon" aria-hidden="true">touch_app</mat-icon>
-              <div class="help-qa-feature__body">
-                <h3 i18n="@@help.confidenceAfterAnswerTitle">Nach der Antwort abfragen</h3>
-                <p i18n="@@help.confidenceAfterAnswerBody">
-                  Progressive Disclosure: Erst Antwort wählen oder eingeben, dann die
-                  Selbsteinschätzung. Während der Abstimmung sieht niemand aggregierte Werte anderer
-                  Personen.
+        <section id="help-common" class="help-section" aria-labelledby="help-common-title">
+          <h2 id="help-common-title" i18n="@@help.commonTitle">Für alle</h2>
+          <mat-accordion class="help-accordion" [multi]="true">
+            <mat-expansion-panel #commonPrivacyPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.commonPrivacyTitle"
+                  >Wie werden Daten und Inhalte behandelt?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div class="help-panel__body" [attr.inert]="commonPrivacyPanel.expanded ? null : ''">
+                <p i18n="@@help.commonPrivacyBody">
+                  Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der
+                  Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer
+                  Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht.
+                  arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa
+                  ausgelegt. Einzelheiten findest du in der
+                  <a [routerLink]="localizedPath('/legal/privacy')">Datenschutzerklärung</a>.
                 </p>
               </div>
-            </li>
-            <li class="help-qa-feature">
-              <mat-icon class="help-qa-feature__icon" aria-hidden="true">tune</mat-icon>
-              <div class="help-qa-feature__body">
-                <h3 i18n="@@help.confidenceEditorTitle">Im Editor konfigurieren</h3>
-                <p i18n="@@help.confidenceEditorBody">
-                  Toggle pro Frage, optionale Labels für niedrige und hohe Antwortsicherheit und
-                  eine Live-Vorschau der Skala. Für neue bewertbare Fragen ist die
-                  Selbsteinschätzung standardmäßig aktiv.
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #commonAccessibilityPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.commonAccessibilityTitle"
+                  >Wie nutze ich arsnova.eu barrierefrei und als App?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="commonAccessibilityPanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.commonAccessibilityBody">
+                  arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung
+                  bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder
+                  deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App
+                  installieren. Weitere Hinweise stehen in der
+                  <a [routerLink]="localizedPath('/legal/accessibility')"
+                    >Erklärung zur Barrierefreiheit</a
+                  >.
                 </p>
               </div>
-            </li>
-            <li class="help-qa-feature">
-              <mat-icon class="help-qa-feature__icon" aria-hidden="true">fact_check</mat-icon>
-              <div class="help-qa-feature__body">
-                <h3 i18n="@@help.confidenceHostTitle">Host-Auswertung nach Freigabe</h3>
-                <p i18n="@@help.confidenceHostBody">
-                  Matrix aus Korrektheit und Antwortsicherheit mit Hervorhebung
-                  <strong>selbstsicher falsch</strong>. Bei Auswahlfragen siehst du, welche falschen
-                  Optionen mit hoher Antwortsicherheit gewählt wurden.
+            </mat-expansion-panel>
+
+            <mat-expansion-panel #commonTroubleshootingPanel class="help-panel">
+              <mat-expansion-panel-header>
+                <mat-panel-title i18n="@@help.commonTroubleshootingTitle"
+                  >Was kann ich bei technischen Problemen tun?</mat-panel-title
+                >
+              </mat-expansion-panel-header>
+              <div
+                class="help-panel__body"
+                [attr.inert]="commonTroubleshootingPanel.expanded ? null : ''"
+              >
+                <p i18n="@@help.commonTroubleshootingBody">
+                  Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session
+                  noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der
+                  Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer
+                  Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal
+                  ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet
+                  wurde.
                 </p>
               </div>
-            </li>
-            <li class="help-qa-feature">
-              <mat-icon class="help-qa-feature__icon" aria-hidden="true">summarize</mat-icon>
-              <div class="help-qa-feature__body">
-                <h3 i18n="@@help.confidenceExportTitle">Abschluss und Export</h3>
-                <p i18n="@@help.confidenceExportBody">
-                  Nach Session-Ende fasst die Auswertung gefestigtes Wissen, Fehlkonzept-Hinweis und
-                  fragiles Wissen zusammen. Fragen mit weniger als 5 Antworten mit
-                  Selbsteinschätzung werden nicht aggregiert ausgewiesen. Der Nachbesprechungsplan
-                  (PDF) ist das empfohlene Format; CSV steht unter „Mehr“ für Excel zur Verfügung.
-                  In der Quiz-Sammlung findest du den Nachbesprechungsplan auf der Quizkarte.
-                </p>
-              </div>
-            </li>
-          </ul>
-        </section>
-
-        <section class="help-section--demo">
-          <h2 i18n="@@help.demoTitle">Demo-Quiz</h2>
-          <p i18n="@@help.demoCardHint">
-            Ein vorinstalliertes Beispiel-Quiz zeigt die Frageformate in konkreten
-            Unterrichtsmomenten: Wissenscheck, Wortwolke, Kurzantwort, Schätzfrage, Bewertungsskala,
-            Selbsteinschätzung, Formeln und Markdown. Du findest es in deiner Quiz-Sammlung und
-            kannst es dort in der Vorschau öffnen.
-          </p>
-          <p i18n="@@help.demoTip">
-            <strong>Tipp:</strong> Öffne die Vorschau vor der ersten Live-Session einmal auf einem
-            zweiten Gerät. So siehst du sofort, wie Host-Ansicht und Teilnehmenden-Screen
-            zusammenspielen.
-          </p>
-        </section>
-
-        <section>
-          <h2 i18n="@@help.quickstartTitle">Schnellstart</h2>
-          <ol class="help-steps">
-            <li i18n="@@help.quickstart1">
-              <strong>Quiz anlegen:</strong> „Quiz-Sammlung öffnen" wählen, neues Quiz erstellen und
-              pro Frage das passende Format wählen.
-            </li>
-            <li i18n="@@help.quickstart2">
-              <strong>Veranstaltung starten:</strong> Stil, Timer, Teams und Rangliste festlegen.
-              Danach entsteht ein 6-stelliger Code, den du als Text oder QR-Code teilst.
-            </li>
-            <li i18n="@@help.quickstart3">
-              <strong>Live moderieren:</strong> Frage zeigen, Antwortphase starten, Ergebnisse
-              freigeben oder zurückhalten und bei Bedarf eine zweite Runde anschließen.
-            </li>
-          </ol>
-        </section>
-
-        <section>
-          <h2 i18n="@@help.hostTitle">Veranstaltung leiten</h2>
-          <p i18n="@@help.hostLead">
-            In der Host-Ansicht führst du durch die Session wie durch eine kleine Senderegie:
-            Teilnehmende reinholen, Inhalte freigeben, Diskussion öffnen und Ergebnisse sichtbar
-            machen.
-          </p>
-          <ul>
-            <li i18n="@@help.hostStartStep">
-              <strong>Session starten:</strong> In deiner Quiz-Sammlung eine Veranstaltung starten
-              und festlegen, ob sie mit Quiz oder Q&amp;A beginnt. Dann entsteht der Beitrittscode.
-            </li>
-            <li i18n="@@help.hostLobby">
-              <strong>Lobby:</strong> Du siehst, wer beigetreten ist; ein QR-Code zum Beitritt wird
-              angezeigt.
-            </li>
-            <li i18n="@@help.hostBeamer">
-              <strong>Beamer- und Presenter-Ansicht:</strong> Frage, Antworten, Countdown und
-              Ergebnisse erscheinen groß genug für Projektion, Stream oder zweiten Bildschirm.
-            </li>
-            <li i18n="@@help.hostSteuerung">
-              <strong>Steuerung:</strong> Nutze „Nächste Frage“, um den Inhalt einzublenden.
-              Optional läuft zuerst eine Lesephase, danach startest du die Antwortphase und
-              entscheidest, wann das Ergebnis auf den Screen kommt.
-            </li>
-            <li i18n="@@help.hostPeer">
-              <strong>Peer Instruction (Doppelrunden):</strong> Bei geeigneten Quizfragen,
-              Schätzfragen und Blitzlicht-Runden: erst abstimmen lassen, Diskussion starten, dann
-              erneut abstimmen. Der Vorher/Nachher-Vergleich macht Lernfortschritt sichtbar.
-            </li>
-            <li i18n="@@help.hostSettings">
-              <strong>Einstellungen:</strong> Beim Start legst du Stil und Optionen fest: seriös
-              oder spielerisch, mit oder ohne Rangliste, Sound, Lesephase, Team-Modus, Nicknamen und
-              Timer.
-            </li>
-          </ul>
-        </section>
-
-        <section class="help-section--qa-wall" aria-labelledby="help-qa-wall-title">
-          <h2 id="help-qa-wall-title" i18n="@@help.qaWallTitle">
-            Fragenwand im Live-Kanal Q&amp;A
-          </h2>
-          <p class="help-section-lead" i18n="@@help.qaWallLead">
-            Q&amp;A soll nicht als Nebenchat verschwinden. Die Fragenwand macht Rückfragen sichtbar,
-            priorisierbar und moderierbar: Du hältst den roten Faden, während die Gruppe gemeinsam
-            zeigt, welche Punkte wirklich Klärung brauchen.
-          </p>
-          <ul
-            class="help-qa-feature-list"
-            i18n-aria-label="@@help.qaWallListAria"
-            aria-label="Didaktische Funktionen der Q&A-Fragenwand"
-          >
-            <li class="help-qa-feature">
-              <mat-icon class="help-qa-feature__icon" aria-hidden="true">rule</mat-icon>
-              <div class="help-qa-feature__body">
-                <h3 i18n="@@help.qaWallModerationTitle">Moderation mit pädagogischem Takt</h3>
-                <p i18n="@@help.qaWallModerationBody">
-                  Auf Wunsch warten neue Fragen erst auf deine Freigabe. Du kannst Beiträge
-                  freigeben, anheften, archivieren oder entfernen und damit Schutzraum, Relevanz und
-                  Timing steuern: sofort beantworten, für später sammeln oder als Diskussionsspur
-                  markieren.
-                </p>
-              </div>
-            </li>
-            <li class="help-qa-feature">
-              <mat-icon class="help-qa-feature__icon" aria-hidden="true">swap_vert</mat-icon>
-              <div class="help-qa-feature__body">
-                <h3 i18n="@@help.qaWallVotingTitle">Kollektives Hoch- und Runtervoting</h3>
-                <p i18n="@@help.qaWallVotingBody">
-                  Teilnehmende gewichten Fragen gemeinsam. Positive und negative Stimmen zeigen
-                  nicht nur Popularität, sondern auch Unsicherheit, Widerspruch und Klärungsbedarf;
-                  Sortierungen wie „meist unterstützt“, „beste Fragen“ und „umstritten“ helfen dir,
-                  knappe Live-Zeit didaktisch zu setzen.
-                </p>
-              </div>
-            </li>
-            <li class="help-qa-feature">
-              <mat-icon class="help-qa-feature__icon" aria-hidden="true">bubble_chart</mat-icon>
-              <div class="help-qa-feature__body">
-                <h3 i18n="@@help.qaWallWordCloudTitle">Q&amp;A-Wortwolke auf Themenebene</h3>
-                <p i18n="@@help.qaWallWordCloudBody">
-                  Die Word-Cloud verdichtet sichtbare Fragen zu Wörtern und Phrasen, gewichtet nach
-                  Unterstützung, belastbarer Zustimmung oder Kontroverse. Sie lässt sich einfrieren,
-                  nach Sortierlogik betrachten und in der Presenter-Ansicht zeigen – als schneller
-                  Blick auf Themencluster, nicht als dekorative Wortliste.
-                </p>
-              </div>
-            </li>
-            <li class="help-qa-feature">
-              <mat-icon class="help-qa-feature__icon" aria-hidden="true">psychology</mat-icon>
-              <div class="help-qa-feature__body">
-                <h3 i18n="@@help.qaWallLlmTitle">Nächster Schritt: Moderationskompass</h3>
-                <p i18n="@@help.qaWallLlmBody">
-                  Geplant ist zuerst ein deterministischer Moderationskompass. Optional können
-                  später asynchrone Q&amp;A-NLP-Signale und quellengebundene Zusammenfassungen
-                  dazukommen – als datenschutzbewusste Moderationshilfe statt Blackbox-Bewertung.
-                </p>
-              </div>
-            </li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 i18n="@@help.blitzTitle">Blitzlicht</h2>
-          <p i18n="@@help.quickFeedbackIntro">
-            Schnelle Stimmungs- und Wissensabfragen – z. B. vor der Pause, zum Einstieg oder für
-            spontane Checks. Nutzbar im Host-Bereich deiner Live-Session oder direkt von der
-            Startseite.
-          </p>
-          <ul>
-            <li i18n="@@help.qfMood">
-              <strong>Stimmungsbild</strong> (😊😐😟): Wie geht es den Teilnehmenden?
-            </li>
-            <li i18n="@@help.qfYesNoMaybe">
-              <strong>Ja / Nein / Vielleicht</strong> (👍👎🤷): Schnelle Zustimmungsabfrage.
-            </li>
-            <li i18n="@@help.quickFeedbackYesNo">
-              <strong>Ja / Nein</strong> (👍👎): Klare Zwei-Optionen-Abfrage ohne Mittelweg.
-            </li>
-            <li i18n="@@help.quickFeedbackTrueFalseUnknown">
-              <strong>Wahr / Falsch / Weiß nicht</strong> (✓ / × / ?): Für schnelle Einschätzungen
-              oder Wissenschecks.
-            </li>
-            <li i18n="@@help.quickFeedbackLetterOptions">
-              <strong>Mehrstufige Schnellabfragen</strong> (A–D): Drei oder vier feste Optionen für
-              spontane Abstimmungen – ohne eine vollständige Quizfrage zu bauen.
-            </li>
-            <li i18n="@@help.quickFeedbackTempo">
-              <strong>Tempo-Feedback</strong> (🙂🐇🐢🙈): Mit vier Icons meldet deine Gruppe laufend
-              zurück, ob sie folgen kann. Teilnehmende können ihre Rückmeldung ändern; du siehst nur
-              die aggregierte Tendenz.
-            </li>
-          </ul>
-          <p i18n="@@help.quickFeedbackStartFlow">
-            Du startest die Runde im Host-Bereich deiner Live-Session oder über die Blitzlicht-Karte
-            „Live mit einem Klick" auf der Startseite. Teilnehmende tippen eine Antwort; du siehst
-            die Ergebnisse live als Balkendiagramm.
-          </p>
-          <ul>
-            <li i18n="@@help.qfPeer">
-              <strong>Peer Instruction (Doppelrunden):</strong> Erste Runde – Ergebnis nicht
-              auflösen – „Diskussionsphase" starten („Diskutiert mit eurem Nachbarn") – „Zweite
-              Abstimmung". Vorher/Nachher-Vergleich zeigt, wie sich das Stimmungsbild durch den
-              Austausch verändert hat.
-            </li>
-            <li i18n="@@help.qfStop">
-              <strong>Stopp:</strong> Abstimmung einfrieren – Teilnehmende sehen „Abstimmung ist
-              pausiert" und können nicht mehr abstimmen, bis du „Fortsetzen" wählst.
-            </li>
-            <li i18n="@@help.qfReset">
-              <strong>Zurücksetzen:</strong> Alle Stimmen löschen und erneut abstimmen lassen.
-            </li>
-            <li i18n="@@help.qfNewRound">
-              <strong>Neue Runde:</strong> Neuen Code erzeugen und eine frische Runde starten.
-            </li>
-            <li i18n="@@help.qfCopyLink">
-              <strong>Link kopieren:</strong> Beitrittslink in die Zwischenablage kopieren, z. B.
-              zum Teilen per Chat.
-            </li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 i18n="@@help.participantsTitle">Für deine Teilnehmenden</h2>
-          <p i18n="@@help.participantsLead">
-            Kurz erklärt, was du in deiner Veranstaltung weitergeben kannst:
-          </p>
-          <ul>
-            <li i18n="@@help.participantsJoin">
-              <strong>Beitreten:</strong> 6-stelligen Code auf arsnova.eu eingeben und „Los geht's"
-              – funktioniert für Quiz, Q&amp;A und Blitzlicht. Keine Anmeldung nötig.
-            </li>
-            <li i18n="@@help.participantsNick">
-              <strong>Nicknamen:</strong> Je nach deiner Einstellung vorgegebene Namen, eigener Name
-              oder anonym.
-            </li>
-            <li i18n="@@help.participantsVote">
-              <strong>Abstimmung:</strong> Frage erscheint auf dem Gerät, Antwort wählen und
-              absenden. Bei aktivierter Selbsteinschätzung folgt danach die Skala 1–5. Bei Zeitlimit
-              läuft ein Countdown.
-            </li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 i18n="@@help.collectionTitle">Deine Quiz-Sammlung</h2>
-          <p i18n="@@help.collectionLead">Hier legst du deine Quizze an und bereitest sie vor.</p>
-          <ul>
-            <li i18n="@@help.collectionEditor">
-              <strong>Editor:</strong> Fragen per Drag-and-Drop sortieren, auf- und zuklappen,
-              Vorschau prüfen.
-            </li>
-            <li i18n="@@help.collectionTypes">
-              <strong>Fragetypen:</strong> Single Choice, Multiple Choice, Kurzantwort, Freitext,
-              Umfrage, Bewertungsskala und numerische Schätzfrage – pro Frage optional mit Timer,
-              Schwierigkeitsgrad und Selbsteinschätzung.
-            </li>
-            <li i18n="@@help.collectionImport">
-              <strong>Import / Export:</strong> Quiz als JSON importieren oder exportieren. Mit der
-              Start- und Prüfvorlage kannst du anspruchsvolle Quizze mit deinem bevorzugten KI-Tool
-              generieren, prüfen und direkt importieren – deine Inhalte und Präsentationen werden
-              nicht an arsnova.eu gesendet; du nutzt dein eigenes KI-Tool.
-            </li>
-            <li i18n="@@help.collectionSync">
-              <strong>Sync:</strong> Mit dem Sync-Link deine Quiz-Sammlung mit Kolleg:innen teilen
-              oder auf anderen Geräten weiterarbeiten. Wer den Link hat, kann die Sammlung öffnen.
-              Die Geräteangaben helfen nur bei der Orientierung.
-            </li>
-            <li i18n="@@help.demoQuizHint">
-              <strong>Demo-Quiz:</strong> Ein vorinstalliertes Quiz zeigt alle Formate mit
-              Beispielen inkl. KaTeX-Formeln und Markdown. In der Quiz-Sammlung in der Vorschau
-              öffnen.
-            </li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 i18n="@@help.stylesTitle">Seriös und Spielerisch</h2>
-          <p i18n="@@help.stylesLead">
-            Zwei Stile für unterschiedliche Situationen – wählbar auf der Startseite und beim
-            Session-Start.
-          </p>
-          <ul>
-            <li i18n="@@help.styleSerious">
-              <strong>Seriös:</strong> Anonym, ohne Rangliste – ideal für formative Assessments,
-              Prüfungsvorbereitung und sensible Themen.
-            </li>
-            <li i18n="@@help.stylePlayful">
-              <strong>Spielerisch:</strong> Mit Rangliste, Sounds und Anfeuerung – ideal für
-              Auflockerung, Wettbewerbe und motivierende Quizze.
-            </li>
-          </ul>
-          <p i18n="@@help.stylesOptions">
-            Alle Optionen (Rangliste, Sound, Lesephase, Team, Bonus) lassen sich einzeln an- und
-            ausschalten.
-          </p>
-        </section>
-
-        <section>
-          <h2 i18n="@@help.moreTitle">Weitere Funktionen</h2>
-          <ul>
-            <li i18n="@@help.moreBonus">
-              <strong>Bonus-Codes:</strong> Top-Platzierte erhalten einen einlösbaren Code (z. B.
-              für Bonuspunkte). Du siehst die Code-Liste; personenbezogene Daten werden nicht
-              gespeichert.
-            </li>
-            <li i18n="@@help.moreTeams">
-              <strong>Team-Modus:</strong> Deine Teilnehmenden spielen in Teams mit eigenem
-              Team-Leaderboard – z. B. für Gruppenwettbewerbe im Seminar.
-            </li>
-            <li i18n="@@help.moreGamification">
-              <strong>Gamification:</strong> Sound-Effekte, Belohnungseffekte für Top-Plätze,
-              Motivationsmeldungen – im Spielerisch-Modus.
-            </li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 i18n="@@help.privacyTitle">Datenschutz und Technik</h2>
-          <p i18n="@@help.privacyBody">
-            arsnova.eu ist kostenlos, Open Source und für den Einsatz an Schulen, Hochschulen und in
-            Weiterbildung gedacht – mit Fokus auf Datenschutz (DSGVO). Quiz-Inhalte werden lokal im
-            Browser gespeichert. Keine Anmeldung nötig, weder für dich noch für deine Teilnehmenden.
-            Als App installierbar (PWA) – z. B. für schnelleren Start auf dem Smartphone. Oberfläche
-            auf Deutsch, Englisch, Französisch, Spanisch und Italienisch.
-          </p>
+            </mat-expansion-panel>
+          </mat-accordion>
         </section>
       </article>
     </div>

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -79,7 +79,10 @@
         </nav>
 
         <section id="help-host" class="help-section" aria-labelledby="help-host-title">
-          <h2 id="help-host-title" i18n="@@help.roleHostTitle">Ich leite eine Veranstaltung</h2>
+          <h2 id="help-host-title" class="help-section__title">
+            <mat-icon class="help-section__title-icon" aria-hidden="true">school</mat-icon>
+            <span i18n="@@help.roleHostTitle">Ich leite eine Veranstaltung</span>
+          </h2>
 
           <h3 class="help-experience-title" i18n="@@help.newUserTitle">Neu bei arsnova.eu</h3>
           <mat-accordion class="help-accordion" [multi]="true">
@@ -233,8 +236,9 @@
           class="help-section"
           aria-labelledby="help-participant-title"
         >
-          <h2 id="help-participant-title" i18n="@@help.roleParticipantTitle">
-            Ich nehme an einer Veranstaltung teil
+          <h2 id="help-participant-title" class="help-section__title">
+            <mat-icon class="help-section__title-icon" aria-hidden="true">groups</mat-icon>
+            <span i18n="@@help.roleParticipantTitle">Ich nehme an einer Veranstaltung teil</span>
           </h2>
 
           <h3 class="help-experience-title" i18n="@@help.newUserTitle">Neu bei arsnova.eu</h3>
@@ -360,7 +364,10 @@
         </section>
 
         <section id="help-common" class="help-section" aria-labelledby="help-common-title">
-          <h2 id="help-common-title" i18n="@@help.commonTitle">Für alle</h2>
+          <h2 id="help-common-title" class="help-section__title">
+            <mat-icon class="help-section__title-icon" aria-hidden="true">info</mat-icon>
+            <span i18n="@@help.commonTitle">Für alle</span>
+          </h2>
           <mat-accordion class="help-accordion" [multi]="true">
             <mat-expansion-panel #commonPrivacyPanel class="help-panel">
               <mat-expansion-panel-header>

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -44,7 +44,11 @@
         </p>
 
         <nav class="help-role-nav" i18n-aria-label="@@help.roleNavAria" aria-label="Rollenwahl">
-          <a class="help-role-card" href="#help-host">
+          <a
+            class="help-role-card"
+            [attr.href]="helpSectionHref('help-host')"
+            (click)="onHelpSectionLinkClick($event, 'help-host')"
+          >
             <mat-icon class="help-role-card__icon" aria-hidden="true">co_present</mat-icon>
             <span class="help-role-card__copy">
               <span class="help-role-card__title" i18n="@@help.roleHostTitle"
@@ -56,7 +60,11 @@
             </span>
             <mat-icon class="help-role-card__chevron" aria-hidden="true">south</mat-icon>
           </a>
-          <a class="help-role-card" href="#help-participant">
+          <a
+            class="help-role-card"
+            [attr.href]="helpSectionHref('help-participant')"
+            (click)="onHelpSectionLinkClick($event, 'help-participant')"
+          >
             <mat-icon class="help-role-card__icon" aria-hidden="true">groups</mat-icon>
             <span class="help-role-card__copy">
               <span class="help-role-card__title" i18n="@@help.roleParticipantTitle"

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -49,7 +49,7 @@
             [attr.href]="helpSectionHref('help-host')"
             (click)="onHelpSectionLinkClick($event, 'help-host')"
           >
-            <mat-icon class="help-role-card__icon" aria-hidden="true">co_present</mat-icon>
+            <mat-icon class="help-role-card__icon" aria-hidden="true">school</mat-icon>
             <span class="help-role-card__copy">
               <span class="help-role-card__title" i18n="@@help.roleHostTitle"
                 >Ich leite eine Veranstaltung</span
@@ -58,7 +58,7 @@
                 >Für Lehrende, Vortragende, Trainer:innen und Moderator:innen</span
               >
             </span>
-            <mat-icon class="help-role-card__chevron" aria-hidden="true">south</mat-icon>
+            <mat-icon class="help-role-card__chevron" aria-hidden="true">arrow_downward</mat-icon>
           </a>
           <a
             class="help-role-card"
@@ -74,7 +74,7 @@
                 >Für alle, die abstimmen, Fragen stellen oder Feedback geben</span
               >
             </span>
-            <mat-icon class="help-role-card__chevron" aria-hidden="true">south</mat-icon>
+            <mat-icon class="help-role-card__chevron" aria-hidden="true">arrow_downward</mat-icon>
           </a>
         </nav>
 

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -39,8 +39,8 @@
           </span>
         </header>
         <p i18n="@@help.intro">
-          Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt
-          Funktionen nachschlagen.
+          Wähle, in welcher Rolle du arsnova.eu nutzt. Hier findest du einen schnellen Einstieg und
+          gezielte Hilfe zu einzelnen Funktionen.
         </p>
 
         <nav class="help-role-nav" i18n-aria-label="@@help.roleNavAria" aria-label="Rollenwahl">
@@ -174,7 +174,7 @@
                   Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine
                   verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen,
                   startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung.
-                  Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.
+                  Der Vorher-Nachher-Vergleich macht Veränderungen sichtbar.
                 </p>
               </div>
             </mat-expansion-panel>
@@ -188,9 +188,9 @@
               <div class="help-panel__body" [attr.inert]="hostQaPanel.expanded ? null : ''">
                 <p i18n="@@help.hostQaBody">
                   Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst
-                  Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes
-                  sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke
-                  verdichtet sichtbare Themen für die Präsentation.
+                  Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative
+                  Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die
+                  Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.
                 </p>
               </div>
             </mat-expansion-panel>
@@ -222,9 +222,9 @@
                   In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und
                   importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die
                   Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen
-                  Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start
-                  konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und
-                  Bonus-Codes.
+                  dich beim Erstellen und Prüfen von Quizzen, ohne dass Inhalte an arsnova.eu
+                  gesendet werden. Beim Session-Start konfigurierst du unter anderem Stil,
+                  Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.
                 </p>
               </div>
             </mat-expansion-panel>
@@ -317,9 +317,8 @@
               >
                 <p i18n="@@help.participantChannelsBody">
                   Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge
-                  der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein
-                  Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die
-                  Veranstaltungsleitung.
+                  den Hinweisen in der jeweils geöffneten Ansicht. Wenn ein Bereich gerade nicht
+                  aktiv ist, warte, bis die Veranstaltungsleitung die nächste Aktivität öffnet.
                 </p>
               </div>
             </mat-expansion-panel>
@@ -390,7 +389,8 @@
             <mat-expansion-panel #commonAccessibilityPanel class="help-panel">
               <mat-expansion-panel-header>
                 <mat-panel-title i18n="@@help.commonAccessibilityTitle"
-                  >Wie nutze ich arsnova.eu barrierefrei und als App?</mat-panel-title
+                  >Welche Barrierefreiheitsfunktionen gibt es, und wie installiere ich arsnova.eu
+                  als App?</mat-panel-title
                 >
               </mat-expansion-panel-header>
               <div

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -187,10 +187,11 @@
               </mat-expansion-panel-header>
               <div class="help-panel__body" [attr.inert]="hostQaPanel.expanded ? null : ''">
                 <p i18n="@@help.hostQaBody">
-                  Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst
-                  Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative
-                  Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die
-                  Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.
+                  Neue Beiträge können zunächst zurückgehalten und erst nach deiner Freigabe
+                  veröffentlicht werden. Du kannst Fragen freigeben, anheften, archivieren oder
+                  entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen
+                  helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für
+                  die Präsentation sichtbar.
                 </p>
               </div>
             </mat-expansion-panel>
@@ -292,10 +293,10 @@
                 [attr.inert]="participantContributePanel.expanded ? null : ''"
               >
                 <p i18n="@@help.participantContributeBody">
-                  Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch-
-                  oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe.
-                  Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein
-                  Tempo-Feedback kannst du während der laufenden Abfrage ändern.
+                  Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen
+                  positiv oder negativ bewerten. Je nach Moderation erscheint deine Frage erst nach
+                  der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung.
+                  Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.
                 </p>
               </div>
             </mat-expansion-panel>
@@ -420,12 +421,12 @@
                 [attr.inert]="commonTroubleshootingPanel.expanded ? null : ''"
               >
                 <p i18n="@@help.commonTroubleshootingBody">
-                  Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session
-                  noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der
-                  Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer
-                  Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal
-                  ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet
-                  wurde.
+                  Prüfe zuerst den Code oder QR-Code und deine Internetverbindung. Vergewissere dich
+                  außerdem, dass die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist,
+                  kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden.
+                  Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den
+                  Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session
+                  bereits beendet wurde.
                 </p>
               </div>
             </mat-expansion-panel>

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -5,7 +5,7 @@
     <div
       class="help-page l-page l-section content-page-panel"
       cdkTrapFocus
-      [cdkTrapFocusAutoCapture]="true"
+      [cdkTrapFocusAutoCapture]="trapAutoCapture"
       role="dialog"
       aria-modal="true"
       aria-labelledby="help-page-title"

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -79,7 +79,7 @@
         </nav>
 
         <section id="help-host" class="help-section" aria-labelledby="help-host-title">
-          <h2 id="help-host-title" class="help-section__title">
+          <h2 id="help-host-title" class="help-section__title" tabindex="-1">
             <mat-icon class="help-section__title-icon" aria-hidden="true">school</mat-icon>
             <span i18n="@@help.roleHostTitle">Ich leite eine Veranstaltung</span>
           </h2>
@@ -236,7 +236,7 @@
           class="help-section"
           aria-labelledby="help-participant-title"
         >
-          <h2 id="help-participant-title" class="help-section__title">
+          <h2 id="help-participant-title" class="help-section__title" tabindex="-1">
             <mat-icon class="help-section__title-icon" aria-hidden="true">groups</mat-icon>
             <span i18n="@@help.roleParticipantTitle">Ich nehme an einer Veranstaltung teil</span>
           </h2>

--- a/apps/frontend/src/app/features/help/help.component.scss
+++ b/apps/frontend/src/app/features/help/help.component.scss
@@ -164,6 +164,13 @@
   align-items: center;
   gap: 0.625rem;
   min-width: 0;
+  border-radius: 2px;
+  outline: none;
+}
+
+.help-section__title:focus-visible {
+  outline: 2px solid var(--mat-sys-primary);
+  outline-offset: 0.25rem;
 }
 
 .help-section__title-icon {

--- a/apps/frontend/src/app/features/help/help.component.scss
+++ b/apps/frontend/src/app/features/help/help.component.scss
@@ -159,6 +159,21 @@
   margin-top: 0.5rem;
 }
 
+.help-section__title {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  min-width: 0;
+}
+
+.help-section__title-icon {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  font-size: 1.75rem;
+  color: var(--mat-sys-primary);
+}
+
 .help-experience-title {
   font: var(--mat-sys-title-medium);
   color: var(--mat-sys-on-surface);

--- a/apps/frontend/src/app/features/help/help.component.scss
+++ b/apps/frontend/src/app/features/help/help.component.scss
@@ -195,6 +195,10 @@
 }
 
 .help-panel.mat-expansion-panel {
+  /* Mehrzeilige fr/es-Titel bei 320px / 200% Zoom: feste Material-Höhen abschalten. */
+  --mat-expansion-header-collapsed-state-height: auto;
+  --mat-expansion-header-expanded-state-height: auto;
+
   border-radius: var(--mat-sys-corner-medium) !important;
   box-shadow: none !important;
   outline: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant) 72%, transparent);
@@ -202,14 +206,17 @@
   background: var(--mat-sys-surface-container-low);
 
   ::ng-deep .mat-expansion-panel-header {
+    height: auto;
     min-height: 3.5rem;
+    padding-block: 0.75rem;
     padding-inline: 1rem;
+    align-items: center;
   }
 
   ::ng-deep .mat-expansion-panel-header .mat-content {
     min-width: 0;
     flex: 1 1 auto;
-    overflow: hidden;
+    overflow: visible;
     align-items: center;
     gap: 0.5rem;
   }

--- a/apps/frontend/src/app/features/help/help.component.scss
+++ b/apps/frontend/src/app/features/help/help.component.scss
@@ -25,7 +25,7 @@
   font: var(--mat-sys-body-large);
   color: var(--mat-sys-on-surface);
   line-height: 1.7;
-  max-inline-size: min(72ch, 100%);
+  max-inline-size: min(52rem, 100%);
   margin-inline: auto;
   overflow-wrap: break-word;
   word-break: break-word;
@@ -40,17 +40,12 @@
 .legal-article :deep(h2) {
   font: var(--mat-sys-title-large);
   color: var(--mat-sys-on-surface);
-  margin: 2rem 0 0.5rem;
+  margin: 2rem 0 0.75rem;
+  scroll-margin-top: 1.25rem;
 }
 
 .legal-article :deep(h2:first-of-type) {
   margin-top: 1.5rem;
-}
-
-.legal-article h3 {
-  font: var(--mat-sys-title-medium);
-  color: var(--mat-sys-on-surface);
-  margin: 0;
 }
 
 .legal-article :deep(p) {
@@ -59,26 +54,6 @@
 
 .legal-article :deep(p:last-child) {
   margin-bottom: 0;
-}
-
-.legal-article :deep(ul),
-.legal-article :deep(ol) {
-  margin: 0 0 1rem;
-  padding-left: 1.5rem;
-}
-
-.legal-article :deep(li) {
-  margin-bottom: 0.5rem;
-}
-
-.legal-article :deep(li::marker) {
-  color: var(--mat-sys-primary);
-}
-
-.legal-article :deep(hr) {
-  border: none;
-  border-top: 1px solid var(--mat-sys-outline-variant);
-  margin: 2rem 0;
 }
 
 .legal-article :deep(strong) {
@@ -102,202 +77,151 @@
   outline-offset: 0.25rem;
 }
 
-.legal-article .help-section-lead {
-  color: var(--mat-sys-on-surface-variant);
-}
-
-.legal-article .help-format-grid {
-  list-style: none;
+.help-role-nav {
   display: grid;
   gap: 0.875rem;
-  margin: 1rem 0;
-  padding-left: 0;
+  margin: 1.25rem 0 0.5rem;
 }
 
-.legal-article .help-format-card {
+@media (min-width: 720px) {
+  .help-role-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.help-role-card {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
   gap: 0.875rem;
   min-width: 0;
-  padding: 1rem;
+  min-height: 4.5rem;
+  padding: 1rem 1.125rem;
   border: 1px solid var(--mat-sys-outline-variant);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--mat-sys-surface-container-high) 72%, transparent);
-}
-
-.legal-article .help-format-card__icon {
-  width: 2rem;
-  height: 2rem;
-  margin-top: 0.1rem;
-  color: var(--mat-sys-primary);
-  font-size: 2rem;
-}
-
-.legal-article .help-format-card__body {
-  min-width: 0;
-}
-
-.legal-article .help-format-card p {
-  margin: 0.25rem 0 0;
-}
-
-.legal-article .help-format-card__tag {
-  display: block;
-  color: var(--mat-sys-primary);
-  font: var(--mat-sys-label-large);
-  text-transform: uppercase;
-}
-
-.legal-article .help-format-note {
-  margin-top: 0.75rem;
-  padding-left: 1rem;
-  border-left: 3px solid var(--mat-sys-primary);
-  color: var(--mat-sys-on-surface-variant);
-}
-
-.legal-article .help-section--qa-wall,
-.legal-article .help-section--confidence {
-  margin: 2rem -1.25rem 0;
-  padding: 1.25rem;
-  border-block: 1px solid var(--mat-sys-outline-variant);
-  background: color-mix(in srgb, var(--mat-sys-tertiary-container) 26%, var(--mat-sys-surface));
-}
-
-.legal-article .help-section--qa-wall h2,
-.legal-article .help-section--confidence h2 {
-  margin-top: 0;
-}
-
-.legal-article .help-qa-feature-list {
-  list-style: none;
-  display: grid;
-  gap: 0.875rem;
-  margin: 1rem 0 0;
-  padding-left: 0;
-}
-
-.legal-article .help-qa-feature {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.875rem;
-  min-width: 0;
-  padding: 0.85rem 0;
-  border-top: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant) 72%, transparent);
-}
-
-.legal-article .help-qa-feature:first-child {
-  border-top: 0;
-}
-
-.legal-article .help-qa-feature__icon {
-  width: 2rem;
-  height: 2rem;
-  margin-top: 0.1rem;
-  color: var(--mat-sys-tertiary);
-  font-size: 2rem;
-}
-
-.legal-article .help-qa-feature__body {
-  min-width: 0;
-}
-
-.legal-article .help-qa-feature p {
-  margin: 0.3rem 0 0;
-}
-
-@media (min-width: 840px) {
-  .legal-article .help-format-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .legal-article .help-format-card--wide {
-    grid-column: 1 / -1;
-  }
-}
-
-.legal-article :deep(.help-section--demo) {
-  padding: 1.25rem 1.25rem 1rem;
-  margin-inline: -1.25rem;
-  padding-inline: 1.25rem;
-  background: color-mix(in srgb, var(--mat-sys-primary-container) 25%, var(--mat-sys-surface));
   border-radius: var(--mat-sys-corner-large);
-  border-inline-start: 4px solid var(--mat-sys-primary);
+  background: color-mix(in srgb, var(--mat-sys-primary-container) 28%, var(--mat-sys-surface));
+  color: var(--mat-sys-on-surface);
+  text-decoration: none;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
 }
 
-@media (min-width: 600px) {
-  .legal-article .help-section--qa-wall,
-  .legal-article .help-section--confidence {
-    margin-inline: -2rem;
-    padding-inline: 2rem;
-  }
-
-  .legal-article :deep(.help-section--stats) {
-    margin-inline: -2rem;
-    padding-inline: 2rem;
-  }
+.help-role-card:hover {
+  text-decoration: none;
+  border-color: color-mix(in srgb, var(--mat-sys-primary) 45%, var(--mat-sys-outline-variant));
+  background: color-mix(in srgb, var(--mat-sys-primary-container) 42%, var(--mat-sys-surface));
 }
 
-@media (min-width: 840px) {
-  .legal-article .help-section--qa-wall,
-  .legal-article .help-section--confidence {
-    margin-inline: -2.5rem;
-    padding-inline: 2.5rem;
-  }
-
-  .legal-article .help-qa-feature-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .legal-article .help-qa-feature:nth-child(2) {
-    border-top: 0;
-  }
-
-  .legal-article :deep(.help-section--stats) {
-    margin-inline: -2.5rem;
-    padding-inline: 2.5rem;
-  }
+.help-role-card:focus-visible {
+  outline: 2px solid var(--mat-sys-primary);
+  outline-offset: 0.25rem;
 }
 
-@media (min-width: 600px) {
-  .legal-article :deep(.help-section--demo) {
-    margin-inline: -2rem;
-    padding-inline: 2rem;
-  }
+.help-role-card__icon,
+.help-role-card__chevron {
+  color: var(--mat-sys-primary);
+  flex-shrink: 0;
 }
 
-@media (min-width: 840px) {
-  .legal-article :deep(.help-section--demo) {
-    margin-inline: -2.5rem;
-    padding-inline: 2.5rem;
-  }
+.help-role-card__icon {
+  width: 2rem;
+  height: 2rem;
+  font-size: 2rem;
 }
 
-.legal-article :deep(.help-steps) {
-  list-style: none;
-  padding-left: 0;
-  counter-reset: step;
-}
-
-.legal-article :deep(.help-steps li) {
-  counter-increment: step;
-  padding-left: 2rem;
-  position: relative;
-  margin-bottom: 0.75rem;
-}
-
-.legal-article :deep(.help-steps li::before) {
-  content: counter(step);
-  position: absolute;
-  left: 0;
+.help-role-card__chevron {
   width: 1.5rem;
   height: 1.5rem;
-  border-radius: var(--mat-sys-corner-full);
-  background: var(--mat-sys-primary-container);
-  color: var(--mat-sys-on-primary-container);
-  font: var(--mat-sys-label-large);
-  font-weight: 600;
+  font-size: 1.5rem;
+}
+
+.help-role-card__copy {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.875rem;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.help-role-card__title {
+  font: var(--mat-sys-title-medium);
+  color: var(--mat-sys-on-surface);
+  overflow-wrap: break-word;
+}
+
+.help-role-card__hint {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  overflow-wrap: break-word;
+}
+
+.help-section {
+  margin-top: 0.5rem;
+}
+
+.help-experience-title {
+  font: var(--mat-sys-title-medium);
+  color: var(--mat-sys-on-surface);
+  margin: 1.25rem 0 0.625rem;
+}
+
+.help-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.help-panel.mat-expansion-panel {
+  border-radius: var(--mat-sys-corner-medium) !important;
+  box-shadow: none !important;
+  outline: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant) 72%, transparent);
+  outline-offset: -1px;
+  background: var(--mat-sys-surface-container-low);
+
+  ::ng-deep .mat-expansion-panel-header {
+    min-height: 3.5rem;
+    padding-inline: 1rem;
+  }
+
+  ::ng-deep .mat-expansion-panel-header .mat-content {
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  ::ng-deep .mat-expansion-panel-header .mat-expansion-panel-header-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-right: 0.75rem;
+    white-space: normal;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    font: var(--mat-sys-title-small);
+    color: var(--mat-sys-on-surface);
+  }
+
+  ::ng-deep .mat-expansion-panel-body {
+    min-width: 0;
+    max-width: 100%;
+    padding: 0 1rem 1rem;
+  }
+
+  ::ng-deep .mat-expansion-panel-header:focus-visible {
+    outline: 2px solid var(--mat-sys-primary);
+    outline-offset: -2px;
+  }
+}
+
+.help-panel__body {
+  min-width: 0;
+  max-inline-size: 72ch;
+}
+
+.help-panel__body p {
+  margin: 0;
+  color: var(--mat-sys-on-surface);
+  line-height: 1.65;
 }

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -101,7 +101,7 @@ describe('HelpComponent', () => {
     ).toBe('info');
   });
 
-  it('setzt bei Rollenkarten-Klick den Fragment-Anker per replaceState ohne History-Push', async () => {
+  it('setzt bei Rollenkarten-Klick Fragment per replaceState und fokussiert den Abschnitt', async () => {
     const fixture = await createFixture();
     const router = TestBed.inject(Router);
     const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
@@ -110,14 +110,19 @@ describe('HelpComponent', () => {
     const hostSection = (fixture.nativeElement as HTMLElement).querySelector(
       '#help-host',
     ) as HTMLElement;
+    const hostTitle = (fixture.nativeElement as HTMLElement).querySelector(
+      '#help-host-title',
+    ) as HTMLElement;
     Object.defineProperty(hostSection, 'scrollIntoView', {
       configurable: true,
       value: vi.fn(),
     });
+    const focusSpy = vi.spyOn(hostTitle, 'focus');
     const hostCard = (fixture.nativeElement as HTMLElement).querySelector<HTMLAnchorElement>(
       'a.help-role-card[href$="#help-host"]',
     );
     expect(hostCard).toBeTruthy();
+    expect(hostTitle.getAttribute('tabindex')).toBe('-1');
 
     hostCard!.dispatchEvent(
       new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }),
@@ -125,6 +130,7 @@ describe('HelpComponent', () => {
     fixture.detectChanges();
 
     expect(hostSection.scrollIntoView).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
     expect(replaceStateSpy).toHaveBeenCalledTimes(1);
     expect(String(replaceStateSpy.mock.calls[0]?.[2] ?? '')).toContain('#help-host');
     expect(pushStateSpy).not.toHaveBeenCalled();

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -1,6 +1,7 @@
 import { Location } from '@angular/common';
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter, Router } from '@angular/router';
+import { provideRouter, Router, RouterOutlet, withInMemoryScrolling } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getLocaleFromPath } from '../../core/locale-from-path';
@@ -14,6 +15,13 @@ vi.mock('../../core/locale-from-path', async (importOriginal) => {
   };
 });
 
+@Component({
+  selector: 'app-help-router-host',
+  imports: [RouterOutlet],
+  template: '<router-outlet />',
+})
+class HelpRouterHostComponent {}
+
 describe('HelpComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -24,6 +32,8 @@ describe('HelpComponent', () => {
 
   afterEach(() => {
     document.querySelectorAll('base').forEach((el) => el.remove());
+    document.querySelectorAll('app-help-router-host').forEach((el) => el.remove());
+    window.history.replaceState(window.history.state, '', '/');
     vi.clearAllMocks();
   });
 
@@ -125,6 +135,61 @@ describe('HelpComponent', () => {
     expect(
       root.querySelector('#help-common-title .help-section__title-icon')?.textContent?.trim(),
     ).toBe('info');
+  });
+
+  it('landet bei initialem Fragmentaufruf am Rollenabschnitt ohne History-Push', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [HelpRouterHostComponent, HelpComponent],
+      providers: [
+        provideRouter(
+          [
+            { path: 'de/help', component: HelpComponent },
+            { path: 'help', component: HelpComponent },
+          ],
+          withInMemoryScrolling({ scrollPositionRestoration: 'top' }),
+        ),
+        { provide: MatDialog, useValue: { openDialogs: [] } },
+      ],
+    });
+
+    const hostFixture = TestBed.createComponent(HelpRouterHostComponent);
+    document.body.appendChild(hostFixture.nativeElement);
+    hostFixture.detectChanges();
+
+    const scrollIntoViewSpy = vi.fn();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      writable: true,
+      value: scrollIntoViewSpy,
+    });
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    const router = TestBed.inject(Router);
+    // Browser-URL inkl. Hash vor Aktivierung setzen (neuer Tab / Fragmentaufruf).
+    window.history.replaceState(window.history.state, '', '/de/help#help-participant');
+    const navigated = await router.navigateByUrl('/de/help#help-participant');
+    expect(navigated).toBe(true);
+    hostFixture.detectChanges();
+    await hostFixture.whenStable();
+    hostFixture.detectChanges();
+
+    // afterNextRender / ngAfterViewInit + setTimeout(0)
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    hostFixture.detectChanges();
+    await hostFixture.whenStable();
+
+    const title = document.querySelector('#help-participant-title') as HTMLElement | null;
+    const section = document.querySelector('#help-participant');
+    expect(router.url).toContain('/de/help');
+    expect(window.location.hash).toBe('#help-participant');
+    expect(title).toBeTruthy();
+    expect(section).toBeTruthy();
+    expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+    expect(scrollIntoViewSpy.mock.instances.some((instance) => instance === section)).toBe(true);
+    expect(document.activeElement).toBe(title);
+    expect(pushStateSpy).not.toHaveBeenCalled();
+    pushStateSpy.mockRestore();
+    Reflect.deleteProperty(Element.prototype, 'scrollIntoView');
   });
 
   it('setzt bei Rollenkarten-Klick Fragment per replaceState, scrollt und fokussiert den Abschnitt', async () => {

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -3,7 +3,16 @@ import { TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLocaleFromPath } from '../../core/locale-from-path';
 import { HelpComponent } from './help.component';
+
+vi.mock('../../core/locale-from-path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/locale-from-path')>();
+  return {
+    ...actual,
+    getLocaleFromPath: vi.fn(actual.getLocaleFromPath),
+  };
+});
 
 describe('HelpComponent', () => {
   beforeEach(() => {
@@ -14,6 +23,7 @@ describe('HelpComponent', () => {
   });
 
   afterEach(() => {
+    document.querySelectorAll('base').forEach((el) => el.remove());
     vi.clearAllMocks();
   });
 
@@ -79,12 +89,28 @@ describe('HelpComponent', () => {
     const participantCard = root.querySelector<HTMLAnchorElement>(
       'a.help-role-card[href$="#help-participant"]',
     );
-    expect(hostCard?.getAttribute('href')).toBe('/help#help-host');
-    expect(participantCard?.getAttribute('href')).toBe('/help#help-participant');
+    expect(hostCard?.getAttribute('href')).toMatch(/\/help#help-host$/);
+    expect(participantCard?.getAttribute('href')).toMatch(/\/help#help-participant$/);
     expect(hostCard?.textContent).toContain('Ich leite eine Veranstaltung');
     expect(participantCard?.textContent).toContain('Ich nehme an einer Veranstaltung teil');
     expect(root.querySelector('#help-host')).toBeTruthy();
     expect(root.querySelector('#help-participant')).toBeTruthy();
+  });
+
+  it('baut Rollenkarten-hrefs unter Production-base href mit Locale', async () => {
+    const base = document.createElement('base');
+    base.setAttribute('href', '/de/');
+    document.head.prepend(base);
+    vi.mocked(getLocaleFromPath).mockReturnValue('de');
+
+    const fixture = await createFixture();
+    const root = fixture.nativeElement as HTMLElement;
+    const hostCard = root.querySelector<HTMLAnchorElement>('a.help-role-card[href$="#help-host"]');
+    const participantCard = root.querySelector<HTMLAnchorElement>(
+      'a.help-role-card[href$="#help-participant"]',
+    );
+    expect(hostCard?.getAttribute('href')).toBe('/de/help#help-host');
+    expect(participantCard?.getAttribute('href')).toBe('/de/help#help-participant');
   });
 
   it('wiederholt die Rollenicons in den Abschnittsüberschriften und zeigt eines für Für alle', async () => {
@@ -101,7 +127,7 @@ describe('HelpComponent', () => {
     ).toBe('info');
   });
 
-  it('setzt bei Rollenkarten-Klick Fragment per replaceState und fokussiert den Abschnitt', async () => {
+  it('setzt bei Rollenkarten-Klick Fragment per replaceState, scrollt und fokussiert den Abschnitt', async () => {
     const fixture = await createFixture();
     const router = TestBed.inject(Router);
     const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
@@ -113,9 +139,10 @@ describe('HelpComponent', () => {
     const hostTitle = (fixture.nativeElement as HTMLElement).querySelector(
       '#help-host-title',
     ) as HTMLElement;
+    const scrollIntoView = vi.fn();
     Object.defineProperty(hostSection, 'scrollIntoView', {
       configurable: true,
-      value: vi.fn(),
+      value: scrollIntoView,
     });
     const focusSpy = vi.spyOn(hostTitle, 'focus');
     const hostCard = (fixture.nativeElement as HTMLElement).querySelector<HTMLAnchorElement>(
@@ -129,7 +156,7 @@ describe('HelpComponent', () => {
     );
     fixture.detectChanges();
 
-    expect(hostSection.scrollIntoView).toHaveBeenCalled();
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
     expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
     expect(replaceStateSpy).toHaveBeenCalledTimes(1);
     expect(String(replaceStateSpy.mock.calls[0]?.[2] ?? '')).toContain('#help-host');
@@ -137,6 +164,53 @@ describe('HelpComponent', () => {
     expect(navigateSpy).not.toHaveBeenCalled();
     replaceStateSpy.mockRestore();
     pushStateSpy.mockRestore();
+  });
+
+  it('nutzt bei prefers-reduced-motion sofortiges Scrollen ohne Router-Navigation', async () => {
+    const previousMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(
+        (query: string) =>
+          ({
+            matches: query.includes('prefers-reduced-motion: reduce'),
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          }) as MediaQueryList,
+      ),
+    });
+    const fixture = await createFixture();
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+    const hostSection = (fixture.nativeElement as HTMLElement).querySelector(
+      '#help-host',
+    ) as HTMLElement;
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(hostSection, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    const hostCard = (fixture.nativeElement as HTMLElement).querySelector<HTMLAnchorElement>(
+      'a.help-role-card[href$="#help-host"]',
+    );
+
+    hostCard!.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }),
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'start' });
+    expect(navigateSpy).not.toHaveBeenCalled();
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: previousMatchMedia,
+    });
   });
 
   it('rendert beide Rollen und beide Erfahrungsgruppen', async () => {

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -87,6 +87,20 @@ describe('HelpComponent', () => {
     expect(root.querySelector('#help-participant')).toBeTruthy();
   });
 
+  it('wiederholt die Rollenicons in den Abschnittsüberschriften und zeigt eines für Für alle', async () => {
+    const fixture = await createFixture();
+    const root = fixture.nativeElement as HTMLElement;
+    expect(
+      root.querySelector('#help-host-title .help-section__title-icon')?.textContent?.trim(),
+    ).toBe('school');
+    expect(
+      root.querySelector('#help-participant-title .help-section__title-icon')?.textContent?.trim(),
+    ).toBe('groups');
+    expect(
+      root.querySelector('#help-common-title .help-section__title-icon')?.textContent?.trim(),
+    ).toBe('info');
+  });
+
   it('hält bei Rollenkarten-Klick die Hilfeseite und setzt den Fragment-Pfad', async () => {
     const fixture = await createFixture();
     const router = TestBed.inject(Router);

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -17,14 +17,19 @@ describe('HelpComponent', () => {
     vi.clearAllMocks();
   });
 
-  it('ruft bei Klick auf den Backdrop location.back auf', async () => {
-    Object.defineProperty(window.history, 'length', { configurable: true, value: 3 });
+  async function createFixture() {
     const fixture = TestBed.createComponent(HelpComponent);
-    const location = TestBed.inject(Location);
-    const spy = vi.spyOn(location, 'back');
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+    return fixture;
+  }
+
+  it('ruft bei Klick auf den Backdrop location.back auf', async () => {
+    Object.defineProperty(window.history, 'length', { configurable: true, value: 3 });
+    const fixture = await createFixture();
+    const location = TestBed.inject(Location);
+    const spy = vi.spyOn(location, 'back');
     const backdrop = (fixture.nativeElement as HTMLElement).querySelector(
       '.content-page-backdrop-sheet',
     );
@@ -33,12 +38,11 @@ describe('HelpComponent', () => {
     expect(spy).toHaveBeenCalledOnce();
   });
 
-  it('schließt per Escape und hält den Fokus im Panel', () => {
+  it('schließt per Escape und hält den Fokus im Panel', async () => {
     Object.defineProperty(window.history, 'length', { configurable: true, value: 3 });
-    const fixture = TestBed.createComponent(HelpComponent);
+    const fixture = await createFixture();
     const location = TestBed.inject(Location);
     const spy = vi.spyOn(location, 'back');
-    fixture.detectChanges();
 
     const panel = fixture.nativeElement.querySelector('.content-page-panel') as HTMLElement;
     expect(panel.getAttribute('role')).toBe('dialog');
@@ -49,87 +53,139 @@ describe('HelpComponent', () => {
     expect(spy).toHaveBeenCalledOnce();
   });
 
-  it('schließt die Seite nicht per Escape solange ein MatDialog offen ist', () => {
+  it('schließt die Seite nicht per Escape solange ein MatDialog offen ist', async () => {
     Object.defineProperty(window.history, 'length', { configurable: true, value: 3 });
-    const fixture = TestBed.createComponent(HelpComponent);
+    await createFixture();
     const location = TestBed.inject(Location);
     const dialog = TestBed.inject(MatDialog);
     const spy = vi.spyOn(location, 'back');
     Object.defineProperty(dialog, 'openDialogs', { configurable: true, get: () => [{}] });
-    fixture.detectChanges();
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('benennt das Navigations-Landmark lokalisierbar', () => {
-    const fixture = TestBed.createComponent(HelpComponent);
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement.querySelector('nav')?.getAttribute('aria-label')).toBe(
-      'Navigation',
-    );
-  });
-
-  it('zeigt keine Rekordteilnahme mehr auf der Hilfeseite', async () => {
-    const fixture = TestBed.createComponent(HelpComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+  it('benennt Navigations-Landmarks lokalisierbar', async () => {
+    const fixture = await createFixture();
     const root = fixture.nativeElement as HTMLElement;
-    expect(root.textContent).not.toMatch(/Rekordteilnahme/i);
+    expect(root.querySelector('nav.content-back')?.getAttribute('aria-label')).toBe('Navigation');
+    expect(root.querySelector('nav.help-role-nav')?.getAttribute('aria-label')).toBe('Rollenwahl');
   });
 
-  it('beschreibt das Tempo-Feedback im Blitzlicht-Abschnitt', async () => {
-    const fixture = TestBed.createComponent(HelpComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+  it('rendert beide Rollenkarten mit korrekten Ankerzielen', async () => {
+    const fixture = await createFixture();
+    const root = fixture.nativeElement as HTMLElement;
+    const hostCard = root.querySelector<HTMLAnchorElement>('a.help-role-card[href="#help-host"]');
+    const participantCard = root.querySelector<HTMLAnchorElement>(
+      'a.help-role-card[href="#help-participant"]',
+    );
+    expect(hostCard?.textContent).toContain('Ich leite eine Veranstaltung');
+    expect(participantCard?.textContent).toContain('Ich nehme an einer Veranstaltung teil');
+    expect(root.querySelector('#help-host')).toBeTruthy();
+    expect(root.querySelector('#help-participant')).toBeTruthy();
+  });
+
+  it('rendert beide Rollen und beide Erfahrungsgruppen', async () => {
+    const fixture = await createFixture();
     const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
-    expect(text).toContain('Tempo-Feedback');
-    expect(text).toContain('aggregierte Tendenz');
+    expect(text).toContain('Ich leite eine Veranstaltung');
+    expect(text).toContain('Ich nehme an einer Veranstaltung teil');
+    expect(text).toContain('Für alle');
+    expect(text.match(/Neu bei arsnova\.eu/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(text.match(/Schon vertraut mit arsnova\.eu/g)?.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('differenziert die verfügbaren Quiz-Frageformate', async () => {
-    const fixture = TestBed.createComponent(HelpComponent);
+  it('rendert die erwarteten Akkordeonpanels ohne Verschachtelung', async () => {
+    const fixture = await createFixture();
+    const root = fixture.nativeElement as HTMLElement;
+    const panels = root.querySelectorAll('mat-expansion-panel.help-panel');
+    expect(panels.length).toBe(17);
+    expect(root.querySelectorAll('mat-expansion-panel mat-expansion-panel').length).toBe(0);
+    expect(root.querySelectorAll('mat-accordion').length).toBe(5);
+  });
+
+  it('öffnet das erste Anfängerpanel pro Rolle und hält Referenzpanels geschlossen', async () => {
+    const fixture = await createFixture();
+    const root = fixture.nativeElement as HTMLElement;
+    const hostPanels = root.querySelectorAll('#help-host mat-expansion-panel.help-panel');
+    const participantPanels = root.querySelectorAll(
+      '#help-participant mat-expansion-panel.help-panel',
+    );
+    const commonPanels = root.querySelectorAll('#help-common mat-expansion-panel.help-panel');
+
+    expect(hostPanels[0]?.classList.contains('mat-expanded')).toBe(true);
+    for (let i = 1; i < hostPanels.length; i++) {
+      expect(hostPanels[i]?.classList.contains('mat-expanded')).toBe(false);
+    }
+
+    expect(participantPanels[0]?.classList.contains('mat-expanded')).toBe(true);
+    for (let i = 1; i < participantPanels.length; i++) {
+      expect(participantPanels[i]?.classList.contains('mat-expanded')).toBe(false);
+    }
+
+    for (const panel of Array.from(commonPanels)) {
+      expect(panel.classList.contains('mat-expanded')).toBe(false);
+    }
+  });
+
+  it('lässt Panels öffnen und schließen und aktualisiert aria-expanded', async () => {
+    const fixture = await createFixture();
+    const root = fixture.nativeElement as HTMLElement;
+    const hostPanels = root.querySelectorAll('#help-host mat-expansion-panel.help-panel');
+    const firstHeader = hostPanels[0]?.querySelector<HTMLElement>('.mat-expansion-panel-header');
+    const secondHeader = hostPanels[1]?.querySelector<HTMLElement>('.mat-expansion-panel-header');
+    expect(firstHeader?.getAttribute('aria-expanded')).toBe('true');
+    expect(secondHeader?.getAttribute('aria-expanded')).toBe('false');
+
+    secondHeader!.click();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+    expect(secondHeader?.getAttribute('aria-expanded')).toBe('true');
+    expect(firstHeader?.getAttribute('aria-expanded')).toBe('true');
+
+    firstHeader!.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(firstHeader?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('setzt inert auf geschlossenen Panelinhalt mit Link', async () => {
+    const fixture = await createFixture();
+    const root = fixture.nativeElement as HTMLElement;
+    const privacyPanel = Array.from(
+      root.querySelectorAll('#help-common mat-expansion-panel.help-panel'),
+    ).find((panel) => panel.textContent?.includes('Wie werden Daten und Inhalte behandelt?'));
+    expect(privacyPanel).toBeTruthy();
+
+    const body = privacyPanel!.querySelector('.help-panel__body');
+    expect(body?.hasAttribute('inert')).toBe(true);
+    expect(privacyPanel!.querySelector('a[href*="/legal/privacy"]')).toBeTruthy();
+
+    const header = privacyPanel!.querySelector<HTMLElement>('.mat-expansion-panel-header');
+    header!.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(body?.hasAttribute('inert')).toBe(false);
+  });
+
+  it('bewahrt zentrale Produktinhalte und entfernt Roadmap-Texte', async () => {
+    const fixture = await createFixture();
     const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
     expect(text).toContain('Single Choice');
-    expect(text).toContain('Multiple Choice');
-    expect(text).toContain('Kurzantwort');
-    expect(text).toContain('Freitext');
-    expect(text).toContain('Umfrage');
-    expect(text).toContain('Bewertungsskala');
-    expect(text).toContain('Numerische Schätzfrage');
-    expect(text).toContain('Musterlösungen');
-    expect(text).toContain('Keine automatische Bewertung');
-    expect(text).toContain('Referenzwert');
-  });
-
-  it('beschreibt die Q&A-Fragenwand didaktisch', async () => {
-    const fixture = TestBed.createComponent(HelpComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
-    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
-    expect(text).toContain('Fragenwand im Live-Kanal Q&A');
-    expect(text).toContain('Kollektives Hoch- und Runtervoting');
-    expect(text).toContain('Q&A-Wortwolke auf Themenebene');
-    expect(text).toContain('Moderationskompass');
-    expect(text).toContain('asynchrone Q&A-NLP-Signale');
-  });
-
-  it('beschreibt die Selbsteinschätzung didaktisch', async () => {
-    const fixture = TestBed.createComponent(HelpComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
-    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
-    expect(text).toContain('Selbsteinschätzung bei bewertbaren Fragen');
-    expect(text).toContain('selbstsicher falsch');
+    expect(text).toContain('Selbsteinschätzung');
+    expect(text).toContain('Peer Instruction');
+    expect(text).toContain('Q&A');
+    expect(text).toContain('Blitzlicht');
+    expect(text).toContain('Tempo-Feedback');
     expect(text).toContain('Nachbesprechungsplan');
-    expect(text).toContain('Progressive Disclosure');
+    expect(text).toContain('Sync-Link');
+    expect(text).toContain('sechsstelligen Code');
+    expect(text).toContain('Demo-Quiz');
+    expect(text).not.toContain('Moderationskompass');
+    expect(text).not.toContain('asynchrone Q&A-NLP-Signale');
+    expect(text).not.toMatch(/Rekordteilnahme/i);
   });
 });

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -101,10 +101,12 @@ describe('HelpComponent', () => {
     ).toBe('info');
   });
 
-  it('hält bei Rollenkarten-Klick die Hilfeseite und setzt den Fragment-Pfad', async () => {
+  it('setzt bei Rollenkarten-Klick den Fragment-Anker per replaceState ohne History-Push', async () => {
     const fixture = await createFixture();
     const router = TestBed.inject(Router);
     const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
     const hostSection = (fixture.nativeElement as HTMLElement).querySelector(
       '#help-host',
     ) as HTMLElement;
@@ -123,7 +125,12 @@ describe('HelpComponent', () => {
     fixture.detectChanges();
 
     expect(hostSection.scrollIntoView).toHaveBeenCalled();
-    expect(navigateSpy).toHaveBeenCalledWith('/help#help-host', { replaceUrl: true });
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(String(replaceStateSpy.mock.calls[0]?.[2] ?? '')).toContain('#help-host');
+    expect(pushStateSpy).not.toHaveBeenCalled();
+    expect(navigateSpy).not.toHaveBeenCalled();
+    replaceStateSpy.mockRestore();
+    pushStateSpy.mockRestore();
   });
 
   it('rendert beide Rollen und beide Erfahrungsgruppen', async () => {

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -1,6 +1,6 @@
 import { Location } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HelpComponent } from './help.component';
@@ -72,17 +72,44 @@ describe('HelpComponent', () => {
     expect(root.querySelector('nav.help-role-nav')?.getAttribute('aria-label')).toBe('Rollenwahl');
   });
 
-  it('rendert beide Rollenkarten mit korrekten Ankerzielen', async () => {
+  it('rendert beide Rollenkarten mit locale-sicheren Ankerzielen', async () => {
     const fixture = await createFixture();
     const root = fixture.nativeElement as HTMLElement;
-    const hostCard = root.querySelector<HTMLAnchorElement>('a.help-role-card[href="#help-host"]');
+    const hostCard = root.querySelector<HTMLAnchorElement>('a.help-role-card[href$="#help-host"]');
     const participantCard = root.querySelector<HTMLAnchorElement>(
-      'a.help-role-card[href="#help-participant"]',
+      'a.help-role-card[href$="#help-participant"]',
     );
+    expect(hostCard?.getAttribute('href')).toBe('/help#help-host');
+    expect(participantCard?.getAttribute('href')).toBe('/help#help-participant');
     expect(hostCard?.textContent).toContain('Ich leite eine Veranstaltung');
     expect(participantCard?.textContent).toContain('Ich nehme an einer Veranstaltung teil');
     expect(root.querySelector('#help-host')).toBeTruthy();
     expect(root.querySelector('#help-participant')).toBeTruthy();
+  });
+
+  it('hält bei Rollenkarten-Klick die Hilfeseite und setzt den Fragment-Pfad', async () => {
+    const fixture = await createFixture();
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+    const hostSection = (fixture.nativeElement as HTMLElement).querySelector(
+      '#help-host',
+    ) as HTMLElement;
+    Object.defineProperty(hostSection, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    const hostCard = (fixture.nativeElement as HTMLElement).querySelector<HTMLAnchorElement>(
+      'a.help-role-card[href$="#help-host"]',
+    );
+    expect(hostCard).toBeTruthy();
+
+    hostCard!.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }),
+    );
+    fixture.detectChanges();
+
+    expect(hostSection.scrollIntoView).toHaveBeenCalled();
+    expect(navigateSpy).toHaveBeenCalledWith('/help#help-host', { replaceUrl: true });
   });
 
   it('rendert beide Rollen und beide Erfahrungsgruppen', async () => {

--- a/apps/frontend/src/app/features/help/help.component.ts
+++ b/apps/frontend/src/app/features/help/help.component.ts
@@ -43,6 +43,35 @@ export class HelpComponent {
 
   readonly localizedPath = localizePath;
 
+  /** Locale-sicherer Abschnittsanker (kein reines `#…` wegen `<base href>`). */
+  helpSectionHref(sectionId: 'help-host' | 'help-participant'): string {
+    return `${localizePath('/help')}#${sectionId}`;
+  }
+
+  /**
+   * Primärklick: im Scroll-Container `#main-content` springen, Locale-Pfad behalten.
+   * Modifizierte Klicks (neuer Tab etc.) nutzen den echten `href`.
+   */
+  onHelpSectionLinkClick(event: MouseEvent, sectionId: 'help-host' | 'help-participant'): void {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    const section = document.getElementById(sectionId);
+    if (!section) {
+      return;
+    }
+    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    void this.router.navigateByUrl(this.helpSectionHref(sectionId), { replaceUrl: true });
+  }
+
   @HostListener('document:keydown.escape', ['$event'])
   onEscape(event: Event): void {
     if (shouldDeferContentPageEscape(this.dialog)) {

--- a/apps/frontend/src/app/features/help/help.component.ts
+++ b/apps/frontend/src/app/features/help/help.component.ts
@@ -1,5 +1,12 @@
-import { Location } from '@angular/common';
-import { Component, HostListener, inject } from '@angular/core';
+import { isPlatformBrowser, Location } from '@angular/common';
+import {
+  afterNextRender,
+  AfterViewInit,
+  Component,
+  HostListener,
+  inject,
+  PLATFORM_ID,
+} from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { CdkTrapFocus } from '@angular/cdk/a11y';
 import { MatButton } from '@angular/material/button';
@@ -13,6 +20,8 @@ import {
 import { MatIcon } from '@angular/material/icon';
 import { localizePath, resolveLocalizedAppUrl } from '../../core/locale-router';
 import { dismissContentPage, shouldDeferContentPageEscape } from '../../shared/content-page-nav';
+
+type HelpRoleSectionId = 'help-host' | 'help-participant';
 
 /**
  * Hilfe & Einstieg: rollen- und erfahrungsbasierte Akkordeons (Issue #190).
@@ -36,18 +45,52 @@ import { dismissContentPage, shouldDeferContentPageEscape } from '../../shared/c
     'help.component.scss',
   ],
 })
-export class HelpComponent {
+export class HelpComponent implements AfterViewInit {
   private readonly location = inject(Location);
   private readonly router = inject(Router);
   private readonly dialog = inject(MatDialog);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  /** Erlaubter Deep-Link beim ersten Render (z. B. neuer Tab mit `#help-participant`). */
+  private readonly hashSectionOnInit = this.readAllowedHelpSectionHash();
+  private initialHashApplied = false;
+
+  /**
+   * Bei Deep-Link zum Rollenabschnitt kein Auto-Capture auf den Zurück-Button —
+   * sonst gewinnt der Focus-Trap gegen den Abschnittstitel.
+   */
+  readonly trapAutoCapture = this.hashSectionOnInit === null;
 
   readonly localizedPath = localizePath;
+
+  constructor() {
+    // Hydration / Browser: nach dem ersten Render denselben Scroll-/Fokuspfad wie beim Klick.
+    afterNextRender(() => this.applyInitialHelpSectionHash());
+  }
+
+  ngAfterViewInit(): void {
+    // Zusätzlich nach View-Init (Tests / Umgebungen ohne zuverlässigen afterNextRender-Flush).
+    this.applyInitialHelpSectionHash();
+  }
+
+  private applyInitialHelpSectionHash(): void {
+    if (this.initialHashApplied) {
+      return;
+    }
+    const sectionId = this.hashSectionOnInit ?? this.readAllowedHelpSectionHash();
+    if (!sectionId) {
+      return;
+    }
+    this.initialHashApplied = true;
+    // Nach scrollPositionRestoration: 'top' und Focus-Trap-Init den Abschnitt ansteuern.
+    setTimeout(() => this.focusHelpSection(sectionId), 0);
+  }
 
   /**
    * Browser-`href` für Rollenkarten: locale-sicher auch bei Production-`<base href="/de/">`
    * (Ctrl/Cmd-Klick, Mittelklick, „In neuem Tab öffnen“).
    */
-  helpSectionHref(sectionId: 'help-host' | 'help-participant'): string {
+  helpSectionHref(sectionId: HelpRoleSectionId): string {
     const absolute = resolveLocalizedAppUrl('/help');
     try {
       const url = new URL(
@@ -67,7 +110,7 @@ export class HelpComponent {
    * bzw. Zurück nur auf den Anker.
    * Modifizierte Klicks (neuer Tab etc.) nutzen den echten `href`.
    */
-  onHelpSectionLinkClick(event: MouseEvent, sectionId: 'help-host' | 'help-participant'): void {
+  onHelpSectionLinkClick(event: MouseEvent, sectionId: HelpRoleSectionId): void {
     if (
       event.defaultPrevented ||
       event.button !== 0 ||
@@ -82,6 +125,13 @@ export class HelpComponent {
     if (typeof window === 'undefined') {
       return;
     }
+    this.focusHelpSection(sectionId);
+    const nextUrl = `${window.location.pathname}${window.location.search}#${sectionId}`;
+    window.history.replaceState(window.history.state, '', nextUrl);
+  }
+
+  /** Scrollt und fokussiert einen erlaubten Rollenabschnitt (Klick und initialer Hash). */
+  private focusHelpSection(sectionId: HelpRoleSectionId): void {
     const section = document.getElementById(sectionId);
     if (!section) {
       return;
@@ -92,8 +142,14 @@ export class HelpComponent {
     // Nach In-Page-Sprung Fokus verschieben; sonst bleibt er auf der Rollenkarte und Tab
     // läuft wieder durch die Karten oberhalb des Ziels.
     heading.focus({ preventScroll: true });
-    const nextUrl = `${window.location.pathname}${window.location.search}#${sectionId}`;
-    window.history.replaceState(window.history.state, '', nextUrl);
+  }
+
+  private readAllowedHelpSectionHash(): HelpRoleSectionId | null {
+    if (!isPlatformBrowser(this.platformId) || typeof window === 'undefined') {
+      return null;
+    }
+    const hash = window.location.hash.replace(/^#/, '');
+    return hash === 'help-host' || hash === 'help-participant' ? hash : null;
   }
 
   private scrollBehavior(): ScrollBehavior {

--- a/apps/frontend/src/app/features/help/help.component.ts
+++ b/apps/frontend/src/app/features/help/help.component.ts
@@ -11,7 +11,7 @@ import {
   MatExpansionPanelTitle,
 } from '@angular/material/expansion';
 import { MatIcon } from '@angular/material/icon';
-import { localizePath } from '../../core/locale-router';
+import { localizePath, resolveLocalizedAppUrl } from '../../core/locale-router';
 import { dismissContentPage, shouldDeferContentPageEscape } from '../../shared/content-page-nav';
 
 /**
@@ -43,15 +43,28 @@ export class HelpComponent {
 
   readonly localizedPath = localizePath;
 
-  /** Locale-sicherer Abschnittsanker (kein reines `#…` wegen `<base href>`). */
+  /**
+   * Browser-`href` für Rollenkarten: locale-sicher auch bei Production-`<base href="/de/">`
+   * (Ctrl/Cmd-Klick, Mittelklick, „In neuem Tab öffnen“).
+   */
   helpSectionHref(sectionId: 'help-host' | 'help-participant'): string {
-    return `${localizePath('/help')}#${sectionId}`;
+    const absolute = resolveLocalizedAppUrl('/help');
+    try {
+      const url = new URL(
+        absolute,
+        typeof window !== 'undefined' ? window.location.origin : undefined,
+      );
+      return `${url.pathname}${url.search}#${sectionId}`;
+    } catch {
+      return `${localizePath('/help')}#${sectionId}`;
+    }
   }
 
   /**
    * Primärklick/Enter: im Scroll-Container springen, Fragment per replaceState setzen und
    * Fokus auf die Abschnittsüberschrift legen, damit Tab danach in diesem Abschnitt weiterläuft.
-   * Kein History-Push — sonst würde dismissContentPage/Zurück nur den Anker entfernen.
+   * Kein Router-Navigate / History-Push — sonst Scroll-Reset (`scrollPositionRestoration: 'top'`)
+   * bzw. Zurück nur auf den Anker.
    * Modifizierte Klicks (neuer Tab etc.) nutzen den echten `href`.
    */
   onHelpSectionLinkClick(event: MouseEvent, sectionId: 'help-host' | 'help-participant'): void {
@@ -75,12 +88,16 @@ export class HelpComponent {
     }
     const heading =
       section.querySelector<HTMLElement>('h2.help-section__title') ?? (section as HTMLElement);
-    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    section.scrollIntoView({ behavior: this.scrollBehavior(), block: 'start' });
     // Nach In-Page-Sprung Fokus verschieben; sonst bleibt er auf der Rollenkarte und Tab
     // läuft wieder durch die Karten oberhalb des Ziels.
     heading.focus({ preventScroll: true });
     const nextUrl = `${window.location.pathname}${window.location.search}#${sectionId}`;
     window.history.replaceState(window.history.state, '', nextUrl);
+  }
+
+  private scrollBehavior(): ScrollBehavior {
+    return globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
   }
 
   @HostListener('document:keydown.escape', ['$event'])

--- a/apps/frontend/src/app/features/help/help.component.ts
+++ b/apps/frontend/src/app/features/help/help.component.ts
@@ -49,7 +49,8 @@ export class HelpComponent {
   }
 
   /**
-   * Primärklick: im Scroll-Container `#main-content` springen, Locale-Pfad behalten.
+   * Primärklick: im Scroll-Container springen und Fragment per replaceState setzen.
+   * Kein History-Push — sonst würde dismissContentPage/Zurück nur den Anker entfernen.
    * Modifizierte Klicks (neuer Tab etc.) nutzen den echten `href`.
    */
   onHelpSectionLinkClick(event: MouseEvent, sectionId: 'help-host' | 'help-participant'): void {
@@ -64,12 +65,16 @@ export class HelpComponent {
       return;
     }
     event.preventDefault();
+    if (typeof window === 'undefined') {
+      return;
+    }
     const section = document.getElementById(sectionId);
     if (!section) {
       return;
     }
     section.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    void this.router.navigateByUrl(this.helpSectionHref(sectionId), { replaceUrl: true });
+    const nextUrl = `${window.location.pathname}${window.location.search}#${sectionId}`;
+    window.history.replaceState(window.history.state, '', nextUrl);
   }
 
   @HostListener('document:keydown.escape', ['$event'])

--- a/apps/frontend/src/app/features/help/help.component.ts
+++ b/apps/frontend/src/app/features/help/help.component.ts
@@ -49,7 +49,8 @@ export class HelpComponent {
   }
 
   /**
-   * Primärklick: im Scroll-Container springen und Fragment per replaceState setzen.
+   * Primärklick/Enter: im Scroll-Container springen, Fragment per replaceState setzen und
+   * Fokus auf die Abschnittsüberschrift legen, damit Tab danach in diesem Abschnitt weiterläuft.
    * Kein History-Push — sonst würde dismissContentPage/Zurück nur den Anker entfernen.
    * Modifizierte Klicks (neuer Tab etc.) nutzen den echten `href`.
    */
@@ -72,7 +73,12 @@ export class HelpComponent {
     if (!section) {
       return;
     }
+    const heading =
+      section.querySelector<HTMLElement>('h2.help-section__title') ?? (section as HTMLElement);
     section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    // Nach In-Page-Sprung Fokus verschieben; sonst bleibt er auf der Rollenkarte und Tab
+    // läuft wieder durch die Karten oberhalb des Ziels.
+    heading.focus({ preventScroll: true });
     const nextUrl = `${window.location.pathname}${window.location.search}#${sectionId}`;
     window.history.replaceState(window.history.state, '', nextUrl);
   }

--- a/apps/frontend/src/app/features/help/help.component.ts
+++ b/apps/frontend/src/app/features/help/help.component.ts
@@ -1,18 +1,34 @@
 import { Location } from '@angular/common';
 import { Component, HostListener, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { CdkTrapFocus } from '@angular/cdk/a11y';
 import { MatButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
+import {
+  MatAccordion,
+  MatExpansionPanel,
+  MatExpansionPanelHeader,
+  MatExpansionPanelTitle,
+} from '@angular/material/expansion';
 import { MatIcon } from '@angular/material/icon';
+import { localizePath } from '../../core/locale-router';
 import { dismissContentPage, shouldDeferContentPageEscape } from '../../shared/content-page-nav';
 
 /**
- * „So funktioniert’s“: Nutzerorientierte Anleitung, Layout und Stil wie Legal-Seiten.
+ * Hilfe & Einstieg: rollen- und erfahrungsbasierte Akkordeons (Issue #190).
  */
 @Component({
   selector: 'app-help',
-  imports: [MatButton, MatIcon, CdkTrapFocus],
+  imports: [
+    MatButton,
+    MatIcon,
+    CdkTrapFocus,
+    MatAccordion,
+    MatExpansionPanel,
+    MatExpansionPanelHeader,
+    MatExpansionPanelTitle,
+    RouterLink,
+  ],
   templateUrl: './help.component.html',
   styleUrls: [
     '../../shared/styles/dialog-title-header.scss',
@@ -24,6 +40,8 @@ export class HelpComponent {
   private readonly location = inject(Location);
   private readonly router = inject(Router);
   private readonly dialog = inject(MatDialog);
+
+  readonly localizedPath = localizePath;
 
   @HostListener('document:keydown.escape', ['$event'])
   onEscape(event: Event): void {

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -359,16 +359,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="seo.titleHelp" datatype="html">
-        <source>So funktioniert’s – arsnova.eu</source>
-        <target>How it works – arsnova.eu</target>
+        <source>Hilfe &amp; Einstieg – arsnova.eu</source>
+        <target>Help &amp; Getting Started – arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="seo.descHelp" datatype="html">
-        <source>Kurz erklärt: Live-Sessions, Quiz-Frageformate, Selbsteinschätzung, Blitzlicht, Q&amp;A und Moderationsabläufe auf arsnova.eu.</source>
-        <target>Quick guide: live sessions, quiz question formats, self-assessment, quick feedback, Q&amp;A, and moderation workflows on arsnova.eu.</target>
+        <source>Hilfe für Veranstaltungsleitungen und Teilnehmende: Session starten, abstimmen, Q&amp;A und Blitzlicht nutzen, Ergebnisse auswerten und Funktionen nachschlagen.</source>
+        <target>Help for hosts and participants: start a session, vote, use Q&amp;A and Pulse Check, review results, and explore advanced features.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">120</context>
@@ -6191,835 +6191,371 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.pageTitle" datatype="html">
-        <source> So funktioniert’s</source>
-        <target>How it works</target>
+        <source> Hilfe &amp; Einstieg</source>
+        <target>Help &amp; Getting Started</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">36,38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Diese Seite richtet sich an <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lehrende, Trainer:innen und Vortragende<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, die aus einer Präsentation eine echte Live-Situation machen wollen: kurze Checks, Diskussionen, Q&amp;A, Blitzlicht und Auswertung laufen in einer Session zusammen. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Ohne Pflichtkonto<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> für deine Gruppe: Code oder QR zeigen, Smartphones raus, loslegen.</source>
-        <target>This page is for <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>educators, trainers, and presenters<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> who want to turn a presentation into a live experience: quick checks, discussion, Q&amp;A, pulse checks, and debriefing all come together in one session. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>No account required<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> for your group: show the code or QR, phones out, and you’re ready to go.</target>
+        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen.</source>
+        <target>Choose how you use arsnova.eu. Get a quick introduction or look up a specific feature.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">41,47</context>
+          <context context-type="linenumber">41,44</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.uspTitle" datatype="html">
-        <source>Was arsnova.eu anders macht</source>
-        <target>What makes arsnova.eu different</target>
+      <trans-unit id="help.roleNavAria" datatype="html">
+        <source>Rollenwahl</source>
+        <target>Role selection</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.usp1" datatype="html">
-        <source> arsnova.eu ist als <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Live-Regie für Unterricht, Training und Talks<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> gedacht: Du wechselst nicht zwischen Präsentation, Chat, Umfragetool und Quiz-App, sondern steuerst Interaktion, Beamer-Ansicht und Ergebnisfreigabe an einem Ort.</source>
-        <target>Think of arsnova.eu as a <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>live control room for teaching, training, and talks<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: instead of switching between slides, chat, polling tool, and quiz app, you manage interaction, projector view, and result reveal in one place.</target>
+      <trans-unit id="help.roleHostTitle" datatype="html">
+        <source>Ich leite eine Veranstaltung</source>
+        <target>I’m hosting a session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">51,55</context>
+          <context context-type="linenumber">54</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.usp2" datatype="html">
-        <source> Der Fokus liegt auf <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>didaktischer Kontrolle und Datenschutz<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: Inhalte bleiben zunächst local-first im Browser, Teilnehmende brauchen kein Konto, das Projekt ist Open Source und für EU-orientierten Betrieb ausgelegt. Markdown und KaTeX machen fachliche Fragen präsentationstauglich, von MINT-Formeln bis zum kurzen Fallbeispiel.</source>
-        <target>The emphasis is on <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>teaching control and privacy<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: content stays local-first in the browser, participants do not need an account, the project is open source and designed for EU-oriented operation. Markdown and KaTeX make subject-specific questions presentation-ready, from STEM formulas to short case studies.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56,61</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsTitle" datatype="html">
-        <source> Frageformate: passend zum didaktischen Ziel</source>
-        <target>Question formats: match the teaching goal</target>
+      <trans-unit id="help.roleHostHint" datatype="html">
+        <source>Für Lehrende, Vortragende, Trainer:innen und Moderator:innen</source>
+        <target>For educators, speakers, trainers, and moderators</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsLead" datatype="html">
-        <source> Wähle das Format nach der Situation im Raum: Willst du Wissen prüfen, Haltungen sichtbar machen, Begriffe einsammeln oder Schätzungen diskutieren? Die Formate sind bewusst getrennt, damit Ergebnisanzeige, Bewertung und Moderation zum Einsatzzweck passen.</source>
-        <target>Choose the format that fits the room: are you checking knowledge, surfacing attitudes, collecting terms, or discussing estimates? The formats are deliberately separate so result display, scoring, and moderation fit the purpose.</target>
+      <trans-unit id="help.roleParticipantTitle" datatype="html">
+        <source>Ich nehme an einer Veranstaltung teil</source>
+        <target>I’m joining a session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">224</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsGridAria" datatype="html">
-        <source>Verfügbare Quiz-Frageformate</source>
-        <target>Available quiz question formats</target>
+      <trans-unit id="help.roleParticipantHint" datatype="html">
+        <source>Für alle, die abstimmen, Fragen stellen oder Feedback geben</source>
+        <target>For anyone voting, asking questions, or sharing feedback</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.newUserTitle" datatype="html">
+        <source>Neu bei arsnova.eu</source>
+        <target>New to arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">76</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
-        <source>Single Choice</source>
-        <target>Single Choice</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTag" datatype="html">
-        <source> eine richtige Option</source>
-        <target>one correct option</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceBody" datatype="html">
-        <source> Für punktgenaue Verständnischecks: Eine Antwort ist korrekt, Ergebnis und Punkte sind sofort klar.</source>
-        <target>For precise understanding checks: one answer is correct, and results and points are immediately clear.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
-        <source>Multiple Choice</source>
-        <target>Multiple Choice</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
-        <source> mehrere richtige Optionen</source>
-        <target>several correct options</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
-        <source> Für komplexere Konzepte, typische Fehlannahmen oder Fragen wie „Welche Aussagen stimmen?“ – mehrere Lösungen können zählen.</source>
-        <target>For more complex concepts, common misconceptions, or questions like “Which statements are true?” — several answers can count.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTitle" datatype="html">
-        <source>Kurzantwort</source>
-        <target>Short answer</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTag" datatype="html">
-        <source> Musterlösung statt Auswahl</source>
-        <target>model answer, not a menu</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextBody" datatype="html">
-        <source> Teilnehmende formulieren kurz selbst. Du hinterlegst Musterlösungen; arsnova.eu kann Schreibvarianten, Toleranz und bei Bedarf Zahlen oder Einheiten auswerten.</source>
-        <target>Participants answer briefly in their own words. You provide model answers; arsnova.eu can evaluate spelling variants, tolerance, and, when needed, numbers or units.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTitle" datatype="html">
-        <source>Freitext</source>
-        <target>Free text</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTag" datatype="html">
-        <source> offene Antworten</source>
-        <target>open responses</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextBody" datatype="html">
-        <source> Für Ideen, Reflexionen und Erwartungsabfragen. Keine automatische Bewertung; Antworten lassen sich sammeln und als Wortwolke sichtbar machen.</source>
-        <target>For ideas, reflections, and expectation checks. No automatic scoring; responses can be collected and shown as a word cloud.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTitle" datatype="html">
-        <source>Umfrage</source>
-        <target>Survey</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTag" datatype="html">
-        <source> Meinungsbild ohne richtig/falsch</source>
-        <target>opinion snapshot, no right/wrong</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyBody" datatype="html">
-        <source> Für Prioritäten, Vorwissen oder Entscheidungen im Raum. Optionen werden gezählt, ohne Scorelogik.</source>
-        <target>For priorities, prior knowledge, or decisions in the room. Options are counted without score logic.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTitle" datatype="html">
-        <source>Bewertungsskala</source>
-        <target>Rating scale</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTag" datatype="html">
-        <source> Skala mit eigenen Polen</source>
-        <target>scale with custom endpoints</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingBody" datatype="html">
-        <source> Für Zustimmung, Sicherheit, Tempo oder Feedback von niedrig bis hoch; optional mit benannten Endpunkten.</source>
-        <target>For agreement, confidence, pace, or feedback from low to high, optionally with named endpoints.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
-        <source>Numerische Schätzfrage</source>
-        <target>Numerical estimate question</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTag" datatype="html">
-        <source> Zahlen schätzen, Streuung sehen</source>
-        <target>estimate numbers, see the spread</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateBody" datatype="html">
-        <source> Für Jahreszahlen, Größenordnungen, Messwerte und Wahrscheinlichkeiten. Mit Referenzwert, Toleranzband, Histogramm, Statistik und optionaler zweiter Runde.</source>
-        <target>For years, orders of magnitude, measurements, and probabilities. Includes reference value, tolerance band, histogram, statistics, and an optional second round.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatsBlitzNote" datatype="html">
-        <source> Blitzlicht ist davon getrennt: Es ist für spontane Live-Rückmeldungen gedacht, wenn du keine vollständige Quizfrage bauen willst.</source>
-        <target>Pulse Check is separate from these formats: it is for spontaneous live feedback when you do not want to build a full quiz question.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceTitle" datatype="html">
-        <source> Selbsteinschätzung bei bewertbaren Fragen</source>
-        <target>Self-assessment for evaluable questions</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceLead" datatype="html">
-        <source> Die Selbsteinschätzung ist kein eigener Fragetyp, sondern eine optionale Zusatzabfrage nach Single Choice, Multiple Choice, Kurzantwort und numerischer Schätzfrage: Teilnehmende geben an, wie sicher sie bei ihrer Antwort sind (Skala 1–5). Das beeinflusst keine Punkte – hilft dir aber, Lernstand und Fehlkonzepte zu erkennen.</source>
-        <target>The self-assessment is not a separate question type, but an optional additional question according to single choice, multiple choice, short answer and numerical estimation question: Participants indicate how confident they are in their answer (scale 1–5). This doesn&apos;t affect any points - but it does help you recognize your level of learning and misconceptions.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceListAria" datatype="html">
-        <source>Didaktische Funktionen der Selbsteinschätzung</source>
-        <target>Didactic functions of self-assessment</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
-        <source>Nach der Antwort abfragen</source>
-        <target>Ask after the answer</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
-        <source> Progressive Disclosure: Erst Antwort wählen oder eingeben, dann die Selbsteinschätzung. Während der Abstimmung sieht niemand aggregierte Werte anderer Personen.</source>
-        <target>Progressive Disclosure: First select or enter the answer, then the self-assessment. During voting, no one sees other people&apos;s aggregated values.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorTitle" datatype="html">
-        <source>Im Editor konfigurieren</source>
-        <target>Configure in the editor</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorBody" datatype="html">
-        <source> Toggle pro Frage, optionale Labels für niedrige und hohe Antwortsicherheit und eine Live-Vorschau der Skala. Für neue bewertbare Fragen ist die Selbsteinschätzung standardmäßig aktiv.</source>
-        <target>Toggle per question, optional labels for low and high response confidence, and a live preview of the scale. Self-assessment is active by default for new assessable questions.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceHostTitle" datatype="html">
-        <source>Host-Auswertung nach Freigabe</source>
-        <target>Host evaluation after results release</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">226</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceHostBody" datatype="html">
-        <source> Matrix aus Korrektheit und Antwortsicherheit mit Hervorhebung <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>selbstsicher falsch<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Bei Auswahlfragen siehst du, welche falschen Optionen mit hoher Antwortsicherheit gewählt wurden.</source>
-        <target>Matrix of correctness and response confidence highlighting <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>confidently wrong<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. For choice questions, you can see which incorrect options were selected with high response confidence.</target>
+      <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
+        <source>Was kann ich mit arsnova.eu machen?</source>
+        <target>What can I do with arsnova.eu?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportTitle" datatype="html">
-        <source>Abschluss und Export</source>
-        <target>Completion and export</target>
+      <trans-unit id="help.hostCapabilitiesBody" datatype="html">
+        <source> Mit einem Quiz stellst du vorbereitete Wissens- oder Meinungsfragen. Im Q&amp;A sammelst und priorisierst du Fragen aus dem Publikum. Das Blitzlicht eignet sich für spontane Stimmungs-, Verständnis- und Tempoabfragen. Du kannst alle drei Bereiche in einer Live-Session verbinden.</source>
+        <target>Use a quiz for prepared knowledge or opinion questions. Use Q&amp;A to collect and prioritize questions from your audience. Pulse Check is designed for spontaneous mood, understanding, and pace checks. You can combine all three in one live session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">88,93</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportBody" datatype="html">
-        <source> Nach Session-Ende fasst die Auswertung gefestigtes Wissen, Fehlkonzept-Hinweis und fragiles Wissen zusammen. Fragen mit weniger als 5 Antworten mit Selbsteinschätzung werden nicht aggregiert ausgewiesen. Der Nachbesprechungsplan (PDF) ist das empfohlene Format; CSV steht unter „Mehr“ für Excel zur Verfügung. In der Quiz-Sammlung findest du den Nachbesprechungsplan auf der Quizkarte.</source>
-        <target> At the end of the session, the evaluation summarizes consolidated knowledge, misconception risk and fragile knowledge. Questions with fewer than 5 responses with a self-assessment are not shown in aggregate. The debrief plan (PDF) is the recommended format; CSV is available under “More” for Excel. In the quiz collection you will find the debrief plan on the quiz card.</target>
+      <trans-unit id="help.hostFirstSessionTitle" datatype="html">
+        <source>Wie starte ich meine erste Session?</source>
+        <target>How do I start my first session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTitle" datatype="html">
-        <source>Demo-Quiz</source>
-        <target>Demo Quiz</target>
+      <trans-unit id="help.hostFirstSessionBody" datatype="html">
+        <source> Öffne die Quiz-Sammlung und nutze das Demo-Quiz oder erstelle ein eigenes Quiz. Wähle „Starten“, lege Stil und Optionen fest und teile anschließend den sechsstelligen Code oder QR-Code. In der Host-Ansicht zeigst du die nächste Frage, startest die Antwortphase und gibst das Ergebnis frei. Tipp: Teste die Vorschau vor dem ersten Einsatz einmal auf einem zweiten Gerät.</source>
+        <target>Open the quiz library and use the demo quiz or create your own. Select “Start,” choose the style and options, then share the 6-character code or QR code. In the host view, show the next question, start the answer phase, and reveal the results. Tip: Try the preview on a second device before your first live session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">107,113</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoCardHint" datatype="html">
-        <source> Ein vorinstalliertes Beispiel-Quiz zeigt die Frageformate in konkreten Unterrichtsmomenten: Wissenscheck, Wortwolke, Kurzantwort, Schätzfrage, Bewertungsskala, Selbsteinschätzung, Formeln und Markdown. Du findest es in deiner Quiz-Sammlung und kannst es dort in der Vorschau öffnen.</source>
-        <target>A preinstalled demo quiz shows the question formats in concrete teaching moments: knowledge check, word cloud, short answer, estimate, rating scale, self-assessment, formulas, and Markdown. You can find it in your quiz library and open it in preview.</target>
+      <trans-unit id="help.hostFinishTitle" datatype="html">
+        <source>Wie beende und werte ich eine Session aus?</source>
+        <target>How do I end and review a session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTip" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tipp:&lt;/stro"/>Tipp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Öffne die Vorschau vor der ersten Live-Session einmal auf einem zweiten Gerät. So siehst du sofort, wie Host-Ansicht und Teilnehmenden-Screen zusammenspielen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Tip:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Open the preview once on a second device before your first live session. You will immediately see how the host view and participant screen work together.</target>
+      <trans-unit id="help.hostFinishBody" datatype="html">
+        <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar.</source>
+        <target>End the session from the host view. The consolidated results are then available. Use the debrief plan PDF for your teaching review; the CSV export is under “More.” The debrief plan remains available from the quiz card.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">124,129</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickstartTitle" datatype="html">
-        <source>Schnellstart</source>
-        <target>Quick start</target>
+      <trans-unit id="help.experiencedUserTitle" datatype="html">
+        <source> Schon vertraut mit arsnova.eu</source>
+        <target>Familiar with arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">134,136</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart1" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Quiz anlegen:&lt;/"/>Quiz anlegen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> „Quiz-Sammlung öffnen&quot; wählen, neues Quiz erstellen und pro Frage das passende Format wählen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Create a quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Choose “Open quiz library”, create a new quiz, and choose the right format for each question.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart2" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Veranstaltung s"/>Veranstaltung starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Stil, Timer, Teams und Rangliste festlegen. Danach entsteht ein 6-stelliger Code, den du als Text oder QR-Code teilst.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Start a session:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Choose style, timers, teams, and leaderboard. Then a 6-character code is created, which you share as text or QR code.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart3" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Live moderieren"/>Live moderieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage zeigen, Antwortphase starten, Ergebnisse freigeben oder zurückhalten und bei Bedarf eine zweite Runde anschließen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Moderate live:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Show the question, start the answer phase, reveal or hold back results, and add a second round when useful.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostTitle" datatype="html">
-        <source>Veranstaltung leiten</source>
-        <target>Host your session</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLead" datatype="html">
-        <source> In der Host-Ansicht führst du durch die Session wie durch eine kleine Senderegie: Teilnehmende reinholen, Inhalte freigeben, Diskussion öffnen und Ergebnisse sichtbar machen.</source>
-        <target>In the host view, you run the session like a small control room: bring participants in, reveal content, open discussion, and make results visible.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostStartStep" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Session starten:&lt;"/>Session starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> In deiner Quiz-Sammlung eine Veranstaltung starten und festlegen, ob sie mit Quiz oder Q&amp;A beginnt. Dann entsteht der Beitrittscode.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Start session:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> From your quiz library, start a session and choose whether it opens with a quiz or Q&amp;A. Then the join code is created.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLobby" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Lobby:&lt;/stron"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Du siehst, wer beigetreten ist; ein QR-Code zum Beitritt wird angezeigt.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> You see who has joined; a QR code for joining is shown.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostBeamer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beamer- und Pr"/>Beamer- und Presenter-Ansicht:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage, Antworten, Countdown und Ergebnisse erscheinen groß genug für Projektion, Stream oder zweiten Bildschirm.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Projector and presenter view:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Question, answers, countdown, and results are large enough for projection, stream, or second screen.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSteuerung" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Steuerung:&lt;/stron"/>Steuerung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Nutze „Nächste Frage“, um den Inhalt einzublenden. Optional läuft zuerst eine Lesephase, danach startest du die Antwortphase und entscheidest, wann das Ergebnis auf den Screen kommt.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Controls:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Use “Next question” to bring content on screen. You can start with a reading phase, then open the answer phase and decide when results appear on the screen.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instruc"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Bei geeigneten Quizfragen, Schätzfragen und Blitzlicht-Runden: erst abstimmen lassen, Diskussion starten, dann erneut abstimmen. Der Vorher/Nachher-Vergleich macht Lernfortschritt sichtbar.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (double rounds):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> For suitable quiz questions, estimate questions, and Pulse Check rounds: vote first, discuss, then vote again. The before/after comparison makes learning progress visible.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSettings" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Einstellungen:&lt;/"/>Einstellungen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beim Start legst du Stil und Optionen fest: seriös oder spielerisch, mit oder ohne Rangliste, Sound, Lesephase, Team-Modus, Nicknamen und Timer.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Settings:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> At the start, choose style and options: business or playful, with or without leaderboard, sound, reading phase, team mode, nicknames, and timer.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallTitle" datatype="html">
-        <source> Fragenwand im Live-Kanal Q&amp;A</source>
-        <target> Question wall in the live Q&amp;A channel </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLead" datatype="html">
-        <source> Q&amp;A soll nicht als Nebenchat verschwinden. Die Fragenwand macht Rückfragen sichtbar, priorisierbar und moderierbar: Du hältst den roten Faden, während die Gruppe gemeinsam zeigt, welche Punkte wirklich Klärung brauchen.</source>
-        <target> Q&amp;A should not disappear into a side chat. The question wall makes audience questions visible, prioritizable, and easy to moderate: you keep the thread of the session while the group collectively signals which points really need clarification. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallListAria" datatype="html">
-        <source>Didaktische Funktionen der Q&amp;A-Fragenwand</source>
-        <target>Teaching functions of the Q&amp;A question wall</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationTitle" datatype="html">
-        <source>Moderation mit pädagogischem Takt</source>
-        <target> Moderation with pedagogical timing </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationBody" datatype="html">
-        <source> Auf Wunsch warten neue Fragen erst auf deine Freigabe. Du kannst Beiträge freigeben, anheften, archivieren oder entfernen und damit Schutzraum, Relevanz und Timing steuern: sofort beantworten, für später sammeln oder als Diskussionsspur markieren.</source>
-        <target> When needed, new questions wait for your approval first. You can approve, pin, archive, or remove contributions and steer psychological safety, relevance, and timing: answer now, collect for later, or mark as a discussion thread. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingTitle" datatype="html">
-        <source>Kollektives Hoch- und Runtervoting</source>
-        <target> Collective upvoting and downvoting </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingBody" datatype="html">
-        <source> Teilnehmende gewichten Fragen gemeinsam. Positive und negative Stimmen zeigen nicht nur Popularität, sondern auch Unsicherheit, Widerspruch und Klärungsbedarf; Sortierungen wie „meist unterstützt“, „beste Fragen“ und „umstritten“ helfen dir, knappe Live-Zeit didaktisch zu setzen.</source>
-        <target> Participants weight questions together. Positive and negative votes show more than popularity: they surface uncertainty, disagreement, and need for clarification. Sort modes such as “most supported”, “best questions”, and “controversial” help you spend limited live time where it matters didactically. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
-        <source>Q&amp;A-Wortwolke auf Themenebene</source>
-        <target> Q&amp;A word cloud at theme level </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudBody" datatype="html">
-        <source> Die Word-Cloud verdichtet sichtbare Fragen zu Wörtern und Phrasen, gewichtet nach Unterstützung, belastbarer Zustimmung oder Kontroverse. Sie lässt sich einfrieren, nach Sortierlogik betrachten und in der Presenter-Ansicht zeigen – als schneller Blick auf Themencluster, nicht als dekorative Wortliste.</source>
-        <target> The word cloud condenses visible questions into words and phrases, weighted by support, robust agreement, or controversy. It can be frozen, viewed through the current sort logic, and shown in Presenter View: a fast read on topic clusters, not a decorative word list. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmTitle" datatype="html">
-        <source>Nächster Schritt: Moderationskompass</source>
-        <target>Next step: moderation compass</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmBody" datatype="html">
-        <source> Geplant ist zuerst ein deterministischer Moderationskompass. Optional können später asynchrone Q&amp;A-NLP-Signale und quellengebundene Zusammenfassungen dazukommen – als datenschutzbewusste Moderationshilfe statt Blackbox-Bewertung.</source>
-        <target> Planned first is a deterministic moderation compass. Later, asynchronous Q&amp;A NLP signals and source-bound summaries can be added optionally, as a privacy-conscious moderation aid rather than black-box grading. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.blitzTitle" datatype="html">
-        <source>Blitzlicht</source>
-        <target>Pulse Check</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackIntro" datatype="html">
-        <source> Schnelle Stimmungs- und Wissensabfragen – z. B. vor der Pause, zum Einstieg oder für spontane Checks. Nutzbar im Host-Bereich deiner Live-Session oder direkt von der Startseite.</source>
-        <target>Quick pulse and comprehension checks, whether before a break, as a warm-up, or when you need an instant read. Available from the host view of your live session or straight from the home page.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfMood" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stimmungsb"/>Stimmungsbild<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): Wie geht es den Teilnehmenden?</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Mood<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): How are participants doing?</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfYesNoMaybe" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein / Viel"/>Ja / Nein / Vielleicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Schnelle Zustimmungsabfrage.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Yes / No / Maybe<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Quick pulse check.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackYesNo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein&lt;/strong&gt; (👍"/>Ja / Nein<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): Klare Zwei-Optionen-Abfrage ohne Mittelweg.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Yes / No<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): Clear two-option poll with no middle ground.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Wahr / Falsch / Weiß nicht&lt;/stron"/>Wahr / Falsch / Weiß nicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): Für schnelle Einschätzungen oder Wissenschecks.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>True / False / Don&apos;t know<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): For quick assessments or knowledge checks.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Mehrstufige Schnellabfragen&lt;/s"/>Mehrstufige Schnellabfragen<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D): Drei oder vier feste Optionen für spontane Abstimmungen – ohne eine vollständige Quizfrage zu bauen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lettered quick polls<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D): Three or four preset choices for on-the-fly votes—no full quiz question required.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTempo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tempo-Feedback&lt;/strong"/>Tempo-Feedback<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): Mit vier Icons meldet deine Gruppe laufend zurück, ob sie folgen kann. Teilnehmende können ihre Rückmeldung ändern; du siehst nur die aggregierte Tendenz.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Tempo feedback<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): Four icons let your group continuously show whether they can follow. Participants can change their feedback; you only see the aggregated trend.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">283,285</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
-        <source> Du startest die Runde im Host-Bereich deiner Live-Session oder über die Blitzlicht-Karte „Live mit einem Klick&quot; auf der Startseite. Teilnehmende tippen eine Antwort; du siehst die Ergebnisse live als Balkendiagramm.</source>
-        <target>You start the round in the host area of your live session or directly via the Pulse Check card “Live in one click” on the home page. Participants vote with one tap, and you see the results live as a bar chart.</target>
+      <trans-unit id="help.hostFormatsTitle" datatype="html">
+        <source>Fragetypen und Selbsteinschätzung</source>
+        <target>Question types and self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">141</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instr"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Erste Runde – Ergebnis nicht auflösen – „Diskussionsphase&quot; starten („Diskutiert mit eurem Nachbarn&quot;) – „Zweite Abstimmung&quot;. Vorher/Nachher-Vergleich zeigt, wie sich das Stimmungsbild durch den Austausch verändert hat.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (double rounds):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Round one: don&apos;t reveal results yet → start the “discussion phase” (“talk to someone next to you”) → “second vote.” The before/after view shows how the mood snapshot shifts after discussion.</target>
+      <trans-unit id="help.hostFormatsBody" datatype="html">
+        <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar.</source>
+        <target>Available question types are Single Choice, Multiple Choice, Short answer, Free text, Survey, Rating scale, and Numerical estimate. Evaluable questions can be followed by a self-assessment on a scale from 1 to 5. It does not affect the score, but it highlights consolidated knowledge, fragile knowledge, and potential misconceptions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">145,151</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfStop" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stopp:&lt;/st"/>Stopp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Abstimmung einfrieren – Teilnehmende sehen „Abstimmung ist pausiert&quot; und können nicht mehr abstimmen, bis du „Fortsetzen&quot; wählst.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Stop:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Freeze the poll – participants see “Poll is paused” and cannot vote until you choose “Resume”.</target>
+      <trans-unit id="help.hostModerationTitle" datatype="html">
+        <source>Live moderieren und Peer Instruction nutzen</source>
+        <target>Moderate live and use Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfReset" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Zurücksetze"/>Zurücksetzen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Alle Stimmen löschen und erneut abstimmen lassen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Reset:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Clear all votes and run the poll again.</target>
+      <trans-unit id="help.hostModerationBody" datatype="html">
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.</source>
+        <target>Use the reading phase, timer, projector or presenter view, and delayed result reveal as needed. For Peer Instruction, run a first vote, start a discussion phase, and then open a second vote. The before-and-after comparison makes changes visible.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">162,167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfNewRound" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Neue Runde:&lt;/s"/>Neue Runde:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Neuen Code erzeugen und eine frische Runde starten.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>New round:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Generate a new code and start a fresh round.</target>
+      <trans-unit id="help.hostQaTitle" datatype="html">
+        <source>Die Q&amp;A-Fragenwand moderieren</source>
+        <target>Moderate the Q&amp;A question wall</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfCopyLink" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Link kopieren:"/>Link kopieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beitrittslink in die Zwischenablage kopieren, z. B. zum Teilen per Chat.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Copy link:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Copy the join link to the clipboard, e.g. to share via chat.</target>
+      <trans-unit id="help.hostQaBody" datatype="html">
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation.</source>
+        <target>New posts can wait for approval before they appear. You can approve, pin, archive, or remove questions. Upvotes, downvotes, and sort modes help you prioritize them; the word cloud condenses visible themes for presentation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">178,183</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsTitle" datatype="html">
-        <source>Für deine Teilnehmenden</source>
-        <target>For your participants</target>
+      <trans-unit id="help.hostPulseTitle" datatype="html">
+        <source>Blitzlicht und Tempo-Feedback einsetzen</source>
+        <target>Use Pulse Check and pace feedback</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsLead" datatype="html">
-        <source> Kurz erklärt, was du in deiner Veranstaltung weitergeben kannst:</source>
-        <target>In short: what you can share with people in your session:</target>
+      <trans-unit id="help.hostPulseBody" datatype="html">
+        <source> Starte ein Blitzlicht aus der Live-Session oder über „Live mit einem Klick“ auf der Startseite. Du kannst die Abstimmung pausieren, fortsetzen, zurücksetzen oder als neue Runde starten. Beim Tempo-Feedback ändern Teilnehmende ihre Rückmeldung jederzeit; du siehst nur die aggregierte Tendenz.</source>
+        <target>Start a Pulse Check from the live session or with “Live in one click” on the home page. You can pause, resume, reset, or start a new round. During pace feedback, participants can change their response at any time; you only see the aggregated trend.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">194,199</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsJoin" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beitreten:&lt;/strong&gt;"/>Beitreten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> 6-stelligen Code auf arsnova.eu eingeben und „Los geht&apos;s&quot; – funktioniert für Quiz, Q&amp;A und Blitzlicht. Keine Anmeldung nötig.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Join:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Enter the 6-character code on arsnova.eu and tap “Let&apos;s go”—works for quiz, Q&amp;A, and Pulse Check. No sign-up required.</target>
+      <trans-unit id="help.hostLibraryTitle" datatype="html">
+        <source>Quiz-Sammlung und Einstellungen verwalten</source>
+        <target>Manage quizzes and settings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsNick" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Nicknamen:&lt;/strong&gt;"/>Nicknamen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Je nach deiner Einstellung vorgegebene Namen, eigener Name oder anonym.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Nicknames:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Depending on your settings, participants will use predefined names, their own names, or stay entirely anonymous.</target>
+      <trans-unit id="help.hostLibraryBody" datatype="html">
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
+        <target>In the quiz library, edit and reorder questions, check the preview, and import or export quizzes as JSON. Use the sync link to share the library or continue on another device. AI generation and review templates help without sending your content to arsnova.eu. When starting a session, configure options such as style, leaderboard, sound, teams, nicknames, timer, and bonus codes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">210,217</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsVote" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Abstimmung:&lt;/strong&gt;"/>Abstimmung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage erscheint auf dem Gerät, Antwort wählen und absenden. Bei aktivierter Selbsteinschätzung folgt danach die Skala 1–5. Bei Zeitlimit läuft ein Countdown.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Voting:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> The question appears on their device; they select an answer and submit. When self-assessment is enabled, the 1–5 scale follows. With a time limit, a countdown runs.</target>
+      <trans-unit id="help.participantJoinTitle" datatype="html">
+        <source>Wie trete ich einer Session bei?</source>
+        <target>How do I join a session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTitle" datatype="html">
-        <source>Deine Quiz-Sammlung</source>
-        <target>Your quiz library</target>
+      <trans-unit id="help.participantJoinBody" datatype="html">
+        <source> Scanne den QR-Code oder öffne arsnova.eu und gib den sechsstelligen Code ein. Du brauchst kein Konto. Je nach Einstellung der Veranstaltungsleitung nimmst du anonym, mit einem vorgegebenen Nickname oder mit einem selbst gewählten Namen teil.</source>
+        <target>Scan the QR code or open arsnova.eu and enter the 6-character code. You do not need an account. Depending on the host’s settings, you can join anonymously, with a preset nickname, or with a name you choose.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">235,240</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionLead" datatype="html">
-        <source>Hier legst du deine Quizze an und bereitest sie vor.</source>
-        <target>Here you create and prepare your quizzes.</target>
+      <trans-unit id="help.participantAnswerTitle" datatype="html">
+        <source>Wie beantworte ich eine Quizfrage?</source>
+        <target>How do I answer a quiz question?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">247</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionEditor" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Editor:&lt;/strong&gt; Fra"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Fragen per Drag-and-Drop sortieren, auf- und zuklappen, Vorschau prüfen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sort questions using drag and drop, expand and collapse, check preview.</target>
+      <trans-unit id="help.participantAnswerBody" datatype="html">
+        <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
+        <target>Select or enter an answer, then submit it. If self-assessment is enabled, rate how confident you are on a scale from 1 to 5. When there is a time limit, a countdown shows the remaining time. Results appear when the host reveals them.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">254,259</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTypes" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Fragetypen:&lt;/strong"/>Fragetypen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage – pro Frage optional mit Timer, Schwierigkeitsgrad und Selbsteinschätzung.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Question types:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single choice, multiple choice, short answer, free text, survey, rating scale, and numerical estimate question — each question can optionally include a timer, difficulty, and self-assessment.</target>
+      <trans-unit id="help.participantContributeTitle" datatype="html">
+        <source>Wie stelle ich eine Frage oder gebe Feedback?</source>
+        <target>How do I ask a question or share feedback?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">266</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionImport" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Import / Export:&lt;/st"/>Import / Export:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Quiz als JSON importieren oder exportieren. Mit der Start- und Prüfvorlage kannst du anspruchsvolle Quizze mit deinem bevorzugten KI-Tool generieren, prüfen und direkt importieren – deine Inhalte und Präsentationen werden nicht an arsnova.eu gesendet; du nutzt dein eigenes KI-Tool.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Import / Export:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Import or export quizzes as JSON. Use the generation and review templates to create high-quality quizzes with your preferred AI tool, review them, and import them directly. Your content and presentations are not sent to arsnova.eu; you use your own AI tool.</target>
+      <trans-unit id="help.participantContributeBody" datatype="html">
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
+        <target>In Q&amp;A, submit your own question and upvote or downvote other posts. Depending on moderation settings, your question may appear only after approval. In Pulse Check, share spontaneous feedback with one tap. You can update your pace feedback while the poll is running.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">273,278</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionSync" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Sync:&lt;/strong&gt; Mit"/>Sync:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit dem Sync-Link deine Quiz-Sammlung mit Kolleg:innen teilen oder auf anderen Geräten weiterarbeiten. Wer den Link hat, kann die Sammlung öffnen. Die Geräteangaben helfen nur bei der Orientierung.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sync:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Use the sync link to share your quiz library with colleagues or continue on other devices. Anyone with the link can open the library. Device details are only there to help you get your bearings.</target>
+      <trans-unit id="help.participantChannelsTitle" datatype="html">
+        <source>Wie nutze ich Quiz, Q&amp;A und Blitzlicht in einer Session?</source>
+        <target>How do I use quiz, Q&amp;A, and Pulse Check in one session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">290</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoQuizHint" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Demo-Quiz:&lt;/stro"/>Demo-Quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ein vorinstalliertes Quiz zeigt alle Formate mit Beispielen inkl. KaTeX-Formeln und Markdown. In der Quiz-Sammlung in der Vorschau öffnen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Demo quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> A preinstalled quiz shows all formats with examples, including KaTeX formulas and Markdown. Open it from the quiz library in preview.</target>
+      <trans-unit id="help.participantChannelsBody" datatype="html">
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung.</source>
+        <target>A live session can combine quiz, Q&amp;A, and Pulse Check. Follow the active view and the instructions on your device. If a channel is not active, wait for the host to open the next activity.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">297,302</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesTitle" datatype="html">
-        <source>Seriös und Spielerisch</source>
-        <target>Business and gamification</target>
+      <trans-unit id="help.participantSecondRoundTitle" datatype="html">
+        <source>Was passiert bei einer zweiten Abstimmungsrunde?</source>
+        <target>What happens in a second voting round?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesLead" datatype="html">
-        <source> Zwei Stile für unterschiedliche Situationen – wählbar auf der Startseite und beim Session-Start.</source>
-        <target>Two styles for different situations—selectable on the home page and at session start.</target>
+      <trans-unit id="help.participantSecondRoundBody" datatype="html">
+        <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden.</source>
+        <target>In Peer Instruction, answer the question on your own first. Then discuss it with other participants and vote again. Submit your answer in the second round as well; it can differ from your first answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">316,321</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.styleSerious" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Seriös:&lt;/strong&gt;"/>Seriös:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonym, ohne Rangliste – ideal für formative Assessments, Prüfungsvorbereitung und sensible Themen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Business:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonymous, no leaderboard—ideal for formative assessments, exam prep, and sensitive topics.</target>
+      <trans-unit id="help.participantResultsTitle" datatype="html">
+        <source>Wie sind Ergebnisse, Rangliste und Teamwertung zu verstehen?</source>
+        <target>How should I read results, leaderboards, and team scores?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylePlayful" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Spielerisch:&lt;/st"/>Spielerisch:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit Rangliste, Sounds und Anfeuerung – ideal für Auflockerung, Wettbewerbe und motivierende Quizze.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Leaderboard, sound effects, and energy—great for icebreakers, team competitions, and high-energy quizzes.</target>
+      <trans-unit id="help.participantResultsBody" datatype="html">
+        <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung.</source>
+        <target>The host decides when results become visible. Leaderboards, team scores, and bonus codes appear only when enabled for the session. Your self-assessment does not affect your score or position.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">335,339</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesOptions" datatype="html">
-        <source> Alle Optionen (Rangliste, Sound, Lesephase, Team, Bonus) lassen sich einzeln an- und ausschalten.</source>
-        <target>All options (leaderboard, sound, reading phase, team, bonus) can be turned on or off individually.</target>
+      <trans-unit id="help.commonTitle" datatype="html">
+        <source>Für alle</source>
+        <target>For everyone</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">346</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTitle" datatype="html">
-        <source>Weitere Funktionen</source>
-        <target>More features</target>
+      <trans-unit id="help.commonPrivacyTitle" datatype="html">
+        <source>Wie werden Daten und Inhalte behandelt?</source>
+        <target>How are data and content handled?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">351</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreBonus" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Bonus-Codes:&lt;"/>Bonus-Codes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Top-Platzierte erhalten einen einlösbaren Code (z. B. für Bonuspunkte). Du siehst die Code-Liste; personenbezogene Daten werden nicht gespeichert.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Bonus codes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Top finishers get a redeemable code (e.g. for bonus points). You see the code list; we don&apos;t store personal data.</target>
+      <trans-unit id="help.commonPrivacyBody" datatype="html">
+        <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target>No account is required. A host’s quiz content is stored locally in the browser first; during a live session, the data needed for interaction is exchanged. arsnova.eu is open source and designed for privacy-focused operation in Europe. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Privacy policy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for details.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">355,362</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTeams" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Team-Modus:&lt;/"/>Team-Modus:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Deine Teilnehmenden spielen in Teams mit eigenem Team-Leaderboard – z. B. für Gruppenwettbewerbe im Seminar.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Team mode:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Your participants play in teams with their own team leaderboard—e.g. for group competitions in seminars.</target>
+      <trans-unit id="help.commonAccessibilityTitle" datatype="html">
+        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
+        <target>How can I use arsnova.eu accessibly and as an app?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreGamification" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Gamification:&lt;/stron"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sound-Effekte, Belohnungseffekte für Top-Plätze, Motivationsmeldungen – im Spielerisch-Modus.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sound effects, rewards for top finishers, and on-screen encouragement—when you use the gamification style.</target>
+      <trans-unit id="help.commonAccessibilityBody" datatype="html">
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target>arsnova.eu supports keyboard operation, screen readers, and zoom. Use the app’s contrast and color-scheme options or those provided by your operating system as needed. You can also install arsnova.eu as a Progressive Web App. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Accessibility statement<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for more information.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">376,382</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyTitle" datatype="html">
-        <source>Datenschutz und Technik</source>
-        <target>Privacy and technology</target>
+      <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
+        <source>Was kann ich bei technischen Problemen tun?</source>
+        <target>What can I do if something is not working?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">389</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyBody" datatype="html">
-        <source> arsnova.eu ist kostenlos, Open Source und für den Einsatz an Schulen, Hochschulen und in Weiterbildung gedacht – mit Fokus auf Datenschutz (DSGVO). Quiz-Inhalte werden lokal im Browser gespeichert. Keine Anmeldung nötig, weder für dich noch für deine Teilnehmenden. Als App installierbar (PWA) – z. B. für schnelleren Start auf dem Smartphone. Oberfläche auf Deutsch, Englisch, Französisch, Spanisch und Italienisch.</source>
-        <target>arsnova.eu is free, open source, and built for schools, universities, and workplace training—with a strong focus on privacy (GDPR). Quiz content stays in your browser first. No sign-up for you or your participants. Installable as a PWA for a faster start on phones. UI in German, English, French, Spanish, and Italian.</target>
+      <trans-unit id="help.commonTroubleshootingBody" datatype="html">
+        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
+        <target>First check the code or QR code, your internet connection, and whether the session is still active. If no question is visible yet, the session may be in the lobby, reading phase, or paused. After a connection interruption, open the join link again or re-enter the code. Ask the host if the session has already ended.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">396,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -6200,7 +6200,7 @@
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
         <source> Wähle, in welcher Rolle du arsnova.eu nutzt. Hier findest du einen schnellen Einstieg und gezielte Hilfe zu einzelnen Funktionen.</source>
-        <target>Choose the role in which you use arsnova.eu. Here you will find a quick start and targeted help for individual features.</target>
+        <target>Choose how you use arsnova.eu. Get a quick introduction or find help with a specific feature.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">41,44</context>
@@ -6243,7 +6243,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">241</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
@@ -6263,7 +6263,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244</context>
+          <context context-type="linenumber">245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
@@ -6308,7 +6308,7 @@
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
         <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar.</source>
-        <target>End the session from the host view. The consolidated results are then available. Use the debriefing plan PDF to reflect on the session from a teaching perspective; the CSV export is under “More.” The debriefing plan remains available from the quiz card.</target>
+        <target>End the session from the host view. A summary of the results is then available. Use the debriefing plan PDF to reflect on the session from a teaching perspective; the CSV export is under “More.” The debriefing plan remains available from the quiz card.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">135,140</context>
@@ -6323,7 +6323,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">304,306</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
@@ -6367,11 +6367,11 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
+        <source> Neue Beiträge können zunächst zurückgehalten und erst nach deiner Freigabe veröffentlicht werden. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
         <target>New posts can be held for approval before they appear. You can approve, pin, archive, or remove questions. Upvotes, downvotes, and sorting options help you prioritize them; the word cloud highlights recurring themes for presentation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">189,194</context>
+          <context context-type="linenumber">189,195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
@@ -6379,7 +6379,7 @@
         <target>Use Pulse Check and pace feedback</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
@@ -6387,7 +6387,7 @@
         <target>Start a Pulse Check from the live session or with “Live in one click” on the home page. You can pause, resume, reset, or start a new round. During pace feedback, participants can change their response at any time; you only see the aggregated trend.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">205,210</context>
+          <context context-type="linenumber">206,211</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
@@ -6395,7 +6395,7 @@
         <target>Manage quizzes and settings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">217</context>
+          <context context-type="linenumber">218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
@@ -6403,7 +6403,7 @@
         <target>In the quiz library, edit and reorder questions, check the preview, and import or export quizzes as JSON. Use the sync link to share the library or continue on another device. AI templates can help you generate and review quizzes without sending your content to arsnova.eu. When starting a session, configure options such as style, leaderboard, sound, teams, nicknames, timer, and bonus codes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">221,228</context>
+          <context context-type="linenumber">222,229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
@@ -6411,7 +6411,7 @@
         <target>How do I join a session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">249</context>
+          <context context-type="linenumber">250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
@@ -6419,7 +6419,7 @@
         <target>Scan the QR code or open arsnova.eu and enter the 6-character code. You do not need an account. Depending on the host’s settings, you can join anonymously, with a preset nickname, or with a name you choose.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">256,261</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
@@ -6427,7 +6427,7 @@
         <target>How do I answer a quiz question?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">268</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
@@ -6435,7 +6435,7 @@
         <target>Select or enter an answer, then submit it. If answer confidence is enabled, rate how confident you are on a scale from 1 to 5. When there is a time limit, a countdown shows the remaining time. Results appear when the host reveals them.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">275,280</context>
+          <context context-type="linenumber">276,281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
@@ -6443,15 +6443,15 @@
         <target>How do I ask a question or share feedback?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">287</context>
+          <context context-type="linenumber">288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
-        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen positiv oder negativ bewerten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
         <target>In Q&amp;A, submit your own question and upvote or downvote other posts. Depending on moderation settings, your question may appear only after approval. In Pulse Check, share spontaneous feedback with one tap. You can update your pace feedback while the poll is running.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">294,299</context>
+          <context context-type="linenumber">295,300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
@@ -6459,7 +6459,7 @@
         <target>How do I use quiz, Q&amp;A, and Pulse Check in one session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">311</context>
+          <context context-type="linenumber">312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
@@ -6467,7 +6467,7 @@
         <target>A live session can combine quiz, Q&amp;A, and Pulse Check. Follow the active view and the instructions on your device. If a channel is not active, wait for the host to open the next activity.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,322</context>
+          <context context-type="linenumber">319,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6475,7 +6475,7 @@
         <target>What happens in a second voting round?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">329</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
@@ -6483,7 +6483,7 @@
         <target>In Peer Instruction, answer the question on your own first. Then discuss it with other participants and vote again. Submit your answer in the second round as well; it can differ from your first answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">336,341</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6491,7 +6491,7 @@
         <target>How should I read results, leaderboards, and team scores?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">348</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
@@ -6499,7 +6499,7 @@
         <target>The host decides when results become visible. Leaderboards, team scores, and bonus codes appear only when enabled for the session. Your answer confidence does not affect your score or position.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,359</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6507,7 +6507,7 @@
         <target>For everyone</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">368</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6515,15 +6515,15 @@
         <target>How are data and content handled?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">374</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
         <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <target>No account is required. A host’s quiz content is stored locally in the browser first; during a live session, the data needed for interaction is exchanged. arsnova.eu is open source and designed for privacy-focused operation in Europe. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Privacy policy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for details.</target>
+        <target>No account is required. A host’s quiz content is stored locally in the browser first; during a live session, the data needed for interaction is exchanged. arsnova.eu is open source and designed with privacy in mind for use in Europe. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Privacy policy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for details.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378,385</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
@@ -6531,7 +6531,7 @@
         <target>What accessibility options are available, and how do I install arsnova.eu as an app?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">393,394</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
@@ -6541,7 +6541,7 @@
         <target>You can use arsnova.eu with a keyboard, a screen reader, and browser or operating-system zoom. Use the app’s contrast and color-scheme options or those provided by your operating system as needed. You can also install arsnova.eu as a Progressive Web App. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Accessibility statement<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for more information.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">400,408</context>
+          <context context-type="linenumber">401,409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
@@ -6549,15 +6549,15 @@
         <target>What can I do if something is not working?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415</context>
+          <context context-type="linenumber">416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
-        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
-        <target>First check the code or QR code, your internet connection, and whether the session is still active. If no question is visible yet, the session may be in the lobby, reading phase, or paused. After a connection interruption, open the join link again or re-enter the code. Ask the host if the session has already ended.</target>
+        <source> Prüfe zuerst den Code oder QR-Code und deine Internetverbindung. Vergewissere dich außerdem, dass die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
+        <target>First check the code or QR code, your internet connection, and whether the session is still active. If no question is visible yet, the session may be in the lobby, reading phase, or paused. If your connection drops, reopen the join link or enter the code again. Ask the host if the session has already ended.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">422,429</context>
+          <context context-type="linenumber">423,430</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -6199,8 +6199,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen.</source>
-        <target>Choose how you use arsnova.eu. Get a quick introduction or look up a specific feature.</target>
+        <source> Wähle, in welcher Rolle du arsnova.eu nutzt. Hier findest du einen schnellen Einstieg und gezielte Hilfe zu einzelnen Funktionen.</source>
+        <target>Choose the role in which you use arsnova.eu. Here you will find a quick start and targeted help for individual features.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">41,44</context>
@@ -6308,7 +6308,7 @@
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
         <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar.</source>
-        <target>End the session from the host view. The consolidated results are then available. Use the debrief plan PDF for your teaching review; the CSV export is under “More.” The debrief plan remains available from the quiz card.</target>
+        <target>End the session from the host view. The consolidated results are then available. Use the debriefing plan PDF to reflect on the session from a teaching perspective; the CSV export is under “More.” The debriefing plan remains available from the quiz card.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">135,140</context>
@@ -6316,7 +6316,7 @@
       </trans-unit>
       <trans-unit id="help.experiencedUserTitle" datatype="html">
         <source> Schon vertraut mit arsnova.eu</source>
-        <target>Familiar with arsnova.eu</target>
+        <target>Already familiar with arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">145,147</context>
@@ -6328,7 +6328,7 @@
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
         <source>Fragetypen und Selbsteinschätzung</source>
-        <target>Question types and self-assessment</target>
+        <target>Question types and answer confidence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">152</context>
@@ -6336,7 +6336,7 @@
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
         <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar.</source>
-        <target>Available question types are Single Choice, Multiple Choice, Short answer, Free text, Survey, Rating scale, and Numerical estimate. Evaluable questions can be followed by a self-assessment on a scale from 1 to 5. It does not affect the score, but it highlights consolidated knowledge, fragile knowledge, and potential misconceptions.</target>
+        <target>Available question types include Single-answer question, Multiple-answer question, Short answer, Free text, Survey, Rating scale, and Numerical estimate. For scorable questions, participants can then rate their confidence on a scale from 1 to 5. This does not affect the score, but it can reveal solid understanding, understanding that is not yet secure, and possible misconceptions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">156,162</context>
@@ -6344,14 +6344,14 @@
       </trans-unit>
       <trans-unit id="help.hostModerationTitle" datatype="html">
         <source>Live moderieren und Peer Instruction nutzen</source>
-        <target>Moderate live and use Peer Instruction</target>
+        <target>Moderate live sessions and use Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
-        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.</source>
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-Nachher-Vergleich macht Veränderungen sichtbar.</source>
         <target>Use the reading phase, timer, projector or presenter view, and delayed result reveal as needed. For Peer Instruction, run a first vote, start a discussion phase, and then open a second vote. The before-and-after comparison makes changes visible.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
@@ -6360,15 +6360,15 @@
       </trans-unit>
       <trans-unit id="help.hostQaTitle" datatype="html">
         <source>Die Q&amp;A-Fragenwand moderieren</source>
-        <target>Moderate the Q&amp;A question wall</target>
+        <target>Moderate the Q&amp;A board</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation.</source>
-        <target>New posts can wait for approval before they appear. You can approve, pin, archive, or remove questions. Upvotes, downvotes, and sort modes help you prioritize them; the word cloud condenses visible themes for presentation.</target>
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
+        <target>New posts can be held for approval before they appear. You can approve, pin, archive, or remove questions. Upvotes, downvotes, and sorting options help you prioritize them; the word cloud highlights recurring themes for presentation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">189,194</context>
@@ -6399,8 +6399,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
-        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
-        <target>In the quiz library, edit and reorder questions, check the preview, and import or export quizzes as JSON. Use the sync link to share the library or continue on another device. AI generation and review templates help without sending your content to arsnova.eu. When starting a session, configure options such as style, leaderboard, sound, teams, nicknames, timer, and bonus codes.</target>
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen dich beim Erstellen und Prüfen von Quizzen, ohne dass Inhalte an arsnova.eu gesendet werden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
+        <target>In the quiz library, edit and reorder questions, check the preview, and import or export quizzes as JSON. Use the sync link to share the library or continue on another device. AI templates can help you generate and review quizzes without sending your content to arsnova.eu. When starting a session, configure options such as style, leaderboard, sound, teams, nicknames, timer, and bonus codes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">221,228</context>
@@ -6432,7 +6432,7 @@
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
         <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
-        <target>Select or enter an answer, then submit it. If self-assessment is enabled, rate how confident you are on a scale from 1 to 5. When there is a time limit, a countdown shows the remaining time. Results appear when the host reveals them.</target>
+        <target>Select or enter an answer, then submit it. If answer confidence is enabled, rate how confident you are on a scale from 1 to 5. When there is a time limit, a countdown shows the remaining time. Results appear when the host reveals them.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">275,280</context>
@@ -6463,11 +6463,11 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
-        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung.</source>
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge den Hinweisen in der jeweils geöffneten Ansicht. Wenn ein Bereich gerade nicht aktiv ist, warte, bis die Veranstaltungsleitung die nächste Aktivität öffnet.</source>
         <target>A live session can combine quiz, Q&amp;A, and Pulse Check. Follow the active view and the instructions on your device. If a channel is not active, wait for the host to open the next activity.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,323</context>
+          <context context-type="linenumber">318,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6475,7 +6475,7 @@
         <target>What happens in a second voting round?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
@@ -6483,7 +6483,7 @@
         <target>In Peer Instruction, answer the question on your own first. Then discuss it with other participants and vote again. Submit your answer in the second round as well; it can differ from your first answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">337,342</context>
+          <context context-type="linenumber">336,341</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6491,15 +6491,15 @@
         <target>How should I read results, leaderboards, and team scores?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">349</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
         <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung.</source>
-        <target>The host decides when results become visible. Leaderboards, team scores, and bonus codes appear only when enabled for the session. Your self-assessment does not affect your score or position.</target>
+        <target>The host decides when results become visible. Leaderboards, team scores, and bonus codes appear only when enabled for the session. Your answer confidence does not affect your score or position.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">356,360</context>
+          <context context-type="linenumber">355,359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6507,7 +6507,7 @@
         <target>For everyone</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6515,7 +6515,7 @@
         <target>How are data and content handled?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">375</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
@@ -6523,22 +6523,22 @@
         <target>No account is required. A host’s quiz content is stored locally in the browser first; during a live session, the data needed for interaction is exchanged. arsnova.eu is open source and designed for privacy-focused operation in Europe. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Privacy policy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for details.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,386</context>
+          <context context-type="linenumber">378,385</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
-        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
-        <target>How can I use arsnova.eu accessibly and as an app?</target>
+        <source>Welche Barrierefreiheitsfunktionen gibt es, und wie installiere ich arsnova.eu als App?</source>
+        <target>What accessibility options are available, and how do I install arsnova.eu as an app?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">393</context>
+          <context context-type="linenumber">392,393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
         <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;
                     &gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a
                   &gt;"/>.</source>
-        <target>arsnova.eu supports keyboard operation, screen readers, and zoom. Use the app’s contrast and color-scheme options or those provided by your operating system as needed. You can also install arsnova.eu as a Progressive Web App. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Accessibility statement<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for more information.</target>
+        <target>You can use arsnova.eu with a keyboard, a screen reader, and browser or operating-system zoom. Use the app’s contrast and color-scheme options or those provided by your operating system as needed. You can also install arsnova.eu as a Progressive Web App. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Accessibility statement<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for more information.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">400,408</context>

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -6211,7 +6211,7 @@
         <target>Role selection</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostTitle" datatype="html">
@@ -6219,11 +6219,11 @@
         <target>I’m hosting a session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostHint" datatype="html">
@@ -6231,7 +6231,7 @@
         <target>For educators, speakers, trainers, and moderators</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantTitle" datatype="html">
@@ -6239,11 +6239,11 @@
         <target>I’m joining a session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">71</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">224</context>
+          <context context-type="linenumber">241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
@@ -6251,7 +6251,7 @@
         <target>For anyone voting, asking questions, or sharing feedback</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.newUserTitle" datatype="html">
@@ -6259,11 +6259,11 @@
         <target>New to arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">87</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">226</context>
+          <context context-type="linenumber">244</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
@@ -6271,7 +6271,7 @@
         <target>What can I do with arsnova.eu?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesBody" datatype="html">
@@ -6279,7 +6279,7 @@
         <target>Use a quiz for prepared knowledge or opinion questions. Use Q&amp;A to collect and prioritize questions from your audience. Pulse Check is designed for spontaneous mood, understanding, and pace checks. You can combine all three in one live session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">88,93</context>
+          <context context-type="linenumber">99,104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionTitle" datatype="html">
@@ -6287,7 +6287,7 @@
         <target>How do I start my first session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionBody" datatype="html">
@@ -6295,7 +6295,7 @@
         <target>Open the quiz library and use the demo quiz or create your own. Select “Start,” choose the style and options, then share the 6-character code or QR code. In the host view, show the next question, start the answer phase, and reveal the results. Tip: Try the preview on a second device before your first live session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">107,113</context>
+          <context context-type="linenumber">118,124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishTitle" datatype="html">
@@ -6303,7 +6303,7 @@
         <target>How do I end and review a session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
@@ -6311,7 +6311,7 @@
         <target>End the session from the host view. The consolidated results are then available. Use the debrief plan PDF for your teaching review; the CSV export is under “More.” The debrief plan remains available from the quiz card.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">124,129</context>
+          <context context-type="linenumber">135,140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.experiencedUserTitle" datatype="html">
@@ -6319,11 +6319,11 @@
         <target>Familiar with arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">134,136</context>
+          <context context-type="linenumber">145,147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">283,285</context>
+          <context context-type="linenumber">304,306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
@@ -6331,7 +6331,7 @@
         <target>Question types and self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
@@ -6339,7 +6339,7 @@
         <target>Available question types are Single Choice, Multiple Choice, Short answer, Free text, Survey, Rating scale, and Numerical estimate. Evaluable questions can be followed by a self-assessment on a scale from 1 to 5. It does not affect the score, but it highlights consolidated knowledge, fragile knowledge, and potential misconceptions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">145,151</context>
+          <context context-type="linenumber">156,162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationTitle" datatype="html">
@@ -6347,7 +6347,7 @@
         <target>Moderate live and use Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
@@ -6355,7 +6355,7 @@
         <target>Use the reading phase, timer, projector or presenter view, and delayed result reveal as needed. For Peer Instruction, run a first vote, start a discussion phase, and then open a second vote. The before-and-after comparison makes changes visible.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,167</context>
+          <context context-type="linenumber">173,178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaTitle" datatype="html">
@@ -6363,7 +6363,7 @@
         <target>Moderate the Q&amp;A question wall</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
@@ -6371,7 +6371,7 @@
         <target>New posts can wait for approval before they appear. You can approve, pin, archive, or remove questions. Upvotes, downvotes, and sort modes help you prioritize them; the word cloud condenses visible themes for presentation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">178,183</context>
+          <context context-type="linenumber">189,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
@@ -6379,7 +6379,7 @@
         <target>Use Pulse Check and pace feedback</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
@@ -6387,7 +6387,7 @@
         <target>Start a Pulse Check from the live session or with “Live in one click” on the home page. You can pause, resume, reset, or start a new round. During pace feedback, participants can change their response at any time; you only see the aggregated trend.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">194,199</context>
+          <context context-type="linenumber">205,210</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
@@ -6395,7 +6395,7 @@
         <target>Manage quizzes and settings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">217</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
@@ -6403,7 +6403,7 @@
         <target>In the quiz library, edit and reorder questions, check the preview, and import or export quizzes as JSON. Use the sync link to share the library or continue on another device. AI generation and review templates help without sending your content to arsnova.eu. When starting a session, configure options such as style, leaderboard, sound, teams, nicknames, timer, and bonus codes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">210,217</context>
+          <context context-type="linenumber">221,228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
@@ -6411,7 +6411,7 @@
         <target>How do I join a session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">231</context>
+          <context context-type="linenumber">249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
@@ -6419,7 +6419,7 @@
         <target>Scan the QR code or open arsnova.eu and enter the 6-character code. You do not need an account. Depending on the host’s settings, you can join anonymously, with a preset nickname, or with a name you choose.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">235,240</context>
+          <context context-type="linenumber">256,261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
@@ -6427,7 +6427,7 @@
         <target>How do I answer a quiz question?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">247</context>
+          <context context-type="linenumber">268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
@@ -6435,7 +6435,7 @@
         <target>Select or enter an answer, then submit it. If self-assessment is enabled, rate how confident you are on a scale from 1 to 5. When there is a time limit, a countdown shows the remaining time. Results appear when the host reveals them.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">254,259</context>
+          <context context-type="linenumber">275,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
@@ -6443,7 +6443,7 @@
         <target>How do I ask a question or share feedback?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">287</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
@@ -6451,7 +6451,7 @@
         <target>In Q&amp;A, submit your own question and upvote or downvote other posts. Depending on moderation settings, your question may appear only after approval. In Pulse Check, share spontaneous feedback with one tap. You can update your pace feedback while the poll is running.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">273,278</context>
+          <context context-type="linenumber">294,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
@@ -6459,7 +6459,7 @@
         <target>How do I use quiz, Q&amp;A, and Pulse Check in one session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">290</context>
+          <context context-type="linenumber">311</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
@@ -6467,7 +6467,7 @@
         <target>A live session can combine quiz, Q&amp;A, and Pulse Check. Follow the active view and the instructions on your device. If a channel is not active, wait for the host to open the next activity.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">297,302</context>
+          <context context-type="linenumber">318,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6475,7 +6475,7 @@
         <target>What happens in a second voting round?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
@@ -6483,7 +6483,7 @@
         <target>In Peer Instruction, answer the question on your own first. Then discuss it with other participants and vote again. Submit your answer in the second round as well; it can differ from your first answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">316,321</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6491,7 +6491,7 @@
         <target>How should I read results, leaderboards, and team scores?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">328</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
@@ -6499,7 +6499,7 @@
         <target>The host decides when results become visible. Leaderboards, team scores, and bonus codes appear only when enabled for the session. Your self-assessment does not affect your score or position.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">335,339</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6507,7 +6507,7 @@
         <target>For everyone</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6515,7 +6515,7 @@
         <target>How are data and content handled?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">351</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
@@ -6523,7 +6523,7 @@
         <target>No account is required. A host’s quiz content is stored locally in the browser first; during a live session, the data needed for interaction is exchanged. arsnova.eu is open source and designed for privacy-focused operation in Europe. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Privacy policy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for details.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,362</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
@@ -6531,15 +6531,17 @@
         <target>How can I use arsnova.eu accessibly and as an app?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
-        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;
+                    &gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a
+                  &gt;"/>.</source>
         <target>arsnova.eu supports keyboard operation, screen readers, and zoom. Use the app’s contrast and color-scheme options or those provided by your operating system as needed. You can also install arsnova.eu as a Progressive Web App. See the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Accessibility statement<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> for more information.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">376,382</context>
+          <context context-type="linenumber">400,408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
@@ -6547,7 +6549,7 @@
         <target>What can I do if something is not working?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389</context>
+          <context context-type="linenumber">415</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
@@ -6555,7 +6557,7 @@
         <target>First check the code or QR code, your internet connection, and whether the session is still active. If no question is visible yet, the session may be in the lobby, reading phase, or paused. After a connection interruption, open the join link again or re-enter the code. Ask the host if the session has already ended.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">396,403</context>
+          <context context-type="linenumber">422,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -6384,7 +6384,7 @@
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
         <source> Starte ein Blitzlicht aus der Live-Session oder über „Live mit einem Klick“ auf der Startseite. Du kannst die Abstimmung pausieren, fortsetzen, zurücksetzen oder als neue Runde starten. Beim Tempo-Feedback ändern Teilnehmende ihre Rückmeldung jederzeit; du siehst nur die aggregierte Tendenz.</source>
-        <target>Start a Pulse Check from the live session or with “Live in one click” on the home page. You can pause, resume, reset, or start a new round. During pace feedback, participants can change their response at any time; you only see the aggregated trend.</target>
+        <target>Start a Pulse Check from the live session or with “Instant feedback with one click” on the home page. You can pause, resume, reset, or start a new round. During pace feedback, participants can change their response at any time; you only see the aggregated trend.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">206,211</context>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -6238,7 +6238,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">241</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
@@ -6258,7 +6258,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244</context>
+          <context context-type="linenumber">245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
@@ -6318,7 +6318,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">304,306</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
@@ -6331,7 +6331,7 @@
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
         <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar.</source>
-        <target>Están disponibles las preguntas de respuesta única, respuesta múltiple, respuesta corta, texto libre, encuesta, escala de valoración y estimación numérica. Las preguntas evaluables pueden ir seguidas de una autoevaluación del grado de seguridad del 1 al 5. Esta no modifica la puntuación, pero puede mostrar qué conocimientos están consolidados, cuáles aún no lo están y qué respuestas pueden indicar posibles concepciones erróneas.</target>
+        <target>Están disponibles las preguntas de respuesta única, respuesta múltiple, respuesta corta, texto libre, encuesta, escala de valoración y estimación numérica. Las preguntas evaluables pueden ir seguidas de una autoevaluación del grado de seguridad en una escala del 1 al 5. Esta no modifica la puntuación, pero puede mostrar qué conocimientos están consolidados, cuáles aún no lo están y qué respuestas pueden indicar posibles concepciones erróneas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">156,162</context>
@@ -6347,7 +6347,7 @@
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
         <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-Nachher-Vergleich macht Veränderungen sichtbar.</source>
-        <target>Utiliza cuando sea necesario la fase de lectura, el temporizador, la vista de proyección o presentación y la visualización diferida de resultados. Para Peer Instruction, realiza una primera votación, abre una fase de debate y después una segunda votación. La comparación antes-después muestra los cambios.</target>
+        <target>Utiliza cuando sea necesario la fase de lectura, el temporizador, la vista de proyección o presentación y la visualización diferida de resultados. Para aplicar Peer Instruction, realiza una primera votación, abre una fase de debate y después una segunda votación. La comparación antes-después muestra los cambios.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">173,178</context>
@@ -6362,11 +6362,11 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
+        <source> Neue Beiträge können zunächst zurückgehalten und erst nach deiner Freigabe veröffentlicht werden. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
         <target>Las nuevas aportaciones pueden quedar pendientes de aprobación antes de mostrarse. Puedes aprobar, fijar, archivar o eliminar preguntas. Los votos positivos y negativos y las distintas formas de ordenación ayudan a priorizarlas; la nube de palabras pone de relieve los temas recurrentes para la presentación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">189,194</context>
+          <context context-type="linenumber">189,195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
@@ -6374,7 +6374,7 @@
         <target>Utilizar el sondeo rápido y la valoración del ritmo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
@@ -6382,7 +6382,7 @@
         <target>Inicia un sondeo rápido desde la sesión en directo o mediante «En vivo con un clic» en la página de inicio. Puedes pausarlo, reanudarlo, reiniciarlo o comenzar una nueva ronda. En la valoración del ritmo, los participantes pueden cambiar su respuesta en cualquier momento; tú solo ves la tendencia agregada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">205,210</context>
+          <context context-type="linenumber">206,211</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
@@ -6390,7 +6390,7 @@
         <target>Gestionar cuestionarios y ajustes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">217</context>
+          <context context-type="linenumber">218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
@@ -6398,7 +6398,7 @@
         <target>En la colección de cuestionarios puedes editar y reordenar preguntas, comprobar la vista previa e importar o exportar cuestionarios en formato JSON. El enlace de sincronización permite compartir la colección o continuar en otro dispositivo. Las plantillas de IA te ayudan a crear y revisar cuestionarios sin enviar el contenido a arsnova.eu. Al iniciar una sesión, configura opciones como el estilo, la clasificación, el sonido, los equipos, los alias, el temporizador y los códigos de bonificación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">221,228</context>
+          <context context-type="linenumber">222,229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
@@ -6406,7 +6406,7 @@
         <target>¿Cómo me uno a una sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">249</context>
+          <context context-type="linenumber">250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
@@ -6414,7 +6414,7 @@
         <target>Escanea el código QR o abre arsnova.eu e introduce el código de seis caracteres. No necesitas una cuenta. Según los ajustes de quien dirige la sesión, puedes participar de forma anónima, con un alias predefinido o con el nombre que elijas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">256,261</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
@@ -6422,15 +6422,15 @@
         <target>¿Cómo respondo a una pregunta del cuestionario?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">268</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
         <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
-        <target>Selecciona o introduce una respuesta y envíala. Si la autoevaluación del grado de seguridad está activada, indica después tu grado de seguridad en una escala del 1 al 5. Si hay un límite de tiempo, una cuenta atrás muestra el tiempo restante. Los resultados aparecen cuando quien dirige la sesión los hace visibles.</target>
+        <target>Selecciona o introduce una respuesta y envíala. Si está activada la autoevaluación de la seguridad en la respuesta, valora tu grado de seguridad en una escala del 1 al 5. Si hay un límite de tiempo, una cuenta atrás muestra el tiempo restante. Los resultados aparecen cuando quien dirige la sesión los hace visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">275,280</context>
+          <context context-type="linenumber">276,281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
@@ -6438,15 +6438,15 @@
         <target>¿Cómo planteo una pregunta o doy mi opinión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">287</context>
+          <context context-type="linenumber">288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
-        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen positiv oder negativ bewerten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
         <target>En el canal Q&amp;A puedes enviar tu propia pregunta y votar a favor o en contra de las aportaciones de otras personas. Según la moderación, tu pregunta puede aparecer solo después de ser aprobada. En el sondeo rápido puedes dar una opinión espontánea con un toque. La valoración del ritmo se puede modificar mientras el sondeo esté abierto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">294,299</context>
+          <context context-type="linenumber">295,300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
@@ -6454,7 +6454,7 @@
         <target>¿Cómo utilizo el cuestionario, el Q&amp;A y el sondeo rápido en una sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">311</context>
+          <context context-type="linenumber">312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
@@ -6462,7 +6462,7 @@
         <target>Una sesión en directo puede combinar cuestionario, Q&amp;A y sondeo rápido. Sigue las indicaciones que aparecen en tu dispositivo. Si un canal no está activo, espera a que quien dirige la sesión abra la siguiente actividad.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,322</context>
+          <context context-type="linenumber">319,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6470,15 +6470,15 @@
         <target>¿Qué ocurre en una segunda ronda de votación?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">329</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
         <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden.</source>
-        <target>En Peer Instruction, responde primero a la pregunta por tu cuenta. Después coméntala con otros participantes y vota de nuevo. Envía también tu respuesta en la segunda ronda; puede ser diferente de la primera.</target>
+        <target>En una secuencia de Peer Instruction, responde primero a la pregunta por tu cuenta. Después coméntala con otros participantes y vota de nuevo. Envía también tu respuesta en la segunda ronda; puede ser diferente de la primera.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">336,341</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6486,7 +6486,7 @@
         <target>¿Cómo interpreto los resultados, la clasificación y las puntuaciones por equipos?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">348</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
@@ -6494,7 +6494,7 @@
         <target>Quien dirige la sesión decide cuándo se muestran los resultados. La clasificación, las puntuaciones por equipos y los códigos de bonificación solo aparecen si están activados para la sesión. El grado de seguridad autoevaluado no influye en la puntuación ni en la posición.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,359</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6502,7 +6502,7 @@
         <target>Para todos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">368</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6510,7 +6510,7 @@
         <target>¿Cómo se tratan los datos y los contenidos?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">374</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
@@ -6518,7 +6518,7 @@
         <target>No se necesita una cuenta. Los cuestionarios de quien dirige la sesión se guardan primero de forma local en el navegador; durante una sesión en directo se intercambian los datos necesarios para la interacción. arsnova.eu es de código abierto y está diseñado para proteger la privacidad en el contexto europeo. Consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Política de privacidad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para obtener más información.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378,385</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
@@ -6526,7 +6526,7 @@
         <target>¿Qué opciones de accesibilidad ofrece arsnova.eu y cómo puedo instalarlo como aplicación?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">393,394</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
@@ -6536,7 +6536,7 @@
         <target>arsnova.eu se puede utilizar con el teclado, con lectores de pantalla y con ampliación. Si lo necesitas, usa las opciones de contraste y tema de la aplicación o del sistema operativo. También puedes instalar arsnova.eu como aplicación web progresiva. Consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Declaración de accesibilidad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para obtener más información.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">400,408</context>
+          <context context-type="linenumber">401,409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
@@ -6544,15 +6544,15 @@
         <target>¿Qué puedo hacer si algo no funciona?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415</context>
+          <context context-type="linenumber">416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
-        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
-        <target>Comprueba primero el código o el código QR, la conexión a Internet y que la sesión siga activa. Si todavía no aparece ninguna pregunta, la sesión puede estar en la sala de espera, en la fase de lectura o en pausa. Tras una interrupción, vuelve a abrir el enlace de acceso o introduce de nuevo el código. Consulta a quien dirige la sesión si ya ha finalizado.</target>
+        <source> Prüfe zuerst den Code oder QR-Code und deine Internetverbindung. Vergewissere dich außerdem, dass die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
+        <target>Comprueba primero el código o el código QR y la conexión a Internet; después, verifica que la sesión siga activa. Si todavía no aparece ninguna pregunta, la sesión puede estar en la sala de espera, en la fase de lectura o en pausa. Tras una interrupción, vuelve a abrir el enlace de acceso o introduce de nuevo el código. Consulta a quien dirige la sesión si ya ha finalizado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">422,429</context>
+          <context context-type="linenumber">423,430</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -359,16 +359,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="seo.titleHelp" datatype="html">
-        <source>So funktioniert’s – arsnova.eu</source>
-        <target>Cómo funciona – arsnova.eu</target>
+        <source>Hilfe &amp; Einstieg – arsnova.eu</source>
+        <target>Ayuda y primeros pasos – arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="seo.descHelp" datatype="html">
-        <source>Kurz erklärt: Live-Sessions, Quiz-Frageformate, Selbsteinschätzung, Blitzlicht, Q&amp;A und Moderationsabläufe auf arsnova.eu.</source>
-        <target>Guía rápida: sesiones en directo, formatos de preguntas, autoevaluación, sondeo rápido, Q&amp;A y flujos de moderación en arsnova.eu.</target>
+        <source>Hilfe für Veranstaltungsleitungen und Teilnehmende: Session starten, abstimmen, Q&amp;A und Blitzlicht nutzen, Ergebnisse auswerten und Funktionen nachschlagen.</source>
+        <target>Ayuda para moderadores y participantes: iniciar una sesión, votar, utilizar Q&amp;A y el sondeo rápido, analizar resultados y descubrir funciones avanzadas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">120</context>
@@ -6186,835 +6186,371 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.pageTitle" datatype="html">
-        <source> So funktioniert’s</source>
-        <target>Cómo funciona</target>
+        <source> Hilfe &amp; Einstieg</source>
+        <target>Ayuda y primeros pasos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">36,38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Diese Seite richtet sich an <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lehrende, Trainer:innen und Vortragende<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, die aus einer Präsentation eine echte Live-Situation machen wollen: kurze Checks, Diskussionen, Q&amp;A, Blitzlicht und Auswertung laufen in einer Session zusammen. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Ohne Pflichtkonto<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> für deine Gruppe: Code oder QR zeigen, Smartphones raus, loslegen.</source>
-        <target>Esta página es para <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>docentes, formadores y ponentes<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> que quieren convertir una presentación en una experiencia en directo: comprobaciones rápidas, debate, Q&amp;A, sondeo rápido y puesta en común, todo en una misma sesión. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sin cuenta obligatoria<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> para tu grupo: muestra el código o el QR, móviles en mano y a empezar.</target>
+        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen.</source>
+        <target>Elige cómo utilizas arsnova.eu. Empieza con una breve introducción o consulta una función concreta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">41,47</context>
+          <context context-type="linenumber">41,44</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.uspTitle" datatype="html">
-        <source>Was arsnova.eu anders macht</source>
-        <target>¿Qué hace que arsnova.eu sea diferente?</target>
+      <trans-unit id="help.roleNavAria" datatype="html">
+        <source>Rollenwahl</source>
+        <target>Selección de rol</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.usp1" datatype="html">
-        <source> arsnova.eu ist als <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Live-Regie für Unterricht, Training und Talks<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> gedacht: Du wechselst nicht zwischen Präsentation, Chat, Umfragetool und Quiz-App, sondern steuerst Interaktion, Beamer-Ansicht und Ergebnisfreigabe an einem Ort.</source>
-        <target>arsnova.eu funciona como una <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>mesa de control en directo para clases, formaciones y charlas<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: en lugar de saltar entre diapositivas, chat, herramienta de encuestas y app de quiz, gestionas la interacción, la vista de proyección y la publicación de resultados desde un único lugar.</target>
+      <trans-unit id="help.roleHostTitle" datatype="html">
+        <source>Ich leite eine Veranstaltung</source>
+        <target>Dirijo una sesión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">51,55</context>
+          <context context-type="linenumber">54</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.usp2" datatype="html">
-        <source> Der Fokus liegt auf <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>didaktischer Kontrolle und Datenschutz<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: Inhalte bleiben zunächst local-first im Browser, Teilnehmende brauchen kein Konto, das Projekt ist Open Source und für EU-orientierten Betrieb ausgelegt. Markdown und KaTeX machen fachliche Fragen präsentationstauglich, von MINT-Formeln bis zum kurzen Fallbeispiel.</source>
-        <target>El foco está en el <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>control didáctico y la protección de datos<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: los contenidos se mantienen primero local-first en el navegador, los participantes no necesitan cuenta, el proyecto es de código abierto y está pensado para un uso orientado a la UE. Markdown y KaTeX dejan listas para presentar preguntas especializadas, desde fórmulas STEM hasta casos breves.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56,61</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsTitle" datatype="html">
-        <source> Frageformate: passend zum didaktischen Ziel</source>
-        <target>Formatos de pregunta: cada objetivo didáctico con su formato</target>
+      <trans-unit id="help.roleHostHint" datatype="html">
+        <source>Für Lehrende, Vortragende, Trainer:innen und Moderator:innen</source>
+        <target>Para docentes, ponentes, formadores y moderadores</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsLead" datatype="html">
-        <source> Wähle das Format nach der Situation im Raum: Willst du Wissen prüfen, Haltungen sichtbar machen, Begriffe einsammeln oder Schätzungen diskutieren? Die Formate sind bewusst getrennt, damit Ergebnisanzeige, Bewertung und Moderation zum Einsatzzweck passen.</source>
-        <target>Elige el formato según lo que ocurre en la sala: ¿quieres comprobar conocimientos, hacer visibles posturas, recoger conceptos o discutir estimaciones? Los formatos están separados a propósito para que la visualización, la evaluación y la moderación encajen con el uso.</target>
+      <trans-unit id="help.roleParticipantTitle" datatype="html">
+        <source>Ich nehme an einer Veranstaltung teil</source>
+        <target>Participo en una sesión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">224</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsGridAria" datatype="html">
-        <source>Verfügbare Quiz-Frageformate</source>
-        <target>Formatos de preguntas de quiz disponibles</target>
+      <trans-unit id="help.roleParticipantHint" datatype="html">
+        <source>Für alle, die abstimmen, Fragen stellen oder Feedback geben</source>
+        <target>Para votar, plantear preguntas o dar una opinión</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.newUserTitle" datatype="html">
+        <source>Neu bei arsnova.eu</source>
+        <target>Primera vez en arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">76</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
-        <source>Single Choice</source>
-        <target>Single Choice</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTag" datatype="html">
-        <source> eine richtige Option</source>
-        <target>una única opción correcta</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceBody" datatype="html">
-        <source> Für punktgenaue Verständnischecks: Eine Antwort ist korrekt, Ergebnis und Punkte sind sofort klar.</source>
-        <target>Para comprobaciones de comprensión precisas: una respuesta es correcta, y resultado y puntos quedan claros al instante.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
-        <source>Multiple Choice</source>
-        <target>Multiple Choice</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
-        <source> mehrere richtige Optionen</source>
-        <target>varias opciones correctas</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
-        <source> Für komplexere Konzepte, typische Fehlannahmen oder Fragen wie „Welche Aussagen stimmen?“ – mehrere Lösungen können zählen.</source>
-        <target>Para conceptos más complejos, malentendidos típicos o preguntas como “¿Qué afirmaciones son correctas?” — pueden contar varias respuestas.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTitle" datatype="html">
-        <source>Kurzantwort</source>
-        <target>Respuesta corta</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTag" datatype="html">
-        <source> Musterlösung statt Auswahl</source>
-        <target>solución modelo, no menú de opciones</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextBody" datatype="html">
-        <source> Teilnehmende formulieren kurz selbst. Du hinterlegst Musterlösungen; arsnova.eu kann Schreibvarianten, Toleranz und bei Bedarf Zahlen oder Einheiten auswerten.</source>
-        <target>Los participantes responden brevemente con sus propias palabras. Tú defines soluciones modelo; arsnova.eu puede evaluar variantes de escritura, tolerancias y, si hace falta, números o unidades.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTitle" datatype="html">
-        <source>Freitext</source>
-        <target>Texto libre</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTag" datatype="html">
-        <source> offene Antworten</source>
-        <target>respuestas abiertas</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextBody" datatype="html">
-        <source> Für Ideen, Reflexionen und Erwartungsabfragen. Keine automatische Bewertung; Antworten lassen sich sammeln und als Wortwolke sichtbar machen.</source>
-        <target>Para ideas, reflexiones y expectativas. Sin evaluación automática; las respuestas se pueden recoger y mostrar como nube de palabras.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTitle" datatype="html">
-        <source>Umfrage</source>
-        <target>Encuesta</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTag" datatype="html">
-        <source> Meinungsbild ohne richtig/falsch</source>
-        <target>mapa de opinión sin correcto/incorrecto</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyBody" datatype="html">
-        <source> Für Prioritäten, Vorwissen oder Entscheidungen im Raum. Optionen werden gezählt, ohne Scorelogik.</source>
-        <target>Para prioridades, conocimientos previos o decisiones en la sala. Las opciones se cuentan sin lógica de puntuación.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTitle" datatype="html">
-        <source>Bewertungsskala</source>
-        <target>Escala de valoración</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTag" datatype="html">
-        <source> Skala mit eigenen Polen</source>
-        <target>escala con extremos propios</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingBody" datatype="html">
-        <source> Für Zustimmung, Sicherheit, Tempo oder Feedback von niedrig bis hoch; optional mit benannten Endpunkten.</source>
-        <target>Para acuerdo, seguridad, ritmo o feedback de bajo a alto, opcionalmente con extremos nombrados.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
-        <source>Numerische Schätzfrage</source>
-        <target>Pregunta de estimación numérica</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTag" datatype="html">
-        <source> Zahlen schätzen, Streuung sehen</source>
-        <target>estimar números, ver la dispersión</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateBody" datatype="html">
-        <source> Für Jahreszahlen, Größenordnungen, Messwerte und Wahrscheinlichkeiten. Mit Referenzwert, Toleranzband, Histogramm, Statistik und optionaler zweiter Runde.</source>
-        <target>Para años, órdenes de magnitud, medidas y probabilidades. Con valor de referencia, banda de tolerancia, histograma, estadísticas y segunda ronda opcional.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatsBlitzNote" datatype="html">
-        <source> Blitzlicht ist davon getrennt: Es ist für spontane Live-Rückmeldungen gedacht, wenn du keine vollständige Quizfrage bauen willst.</source>
-        <target>El sondeo rápido va aparte de estos formatos: sirve para feedback espontáneo en directo cuando no quieres crear una pregunta de quiz completa.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceTitle" datatype="html">
-        <source> Selbsteinschätzung bei bewertbaren Fragen</source>
-        <target>Autoevaluación para preguntas evaluables</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceLead" datatype="html">
-        <source> Die Selbsteinschätzung ist kein eigener Fragetyp, sondern eine optionale Zusatzabfrage nach Single Choice, Multiple Choice, Kurzantwort und numerischer Schätzfrage: Teilnehmende geben an, wie sicher sie bei ihrer Antwort sind (Skala 1–5). Das beeinflusst keine Punkte – hilft dir aber, Lernstand und Fehlkonzepte zu erkennen.</source>
-        <target>La autoevaluación no es un tipo de pregunta separada, sino una pregunta adicional opcional de opción única, opción múltiple, respuesta corta y pregunta de estimación numérica: los participantes indican qué tan seguros están en su respuesta (escala 1-5). Esto no afecta ningún punto, pero le ayuda a reconocer su nivel de aprendizaje y sus ideas erróneas.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceListAria" datatype="html">
-        <source>Didaktische Funktionen der Selbsteinschätzung</source>
-        <target>Funciones didácticas de la autoevaluación.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
-        <source>Nach der Antwort abfragen</source>
-        <target>Después de la respuesta</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
-        <source> Progressive Disclosure: Erst Antwort wählen oder eingeben, dann die Selbsteinschätzung. Während der Abstimmung sieht niemand aggregierte Werte anderer Personen.</source>
-        <target>Divulgación progresiva: Primero seleccione o ingrese la respuesta, luego la autoevaluación. Durante la votación, nadie ve los valores agregados de otras personas.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorTitle" datatype="html">
-        <source>Im Editor konfigurieren</source>
-        <target>Configurar en el editor</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorBody" datatype="html">
-        <source> Toggle pro Frage, optionale Labels für niedrige und hohe Antwortsicherheit und eine Live-Vorschau der Skala. Für neue bewertbare Fragen ist die Selbsteinschätzung standardmäßig aktiv.</source>
-        <target>Alternar por pregunta, etiquetas opcionales para confianza de respuesta alta y baja y una vista previa en vivo de la escala. La autoevaluación está activa por defecto para nuevas preguntas evaluables.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceHostTitle" datatype="html">
-        <source>Host-Auswertung nach Freigabe</source>
-        <target>Evaluación en la vista host tras publicar resultados</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">226</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceHostBody" datatype="html">
-        <source> Matrix aus Korrektheit und Antwortsicherheit mit Hervorhebung <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>selbstsicher falsch<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Bei Auswahlfragen siehst du, welche falschen Optionen mit hoher Antwortsicherheit gewählt wurden.</source>
-        <target>Matriz de corrección y confianza en la respuesta con resaltado de respuestas <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>falsas y muy seguras<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. En preguntas de opción ves qué opciones incorrectas se eligieron con alta confianza en la respuesta.</target>
+      <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
+        <source>Was kann ich mit arsnova.eu machen?</source>
+        <target>¿Qué puedo hacer con arsnova.eu?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportTitle" datatype="html">
-        <source>Abschluss und Export</source>
-        <target>Finalización y exportación</target>
+      <trans-unit id="help.hostCapabilitiesBody" datatype="html">
+        <source> Mit einem Quiz stellst du vorbereitete Wissens- oder Meinungsfragen. Im Q&amp;A sammelst und priorisierst du Fragen aus dem Publikum. Das Blitzlicht eignet sich für spontane Stimmungs-, Verständnis- und Tempoabfragen. Du kannst alle drei Bereiche in einer Live-Session verbinden.</source>
+        <target>Utiliza un cuestionario para plantear preguntas de conocimientos u opinión preparadas de antemano. Con el canal Q&amp;A puedes recopilar y priorizar las preguntas del público. El sondeo rápido es adecuado para valorar de forma espontánea el ambiente, la comprensión o el ritmo. Puedes combinar las tres funciones en una misma sesión en directo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">88,93</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportBody" datatype="html">
-        <source> Nach Session-Ende fasst die Auswertung gefestigtes Wissen, Fehlkonzept-Hinweis und fragiles Wissen zusammen. Fragen mit weniger als 5 Antworten mit Selbsteinschätzung werden nicht aggregiert ausgewiesen. Der Nachbesprechungsplan (PDF) ist das empfohlene Format; CSV steht unter „Mehr“ für Excel zur Verfügung. In der Quiz-Sammlung findest du den Nachbesprechungsplan auf der Quizkarte.</source>
-        <target> Al final de la sesión, la evaluación resume los conocimientos consolidados, el riesgo de malentendidos y los conocimientos frágiles. Las preguntas con menos de 5 respuestas con autoevaluación no se muestran de forma agregada. El plan de debriefing (PDF) es el formato recomendado; el CSV está disponible en «Más» para Excel. En la colección de quizzes encontrarás el plan de debriefing en la tarjeta del quiz.</target>
+      <trans-unit id="help.hostFirstSessionTitle" datatype="html">
+        <source>Wie starte ich meine erste Session?</source>
+        <target>¿Cómo inicio mi primera sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTitle" datatype="html">
-        <source>Demo-Quiz</source>
-        <target>Prueba de demostración</target>
+      <trans-unit id="help.hostFirstSessionBody" datatype="html">
+        <source> Öffne die Quiz-Sammlung und nutze das Demo-Quiz oder erstelle ein eigenes Quiz. Wähle „Starten“, lege Stil und Optionen fest und teile anschließend den sechsstelligen Code oder QR-Code. In der Host-Ansicht zeigst du die nächste Frage, startest die Antwortphase und gibst das Ergebnis frei. Tipp: Teste die Vorschau vor dem ersten Einsatz einmal auf einem zweiten Gerät.</source>
+        <target>Abre la colección de cuestionarios y utiliza el cuestionario de demostración o crea uno propio. Selecciona «Iniciar», elige el estilo y las opciones y comparte el código de seis caracteres o el código QR. En la vista de moderación, muestra la siguiente pregunta, inicia la fase de respuesta y presenta los resultados. Consejo: prueba la vista previa en un segundo dispositivo antes de tu primera sesión.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">107,113</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoCardHint" datatype="html">
-        <source> Ein vorinstalliertes Beispiel-Quiz zeigt die Frageformate in konkreten Unterrichtsmomenten: Wissenscheck, Wortwolke, Kurzantwort, Schätzfrage, Bewertungsskala, Selbsteinschätzung, Formeln und Markdown. Du findest es in deiner Quiz-Sammlung und kannst es dort in der Vorschau öffnen.</source>
-        <target>Un quiz de ejemplo preinstalado muestra los formatos de pregunta en momentos didácticos concretos: comprobación de conocimientos, nube de palabras, respuesta corta, estimación, escala de valoración, autoevaluación, fórmulas y Markdown. Lo encuentras en tu colección de quizzes y puedes abrirlo en vista previa.</target>
+      <trans-unit id="help.hostFinishTitle" datatype="html">
+        <source>Wie beende und werte ich eine Session aus?</source>
+        <target>¿Cómo finalizo y analizo una sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTip" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tipp:&lt;/stro"/>Tipp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Öffne die Vorschau vor der ersten Live-Session einmal auf einem zweiten Gerät. So siehst du sofort, wie Host-Ansicht und Teilnehmenden-Screen zusammenspielen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Consejo:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> abre la vista previa una vez en un segundo dispositivo antes de tu primera sesión en directo. Verás enseguida cómo encajan la vista de host y la pantalla de participantes.</target>
+      <trans-unit id="help.hostFinishBody" datatype="html">
+        <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar.</source>
+        <target>Finaliza la sesión desde la vista de moderación. A continuación estarán disponibles los resultados consolidados. Utiliza el plan de revisión en PDF para el análisis didáctico; la exportación CSV está en «Más». El plan seguirá disponible desde la tarjeta del cuestionario.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">124,129</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickstartTitle" datatype="html">
-        <source>Schnellstart</source>
-        <target>Inicio rápido</target>
+      <trans-unit id="help.experiencedUserTitle" datatype="html">
+        <source> Schon vertraut mit arsnova.eu</source>
+        <target>Ya conozco arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">134,136</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart1" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Quiz anlegen:&lt;/"/>Quiz anlegen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> „Quiz-Sammlung öffnen&quot; wählen, neues Quiz erstellen und pro Frage das passende Format wählen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Crear quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> elige “Abrir colección de quizzes”, crea un nuevo quiz y elige el formato adecuado para cada pregunta.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart2" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Veranstaltung s"/>Veranstaltung starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Stil, Timer, Teams und Rangliste festlegen. Danach entsteht ein 6-stelliger Code, den du als Text oder QR-Code teilst.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Iniciar evento:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> define estilo, temporizadores, equipos y ranking. Después se crea un código de 6 caracteres, que puedes compartir como texto o QR.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart3" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Live moderieren"/>Live moderieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage zeigen, Antwortphase starten, Ergebnisse freigeben oder zurückhalten und bei Bedarf eine zweite Runde anschließen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Moderar en directo:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> muestra la pregunta, inicia la fase de respuesta, publica o reserva los resultados y añade una segunda ronda cuando aporte valor.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostTitle" datatype="html">
-        <source>Veranstaltung leiten</source>
-        <target>Liderar el evento</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLead" datatype="html">
-        <source> In der Host-Ansicht führst du durch die Session wie durch eine kleine Senderegie: Teilnehmende reinholen, Inhalte freigeben, Diskussion öffnen und Ergebnisse sichtbar machen.</source>
-        <target>En la vista de host diriges la sesión como una pequeña mesa de control: das entrada a participantes, muestras contenidos, abres el debate y haces visibles los resultados.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostStartStep" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Session starten:&lt;"/>Session starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> In deiner Quiz-Sammlung eine Veranstaltung starten und festlegen, ob sie mit Quiz oder Q&amp;A beginnt. Dann entsteht der Beitrittscode.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Iniciar sesión:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> desde tu colección de quizzes, inicia un evento y elige si empieza con quiz o con Q&amp;A. Entonces se crea el código de acceso.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLobby" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Lobby:&lt;/stron"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Du siehst, wer beigetreten ist; ein QR-Code zum Beitritt wird angezeigt.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ves quién se ha unido; se muestra un código QR para unirse.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostBeamer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beamer- und Pr"/>Beamer- und Presenter-Ansicht:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage, Antworten, Countdown und Ergebnisse erscheinen groß genug für Projektion, Stream oder zweiten Bildschirm.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vista de proyección y presentación:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> pregunta, respuestas, cuenta atrás y resultados aparecen con tamaño suficiente para proyector, emisión o segunda pantalla.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSteuerung" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Steuerung:&lt;/stron"/>Steuerung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Nutze „Nächste Frage“, um den Inhalt einzublenden. Optional läuft zuerst eine Lesephase, danach startest du die Antwortphase und entscheidest, wann das Ergebnis auf den Screen kommt.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Controles:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> usa “Siguiente pregunta” para llevar el contenido a pantalla. Puedes empezar con una fase de lectura, abrir después la fase de respuesta y decidir cuándo aparece el resultado.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instruc"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Bei geeigneten Quizfragen, Schätzfragen und Blitzlicht-Runden: erst abstimmen lassen, Diskussion starten, dann erneut abstimmen. Der Vorher/Nachher-Vergleich macht Lernfortschritt sichtbar.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (rondas dobles):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> para preguntas de quiz adecuadas, estimaciones y sondeos rápidos: primero se vota, luego se debate y después se vuelve a votar. La comparación antes/después hace visible el avance de aprendizaje.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSettings" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Einstellungen:&lt;/"/>Einstellungen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beim Start legst du Stil und Optionen fest: seriös oder spielerisch, mit oder ohne Rangliste, Sound, Lesephase, Team-Modus, Nicknamen und Timer.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Ajustes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> al iniciar eliges estilo y opciones: serio o lúdico, con o sin ranking, sonido, fase de lectura, modo equipo, apodos y temporizador.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallTitle" datatype="html">
-        <source> Fragenwand im Live-Kanal Q&amp;A</source>
-        <target> Muro de preguntas en el canal Q&amp;A en directo </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLead" datatype="html">
-        <source> Q&amp;A soll nicht als Nebenchat verschwinden. Die Fragenwand macht Rückfragen sichtbar, priorisierbar und moderierbar: Du hältst den roten Faden, während die Gruppe gemeinsam zeigt, welche Punkte wirklich Klärung brauchen.</source>
-        <target> El Q&amp;A no debería perderse en un chat paralelo. El muro de preguntas hace visibles, priorizables y moderables las dudas: mantienes el hilo de la sesión mientras el grupo señala de forma colectiva qué puntos necesitan aclaración. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallListAria" datatype="html">
-        <source>Didaktische Funktionen der Q&amp;A-Fragenwand</source>
-        <target>Funciones didácticas del muro de preguntas Q&amp;A</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationTitle" datatype="html">
-        <source>Moderation mit pädagogischem Takt</source>
-        <target> Moderación con criterio didáctico </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationBody" datatype="html">
-        <source> Auf Wunsch warten neue Fragen erst auf deine Freigabe. Du kannst Beiträge freigeben, anheften, archivieren oder entfernen und damit Schutzraum, Relevanz und Timing steuern: sofort beantworten, für später sammeln oder als Diskussionsspur markieren.</source>
-        <target> Si lo necesitas, las nuevas preguntas esperan primero tu aprobación. Puedes aprobar, fijar, archivar o retirar aportaciones y cuidar el espacio, la relevancia y el momento: responder ahora, guardar para después o abrir una línea de debate. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingTitle" datatype="html">
-        <source>Kollektives Hoch- und Runtervoting</source>
-        <target> Voto colectivo a favor y en contra </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingBody" datatype="html">
-        <source> Teilnehmende gewichten Fragen gemeinsam. Positive und negative Stimmen zeigen nicht nur Popularität, sondern auch Unsicherheit, Widerspruch und Klärungsbedarf; Sortierungen wie „meist unterstützt“, „beste Fragen“ und „umstritten“ helfen dir, knappe Live-Zeit didaktisch zu setzen.</source>
-        <target> Las personas participantes ponderan juntas las preguntas. Los votos positivos y negativos muestran algo más que popularidad: sacan a la luz incertidumbre, desacuerdo y necesidad de aclaración. Ordenaciones como «más apoyadas», «mejores preguntas» y «controvertidas» te ayudan a dedicar el tiempo en directo donde tiene más sentido didáctico. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
-        <source>Q&amp;A-Wortwolke auf Themenebene</source>
-        <target> Nube de palabras Q&amp;A a nivel temático </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudBody" datatype="html">
-        <source> Die Word-Cloud verdichtet sichtbare Fragen zu Wörtern und Phrasen, gewichtet nach Unterstützung, belastbarer Zustimmung oder Kontroverse. Sie lässt sich einfrieren, nach Sortierlogik betrachten und in der Presenter-Ansicht zeigen – als schneller Blick auf Themencluster, nicht als dekorative Wortliste.</source>
-        <target> La nube de palabras condensa las preguntas visibles en palabras y frases, ponderadas por apoyo, acuerdo sólido o controversia. Puede congelarse, leerse según la lógica de ordenación y mostrarse en la vista de presentación: una lectura rápida de grupos temáticos, no una lista decorativa de palabras. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmTitle" datatype="html">
-        <source>Nächster Schritt: Moderationskompass</source>
-        <target>Siguiente paso: brújula de moderación</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmBody" datatype="html">
-        <source> Geplant ist zuerst ein deterministischer Moderationskompass. Optional können später asynchrone Q&amp;A-NLP-Signale und quellengebundene Zusammenfassungen dazukommen – als datenschutzbewusste Moderationshilfe statt Blackbox-Bewertung.</source>
-        <target> Primero se prevé una brújula de moderación determinista. Más adelante se podrán añadir de forma opcional señales Q&amp;A NLP asíncronas y resúmenes vinculados a las fuentes, como ayuda de moderación respetuosa con los datos en lugar de una valoración de caja negra. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.blitzTitle" datatype="html">
-        <source>Blitzlicht</source>
-        <target>Sondeo rápido</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackIntro" datatype="html">
-        <source> Schnelle Stimmungs- und Wissensabfragen – z. B. vor der Pause, zum Einstieg oder für spontane Checks. Nutzbar im Host-Bereich deiner Live-Session oder direkt von der Startseite.</source>
-        <target>Sondeos rápidos sobre ánimo y comprensión, antes de una pausa, al arrancar o para tomar el pulso en el momento. Disponibles en la vista de anfitrión de tu sesión en directo o desde la página de inicio.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfMood" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stimmungsb"/>Stimmungsbild<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): Wie geht es den Teilnehmenden?</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Imagen del estado de ánimo<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): ¿Cómo les va a los participantes?</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfYesNoMaybe" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein / Viel"/>Ja / Nein / Vielleicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Schnelle Zustimmungsabfrage.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sí / No / Quizás<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Consulta de consentimiento rápido.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackYesNo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein&lt;/strong&gt; (👍"/>Ja / Nein<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): Klare Zwei-Optionen-Abfrage ohne Mittelweg.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sí / No<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): pregunta binaria clara, sin término medio.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Wahr / Falsch / Weiß nicht&lt;/stron"/>Wahr / Falsch / Weiß nicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): Für schnelle Einschätzungen oder Wissenschecks.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Verdadero / Falso / No lo sé<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): para valoraciones rápidas o comprobaciones de conocimiento.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Mehrstufige Schnellabfragen&lt;/s"/>Mehrstufige Schnellabfragen<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D): Drei oder vier feste Optionen für spontane Abstimmungen – ohne eine vollständige Quizfrage zu bauen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Encuestas rápidas de varias etapas<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A-D): tres o cuatro opciones fijas para la votación espontánea, sin crear una pregunta de prueba completa.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTempo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tempo-Feedback&lt;/strong"/>Tempo-Feedback<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): Mit vier Icons meldet deine Gruppe laufend zurück, ob sie folgen kann. Teilnehmende können ihre Rückmeldung ändern; du siehst nur die aggregierte Tendenz.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Feedback de ritmo<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): con cuatro iconos, tu grupo indica en todo momento si puede seguir. Las personas participantes pueden cambiar su respuesta; tú solo ves la tendencia agregada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">283,285</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
-        <source> Du startest die Runde im Host-Bereich deiner Live-Session oder über die Blitzlicht-Karte „Live mit einem Klick&quot; auf der Startseite. Teilnehmende tippen eine Antwort; du siehst die Ergebnisse live als Balkendiagramm.</source>
-        <target>Inicias la ronda en la vista de anfitrión de tu sesión en directo o directamente desde la tarjeta «Sondeo rápido» («En vivo con un clic») en la página de inicio. Las personas participantes votan con un toque y ves los resultados al instante en un gráfico de barras.</target>
+      <trans-unit id="help.hostFormatsTitle" datatype="html">
+        <source>Fragetypen und Selbsteinschätzung</source>
+        <target>Tipos de pregunta y autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">141</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instr"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Erste Runde – Ergebnis nicht auflösen – „Diskussionsphase&quot; starten („Diskutiert mit eurem Nachbarn&quot;) – „Zweite Abstimmung&quot;. Vorher/Nachher-Vergleich zeigt, wie sich das Stimmungsbild durch den Austausch verändert hat.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Instrucción entre pares (rondas dobles):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Primera ronda - No resolver el resultado - Iniciar la "fase de discusión" ("Discute con tu vecino") - "Segunda votación". La comparación antes/después muestra cómo cambia el estado de ánimo tras el intercambio.</target>
+      <trans-unit id="help.hostFormatsBody" datatype="html">
+        <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar.</source>
+        <target>Están disponibles las preguntas de respuesta única, respuesta múltiple, respuesta corta, texto libre, encuesta, escala de valoración y estimación numérica. Las preguntas evaluables pueden ir seguidas de una autoevaluación del 1 al 5. No modifica la puntuación, pero permite reconocer conocimientos consolidados, conocimientos frágiles y posibles conceptos erróneos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">145,151</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfStop" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stopp:&lt;/st"/>Stopp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Abstimmung einfrieren – Teilnehmende sehen „Abstimmung ist pausiert&quot; und können nicht mehr abstimmen, bis du „Fortsetzen&quot; wählst.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Detener:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Congelar la votación: los participantes ven &quot;La votación está en pausa&quot; y ya no pueden votar hasta que elijas &quot;Reanudar&quot;.</target>
+      <trans-unit id="help.hostModerationTitle" datatype="html">
+        <source>Live moderieren und Peer Instruction nutzen</source>
+        <target>Moderar en directo y utilizar la instrucción entre pares</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfReset" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Zurücksetze"/>Zurücksetzen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Alle Stimmen löschen und erneut abstimmen lassen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Restablecer:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Elimina todos los votos y déjalos votar nuevamente.</target>
+      <trans-unit id="help.hostModerationBody" datatype="html">
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.</source>
+        <target>Utiliza cuando sea necesario la fase de lectura, el temporizador, la vista de proyección o presentación y la visualización diferida de resultados. Para la instrucción entre pares, realiza una primera votación, abre una fase de debate y después una segunda votación. La comparación antes-después muestra los cambios.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">162,167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfNewRound" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Neue Runde:&lt;/s"/>Neue Runde:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Neuen Code erzeugen und eine frische Runde starten.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Nueva ronda:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Genera nuevo código y comienza una nueva ronda.</target>
+      <trans-unit id="help.hostQaTitle" datatype="html">
+        <source>Die Q&amp;A-Fragenwand moderieren</source>
+        <target>Moderar el muro de preguntas Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfCopyLink" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Link kopieren:"/>Link kopieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beitrittslink in die Zwischenablage kopieren, z. B. zum Teilen per Chat.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Copiar enlace:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Copiar enlace de unión al portapapeles, p. ej. para compartir a través del chat.</target>
+      <trans-unit id="help.hostQaBody" datatype="html">
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation.</source>
+        <target>Las nuevas aportaciones pueden quedar pendientes de aprobación antes de mostrarse. Puedes aprobar, fijar, archivar o eliminar preguntas. Los votos positivos y negativos y las distintas formas de ordenación ayudan a priorizarlas; la nube de palabras resume los temas visibles para la presentación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">178,183</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsTitle" datatype="html">
-        <source>Für deine Teilnehmenden</source>
-        <target>Para tus participantes</target>
+      <trans-unit id="help.hostPulseTitle" datatype="html">
+        <source>Blitzlicht und Tempo-Feedback einsetzen</source>
+        <target>Utilizar el sondeo rápido y la valoración del ritmo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsLead" datatype="html">
-        <source> Kurz erklärt, was du in deiner Veranstaltung weitergeben kannst:</source>
-        <target>En pocas palabras, qué puedes compartir en tu evento:</target>
+      <trans-unit id="help.hostPulseBody" datatype="html">
+        <source> Starte ein Blitzlicht aus der Live-Session oder über „Live mit einem Klick“ auf der Startseite. Du kannst die Abstimmung pausieren, fortsetzen, zurücksetzen oder als neue Runde starten. Beim Tempo-Feedback ändern Teilnehmende ihre Rückmeldung jederzeit; du siehst nur die aggregierte Tendenz.</source>
+        <target>Inicia un sondeo rápido desde la sesión en directo o mediante «En vivo con un clic» en la página de inicio. Puedes pausarlo, reanudarlo, reiniciarlo o comenzar una nueva ronda. En la valoración del ritmo, los participantes pueden cambiar su respuesta en cualquier momento; tú solo ves la tendencia agregada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">194,199</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsJoin" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beitreten:&lt;/strong&gt;"/>Beitreten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> 6-stelligen Code auf arsnova.eu eingeben und „Los geht&apos;s&quot; – funktioniert für Quiz, Q&amp;A und Blitzlicht. Keine Anmeldung nötig.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Unirse:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Introduce el código de 6 dígitos en arsnova.eu y «Vamos» — vale para cuestionario, Q&amp;A y sondeo rápido. Sin registro.</target>
+      <trans-unit id="help.hostLibraryTitle" datatype="html">
+        <source>Quiz-Sammlung und Einstellungen verwalten</source>
+        <target>Gestionar cuestionarios y ajustes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsNick" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Nicknamen:&lt;/strong&gt;"/>Nicknamen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Je nach deiner Einstellung vorgegebene Namen, eigener Name oder anonym.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Apodos:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Dependiendo de tu configuración, nombres predefinidos, tu propio nombre o anónimo.</target>
+      <trans-unit id="help.hostLibraryBody" datatype="html">
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
+        <target>En la colección de cuestionarios puedes editar y reordenar preguntas, comprobar la vista previa e importar o exportar cuestionarios en formato JSON. El enlace de sincronización permite compartir la colección o continuar en otro dispositivo. Las plantillas de IA ayudan a generar y revisar contenido sin enviarlo a arsnova.eu. Al iniciar una sesión, configura opciones como el estilo, la clasificación, el sonido, los equipos, los alias, el temporizador y los códigos de bonificación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">210,217</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsVote" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Abstimmung:&lt;/strong&gt;"/>Abstimmung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage erscheint auf dem Gerät, Antwort wählen und absenden. Bei aktivierter Selbsteinschätzung folgt danach die Skala 1–5. Bei Zeitlimit läuft ein Countdown.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vota:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> La pregunta aparece en el dispositivo; elige la respuesta y envíala. Si la autoevaluación está activada, sigue la escala 1–5. Con límite de tiempo, hay una cuenta atrás.</target>
+      <trans-unit id="help.participantJoinTitle" datatype="html">
+        <source>Wie trete ich einer Session bei?</source>
+        <target>¿Cómo me uno a una sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTitle" datatype="html">
-        <source>Deine Quiz-Sammlung</source>
-        <target>Tu colección de quizzes</target>
+      <trans-unit id="help.participantJoinBody" datatype="html">
+        <source> Scanne den QR-Code oder öffne arsnova.eu und gib den sechsstelligen Code ein. Du brauchst kein Konto. Je nach Einstellung der Veranstaltungsleitung nimmst du anonym, mit einem vorgegebenen Nickname oder mit einem selbst gewählten Namen teil.</source>
+        <target>Escanea el código QR o abre arsnova.eu e introduce el código de seis caracteres. No necesitas una cuenta. Según los ajustes de quien dirige la sesión, puedes participar de forma anónima, con un alias predefinido o con el nombre que elijas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">235,240</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionLead" datatype="html">
-        <source>Hier legst du deine Quizze an und bereitest sie vor.</source>
-        <target>Aquí creas y preparas tus cuestionarios.</target>
+      <trans-unit id="help.participantAnswerTitle" datatype="html">
+        <source>Wie beantworte ich eine Quizfrage?</source>
+        <target>¿Cómo respondo a una pregunta del cuestionario?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">247</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionEditor" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Editor:&lt;/strong&gt; Fra"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Fragen per Drag-and-Drop sortieren, auf- und zuklappen, Vorschau prüfen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ordene las preguntas arrastrando y soltando, expandiendo y contrayendo, verifique la vista previa.</target>
+      <trans-unit id="help.participantAnswerBody" datatype="html">
+        <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
+        <target>Selecciona o introduce una respuesta y envíala. Si la autoevaluación está activada, indica después tu grado de seguridad en una escala del 1 al 5. Si hay un límite de tiempo, una cuenta atrás muestra el tiempo restante. Los resultados aparecen cuando quien dirige la sesión los hace visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">254,259</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTypes" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Fragetypen:&lt;/strong"/>Fragetypen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage – pro Frage optional mit Timer, Schwierigkeitsgrad und Selbsteinschätzung.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Tipos de pregunta:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single choice, multiple choice, respuesta corta, texto libre, encuesta, escala de valoración y pregunta de estimación numérica — cada pregunta puede incluir temporizador, dificultad y autoevaluación opcionales.</target>
+      <trans-unit id="help.participantContributeTitle" datatype="html">
+        <source>Wie stelle ich eine Frage oder gebe Feedback?</source>
+        <target>¿Cómo planteo una pregunta o doy mi opinión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">266</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionImport" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Import / Export:&lt;/st"/>Import / Export:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Quiz als JSON importieren oder exportieren. Mit der Start- und Prüfvorlage kannst du anspruchsvolle Quizze mit deinem bevorzugten KI-Tool generieren, prüfen und direkt importieren – deine Inhalte und Präsentationen werden nicht an arsnova.eu gesendet; du nutzt dein eigenes KI-Tool.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Importar / exportar:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Importa o exporta quizzes como JSON. Usa las plantillas de generación y revisión para crear quizzes de calidad con tu herramienta de IA preferida, revisarlos e importarlos directamente. Tus contenidos y presentaciones no se envían a arsnova.eu; usas tu propia herramienta de IA.</target>
+      <trans-unit id="help.participantContributeBody" datatype="html">
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
+        <target>En el canal Q&amp;A puedes enviar tu propia pregunta y votar positiva o negativamente las aportaciones de otras personas. Según la moderación, tu pregunta puede aparecer solo después de ser aprobada. En el sondeo rápido puedes dar una opinión espontánea con un toque. La valoración del ritmo se puede modificar mientras el sondeo esté abierto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">273,278</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionSync" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Sync:&lt;/strong&gt; Mit"/>Sync:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit dem Sync-Link deine Quiz-Sammlung mit Kolleg:innen teilen oder auf anderen Geräten weiterarbeiten. Wer den Link hat, kann die Sammlung öffnen. Die Geräteangaben helfen nur bei der Orientierung.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sincronización:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Usa el enlace de sync para compartir tu colección de quizzes o continuar en otros dispositivos. Quien tenga el enlace puede abrir la colección. Los datos del dispositivo solo sirven para orientarte.</target>
+      <trans-unit id="help.participantChannelsTitle" datatype="html">
+        <source>Wie nutze ich Quiz, Q&amp;A und Blitzlicht in einer Session?</source>
+        <target>¿Cómo utilizo cuestionario, Q&amp;A y sondeo rápido en una sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">290</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoQuizHint" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Demo-Quiz:&lt;/stro"/>Demo-Quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ein vorinstalliertes Quiz zeigt alle Formate mit Beispielen inkl. KaTeX-Formeln und Markdown. In der Quiz-Sammlung in der Vorschau öffnen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Quiz de demostración:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> un quiz preinstalado muestra todos los formatos con ejemplos, incluidas fórmulas KaTeX y Markdown. Ábrelo desde la colección de quizzes en vista previa.</target>
+      <trans-unit id="help.participantChannelsBody" datatype="html">
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung.</source>
+        <target>Una sesión en directo puede combinar cuestionario, Q&amp;A y sondeo rápido. Sigue la vista activa y las indicaciones de tu dispositivo. Si un canal no está activo, espera a que quien dirige la sesión abra la siguiente actividad.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">297,302</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesTitle" datatype="html">
-        <source>Seriös und Spielerisch</source>
-        <target>Serio y juguetón</target>
+      <trans-unit id="help.participantSecondRoundTitle" datatype="html">
+        <source>Was passiert bei einer zweiten Abstimmungsrunde?</source>
+        <target>¿Qué ocurre en una segunda ronda de votación?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesLead" datatype="html">
-        <source> Zwei Stile für unterschiedliche Situationen – wählbar auf der Startseite und beim Session-Start.</source>
-        <target>Dos estilos para diferentes situaciones: seleccionables en la página de inicio y al inicio de la sesión.</target>
+      <trans-unit id="help.participantSecondRoundBody" datatype="html">
+        <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden.</source>
+        <target>En la instrucción entre pares, responde primero a la pregunta por tu cuenta. Después coméntala con otros participantes y vota de nuevo. Envía también tu respuesta en la segunda ronda; puede ser diferente de la primera.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">316,321</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.styleSerious" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Seriös:&lt;/strong&gt;"/>Seriös:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonym, ohne Rangliste – ideal für formative Assessments, Prüfungsvorbereitung und sensible Themen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Serio:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anónimo, sin clasificaciones: ideal para evaluaciones formativas, preparación de exámenes y temas delicados.</target>
+      <trans-unit id="help.participantResultsTitle" datatype="html">
+        <source>Wie sind Ergebnisse, Rangliste und Teamwertung zu verstehen?</source>
+        <target>¿Cómo interpreto los resultados, la clasificación y las puntuaciones por equipos?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylePlayful" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Spielerisch:&lt;/st"/>Spielerisch:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit Rangliste, Sounds und Anfeuerung – ideal für Auflockerung, Wettbewerbe und motivierende Quizze.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Juguetón:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Con clasificación, sonidos y mensajes de ánimo: ideal para romper el hielo, competir y hacer cuestionarios motivadores.</target>
+      <trans-unit id="help.participantResultsBody" datatype="html">
+        <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung.</source>
+        <target>Quien dirige la sesión decide cuándo se muestran los resultados. La clasificación, las puntuaciones por equipos y los códigos de bonificación solo aparecen si están activados para la sesión. Tu autoevaluación no influye en la puntuación ni en la posición.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">335,339</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesOptions" datatype="html">
-        <source> Alle Optionen (Rangliste, Sound, Lesephase, Team, Bonus) lassen sich einzeln an- und ausschalten.</source>
-        <target>Todas las opciones (clasificaciones, sonido, fase de lectura, equipo, bonificación) se pueden activar y desactivar individualmente.</target>
+      <trans-unit id="help.commonTitle" datatype="html">
+        <source>Für alle</source>
+        <target>Para todos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">346</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTitle" datatype="html">
-        <source>Weitere Funktionen</source>
-        <target>Más funciones</target>
+      <trans-unit id="help.commonPrivacyTitle" datatype="html">
+        <source>Wie werden Daten und Inhalte behandelt?</source>
+        <target>¿Cómo se tratan los datos y los contenidos?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">351</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreBonus" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Bonus-Codes:&lt;"/>Bonus-Codes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Top-Platzierte erhalten einen einlösbaren Code (z. B. für Bonuspunkte). Du siehst die Code-Liste; personenbezogene Daten werden nicht gespeichert.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Códigos de bonificación:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Los primeros lugares reciben un código canjeable (por ejemplo, por puntos de bonificación). Verá la lista de códigos; Los datos personales no se almacenan.</target>
+      <trans-unit id="help.commonPrivacyBody" datatype="html">
+        <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target>No se necesita una cuenta. Los cuestionarios de quien dirige la sesión se guardan primero de forma local en el navegador; durante una sesión en directo se intercambian los datos necesarios para la interacción. arsnova.eu es de código abierto y está diseñado para un funcionamiento orientado a la privacidad en Europa. Consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Política de privacidad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para obtener más información.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">355,362</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTeams" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Team-Modus:&lt;/"/>Team-Modus:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Deine Teilnehmenden spielen in Teams mit eigenem Team-Leaderboard – z. B. für Gruppenwettbewerbe im Seminar.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Modo de equipo:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Tus participantes juegan en equipos con su propia tabla de clasificación de equipos, p. ej. para competiciones grupales en seminarios.</target>
+      <trans-unit id="help.commonAccessibilityTitle" datatype="html">
+        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
+        <target>¿Cómo utilizo arsnova.eu de forma accesible y como aplicación?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreGamification" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Gamification:&lt;/stron"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sound-Effekte, Belohnungseffekte für Top-Plätze, Motivationsmeldungen – im Spielerisch-Modus.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamificación:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Efectos de sonido, efectos de recompensa para los mejores lugares, mensajes motivadores, en modo lúdico.</target>
+      <trans-unit id="help.commonAccessibilityBody" datatype="html">
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target>arsnova.eu se puede utilizar con el teclado, con lectores de pantalla y con ampliación. Si lo necesitas, usa las opciones de contraste y tema de la aplicación o del sistema operativo. También puedes instalar arsnova.eu como aplicación web progresiva. Consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Declaración de accesibilidad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para obtener más información.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">376,382</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyTitle" datatype="html">
-        <source>Datenschutz und Technik</source>
-        <target>Protección de datos y tecnología</target>
+      <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
+        <source>Was kann ich bei technischen Problemen tun?</source>
+        <target>¿Qué puedo hacer si algo no funciona?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">389</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyBody" datatype="html">
-        <source> arsnova.eu ist kostenlos, Open Source und für den Einsatz an Schulen, Hochschulen und in Weiterbildung gedacht – mit Fokus auf Datenschutz (DSGVO). Quiz-Inhalte werden lokal im Browser gespeichert. Keine Anmeldung nötig, weder für dich noch für deine Teilnehmenden. Als App installierbar (PWA) – z. B. für schnelleren Start auf dem Smartphone. Oberfläche auf Deutsch, Englisch, Französisch, Spanisch und Italienisch.</source>
-        <target>arsnova.eu es gratuito, de código abierto y está destinado a su uso en escuelas, universidades y educación superior, centrándose en la protección de datos (GDPR). El contenido del cuestionario se guarda localmente en el navegador. No es necesario registrarse, ni para usted ni para sus participantes. Se puede instalar como una aplicación (PWA), p. B. para un inicio más rápido en el teléfono inteligente. Interfaz en alemán, inglés, francés, español e italiano.</target>
+      <trans-unit id="help.commonTroubleshootingBody" datatype="html">
+        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
+        <target>Comprueba primero el código o el código QR, la conexión a Internet y que la sesión siga activa. Si todavía no aparece ninguna pregunta, la sesión puede estar en la sala de espera, en la fase de lectura o en pausa. Tras una interrupción, vuelve a abrir el enlace de acceso o introduce de nuevo el código. Consulta a quien dirige la sesión si ya ha finalizado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">396,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -6194,8 +6194,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen.</source>
-        <target>Elige cómo utilizas arsnova.eu. Empieza con una breve introducción o consulta una función concreta.</target>
+        <source> Wähle, in welcher Rolle du arsnova.eu nutzt. Hier findest du einen schnellen Einstieg und gezielte Hilfe zu einzelnen Funktionen.</source>
+        <target>Elige el rol con el que utilizas arsnova.eu. Aquí encontrarás una introducción rápida y ayuda concreta para cada función.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">41,44</context>
@@ -6303,7 +6303,7 @@
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
         <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar.</source>
-        <target>Finaliza la sesión desde la vista de moderación. A continuación estarán disponibles los resultados consolidados. Utiliza el plan de revisión en PDF para el análisis didáctico; la exportación CSV está en «Más». El plan seguirá disponible desde la tarjeta del cuestionario.</target>
+        <target>Finaliza la sesión desde la vista de moderación. A continuación estará disponible el resumen de los resultados. Utiliza el plan para la puesta en común en PDF para el análisis didáctico; la exportación CSV está en «Más». El plan seguirá disponible desde la tarjeta del cuestionario.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">135,140</context>
@@ -6323,7 +6323,7 @@
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
         <source>Fragetypen und Selbsteinschätzung</source>
-        <target>Tipos de pregunta y autoevaluación</target>
+        <target>Tipos de pregunta y seguridad en la respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">152</context>
@@ -6331,7 +6331,7 @@
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
         <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar.</source>
-        <target>Están disponibles las preguntas de respuesta única, respuesta múltiple, respuesta corta, texto libre, encuesta, escala de valoración y estimación numérica. Las preguntas evaluables pueden ir seguidas de una autoevaluación del 1 al 5. No modifica la puntuación, pero permite reconocer conocimientos consolidados, conocimientos frágiles y posibles conceptos erróneos.</target>
+        <target>Están disponibles las preguntas de respuesta única, respuesta múltiple, respuesta corta, texto libre, encuesta, escala de valoración y estimación numérica. Las preguntas evaluables pueden ir seguidas de una autoevaluación del grado de seguridad del 1 al 5. Esta no modifica la puntuación, pero puede mostrar qué conocimientos están consolidados, cuáles aún no lo están y qué respuestas pueden indicar posibles concepciones erróneas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">156,162</context>
@@ -6339,15 +6339,15 @@
       </trans-unit>
       <trans-unit id="help.hostModerationTitle" datatype="html">
         <source>Live moderieren und Peer Instruction nutzen</source>
-        <target>Moderar en directo y utilizar la instrucción entre pares</target>
+        <target>Moderar en directo y utilizar Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
-        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.</source>
-        <target>Utiliza cuando sea necesario la fase de lectura, el temporizador, la vista de proyección o presentación y la visualización diferida de resultados. Para la instrucción entre pares, realiza una primera votación, abre una fase de debate y después una segunda votación. La comparación antes-después muestra los cambios.</target>
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-Nachher-Vergleich macht Veränderungen sichtbar.</source>
+        <target>Utiliza cuando sea necesario la fase de lectura, el temporizador, la vista de proyección o presentación y la visualización diferida de resultados. Para Peer Instruction, realiza una primera votación, abre una fase de debate y después una segunda votación. La comparación antes-después muestra los cambios.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">173,178</context>
@@ -6362,8 +6362,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation.</source>
-        <target>Las nuevas aportaciones pueden quedar pendientes de aprobación antes de mostrarse. Puedes aprobar, fijar, archivar o eliminar preguntas. Los votos positivos y negativos y las distintas formas de ordenación ayudan a priorizarlas; la nube de palabras resume los temas visibles para la presentación.</target>
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
+        <target>Las nuevas aportaciones pueden quedar pendientes de aprobación antes de mostrarse. Puedes aprobar, fijar, archivar o eliminar preguntas. Los votos positivos y negativos y las distintas formas de ordenación ayudan a priorizarlas; la nube de palabras pone de relieve los temas recurrentes para la presentación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">189,194</context>
@@ -6394,8 +6394,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
-        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
-        <target>En la colección de cuestionarios puedes editar y reordenar preguntas, comprobar la vista previa e importar o exportar cuestionarios en formato JSON. El enlace de sincronización permite compartir la colección o continuar en otro dispositivo. Las plantillas de IA ayudan a generar y revisar contenido sin enviarlo a arsnova.eu. Al iniciar una sesión, configura opciones como el estilo, la clasificación, el sonido, los equipos, los alias, el temporizador y los códigos de bonificación.</target>
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen dich beim Erstellen und Prüfen von Quizzen, ohne dass Inhalte an arsnova.eu gesendet werden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
+        <target>En la colección de cuestionarios puedes editar y reordenar preguntas, comprobar la vista previa e importar o exportar cuestionarios en formato JSON. El enlace de sincronización permite compartir la colección o continuar en otro dispositivo. Las plantillas de IA te ayudan a crear y revisar cuestionarios sin enviar el contenido a arsnova.eu. Al iniciar una sesión, configura opciones como el estilo, la clasificación, el sonido, los equipos, los alias, el temporizador y los códigos de bonificación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">221,228</context>
@@ -6427,7 +6427,7 @@
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
         <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
-        <target>Selecciona o introduce una respuesta y envíala. Si la autoevaluación está activada, indica después tu grado de seguridad en una escala del 1 al 5. Si hay un límite de tiempo, una cuenta atrás muestra el tiempo restante. Los resultados aparecen cuando quien dirige la sesión los hace visibles.</target>
+        <target>Selecciona o introduce una respuesta y envíala. Si la autoevaluación del grado de seguridad está activada, indica después tu grado de seguridad en una escala del 1 al 5. Si hay un límite de tiempo, una cuenta atrás muestra el tiempo restante. Los resultados aparecen cuando quien dirige la sesión los hace visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">275,280</context>
@@ -6443,7 +6443,7 @@
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
         <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
-        <target>En el canal Q&amp;A puedes enviar tu propia pregunta y votar positiva o negativamente las aportaciones de otras personas. Según la moderación, tu pregunta puede aparecer solo después de ser aprobada. En el sondeo rápido puedes dar una opinión espontánea con un toque. La valoración del ritmo se puede modificar mientras el sondeo esté abierto.</target>
+        <target>En el canal Q&amp;A puedes enviar tu propia pregunta y votar a favor o en contra de las aportaciones de otras personas. Según la moderación, tu pregunta puede aparecer solo después de ser aprobada. En el sondeo rápido puedes dar una opinión espontánea con un toque. La valoración del ritmo se puede modificar mientras el sondeo esté abierto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">294,299</context>
@@ -6451,18 +6451,18 @@
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
         <source>Wie nutze ich Quiz, Q&amp;A und Blitzlicht in einer Session?</source>
-        <target>¿Cómo utilizo cuestionario, Q&amp;A y sondeo rápido en una sesión?</target>
+        <target>¿Cómo utilizo el cuestionario, el Q&amp;A y el sondeo rápido en una sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">311</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
-        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung.</source>
-        <target>Una sesión en directo puede combinar cuestionario, Q&amp;A y sondeo rápido. Sigue la vista activa y las indicaciones de tu dispositivo. Si un canal no está activo, espera a que quien dirige la sesión abra la siguiente actividad.</target>
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge den Hinweisen in der jeweils geöffneten Ansicht. Wenn ein Bereich gerade nicht aktiv ist, warte, bis die Veranstaltungsleitung die nächste Aktivität öffnet.</source>
+        <target>Una sesión en directo puede combinar cuestionario, Q&amp;A y sondeo rápido. Sigue las indicaciones que aparecen en tu dispositivo. Si un canal no está activo, espera a que quien dirige la sesión abra la siguiente actividad.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,323</context>
+          <context context-type="linenumber">318,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6470,15 +6470,15 @@
         <target>¿Qué ocurre en una segunda ronda de votación?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
         <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden.</source>
-        <target>En la instrucción entre pares, responde primero a la pregunta por tu cuenta. Después coméntala con otros participantes y vota de nuevo. Envía también tu respuesta en la segunda ronda; puede ser diferente de la primera.</target>
+        <target>En Peer Instruction, responde primero a la pregunta por tu cuenta. Después coméntala con otros participantes y vota de nuevo. Envía también tu respuesta en la segunda ronda; puede ser diferente de la primera.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">337,342</context>
+          <context context-type="linenumber">336,341</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6486,15 +6486,15 @@
         <target>¿Cómo interpreto los resultados, la clasificación y las puntuaciones por equipos?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">349</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
         <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung.</source>
-        <target>Quien dirige la sesión decide cuándo se muestran los resultados. La clasificación, las puntuaciones por equipos y los códigos de bonificación solo aparecen si están activados para la sesión. Tu autoevaluación no influye en la puntuación ni en la posición.</target>
+        <target>Quien dirige la sesión decide cuándo se muestran los resultados. La clasificación, las puntuaciones por equipos y los códigos de bonificación solo aparecen si están activados para la sesión. El grado de seguridad autoevaluado no influye en la puntuación ni en la posición.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">356,360</context>
+          <context context-type="linenumber">355,359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6502,7 +6502,7 @@
         <target>Para todos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6510,23 +6510,23 @@
         <target>¿Cómo se tratan los datos y los contenidos?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">375</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
         <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <target>No se necesita una cuenta. Los cuestionarios de quien dirige la sesión se guardan primero de forma local en el navegador; durante una sesión en directo se intercambian los datos necesarios para la interacción. arsnova.eu es de código abierto y está diseñado para un funcionamiento orientado a la privacidad en Europa. Consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Política de privacidad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para obtener más información.</target>
+        <target>No se necesita una cuenta. Los cuestionarios de quien dirige la sesión se guardan primero de forma local en el navegador; durante una sesión en directo se intercambian los datos necesarios para la interacción. arsnova.eu es de código abierto y está diseñado para proteger la privacidad en el contexto europeo. Consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Política de privacidad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para obtener más información.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,386</context>
+          <context context-type="linenumber">378,385</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
-        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
-        <target>¿Cómo utilizo arsnova.eu de forma accesible y como aplicación?</target>
+        <source>Welche Barrierefreiheitsfunktionen gibt es, und wie installiere ich arsnova.eu als App?</source>
+        <target>¿Qué opciones de accesibilidad ofrece arsnova.eu y cómo puedo instalarlo como aplicación?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">393</context>
+          <context context-type="linenumber">392,393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -6206,7 +6206,7 @@
         <target>Selección de rol</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostTitle" datatype="html">
@@ -6214,11 +6214,11 @@
         <target>Dirijo una sesión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostHint" datatype="html">
@@ -6226,7 +6226,7 @@
         <target>Para docentes, ponentes, formadores y moderadores</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantTitle" datatype="html">
@@ -6234,11 +6234,11 @@
         <target>Participo en una sesión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">71</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">224</context>
+          <context context-type="linenumber">241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
@@ -6246,7 +6246,7 @@
         <target>Para votar, plantear preguntas o dar una opinión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.newUserTitle" datatype="html">
@@ -6254,11 +6254,11 @@
         <target>Primera vez en arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">87</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">226</context>
+          <context context-type="linenumber">244</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
@@ -6266,7 +6266,7 @@
         <target>¿Qué puedo hacer con arsnova.eu?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesBody" datatype="html">
@@ -6274,7 +6274,7 @@
         <target>Utiliza un cuestionario para plantear preguntas de conocimientos u opinión preparadas de antemano. Con el canal Q&amp;A puedes recopilar y priorizar las preguntas del público. El sondeo rápido es adecuado para valorar de forma espontánea el ambiente, la comprensión o el ritmo. Puedes combinar las tres funciones en una misma sesión en directo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">88,93</context>
+          <context context-type="linenumber">99,104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionTitle" datatype="html">
@@ -6282,7 +6282,7 @@
         <target>¿Cómo inicio mi primera sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionBody" datatype="html">
@@ -6290,7 +6290,7 @@
         <target>Abre la colección de cuestionarios y utiliza el cuestionario de demostración o crea uno propio. Selecciona «Iniciar», elige el estilo y las opciones y comparte el código de seis caracteres o el código QR. En la vista de moderación, muestra la siguiente pregunta, inicia la fase de respuesta y presenta los resultados. Consejo: prueba la vista previa en un segundo dispositivo antes de tu primera sesión.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">107,113</context>
+          <context context-type="linenumber">118,124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishTitle" datatype="html">
@@ -6298,7 +6298,7 @@
         <target>¿Cómo finalizo y analizo una sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
@@ -6306,7 +6306,7 @@
         <target>Finaliza la sesión desde la vista de moderación. A continuación estarán disponibles los resultados consolidados. Utiliza el plan de revisión en PDF para el análisis didáctico; la exportación CSV está en «Más». El plan seguirá disponible desde la tarjeta del cuestionario.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">124,129</context>
+          <context context-type="linenumber">135,140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.experiencedUserTitle" datatype="html">
@@ -6314,11 +6314,11 @@
         <target>Ya conozco arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">134,136</context>
+          <context context-type="linenumber">145,147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">283,285</context>
+          <context context-type="linenumber">304,306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
@@ -6326,7 +6326,7 @@
         <target>Tipos de pregunta y autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
@@ -6334,7 +6334,7 @@
         <target>Están disponibles las preguntas de respuesta única, respuesta múltiple, respuesta corta, texto libre, encuesta, escala de valoración y estimación numérica. Las preguntas evaluables pueden ir seguidas de una autoevaluación del 1 al 5. No modifica la puntuación, pero permite reconocer conocimientos consolidados, conocimientos frágiles y posibles conceptos erróneos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">145,151</context>
+          <context context-type="linenumber">156,162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationTitle" datatype="html">
@@ -6342,7 +6342,7 @@
         <target>Moderar en directo y utilizar la instrucción entre pares</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
@@ -6350,7 +6350,7 @@
         <target>Utiliza cuando sea necesario la fase de lectura, el temporizador, la vista de proyección o presentación y la visualización diferida de resultados. Para la instrucción entre pares, realiza una primera votación, abre una fase de debate y después una segunda votación. La comparación antes-después muestra los cambios.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,167</context>
+          <context context-type="linenumber">173,178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaTitle" datatype="html">
@@ -6358,7 +6358,7 @@
         <target>Moderar el muro de preguntas Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
@@ -6366,7 +6366,7 @@
         <target>Las nuevas aportaciones pueden quedar pendientes de aprobación antes de mostrarse. Puedes aprobar, fijar, archivar o eliminar preguntas. Los votos positivos y negativos y las distintas formas de ordenación ayudan a priorizarlas; la nube de palabras resume los temas visibles para la presentación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">178,183</context>
+          <context context-type="linenumber">189,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
@@ -6374,7 +6374,7 @@
         <target>Utilizar el sondeo rápido y la valoración del ritmo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
@@ -6382,7 +6382,7 @@
         <target>Inicia un sondeo rápido desde la sesión en directo o mediante «En vivo con un clic» en la página de inicio. Puedes pausarlo, reanudarlo, reiniciarlo o comenzar una nueva ronda. En la valoración del ritmo, los participantes pueden cambiar su respuesta en cualquier momento; tú solo ves la tendencia agregada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">194,199</context>
+          <context context-type="linenumber">205,210</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
@@ -6390,7 +6390,7 @@
         <target>Gestionar cuestionarios y ajustes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">217</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
@@ -6398,7 +6398,7 @@
         <target>En la colección de cuestionarios puedes editar y reordenar preguntas, comprobar la vista previa e importar o exportar cuestionarios en formato JSON. El enlace de sincronización permite compartir la colección o continuar en otro dispositivo. Las plantillas de IA ayudan a generar y revisar contenido sin enviarlo a arsnova.eu. Al iniciar una sesión, configura opciones como el estilo, la clasificación, el sonido, los equipos, los alias, el temporizador y los códigos de bonificación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">210,217</context>
+          <context context-type="linenumber">221,228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
@@ -6406,7 +6406,7 @@
         <target>¿Cómo me uno a una sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">231</context>
+          <context context-type="linenumber">249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
@@ -6414,7 +6414,7 @@
         <target>Escanea el código QR o abre arsnova.eu e introduce el código de seis caracteres. No necesitas una cuenta. Según los ajustes de quien dirige la sesión, puedes participar de forma anónima, con un alias predefinido o con el nombre que elijas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">235,240</context>
+          <context context-type="linenumber">256,261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
@@ -6422,7 +6422,7 @@
         <target>¿Cómo respondo a una pregunta del cuestionario?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">247</context>
+          <context context-type="linenumber">268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
@@ -6430,7 +6430,7 @@
         <target>Selecciona o introduce una respuesta y envíala. Si la autoevaluación está activada, indica después tu grado de seguridad en una escala del 1 al 5. Si hay un límite de tiempo, una cuenta atrás muestra el tiempo restante. Los resultados aparecen cuando quien dirige la sesión los hace visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">254,259</context>
+          <context context-type="linenumber">275,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
@@ -6438,7 +6438,7 @@
         <target>¿Cómo planteo una pregunta o doy mi opinión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">287</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
@@ -6446,7 +6446,7 @@
         <target>En el canal Q&amp;A puedes enviar tu propia pregunta y votar positiva o negativamente las aportaciones de otras personas. Según la moderación, tu pregunta puede aparecer solo después de ser aprobada. En el sondeo rápido puedes dar una opinión espontánea con un toque. La valoración del ritmo se puede modificar mientras el sondeo esté abierto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">273,278</context>
+          <context context-type="linenumber">294,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
@@ -6454,7 +6454,7 @@
         <target>¿Cómo utilizo cuestionario, Q&amp;A y sondeo rápido en una sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">290</context>
+          <context context-type="linenumber">311</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
@@ -6462,7 +6462,7 @@
         <target>Una sesión en directo puede combinar cuestionario, Q&amp;A y sondeo rápido. Sigue la vista activa y las indicaciones de tu dispositivo. Si un canal no está activo, espera a que quien dirige la sesión abra la siguiente actividad.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">297,302</context>
+          <context context-type="linenumber">318,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6470,7 +6470,7 @@
         <target>¿Qué ocurre en una segunda ronda de votación?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
@@ -6478,7 +6478,7 @@
         <target>En la instrucción entre pares, responde primero a la pregunta por tu cuenta. Después coméntala con otros participantes y vota de nuevo. Envía también tu respuesta en la segunda ronda; puede ser diferente de la primera.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">316,321</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6486,7 +6486,7 @@
         <target>¿Cómo interpreto los resultados, la clasificación y las puntuaciones por equipos?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">328</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
@@ -6494,7 +6494,7 @@
         <target>Quien dirige la sesión decide cuándo se muestran los resultados. La clasificación, las puntuaciones por equipos y los códigos de bonificación solo aparecen si están activados para la sesión. Tu autoevaluación no influye en la puntuación ni en la posición.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">335,339</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6502,7 +6502,7 @@
         <target>Para todos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6510,7 +6510,7 @@
         <target>¿Cómo se tratan los datos y los contenidos?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">351</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
@@ -6518,7 +6518,7 @@
         <target>No se necesita una cuenta. Los cuestionarios de quien dirige la sesión se guardan primero de forma local en el navegador; durante una sesión en directo se intercambian los datos necesarios para la interacción. arsnova.eu es de código abierto y está diseñado para un funcionamiento orientado a la privacidad en Europa. Consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Política de privacidad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para obtener más información.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,362</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
@@ -6526,15 +6526,17 @@
         <target>¿Cómo utilizo arsnova.eu de forma accesible y como aplicación?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
-        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;
+                    &gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a
+                  &gt;"/>.</source>
         <target>arsnova.eu se puede utilizar con el teclado, con lectores de pantalla y con ampliación. Si lo necesitas, usa las opciones de contraste y tema de la aplicación o del sistema operativo. También puedes instalar arsnova.eu como aplicación web progresiva. Consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Declaración de accesibilidad<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> para obtener más información.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">376,382</context>
+          <context context-type="linenumber">400,408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
@@ -6542,7 +6544,7 @@
         <target>¿Qué puedo hacer si algo no funciona?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389</context>
+          <context context-type="linenumber">415</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
@@ -6550,7 +6552,7 @@
         <target>Comprueba primero el código o el código QR, la conexión a Internet y que la sesión siga activa. Si todavía no aparece ninguna pregunta, la sesión puede estar en la sala de espera, en la fase de lectura o en pausa. Tras una interrupción, vuelve a abrir el enlace de acceso o introduce de nuevo el código. Consulta a quien dirige la sesión si ya ha finalizado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">396,403</context>
+          <context context-type="linenumber">422,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -359,16 +359,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="seo.titleHelp" datatype="html">
-        <source>So funktioniert’s – arsnova.eu</source>
-        <target>Comment ça marche – arsnova.eu</target>
+        <source>Hilfe &amp; Einstieg – arsnova.eu</source>
+        <target>Aide et prise en main – arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="seo.descHelp" datatype="html">
-        <source>Kurz erklärt: Live-Sessions, Quiz-Frageformate, Selbsteinschätzung, Blitzlicht, Q&amp;A und Moderationsabläufe auf arsnova.eu.</source>
-        <target>Guide rapide : sessions live, formats de questions, auto-évaluation, feedback express, Q&amp;A et déroulés de modération sur arsnova.eu.</target>
+        <source>Hilfe für Veranstaltungsleitungen und Teilnehmende: Session starten, abstimmen, Q&amp;A und Blitzlicht nutzen, Ergebnisse auswerten und Funktionen nachschlagen.</source>
+        <target>Aide pour l’animation et la participation : lancer une session, voter, utiliser le Q&amp;A et le Feedback express, analyser les résultats et découvrir les fonctions avancées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">120</context>
@@ -6186,835 +6186,371 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.pageTitle" datatype="html">
-        <source> So funktioniert’s</source>
-        <target>Comment ça marche</target>
+        <source> Hilfe &amp; Einstieg</source>
+        <target>Aide et prise en main</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">36,38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Diese Seite richtet sich an <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lehrende, Trainer:innen und Vortragende<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, die aus einer Präsentation eine echte Live-Situation machen wollen: kurze Checks, Diskussionen, Q&amp;A, Blitzlicht und Auswertung laufen in einer Session zusammen. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Ohne Pflichtkonto<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> für deine Gruppe: Code oder QR zeigen, Smartphones raus, loslegen.</source>
-        <target>Cette page s’adresse aux <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>enseignant·es, formateur·rices et intervenant·es<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> qui veulent transformer une présentation en vraie situation live : vérifications rapides, discussion, Q&amp;A, feedback express et restitution tiennent dans une même session. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sans compte obligatoire<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> pour votre groupe : affichez le code ou le QR, sortez les smartphones, c’est parti.</target>
+        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen.</source>
+        <target>Choisis la façon dont tu utilises arsnova.eu. Découvre l’essentiel ou consulte directement une fonctionnalité.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">41,47</context>
+          <context context-type="linenumber">41,44</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.uspTitle" datatype="html">
-        <source>Was arsnova.eu anders macht</source>
-        <target>Ce qui différencie arsnova.eu</target>
+      <trans-unit id="help.roleNavAria" datatype="html">
+        <source>Rollenwahl</source>
+        <target>Choix du rôle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.usp1" datatype="html">
-        <source> arsnova.eu ist als <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Live-Regie für Unterricht, Training und Talks<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> gedacht: Du wechselst nicht zwischen Präsentation, Chat, Umfragetool und Quiz-App, sondern steuerst Interaktion, Beamer-Ansicht und Ergebnisfreigabe an einem Ort.</source>
-        <target>arsnova.eu fonctionne comme une <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>régie live pour vos cours, formations et interventions<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> : au lieu de passer des diapositives au chat, puis à un outil de sondage ou à une appli de quiz, vous pilotez interaction, vue projecteur et affichage des résultats au même endroit.</target>
+      <trans-unit id="help.roleHostTitle" datatype="html">
+        <source>Ich leite eine Veranstaltung</source>
+        <target>J’anime une session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">51,55</context>
+          <context context-type="linenumber">54</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.usp2" datatype="html">
-        <source> Der Fokus liegt auf <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>didaktischer Kontrolle und Datenschutz<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: Inhalte bleiben zunächst local-first im Browser, Teilnehmende brauchen kein Konto, das Projekt ist Open Source und für EU-orientierten Betrieb ausgelegt. Markdown und KaTeX machen fachliche Fragen präsentationstauglich, von MINT-Formeln bis zum kurzen Fallbeispiel.</source>
-        <target>L’accent est mis sur la <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>maîtrise pédagogique et la protection des données<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> : les contenus restent d’abord local-first dans le navigateur, les participant·es n’ont pas besoin de compte, le projet est open source et pensé pour un déploiement orienté UE. Markdown et KaTeX rendent les questions métier prêtes à être projetées, des formules scientifiques au court cas pratique.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56,61</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsTitle" datatype="html">
-        <source> Frageformate: passend zum didaktischen Ziel</source>
-        <target>Formats de questions : à chaque objectif pédagogique son format</target>
+      <trans-unit id="help.roleHostHint" datatype="html">
+        <source>Für Lehrende, Vortragende, Trainer:innen und Moderator:innen</source>
+        <target>Pour les enseignant·es, intervenant·es, formateur·rices et animateur·rices</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsLead" datatype="html">
-        <source> Wähle das Format nach der Situation im Raum: Willst du Wissen prüfen, Haltungen sichtbar machen, Begriffe einsammeln oder Schätzungen diskutieren? Die Formate sind bewusst getrennt, damit Ergebnisanzeige, Bewertung und Moderation zum Einsatzzweck passen.</source>
-        <target>Choisissez le format selon ce qui se passe dans la salle : voulez-vous vérifier des connaissances, rendre visibles des positions, collecter des notions ou discuter des estimations ? Les formats sont volontairement distincts pour que l’affichage, l’évaluation et la modération correspondent à l’usage.</target>
+      <trans-unit id="help.roleParticipantTitle" datatype="html">
+        <source>Ich nehme an einer Veranstaltung teil</source>
+        <target>Je participe à une session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">224</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsGridAria" datatype="html">
-        <source>Verfügbare Quiz-Frageformate</source>
-        <target>Formats de questions de quiz disponibles</target>
+      <trans-unit id="help.roleParticipantHint" datatype="html">
+        <source>Für alle, die abstimmen, Fragen stellen oder Feedback geben</source>
+        <target>Pour voter, poser des questions ou donner son avis</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.newUserTitle" datatype="html">
+        <source>Neu bei arsnova.eu</source>
+        <target>Première utilisation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">76</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
-        <source>Single Choice</source>
-        <target>Single Choice</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTag" datatype="html">
-        <source> eine richtige Option</source>
-        <target>une seule bonne réponse</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceBody" datatype="html">
-        <source> Für punktgenaue Verständnischecks: Eine Antwort ist korrekt, Ergebnis und Punkte sind sofort klar.</source>
-        <target>Pour des checks de compréhension ciblés : une réponse est correcte, le résultat et les points sont immédiatement lisibles.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
-        <source>Multiple Choice</source>
-        <target>Multiple Choice</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
-        <source> mehrere richtige Optionen</source>
-        <target>plusieurs bonnes réponses</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
-        <source> Für komplexere Konzepte, typische Fehlannahmen oder Fragen wie „Welche Aussagen stimmen?“ – mehrere Lösungen können zählen.</source>
-        <target>Pour les notions plus complexes, les idées reçues ou les questions du type « Quelles affirmations sont vraies ? » — plusieurs réponses peuvent compter.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTitle" datatype="html">
-        <source>Kurzantwort</source>
-        <target>Réponse courte</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTag" datatype="html">
-        <source> Musterlösung statt Auswahl</source>
-        <target>réponse modèle plutôt que choix</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextBody" datatype="html">
-        <source> Teilnehmende formulieren kurz selbst. Du hinterlegst Musterlösungen; arsnova.eu kann Schreibvarianten, Toleranz und bei Bedarf Zahlen oder Einheiten auswerten.</source>
-        <target>Les participant·es répondent en quelques mots. Vous indiquez des réponses modèles ; arsnova.eu peut évaluer les variantes d’écriture, les tolérances et, si nécessaire, les nombres ou les unités.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTitle" datatype="html">
-        <source>Freitext</source>
-        <target>Texte libre</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTag" datatype="html">
-        <source> offene Antworten</source>
-        <target>réponses ouvertes</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextBody" datatype="html">
-        <source> Für Ideen, Reflexionen und Erwartungsabfragen. Keine automatische Bewertung; Antworten lassen sich sammeln und als Wortwolke sichtbar machen.</source>
-        <target>Pour les idées, les réflexions et les attentes. Pas de correction automatique ; les réponses peuvent être collectées et affichées sous forme de nuage de mots.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTitle" datatype="html">
-        <source>Umfrage</source>
-        <target>Sondage</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTag" datatype="html">
-        <source> Meinungsbild ohne richtig/falsch</source>
-        <target>opinion sans vrai/faux</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyBody" datatype="html">
-        <source> Für Prioritäten, Vorwissen oder Entscheidungen im Raum. Optionen werden gezählt, ohne Scorelogik.</source>
-        <target>Pour les priorités, les connaissances de départ ou les décisions dans la salle. Les options sont comptées sans logique de score.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTitle" datatype="html">
-        <source>Bewertungsskala</source>
-        <target>Échelle d’évaluation</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTag" datatype="html">
-        <source> Skala mit eigenen Polen</source>
-        <target>échelle avec pôles personnalisés</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingBody" datatype="html">
-        <source> Für Zustimmung, Sicherheit, Tempo oder Feedback von niedrig bis hoch; optional mit benannten Endpunkten.</source>
-        <target>Pour mesurer l’accord, la confiance, le rythme ou un feedback de faible à élevé, avec des extrémités nommées si besoin.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
-        <source>Numerische Schätzfrage</source>
-        <target>Question d’estimation numérique</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTag" datatype="html">
-        <source> Zahlen schätzen, Streuung sehen</source>
-        <target>estimer des nombres, voir la dispersion</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateBody" datatype="html">
-        <source> Für Jahreszahlen, Größenordnungen, Messwerte und Wahrscheinlichkeiten. Mit Referenzwert, Toleranzband, Histogramm, Statistik und optionaler zweiter Runde.</source>
-        <target>Pour les années, les ordres de grandeur, les mesures et les probabilités. Avec valeur de référence, bande de tolérance, histogramme, statistiques et deuxième tour en option.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatsBlitzNote" datatype="html">
-        <source> Blitzlicht ist davon getrennt: Es ist für spontane Live-Rückmeldungen gedacht, wenn du keine vollständige Quizfrage bauen willst.</source>
-        <target>Le feedback express est séparé de ces formats : il sert aux retours live spontanés quand vous ne voulez pas créer une question de quiz complète.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceTitle" datatype="html">
-        <source> Selbsteinschätzung bei bewertbaren Fragen</source>
-        <target>Auto-évaluation pour les questions évaluables</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceLead" datatype="html">
-        <source> Die Selbsteinschätzung ist kein eigener Fragetyp, sondern eine optionale Zusatzabfrage nach Single Choice, Multiple Choice, Kurzantwort und numerischer Schätzfrage: Teilnehmende geben an, wie sicher sie bei ihrer Antwort sind (Skala 1–5). Das beeinflusst keine Punkte – hilft dir aber, Lernstand und Fehlkonzepte zu erkennen.</source>
-        <target>L&apos;auto-évaluation n&apos;est pas un type de question distinct, mais une question supplémentaire facultative selon une question à choix unique, à choix multiple, à réponse courte et d&apos;estimation numérique : les participants indiquent dans quelle mesure ils sont confiants dans leur réponse (échelle 1 à 5). Cela n&apos;affecte aucun point, mais cela vous aide à reconnaître votre niveau d&apos;apprentissage et vos idées fausses.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceListAria" datatype="html">
-        <source>Didaktische Funktionen der Selbsteinschätzung</source>
-        <target>Fonctions didactiques d&apos;auto-évaluation</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
-        <source>Nach der Antwort abfragen</source>
-        <target>Après la réponse</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
-        <source> Progressive Disclosure: Erst Antwort wählen oder eingeben, dann die Selbsteinschätzung. Während der Abstimmung sieht niemand aggregierte Werte anderer Personen.</source>
-        <target>Divulgation progressive : sélectionnez ou saisissez d&apos;abord la réponse, puis l&apos;auto-évaluation. Lors du vote, personne ne voit les valeurs globales des autres.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorTitle" datatype="html">
-        <source>Im Editor konfigurieren</source>
-        <target>Configurer dans l&apos;éditeur</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorBody" datatype="html">
-        <source> Toggle pro Frage, optionale Labels für niedrige und hohe Antwortsicherheit und eine Live-Vorschau der Skala. Für neue bewertbare Fragen ist die Selbsteinschätzung standardmäßig aktiv.</source>
-        <target>Basculez par question, étiquettes facultatives pour une confiance de réponse faible et élevée et un aperçu en direct de l&apos;échelle. L&apos;auto-évaluation est active par défaut pour les nouvelles questions évaluables.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceHostTitle" datatype="html">
-        <source>Host-Auswertung nach Freigabe</source>
-        <target>Évaluation hôte après publication des résultats</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">226</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceHostBody" datatype="html">
-        <source> Matrix aus Korrektheit und Antwortsicherheit mit Hervorhebung <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>selbstsicher falsch<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Bei Auswahlfragen siehst du, welche falschen Optionen mit hoher Antwortsicherheit gewählt wurden.</source>
-        <target>Matrice croisant exactitude et confiance en la réponse, avec mise en évidence des réponses <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>fausses et très sûres<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Pour les questions à choix, tu vois quelles mauvaises options ont été choisies avec une haute confiance en la réponse.</target>
+      <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
+        <source>Was kann ich mit arsnova.eu machen?</source>
+        <target>Que puis-je faire avec arsnova.eu ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportTitle" datatype="html">
-        <source>Abschluss und Export</source>
-        <target>Finalisation et export</target>
+      <trans-unit id="help.hostCapabilitiesBody" datatype="html">
+        <source> Mit einem Quiz stellst du vorbereitete Wissens- oder Meinungsfragen. Im Q&amp;A sammelst und priorisierst du Fragen aus dem Publikum. Das Blitzlicht eignet sich für spontane Stimmungs-, Verständnis- und Tempoabfragen. Du kannst alle drei Bereiche in einer Live-Session verbinden.</source>
+        <target>Un quiz te permet de poser des questions de connaissance ou d’opinion préparées à l’avance. Le canal Q&amp;A sert à recueillir et à hiérarchiser les questions du public. Le Feedback express convient aux retours spontanés sur l’ambiance, la compréhension ou le rythme. Tu peux réunir les trois dans une même session en direct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">88,93</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportBody" datatype="html">
-        <source> Nach Session-Ende fasst die Auswertung gefestigtes Wissen, Fehlkonzept-Hinweis und fragiles Wissen zusammen. Fragen mit weniger als 5 Antworten mit Selbsteinschätzung werden nicht aggregiert ausgewiesen. Der Nachbesprechungsplan (PDF) ist das empfohlene Format; CSV steht unter „Mehr“ für Excel zur Verfügung. In der Quiz-Sammlung findest du den Nachbesprechungsplan auf der Quizkarte.</source>
-        <target> À la fin de la session, l’évaluation résume les connaissances consolidées, le risque d’idées fausses et les connaissances fragiles. Les questions avec moins de 5 réponses avec autoévaluation ne sont pas agrégées. Le plan de débriefing (PDF) est le format recommandé ; le CSV est disponible sous « Plus » pour Excel. Dans la collection de quiz, tu trouveras le plan de débriefing sur la carte du quiz.</target>
+      <trans-unit id="help.hostFirstSessionTitle" datatype="html">
+        <source>Wie starte ich meine erste Session?</source>
+        <target>Comment lancer ma première session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTitle" datatype="html">
-        <source>Demo-Quiz</source>
-        <target>Quiz de démonstration</target>
+      <trans-unit id="help.hostFirstSessionBody" datatype="html">
+        <source> Öffne die Quiz-Sammlung und nutze das Demo-Quiz oder erstelle ein eigenes Quiz. Wähle „Starten“, lege Stil und Optionen fest und teile anschließend den sechsstelligen Code oder QR-Code. In der Host-Ansicht zeigst du die nächste Frage, startest die Antwortphase und gibst das Ergebnis frei. Tipp: Teste die Vorschau vor dem ersten Einsatz einmal auf einem zweiten Gerät.</source>
+        <target>Ouvre ta collection de quiz et utilise le quiz de démonstration ou crée le tien. Sélectionne « Démarrer », choisis le style et les options, puis partage le code à six caractères ou le QR code. Dans la vue d’animation, affiche la question suivante, lance la phase de réponse et révèle les résultats. Conseil : teste l’aperçu sur un deuxième appareil avant ta première session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">107,113</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoCardHint" datatype="html">
-        <source> Ein vorinstalliertes Beispiel-Quiz zeigt die Frageformate in konkreten Unterrichtsmomenten: Wissenscheck, Wortwolke, Kurzantwort, Schätzfrage, Bewertungsskala, Selbsteinschätzung, Formeln und Markdown. Du findest es in deiner Quiz-Sammlung und kannst es dort in der Vorschau öffnen.</source>
-        <target>Un quiz d’exemple préinstallé montre les formats de questions dans des moments pédagogiques concrets : check de connaissances, nuage de mots, réponse courte, estimation, échelle d’évaluation, auto-évaluation, formules et Markdown. Vous le trouverez dans votre bibliothèque de quiz et pourrez l’ouvrir en aperçu.</target>
+      <trans-unit id="help.hostFinishTitle" datatype="html">
+        <source>Wie beende und werte ich eine Session aus?</source>
+        <target>Comment terminer et analyser une session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTip" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tipp:&lt;/stro"/>Tipp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Öffne die Vorschau vor der ersten Live-Session einmal auf einem zweiten Gerät. So siehst du sofort, wie Host-Ansicht und Teilnehmenden-Screen zusammenspielen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Conseil :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> ouvrez l’aperçu une fois sur un deuxième appareil avant votre première session live. Vous verrez tout de suite comment la vue hôte et l’écran des participant·es fonctionnent ensemble.</target>
+      <trans-unit id="help.hostFinishBody" datatype="html">
+        <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar.</source>
+        <target>Termine la session dans la vue d’animation. Les résultats consolidés sont alors disponibles. Utilise le plan de débriefing au format PDF pour l’analyse pédagogique ; l’export CSV se trouve sous « Plus ». Le plan reste accessible depuis la carte du quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">124,129</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickstartTitle" datatype="html">
-        <source>Schnellstart</source>
-        <target>Démarrage rapide</target>
+      <trans-unit id="help.experiencedUserTitle" datatype="html">
+        <source> Schon vertraut mit arsnova.eu</source>
+        <target>Je connais déjà arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">134,136</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart1" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Quiz anlegen:&lt;/"/>Quiz anlegen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> „Quiz-Sammlung öffnen&quot; wählen, neues Quiz erstellen und pro Frage das passende Format wählen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Créer un quiz :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> choisissez « Ouvrir la collection de quiz », créez un nouveau quiz et choisissez le bon format pour chaque question.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart2" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Veranstaltung s"/>Veranstaltung starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Stil, Timer, Teams und Rangliste festlegen. Danach entsteht ein 6-stelliger Code, den du als Text oder QR-Code teilst.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lancer l’événement :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> définissez le style, les minuteurs, les équipes et le classement. Un code à 6 caractères est ensuite créé ; vous le partagez sous forme de texte ou de QR code.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart3" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Live moderieren"/>Live moderieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage zeigen, Antwortphase starten, Ergebnisse freigeben oder zurückhalten und bei Bedarf eine zweite Runde anschließen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Modérer en live :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> affichez la question, lancez la phase de réponse, publiez ou gardez les résultats en réserve et ajoutez un deuxième tour si cela aide.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostTitle" datatype="html">
-        <source>Veranstaltung leiten</source>
-        <target>Diriger l&apos;événement</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLead" datatype="html">
-        <source> In der Host-Ansicht führst du durch die Session wie durch eine kleine Senderegie: Teilnehmende reinholen, Inhalte freigeben, Diskussion öffnen und Ergebnisse sichtbar machen.</source>
-        <target>Dans la vue hôte, vous pilotez la session comme une petite régie : faire entrer les participant·es, afficher les contenus, ouvrir la discussion et rendre les résultats visibles.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostStartStep" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Session starten:&lt;"/>Session starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> In deiner Quiz-Sammlung eine Veranstaltung starten und festlegen, ob sie mit Quiz oder Q&amp;A beginnt. Dann entsteht der Beitrittscode.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lancer la session :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> depuis votre bibliothèque de quiz, démarrez un événement et choisissez s’il commence par un quiz ou par le Q&amp;A. Le code d’accès est alors créé.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLobby" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Lobby:&lt;/stron"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Du siehst, wer beigetreten ist; ein QR-Code zum Beitritt wird angezeigt.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lobby :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Vous voyez qui a rejoint ; un code QR pour rejoindre s&apos;affichera.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostBeamer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beamer- und Pr"/>Beamer- und Presenter-Ansicht:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage, Antworten, Countdown und Ergebnisse erscheinen groß genug für Projektion, Stream oder zweiten Bildschirm.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vue projecteur et vue présentateur :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> question, réponses, compte à rebours et résultats sont assez grands pour une projection, une diffusion ou un deuxième écran.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSteuerung" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Steuerung:&lt;/stron"/>Steuerung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Nutze „Nächste Frage“, um den Inhalt einzublenden. Optional läuft zuerst eine Lesephase, danach startest du die Antwortphase und entscheidest, wann das Ergebnis auf den Screen kommt.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Pilotage :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> utilisez « Question suivante » pour afficher le contenu. Vous pouvez commencer par une phase de lecture, ouvrir ensuite la phase de réponse et décider du moment où le résultat arrive à l’écran.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instruc"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Bei geeigneten Quizfragen, Schätzfragen und Blitzlicht-Runden: erst abstimmen lassen, Diskussion starten, dann erneut abstimmen. Der Vorher/Nachher-Vergleich macht Lernfortschritt sichtbar.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (doubles tours) :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> pour les questions de quiz adaptées, les estimations et les retours express : vote, discussion, puis nouveau vote. La comparaison avant/après rend les progrès visibles.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSettings" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Einstellungen:&lt;/"/>Einstellungen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beim Start legst du Stil und Optionen fest: seriös oder spielerisch, mit oder ohne Rangliste, Sound, Lesephase, Team-Modus, Nicknamen und Timer.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Paramètres :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> au lancement, vous choisissez le style et les options : sobre ou ludique, avec ou sans classement, son, phase de lecture, mode équipe, pseudonymes et minuteur.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallTitle" datatype="html">
-        <source> Fragenwand im Live-Kanal Q&amp;A</source>
-        <target> Mur de questions dans le canal live Q&amp;A </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLead" datatype="html">
-        <source> Q&amp;A soll nicht als Nebenchat verschwinden. Die Fragenwand macht Rückfragen sichtbar, priorisierbar und moderierbar: Du hältst den roten Faden, während die Gruppe gemeinsam zeigt, welche Punkte wirklich Klärung brauchen.</source>
-        <target> Le Q&amp;A ne doit pas disparaître dans un chat parallèle. Le mur de questions rend les questions visibles, priorisables et modérables : vous gardez le fil, tandis que le groupe indique collectivement les points qui demandent vraiment clarification. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallListAria" datatype="html">
-        <source>Didaktische Funktionen der Q&amp;A-Fragenwand</source>
-        <target>Fonctions pédagogiques du mur de questions Q&amp;A</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationTitle" datatype="html">
-        <source>Moderation mit pädagogischem Takt</source>
-        <target> Modération au bon tempo pédagogique </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationBody" datatype="html">
-        <source> Auf Wunsch warten neue Fragen erst auf deine Freigabe. Du kannst Beiträge freigeben, anheften, archivieren oder entfernen und damit Schutzraum, Relevanz und Timing steuern: sofort beantworten, für später sammeln oder als Diskussionsspur markieren.</source>
-        <target> Si besoin, les nouvelles questions attendent d’abord votre validation. Vous pouvez valider, épingler, archiver ou retirer des contributions et piloter cadre de confiance, pertinence et timing : répondre tout de suite, garder pour plus tard ou ouvrir une piste de discussion. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingTitle" datatype="html">
-        <source>Kollektives Hoch- und Runtervoting</source>
-        <target> Vote collectif pour ou contre </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingBody" datatype="html">
-        <source> Teilnehmende gewichten Fragen gemeinsam. Positive und negative Stimmen zeigen nicht nur Popularität, sondern auch Unsicherheit, Widerspruch und Klärungsbedarf; Sortierungen wie „meist unterstützt“, „beste Fragen“ und „umstritten“ helfen dir, knappe Live-Zeit didaktisch zu setzen.</source>
-        <target> Les participant·es pondèrent ensemble les questions. Les votes positifs et négatifs montrent plus que la popularité : ils font apparaître incertitudes, désaccords et besoins de clarification. Les tris « les plus soutenues », « meilleures questions » et « controversées » aident à placer le temps live là où il a le plus de valeur pédagogique. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
-        <source>Q&amp;A-Wortwolke auf Themenebene</source>
-        <target> Nuage de mots Q&amp;A au niveau des thèmes </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudBody" datatype="html">
-        <source> Die Word-Cloud verdichtet sichtbare Fragen zu Wörtern und Phrasen, gewichtet nach Unterstützung, belastbarer Zustimmung oder Kontroverse. Sie lässt sich einfrieren, nach Sortierlogik betrachten und in der Presenter-Ansicht zeigen – als schneller Blick auf Themencluster, nicht als dekorative Wortliste.</source>
-        <target> Le nuage de mots condense les questions visibles en mots et expressions, pondérés par le soutien, l’accord robuste ou la controverse. Il peut être figé, lu selon la logique de tri et affiché dans la vue présentateur : une lecture rapide des clusters thématiques, pas une liste décorative. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmTitle" datatype="html">
-        <source>Nächster Schritt: Moderationskompass</source>
-        <target>Prochaine étape : boussole de modération</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmBody" datatype="html">
-        <source> Geplant ist zuerst ein deterministischer Moderationskompass. Optional können später asynchrone Q&amp;A-NLP-Signale und quellengebundene Zusammenfassungen dazukommen – als datenschutzbewusste Moderationshilfe statt Blackbox-Bewertung.</source>
-        <target> La première étape prévue est une boussole de modération déterministe. Plus tard, des signaux Q&amp;A NLP asynchrones et des résumés liés aux sources pourront être ajoutés en option, comme aide à la modération respectueuse des données plutôt qu’une notation boîte noire. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.blitzTitle" datatype="html">
-        <source>Blitzlicht</source>
-        <target>Feedback express</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackIntro" datatype="html">
-        <source> Schnelle Stimmungs- und Wissensabfragen – z. B. vor der Pause, zum Einstieg oder für spontane Checks. Nutzbar im Host-Bereich deiner Live-Session oder direkt von der Startseite.</source>
-        <target>Sondages rapides sur l’humeur ou la compréhension, avant une pause, en ouverture ou pour prendre la température à chaud. Disponibles dans la vue hôte de votre session live ou directement depuis la page d’accueil.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfMood" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stimmungsb"/>Stimmungsbild<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): Wie geht es den Teilnehmenden?</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Baromètre d’ambiance<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟) : comment va le groupe ?</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfYesNoMaybe" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein / Viel"/>Ja / Nein / Vielleicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Schnelle Zustimmungsabfrage.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Oui / Non / Peut-être<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷) : prise de position rapide.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackYesNo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein&lt;/strong&gt; (👍"/>Ja / Nein<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): Klare Zwei-Optionen-Abfrage ohne Mittelweg.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Oui / Non<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎) : question binaire claire, sans réponse intermédiaire.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Wahr / Falsch / Weiß nicht&lt;/stron"/>Wahr / Falsch / Weiß nicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): Für schnelle Einschätzungen oder Wissenschecks.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vrai / Faux / Je ne sais pas<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?) : pour des estimations rapides ou de petits tests de connaissances.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Mehrstufige Schnellabfragen&lt;/s"/>Mehrstufige Schnellabfragen<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D): Drei oder vier feste Optionen für spontane Abstimmungen – ohne eine vollständige Quizfrage zu bauen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Options rapides en plusieurs niveaux<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D) : trois ou quatre options fixes pour voter spontanément, sans créer une vraie question de quiz.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTempo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tempo-Feedback&lt;/strong"/>Tempo-Feedback<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): Mit vier Icons meldet deine Gruppe laufend zurück, ob sie folgen kann. Teilnehmende können ihre Rückmeldung ändern; du siehst nur die aggregierte Tendenz.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Feedback sur le rythme<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈) : avec quatre icônes, votre groupe indique en continu s’il suit. Les participant·es peuvent modifier leur retour ; vous ne voyez que la tendance agrégée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">283,285</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
-        <source> Du startest die Runde im Host-Bereich deiner Live-Session oder über die Blitzlicht-Karte „Live mit einem Klick&quot; auf der Startseite. Teilnehmende tippen eine Antwort; du siehst die Ergebnisse live als Balkendiagramm.</source>
-        <target>Vous lancez le tour depuis la vue hôte de votre session live ou via la carte « Feedback express » (« Feedback instantané en un clic ») sur la page d’accueil. Les participant·es votent d’un geste ; les résultats s’affichent en live sous forme de graphique en barres.</target>
+      <trans-unit id="help.hostFormatsTitle" datatype="html">
+        <source>Fragetypen und Selbsteinschätzung</source>
+        <target>Types de questions et auto-évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">141</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instr"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Erste Runde – Ergebnis nicht auflösen – „Diskussionsphase&quot; starten („Diskutiert mit eurem Nachbarn&quot;) – „Zweite Abstimmung&quot;. Vorher/Nachher-Vergleich zeigt, wie sich das Stimmungsbild durch den Austausch verändert hat.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Instruction par les pairs (deux tours) :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Premier vote, résultat masqué, phase de discussion, puis deuxième vote. La comparaison avant/après montre comment l’avis du groupe évolue après l’échange.</target>
+      <trans-unit id="help.hostFormatsBody" datatype="html">
+        <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar.</source>
+        <target>Les formats disponibles sont : choix unique, choix multiple, réponse courte, texte libre, sondage, échelle d’évaluation et estimation numérique. Une question évaluable peut être suivie d’une auto-évaluation de 1 à 5. Elle ne modifie pas le score, mais met en évidence les acquis solides, les acquis fragiles et les éventuelles idées fausses.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">145,151</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfStop" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stopp:&lt;/st"/>Stopp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Abstimmung einfrieren – Teilnehmende sehen „Abstimmung ist pausiert&quot; und können nicht mehr abstimmen, bis du „Fortsetzen&quot; wählst.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Arrêter :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Fige le vote : les participant·es voient « Le vote est en pause » et ne peuvent plus voter jusqu’à ce que vous choisissiez « Reprendre ».</target>
+      <trans-unit id="help.hostModerationTitle" datatype="html">
+        <source>Live moderieren und Peer Instruction nutzen</source>
+        <target>Animer en direct et utiliser l’instruction par les pairs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfReset" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Zurücksetze"/>Zurücksetzen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Alle Stimmen löschen und erneut abstimmen lassen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Réinitialiser :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Supprimez tous les votes et laissez-les voter à nouveau.</target>
+      <trans-unit id="help.hostModerationBody" datatype="html">
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.</source>
+        <target>Utilise selon les besoins la phase de lecture, le minuteur, la vue de projection ou de présentation et l’affichage différé des résultats. Pour l’instruction par les pairs, lance un premier vote, ouvre une phase de discussion, puis un second vote. La comparaison avant-après rend les évolutions visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">162,167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfNewRound" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Neue Runde:&lt;/s"/>Neue Runde:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Neuen Code erzeugen und eine frische Runde starten.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Nouveau tour :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Générez un nouveau code et démarrez un nouveau tour.</target>
+      <trans-unit id="help.hostQaTitle" datatype="html">
+        <source>Die Q&amp;A-Fragenwand moderieren</source>
+        <target>Modérer le mur de questions Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfCopyLink" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Link kopieren:"/>Link kopieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beitrittslink in die Zwischenablage kopieren, z. B. zum Teilen per Chat.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Copier le lien :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Copiez le lien de participation dans le presse-papiers, par exemple pour le partager dans un chat.</target>
+      <trans-unit id="help.hostQaBody" datatype="html">
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation.</source>
+        <target>Les nouvelles contributions peuvent attendre une validation avant d’apparaître. Tu peux valider, épingler, archiver ou supprimer des questions. Les votes positifs et négatifs ainsi que les modes de tri facilitent leur hiérarchisation ; le nuage de mots synthétise les thèmes visibles pour la présentation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">178,183</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsTitle" datatype="html">
-        <source>Für deine Teilnehmenden</source>
-        <target>Pour vos participants</target>
+      <trans-unit id="help.hostPulseTitle" datatype="html">
+        <source>Blitzlicht und Tempo-Feedback einsetzen</source>
+        <target>Utiliser le Feedback express et le retour sur le rythme</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsLead" datatype="html">
-        <source> Kurz erklärt, was du in deiner Veranstaltung weitergeben kannst:</source>
-        <target>En bref : ce que vous pouvez transmettre pendant votre événement :</target>
+      <trans-unit id="help.hostPulseBody" datatype="html">
+        <source> Starte ein Blitzlicht aus der Live-Session oder über „Live mit einem Klick“ auf der Startseite. Du kannst die Abstimmung pausieren, fortsetzen, zurücksetzen oder als neue Runde starten. Beim Tempo-Feedback ändern Teilnehmende ihre Rückmeldung jederzeit; du siehst nur die aggregierte Tendenz.</source>
+        <target>Lance un Feedback express depuis la session en direct ou avec « Feedback instantané en un clic » sur la page d’accueil. Tu peux le mettre en pause, le reprendre, le réinitialiser ou démarrer un nouveau tour. Pour le retour sur le rythme, les participant·es peuvent modifier leur réponse à tout moment ; tu ne vois que la tendance agrégée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">194,199</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsJoin" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beitreten:&lt;/strong&gt;"/>Beitreten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> 6-stelligen Code auf arsnova.eu eingeben und „Los geht&apos;s&quot; – funktioniert für Quiz, Q&amp;A und Blitzlicht. Keine Anmeldung nötig.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Rejoindre :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Saisissez le code à 6 chiffres sur arsnova.eu et « C’est parti » — valable pour quiz, Q&amp;A et feedback express. Aucune inscription.</target>
+      <trans-unit id="help.hostLibraryTitle" datatype="html">
+        <source>Quiz-Sammlung und Einstellungen verwalten</source>
+        <target>Gérer les quiz et les paramètres</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsNick" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Nicknamen:&lt;/strong&gt;"/>Nicknamen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Je nach deiner Einstellung vorgegebene Namen, eigener Name oder anonym.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Pseudos :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Selon vos paramètres, noms prédéfinis, votre nom propre ou anonyme.</target>
+      <trans-unit id="help.hostLibraryBody" datatype="html">
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
+        <target>Dans la collection de quiz, modifie et réorganise les questions, vérifie l’aperçu et importe ou exporte des quiz au format JSON. Le lien de synchronisation permet de partager la collection ou de continuer sur un autre appareil. Les modèles d’IA facilitent la génération et la vérification sans envoyer tes contenus à arsnova.eu. Au démarrage, règle notamment le style, le classement, le son, les équipes, les pseudonymes, le minuteur et les codes bonus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">210,217</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsVote" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Abstimmung:&lt;/strong&gt;"/>Abstimmung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage erscheint auf dem Gerät, Antwort wählen und absenden. Bei aktivierter Selbsteinschätzung folgt danach die Skala 1–5. Bei Zeitlimit läuft ein Countdown.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Votez :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> La question apparaît sur l'appareil ; choisis la réponse et envoie-la. Si l'auto-évaluation est activée, l'échelle 1–5 suit. Avec limite de temps, un compte à rebours démarre.</target>
+      <trans-unit id="help.participantJoinTitle" datatype="html">
+        <source>Wie trete ich einer Session bei?</source>
+        <target>Comment rejoindre une session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTitle" datatype="html">
-        <source>Deine Quiz-Sammlung</source>
-        <target>Votre bibliothèque de quiz</target>
+      <trans-unit id="help.participantJoinBody" datatype="html">
+        <source> Scanne den QR-Code oder öffne arsnova.eu und gib den sechsstelligen Code ein. Du brauchst kein Konto. Je nach Einstellung der Veranstaltungsleitung nimmst du anonym, mit einem vorgegebenen Nickname oder mit einem selbst gewählten Namen teil.</source>
+        <target>Scanne le QR code ou ouvre arsnova.eu et saisis le code à six caractères. Aucun compte n’est nécessaire. Selon les réglages de la personne qui anime, tu participes anonymement, avec un pseudonyme prédéfini ou avec le nom de ton choix.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">235,240</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionLead" datatype="html">
-        <source>Hier legst du deine Quizze an und bereitest sie vor.</source>
-        <target>Ici, vous créez et préparez vos quiz.</target>
+      <trans-unit id="help.participantAnswerTitle" datatype="html">
+        <source>Wie beantworte ich eine Quizfrage?</source>
+        <target>Comment répondre à une question de quiz ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">247</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionEditor" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Editor:&lt;/strong&gt; Fra"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Fragen per Drag-and-Drop sortieren, auf- und zuklappen, Vorschau prüfen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Éditeur :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Triez les questions par glisser-déposer, développez et réduisez, vérifiez l'aperçu.</target>
+      <trans-unit id="help.participantAnswerBody" datatype="html">
+        <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
+        <target>Sélectionne ou saisis ta réponse, puis envoie-la. Si l’auto-évaluation est activée, indique ensuite ton degré de certitude sur une échelle de 1 à 5. En cas de limite de temps, un compte à rebours affiche le temps restant. Le résultat apparaît lorsque la personne qui anime le révèle.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">254,259</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTypes" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Fragetypen:&lt;/strong"/>Fragetypen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage – pro Frage optional mit Timer, Schwierigkeitsgrad und Selbsteinschätzung.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Types de questions :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single choice, multiple choice, réponse courte, texte libre, sondage, échelle d’évaluation et question d’estimation numérique — chaque question peut aussi avoir un minuteur, une difficulté et une auto-évaluation.</target>
+      <trans-unit id="help.participantContributeTitle" datatype="html">
+        <source>Wie stelle ich eine Frage oder gebe Feedback?</source>
+        <target>Comment poser une question ou donner mon avis ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">266</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionImport" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Import / Export:&lt;/st"/>Import / Export:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Quiz als JSON importieren oder exportieren. Mit der Start- und Prüfvorlage kannst du anspruchsvolle Quizze mit deinem bevorzugten KI-Tool generieren, prüfen und direkt importieren – deine Inhalte und Präsentationen werden nicht an arsnova.eu gesendet; du nutzt dein eigenes KI-Tool.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Import / export :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Importez ou exportez des quiz en JSON. Utilisez les modèles de génération et de vérification pour créer des quiz exigeants avec votre outil d’IA préféré, les vérifier et les importer directement. Vos contenus et présentations ne sont pas envoyés à arsnova.eu ; vous utilisez votre propre outil d’IA.</target>
+      <trans-unit id="help.participantContributeBody" datatype="html">
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
+        <target>Dans le canal Q&amp;A, envoie ta propre question et vote pour ou contre les autres contributions. Selon les réglages de modération, ta question peut n’apparaître qu’après validation. Dans le Feedback express, donne un retour spontané en un geste. Tu peux modifier ton retour sur le rythme tant que le sondage est ouvert.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">273,278</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionSync" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Sync:&lt;/strong&gt; Mit"/>Sync:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit dem Sync-Link deine Quiz-Sammlung mit Kolleg:innen teilen oder auf anderen Geräten weiterarbeiten. Wer den Link hat, kann die Sammlung öffnen. Die Geräteangaben helfen nur bei der Orientierung.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sync :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Utilisez le lien de sync pour partager votre bibliothèque de quiz avec des collègues ou continuer sur d&apos;autres appareils. Toute personne qui a le lien peut ouvrir la bibliothèque. Les infos sur l&apos;appareil servent seulement à vous aider à vous repérer.</target>
+      <trans-unit id="help.participantChannelsTitle" datatype="html">
+        <source>Wie nutze ich Quiz, Q&amp;A und Blitzlicht in einer Session?</source>
+        <target>Comment utiliser le quiz, le Q&amp;A et le Feedback express dans une même session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">290</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoQuizHint" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Demo-Quiz:&lt;/stro"/>Demo-Quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ein vorinstalliertes Quiz zeigt alle Formate mit Beispielen inkl. KaTeX-Formeln und Markdown. In der Quiz-Sammlung in der Vorschau öffnen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Quiz de démonstration :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> un quiz préinstallé montre tous les formats avec des exemples, y compris des formules KaTeX et du Markdown. Ouvrez-le depuis la bibliothèque de quiz en aperçu.</target>
+      <trans-unit id="help.participantChannelsBody" datatype="html">
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung.</source>
+        <target>Une session en direct peut combiner quiz, Q&amp;A et Feedback express. Suis la vue active et les indications sur ton appareil. Si un canal n’est pas actif, attends que la personne qui anime lance l’activité suivante.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">297,302</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesTitle" datatype="html">
-        <source>Seriös und Spielerisch</source>
-        <target>Sérieux et ludique</target>
+      <trans-unit id="help.participantSecondRoundTitle" datatype="html">
+        <source>Was passiert bei einer zweiten Abstimmungsrunde?</source>
+        <target>Que se passe-t-il lors d’un second tour de vote ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesLead" datatype="html">
-        <source> Zwei Stile für unterschiedliche Situationen – wählbar auf der Startseite und beim Session-Start.</source>
-        <target>Deux styles pour différentes situations – sélectionnables sur la page d&apos;accueil et au début de la session.</target>
+      <trans-unit id="help.participantSecondRoundBody" datatype="html">
+        <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden.</source>
+        <target>Dans l’instruction par les pairs, réponds d’abord seul·e à la question. Discute ensuite avec d’autres participant·es, puis vote une seconde fois. Envoie également ta réponse au second tour ; elle peut différer de la première.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">316,321</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.styleSerious" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Seriös:&lt;/strong&gt;"/>Seriös:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonym, ohne Rangliste – ideal für formative Assessments, Prüfungsvorbereitung und sensible Themen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sérieux :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonyme, sans classement — idéal pour les évaluations formatives, la préparation aux examens et les sujets sensibles.</target>
+      <trans-unit id="help.participantResultsTitle" datatype="html">
+        <source>Wie sind Ergebnisse, Rangliste und Teamwertung zu verstehen?</source>
+        <target>Comment interpréter les résultats, le classement et les scores d’équipe ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylePlayful" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Spielerisch:&lt;/st"/>Spielerisch:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit Rangliste, Sounds und Anfeuerung – ideal für Auflockerung, Wettbewerbe und motivierende Quizze.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Ludique :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Avec classement, sons et encouragements - idéal pour se détendre, participer à des compétitions et des quiz motivants.</target>
+      <trans-unit id="help.participantResultsBody" datatype="html">
+        <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung.</source>
+        <target>La personne qui anime décide quand les résultats deviennent visibles. Le classement, les scores d’équipe et les codes bonus n’apparaissent que s’ils sont activés pour la session. Ton auto-évaluation n’a aucun effet sur ton score ni sur ta position.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">335,339</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesOptions" datatype="html">
-        <source> Alle Optionen (Rangliste, Sound, Lesephase, Team, Bonus) lassen sich einzeln an- und ausschalten.</source>
-        <target>Toutes les options (classements, son, phase de lecture, équipe, bonus) peuvent être activées et désactivées individuellement.</target>
+      <trans-unit id="help.commonTitle" datatype="html">
+        <source>Für alle</source>
+        <target>Pour tout le monde</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">346</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTitle" datatype="html">
-        <source>Weitere Funktionen</source>
-        <target>Plus de fonctionnalités</target>
+      <trans-unit id="help.commonPrivacyTitle" datatype="html">
+        <source>Wie werden Daten und Inhalte behandelt?</source>
+        <target>Comment les données et les contenus sont-ils traités ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">351</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreBonus" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Bonus-Codes:&lt;"/>Bonus-Codes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Top-Platzierte erhalten einen einlösbaren Code (z. B. für Bonuspunkte). Du siehst die Code-Liste; personenbezogene Daten werden nicht gespeichert.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Codes bonus :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Les premiers finalistes reçoivent un code échangeable (par exemple, contre des points bonus). Vous voyez la liste des codes ; Les données personnelles ne sont pas stockées.</target>
+      <trans-unit id="help.commonPrivacyBody" datatype="html">
+        <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target>Aucun compte n’est nécessaire. Les quiz de la personne qui anime sont d’abord stockés localement dans son navigateur ; pendant une session en direct, seules les données nécessaires à l’interaction sont échangées. arsnova.eu est open source et conçu pour un fonctionnement respectueux de la vie privée en Europe. Consulte la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Politique de confidentialité<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> pour en savoir plus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">355,362</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTeams" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Team-Modus:&lt;/"/>Team-Modus:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Deine Teilnehmenden spielen in Teams mit eigenem Team-Leaderboard – z. B. für Gruppenwettbewerbe im Seminar.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Mode équipe :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Vos participants jouent en équipes avec leur propre classement d'équipe - p. ex. pour les compétitions de groupe en séminaires.</target>
+      <trans-unit id="help.commonAccessibilityTitle" datatype="html">
+        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
+        <target>Comment utiliser arsnova.eu de façon accessible et comme application ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreGamification" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Gamification:&lt;/stron"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sound-Effekte, Belohnungseffekte für Top-Plätze, Motivationsmeldungen – im Spielerisch-Modus.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamification :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Effets sonores, effets de récompense pour les meilleures places, messages de motivation - en mode ludique.</target>
+      <trans-unit id="help.commonAccessibilityBody" datatype="html">
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target>arsnova.eu est utilisable au clavier, avec un lecteur d’écran et avec un affichage agrandi. Utilise si nécessaire les options de contraste et de thème de l’application ou de ton système d’exploitation. Tu peux aussi installer arsnova.eu comme Progressive Web App. Consulte la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Déclaration d’accessibilité<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> pour en savoir plus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">376,382</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyTitle" datatype="html">
-        <source>Datenschutz und Technik</source>
-        <target>Protection des données et technologie</target>
+      <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
+        <source>Was kann ich bei technischen Problemen tun?</source>
+        <target>Que faire en cas de problème technique ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">389</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyBody" datatype="html">
-        <source> arsnova.eu ist kostenlos, Open Source und für den Einsatz an Schulen, Hochschulen und in Weiterbildung gedacht – mit Fokus auf Datenschutz (DSGVO). Quiz-Inhalte werden lokal im Browser gespeichert. Keine Anmeldung nötig, weder für dich noch für deine Teilnehmenden. Als App installierbar (PWA) – z. B. für schnelleren Start auf dem Smartphone. Oberfläche auf Deutsch, Englisch, Französisch, Spanisch und Italienisch.</source>
-        <target>arsnova.eu est gratuit, open source et conçu pour les écoles, l’enseignement supérieur et la formation continue — avec un vrai focus sur la protection des données (RGPD). Les contenus de quiz restent stockés localement dans le navigateur. Aucune inscription nécessaire, ni pour vous ni pour vos participant·es. Installable comme application (PWA), par exemple pour démarrer plus vite sur smartphone. Interface disponible en allemand, anglais, français, espagnol et italien.</target>
+      <trans-unit id="help.commonTroubleshootingBody" datatype="html">
+        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
+        <target>Vérifie d’abord le code ou le QR code, ta connexion Internet et que la session est toujours active. Si aucune question n’est encore visible, la session peut être dans le hall d’attente, en phase de lecture ou en pause. Après une coupure, rouvre le lien de participation ou saisis de nouveau le code. Adresse-toi à la personne qui anime si la session est déjà terminée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">396,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -6363,7 +6363,7 @@
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
         <source> Neue Beiträge können zunächst zurückgehalten und erst nach deiner Freigabe veröffentlicht werden. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
-        <target>Les nouvelles contributions peuvent attendre une validation avant d’apparaître. Tu peux valider, épingler, archiver ou supprimer des questions. Les votes positifs et négatifs ainsi que les modes de tri facilitent leur hiérarchisation ; le nuage de mots met en évidence les thèmes récurrents pour la présentation.</target>
+        <target>Les nouvelles contributions peuvent être mises en attente et n’apparaître qu’après validation. Tu peux valider, épingler, archiver ou supprimer des questions. Les votes positifs et négatifs ainsi que les modes de tri facilitent leur hiérarchisation ; le nuage de mots met en évidence les thèmes récurrents pour la présentation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">189,195</context>
@@ -6549,7 +6549,7 @@
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
         <source> Prüfe zuerst den Code oder QR-Code und deine Internetverbindung. Vergewissere dich außerdem, dass die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
-        <target>Vérifie d’abord le code ou le QR code et ta connexion Internet, puis assure-toi que la session est toujours active. Si aucune question n’est encore visible, la session peut être dans le hall d’attente, en phase de lecture ou en pause. Après une coupure, rouvre le lien de participation ou saisis de nouveau le code. Adresse-toi à la personne qui anime si la session est déjà terminée.</target>
+        <target>Vérifie d’abord le code ou le QR code et ta connexion Internet, puis assure-toi que la session est toujours active. Si aucune question n’est encore visible, la session peut être dans la salle d’attente, en phase de lecture ou en pause. Après une coupure, rouvre le lien de participation ou saisis de nouveau le code. Adresse-toi à la personne qui anime si la session est déjà terminée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">423,430</context>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -6206,7 +6206,7 @@
         <target>Choix du rôle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostTitle" datatype="html">
@@ -6214,11 +6214,11 @@
         <target>J’anime une session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostHint" datatype="html">
@@ -6226,7 +6226,7 @@
         <target>Pour les enseignant·es, intervenant·es, formateur·rices et animateur·rices</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantTitle" datatype="html">
@@ -6234,11 +6234,11 @@
         <target>Je participe à une session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">71</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">224</context>
+          <context context-type="linenumber">241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
@@ -6246,7 +6246,7 @@
         <target>Pour voter, poser des questions ou donner son avis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.newUserTitle" datatype="html">
@@ -6254,11 +6254,11 @@
         <target>Première utilisation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">87</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">226</context>
+          <context context-type="linenumber">244</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
@@ -6266,7 +6266,7 @@
         <target>Que puis-je faire avec arsnova.eu ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesBody" datatype="html">
@@ -6274,7 +6274,7 @@
         <target>Un quiz te permet de poser des questions de connaissance ou d’opinion préparées à l’avance. Le canal Q&amp;A sert à recueillir et à hiérarchiser les questions du public. Le Feedback express convient aux retours spontanés sur l’ambiance, la compréhension ou le rythme. Tu peux réunir les trois dans une même session en direct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">88,93</context>
+          <context context-type="linenumber">99,104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionTitle" datatype="html">
@@ -6282,7 +6282,7 @@
         <target>Comment lancer ma première session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionBody" datatype="html">
@@ -6290,7 +6290,7 @@
         <target>Ouvre ta collection de quiz et utilise le quiz de démonstration ou crée le tien. Sélectionne « Démarrer », choisis le style et les options, puis partage le code à six caractères ou le QR code. Dans la vue d’animation, affiche la question suivante, lance la phase de réponse et révèle les résultats. Conseil : teste l’aperçu sur un deuxième appareil avant ta première session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">107,113</context>
+          <context context-type="linenumber">118,124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishTitle" datatype="html">
@@ -6298,7 +6298,7 @@
         <target>Comment terminer et analyser une session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
@@ -6306,7 +6306,7 @@
         <target>Termine la session dans la vue d’animation. Les résultats consolidés sont alors disponibles. Utilise le plan de débriefing au format PDF pour l’analyse pédagogique ; l’export CSV se trouve sous « Plus ». Le plan reste accessible depuis la carte du quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">124,129</context>
+          <context context-type="linenumber">135,140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.experiencedUserTitle" datatype="html">
@@ -6314,11 +6314,11 @@
         <target>Je connais déjà arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">134,136</context>
+          <context context-type="linenumber">145,147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">283,285</context>
+          <context context-type="linenumber">304,306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
@@ -6326,7 +6326,7 @@
         <target>Types de questions et auto-évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
@@ -6334,7 +6334,7 @@
         <target>Les formats disponibles sont : choix unique, choix multiple, réponse courte, texte libre, sondage, échelle d’évaluation et estimation numérique. Une question évaluable peut être suivie d’une auto-évaluation de 1 à 5. Elle ne modifie pas le score, mais met en évidence les acquis solides, les acquis fragiles et les éventuelles idées fausses.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">145,151</context>
+          <context context-type="linenumber">156,162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationTitle" datatype="html">
@@ -6342,7 +6342,7 @@
         <target>Animer en direct et utiliser l’instruction par les pairs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
@@ -6350,7 +6350,7 @@
         <target>Utilise selon les besoins la phase de lecture, le minuteur, la vue de projection ou de présentation et l’affichage différé des résultats. Pour l’instruction par les pairs, lance un premier vote, ouvre une phase de discussion, puis un second vote. La comparaison avant-après rend les évolutions visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,167</context>
+          <context context-type="linenumber">173,178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaTitle" datatype="html">
@@ -6358,7 +6358,7 @@
         <target>Modérer le mur de questions Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
@@ -6366,7 +6366,7 @@
         <target>Les nouvelles contributions peuvent attendre une validation avant d’apparaître. Tu peux valider, épingler, archiver ou supprimer des questions. Les votes positifs et négatifs ainsi que les modes de tri facilitent leur hiérarchisation ; le nuage de mots synthétise les thèmes visibles pour la présentation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">178,183</context>
+          <context context-type="linenumber">189,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
@@ -6374,7 +6374,7 @@
         <target>Utiliser le Feedback express et le retour sur le rythme</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
@@ -6382,7 +6382,7 @@
         <target>Lance un Feedback express depuis la session en direct ou avec « Feedback instantané en un clic » sur la page d’accueil. Tu peux le mettre en pause, le reprendre, le réinitialiser ou démarrer un nouveau tour. Pour le retour sur le rythme, les participant·es peuvent modifier leur réponse à tout moment ; tu ne vois que la tendance agrégée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">194,199</context>
+          <context context-type="linenumber">205,210</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
@@ -6390,7 +6390,7 @@
         <target>Gérer les quiz et les paramètres</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">217</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
@@ -6398,7 +6398,7 @@
         <target>Dans la collection de quiz, modifie et réorganise les questions, vérifie l’aperçu et importe ou exporte des quiz au format JSON. Le lien de synchronisation permet de partager la collection ou de continuer sur un autre appareil. Les modèles d’IA facilitent la génération et la vérification sans envoyer tes contenus à arsnova.eu. Au démarrage, règle notamment le style, le classement, le son, les équipes, les pseudonymes, le minuteur et les codes bonus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">210,217</context>
+          <context context-type="linenumber">221,228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
@@ -6406,7 +6406,7 @@
         <target>Comment rejoindre une session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">231</context>
+          <context context-type="linenumber">249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
@@ -6414,7 +6414,7 @@
         <target>Scanne le QR code ou ouvre arsnova.eu et saisis le code à six caractères. Aucun compte n’est nécessaire. Selon les réglages de la personne qui anime, tu participes anonymement, avec un pseudonyme prédéfini ou avec le nom de ton choix.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">235,240</context>
+          <context context-type="linenumber">256,261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
@@ -6422,7 +6422,7 @@
         <target>Comment répondre à une question de quiz ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">247</context>
+          <context context-type="linenumber">268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
@@ -6430,7 +6430,7 @@
         <target>Sélectionne ou saisis ta réponse, puis envoie-la. Si l’auto-évaluation est activée, indique ensuite ton degré de certitude sur une échelle de 1 à 5. En cas de limite de temps, un compte à rebours affiche le temps restant. Le résultat apparaît lorsque la personne qui anime le révèle.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">254,259</context>
+          <context context-type="linenumber">275,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
@@ -6438,7 +6438,7 @@
         <target>Comment poser une question ou donner mon avis ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">287</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
@@ -6446,7 +6446,7 @@
         <target>Dans le canal Q&amp;A, envoie ta propre question et vote pour ou contre les autres contributions. Selon les réglages de modération, ta question peut n’apparaître qu’après validation. Dans le Feedback express, donne un retour spontané en un geste. Tu peux modifier ton retour sur le rythme tant que le sondage est ouvert.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">273,278</context>
+          <context context-type="linenumber">294,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
@@ -6454,7 +6454,7 @@
         <target>Comment utiliser le quiz, le Q&amp;A et le Feedback express dans une même session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">290</context>
+          <context context-type="linenumber">311</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
@@ -6462,7 +6462,7 @@
         <target>Une session en direct peut combiner quiz, Q&amp;A et Feedback express. Suis la vue active et les indications sur ton appareil. Si un canal n’est pas actif, attends que la personne qui anime lance l’activité suivante.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">297,302</context>
+          <context context-type="linenumber">318,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6470,7 +6470,7 @@
         <target>Que se passe-t-il lors d’un second tour de vote ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
@@ -6478,7 +6478,7 @@
         <target>Dans l’instruction par les pairs, réponds d’abord seul·e à la question. Discute ensuite avec d’autres participant·es, puis vote une seconde fois. Envoie également ta réponse au second tour ; elle peut différer de la première.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">316,321</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6486,7 +6486,7 @@
         <target>Comment interpréter les résultats, le classement et les scores d’équipe ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">328</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
@@ -6494,7 +6494,7 @@
         <target>La personne qui anime décide quand les résultats deviennent visibles. Le classement, les scores d’équipe et les codes bonus n’apparaissent que s’ils sont activés pour la session. Ton auto-évaluation n’a aucun effet sur ton score ni sur ta position.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">335,339</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6502,7 +6502,7 @@
         <target>Pour tout le monde</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6510,7 +6510,7 @@
         <target>Comment les données et les contenus sont-ils traités ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">351</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
@@ -6518,7 +6518,7 @@
         <target>Aucun compte n’est nécessaire. Les quiz de la personne qui anime sont d’abord stockés localement dans son navigateur ; pendant une session en direct, seules les données nécessaires à l’interaction sont échangées. arsnova.eu est open source et conçu pour un fonctionnement respectueux de la vie privée en Europe. Consulte la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Politique de confidentialité<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> pour en savoir plus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,362</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
@@ -6526,15 +6526,17 @@
         <target>Comment utiliser arsnova.eu de façon accessible et comme application ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
-        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;
+                    &gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a
+                  &gt;"/>.</source>
         <target>arsnova.eu est utilisable au clavier, avec un lecteur d’écran et avec un affichage agrandi. Utilise si nécessaire les options de contraste et de thème de l’application ou de ton système d’exploitation. Tu peux aussi installer arsnova.eu comme Progressive Web App. Consulte la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Déclaration d’accessibilité<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> pour en savoir plus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">376,382</context>
+          <context context-type="linenumber">400,408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
@@ -6542,7 +6544,7 @@
         <target>Que faire en cas de problème technique ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389</context>
+          <context context-type="linenumber">415</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
@@ -6550,7 +6552,7 @@
         <target>Vérifie d’abord le code ou le QR code, ta connexion Internet et que la session est toujours active. Si aucune question n’est encore visible, la session peut être dans le hall d’attente, en phase de lecture ou en pause. Après une coupure, rouvre le lien de participation ou saisis de nouveau le code. Adresse-toi à la personne qui anime si la session est déjà terminée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">396,403</context>
+          <context context-type="linenumber">422,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -6195,7 +6195,7 @@
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
         <source> Wähle, in welcher Rolle du arsnova.eu nutzt. Hier findest du einen schnellen Einstieg und gezielte Hilfe zu einzelnen Funktionen.</source>
-        <target>Choisis le rôle dans lequel tu utilises arsnova.eu. Tu y trouveras une prise en main rapide et une aide ciblée pour chaque fonctionnalité.</target>
+        <target>Choisis ton rôle sur arsnova.eu. Tu y trouveras une prise en main rapide et une aide ciblée pour chaque fonctionnalité.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">41,44</context>
@@ -6238,7 +6238,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">241</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
@@ -6258,7 +6258,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244</context>
+          <context context-type="linenumber">245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
@@ -6303,7 +6303,7 @@
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
         <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar.</source>
-        <target>Termine la session dans la vue d’animation. Les résultats consolidés sont alors disponibles. Utilise le plan de débriefing au format PDF pour l’analyse pédagogique ; l’export CSV se trouve sous « Plus ». Le plan reste accessible depuis la carte du quiz.</target>
+        <target>Termine la session dans la vue d’animation. Un récapitulatif des résultats est alors disponible. Utilise le plan de débriefing au format PDF pour l’analyse pédagogique ; l’export CSV se trouve sous « Plus ». Le plan reste accessible depuis la carte du quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">135,140</context>
@@ -6318,7 +6318,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">304,306</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
@@ -6362,11 +6362,11 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
+        <source> Neue Beiträge können zunächst zurückgehalten und erst nach deiner Freigabe veröffentlicht werden. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
         <target>Les nouvelles contributions peuvent attendre une validation avant d’apparaître. Tu peux valider, épingler, archiver ou supprimer des questions. Les votes positifs et négatifs ainsi que les modes de tri facilitent leur hiérarchisation ; le nuage de mots met en évidence les thèmes récurrents pour la présentation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">189,194</context>
+          <context context-type="linenumber">189,195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
@@ -6374,7 +6374,7 @@
         <target>Utiliser le Feedback express et le retour sur le rythme</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
@@ -6382,7 +6382,7 @@
         <target>Lance un Feedback express depuis la session en direct ou avec « Feedback instantané en un clic » sur la page d’accueil. Tu peux le mettre en pause, le reprendre, le réinitialiser ou démarrer un nouveau tour. Pour le retour sur le rythme, les participant·es peuvent modifier leur réponse à tout moment ; tu ne vois que la tendance agrégée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">205,210</context>
+          <context context-type="linenumber">206,211</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
@@ -6390,7 +6390,7 @@
         <target>Gérer les quiz et les paramètres</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">217</context>
+          <context context-type="linenumber">218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
@@ -6398,7 +6398,7 @@
         <target>Dans la collection de quiz, modifie et réorganise les questions, vérifie l’aperçu et importe ou exporte des quiz au format JSON. Le lien de synchronisation permet de partager la collection ou de continuer sur un autre appareil. Les modèles d’IA t’aident à créer et à vérifier des quiz sans envoyer tes contenus à arsnova.eu. Au démarrage, règle notamment le style, le classement, le son, les équipes, les pseudonymes, le minuteur et les codes bonus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">221,228</context>
+          <context context-type="linenumber">222,229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
@@ -6406,7 +6406,7 @@
         <target>Comment rejoindre une session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">249</context>
+          <context context-type="linenumber">250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
@@ -6414,7 +6414,7 @@
         <target>Scanne le QR code ou ouvre arsnova.eu et saisis le code à six caractères. Aucun compte n’est nécessaire. Selon les réglages de la personne qui anime, tu participes anonymement, avec un pseudonyme prédéfini ou avec le nom de ton choix.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">256,261</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
@@ -6422,15 +6422,15 @@
         <target>Comment répondre à une question de quiz ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">268</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
         <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
-        <target>Sélectionne ou saisis ta réponse, puis envoie-la. Si l’autoévaluation du degré de confiance est activée, indique ensuite ton degré de certitude sur une échelle de 1 à 5. En cas de limite de temps, un compte à rebours affiche le temps restant. Le résultat apparaît lorsque la personne qui anime le révèle.</target>
+        <target>Sélectionne ou saisis ta réponse, puis envoie-la. Si l’autoévaluation du degré de confiance est activée, évalue ensuite ta confiance sur une échelle de 1 à 5. En cas de limite de temps, un compte à rebours affiche le temps restant. Le résultat apparaît lorsque la personne qui anime le révèle.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">275,280</context>
+          <context context-type="linenumber">276,281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
@@ -6438,15 +6438,15 @@
         <target>Comment poser une question ou donner mon avis ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">287</context>
+          <context context-type="linenumber">288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
-        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen positiv oder negativ bewerten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
         <target>Dans le canal Q&amp;A, envoie ta propre question et vote pour ou contre les autres contributions. Selon les réglages de modération, ta question peut n’apparaître qu’après validation. Dans le Feedback express, donne un retour spontané en un geste. Tu peux modifier ton retour sur le rythme tant que le sondage est ouvert.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">294,299</context>
+          <context context-type="linenumber">295,300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
@@ -6454,7 +6454,7 @@
         <target>Comment utiliser le quiz, le Q&amp;A et le Feedback express dans une même session ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">311</context>
+          <context context-type="linenumber">312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
@@ -6462,7 +6462,7 @@
         <target>Une session en direct peut combiner quiz, Q&amp;A et Feedback express. Suis les indications dans la vue actuellement ouverte. Si un canal n’est pas actif, attends que la personne qui anime lance l’activité suivante.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,322</context>
+          <context context-type="linenumber">319,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6470,7 +6470,7 @@
         <target>Que se passe-t-il lors d’un second tour de vote ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">329</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
@@ -6478,7 +6478,7 @@
         <target>Dans une séquence de Peer Instruction, réponds d’abord seul·e à la question. Discute ensuite avec d’autres participant·es, puis vote une seconde fois. Envoie également ta réponse au second tour ; elle peut différer de la première.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">336,341</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6486,7 +6486,7 @@
         <target>Comment interpréter les résultats, le classement et les scores d’équipe ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">348</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
@@ -6494,7 +6494,7 @@
         <target>La personne qui anime décide quand les résultats deviennent visibles. Le classement, les scores d’équipe et les codes bonus n’apparaissent que s’ils sont activés pour la session. Ton degré de confiance autoévalué n’a aucun effet sur ton score ni sur ta position.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,359</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6502,7 +6502,7 @@
         <target>Pour tout le monde</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">368</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6510,7 +6510,7 @@
         <target>Comment les données et les contenus sont-ils traités ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">374</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
@@ -6518,7 +6518,7 @@
         <target>Aucun compte n’est nécessaire. Les quiz de la personne qui anime sont d’abord stockés localement dans son navigateur ; pendant une session en direct, seules les données nécessaires à l’interaction sont échangées. arsnova.eu est open source et conçu pour un fonctionnement respectueux de la vie privée en Europe. Consulte la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Politique de confidentialité<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> pour en savoir plus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378,385</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
@@ -6526,7 +6526,7 @@
         <target>Quelles options d’accessibilité sont disponibles et comment installer arsnova.eu comme application ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">393,394</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
@@ -6536,7 +6536,7 @@
         <target>arsnova.eu est utilisable au clavier, avec un lecteur d’écran et avec un affichage agrandi. Utilise si nécessaire les options de contraste et de thème de l’application ou de ton système d’exploitation. Tu peux aussi installer arsnova.eu comme Progressive Web App. Consulte la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Déclaration d’accessibilité<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> pour en savoir plus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">400,408</context>
+          <context context-type="linenumber">401,409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
@@ -6544,15 +6544,15 @@
         <target>Que faire en cas de problème technique ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415</context>
+          <context context-type="linenumber">416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
-        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
-        <target>Vérifie d’abord le code ou le QR code, ta connexion Internet et que la session est toujours active. Si aucune question n’est encore visible, la session peut être dans le hall d’attente, en phase de lecture ou en pause. Après une coupure, rouvre le lien de participation ou saisis de nouveau le code. Adresse-toi à la personne qui anime si la session est déjà terminée.</target>
+        <source> Prüfe zuerst den Code oder QR-Code und deine Internetverbindung. Vergewissere dich außerdem, dass die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
+        <target>Vérifie d’abord le code ou le QR code et ta connexion Internet, puis assure-toi que la session est toujours active. Si aucune question n’est encore visible, la session peut être dans le hall d’attente, en phase de lecture ou en pause. Après une coupure, rouvre le lien de participation ou saisis de nouveau le code. Adresse-toi à la personne qui anime si la session est déjà terminée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">422,429</context>
+          <context context-type="linenumber">423,430</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -6194,8 +6194,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen.</source>
-        <target>Choisis la façon dont tu utilises arsnova.eu. Découvre l’essentiel ou consulte directement une fonctionnalité.</target>
+        <source> Wähle, in welcher Rolle du arsnova.eu nutzt. Hier findest du einen schnellen Einstieg und gezielte Hilfe zu einzelnen Funktionen.</source>
+        <target>Choisis le rôle dans lequel tu utilises arsnova.eu. Tu y trouveras une prise en main rapide et une aide ciblée pour chaque fonctionnalité.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">41,44</context>
@@ -6323,7 +6323,7 @@
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
         <source>Fragetypen und Selbsteinschätzung</source>
-        <target>Types de questions et auto-évaluation</target>
+        <target>Types de questions et confiance dans la réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">152</context>
@@ -6331,7 +6331,7 @@
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
         <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar.</source>
-        <target>Les formats disponibles sont : choix unique, choix multiple, réponse courte, texte libre, sondage, échelle d’évaluation et estimation numérique. Une question évaluable peut être suivie d’une auto-évaluation de 1 à 5. Elle ne modifie pas le score, mais met en évidence les acquis solides, les acquis fragiles et les éventuelles idées fausses.</target>
+        <target>Les formats disponibles sont : question à réponse unique, question à réponses multiples, réponse courte, texte libre, sondage, échelle d’évaluation et estimation numérique. Une question pouvant être notée peut être suivie d’une autoévaluation du degré de confiance sur une échelle de 1 à 5. Cette évaluation ne modifie pas le score, mais peut mettre en évidence des connaissances consolidées, des connaissances encore fragiles et de possibles conceptions erronées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">156,162</context>
@@ -6339,15 +6339,15 @@
       </trans-unit>
       <trans-unit id="help.hostModerationTitle" datatype="html">
         <source>Live moderieren und Peer Instruction nutzen</source>
-        <target>Animer en direct et utiliser l’instruction par les pairs</target>
+        <target>Animer en direct et utiliser la méthode Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
-        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.</source>
-        <target>Utilise selon les besoins la phase de lecture, le minuteur, la vue de projection ou de présentation et l’affichage différé des résultats. Pour l’instruction par les pairs, lance un premier vote, ouvre une phase de discussion, puis un second vote. La comparaison avant-après rend les évolutions visibles.</target>
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-Nachher-Vergleich macht Veränderungen sichtbar.</source>
+        <target>Utilise selon les besoins la phase de lecture, le minuteur, la vue de projection ou de présentation et l’affichage différé des résultats. Avec la méthode Peer Instruction, lance un premier vote, ouvre une phase de discussion, puis un second vote. La comparaison avant-après rend les évolutions visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">173,178</context>
@@ -6362,8 +6362,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation.</source>
-        <target>Les nouvelles contributions peuvent attendre une validation avant d’apparaître. Tu peux valider, épingler, archiver ou supprimer des questions. Les votes positifs et négatifs ainsi que les modes de tri facilitent leur hiérarchisation ; le nuage de mots synthétise les thèmes visibles pour la présentation.</target>
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
+        <target>Les nouvelles contributions peuvent attendre une validation avant d’apparaître. Tu peux valider, épingler, archiver ou supprimer des questions. Les votes positifs et négatifs ainsi que les modes de tri facilitent leur hiérarchisation ; le nuage de mots met en évidence les thèmes récurrents pour la présentation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">189,194</context>
@@ -6394,8 +6394,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
-        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
-        <target>Dans la collection de quiz, modifie et réorganise les questions, vérifie l’aperçu et importe ou exporte des quiz au format JSON. Le lien de synchronisation permet de partager la collection ou de continuer sur un autre appareil. Les modèles d’IA facilitent la génération et la vérification sans envoyer tes contenus à arsnova.eu. Au démarrage, règle notamment le style, le classement, le son, les équipes, les pseudonymes, le minuteur et les codes bonus.</target>
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen dich beim Erstellen und Prüfen von Quizzen, ohne dass Inhalte an arsnova.eu gesendet werden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
+        <target>Dans la collection de quiz, modifie et réorganise les questions, vérifie l’aperçu et importe ou exporte des quiz au format JSON. Le lien de synchronisation permet de partager la collection ou de continuer sur un autre appareil. Les modèles d’IA t’aident à créer et à vérifier des quiz sans envoyer tes contenus à arsnova.eu. Au démarrage, règle notamment le style, le classement, le son, les équipes, les pseudonymes, le minuteur et les codes bonus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">221,228</context>
@@ -6427,7 +6427,7 @@
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
         <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
-        <target>Sélectionne ou saisis ta réponse, puis envoie-la. Si l’auto-évaluation est activée, indique ensuite ton degré de certitude sur une échelle de 1 à 5. En cas de limite de temps, un compte à rebours affiche le temps restant. Le résultat apparaît lorsque la personne qui anime le révèle.</target>
+        <target>Sélectionne ou saisis ta réponse, puis envoie-la. Si l’autoévaluation du degré de confiance est activée, indique ensuite ton degré de certitude sur une échelle de 1 à 5. En cas de limite de temps, un compte à rebours affiche le temps restant. Le résultat apparaît lorsque la personne qui anime le révèle.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">275,280</context>
@@ -6458,11 +6458,11 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
-        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung.</source>
-        <target>Une session en direct peut combiner quiz, Q&amp;A et Feedback express. Suis la vue active et les indications sur ton appareil. Si un canal n’est pas actif, attends que la personne qui anime lance l’activité suivante.</target>
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge den Hinweisen in der jeweils geöffneten Ansicht. Wenn ein Bereich gerade nicht aktiv ist, warte, bis die Veranstaltungsleitung die nächste Aktivität öffnet.</source>
+        <target>Une session en direct peut combiner quiz, Q&amp;A et Feedback express. Suis les indications dans la vue actuellement ouverte. Si un canal n’est pas actif, attends que la personne qui anime lance l’activité suivante.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,323</context>
+          <context context-type="linenumber">318,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6470,15 +6470,15 @@
         <target>Que se passe-t-il lors d’un second tour de vote ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
         <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden.</source>
-        <target>Dans l’instruction par les pairs, réponds d’abord seul·e à la question. Discute ensuite avec d’autres participant·es, puis vote une seconde fois. Envoie également ta réponse au second tour ; elle peut différer de la première.</target>
+        <target>Dans une séquence de Peer Instruction, réponds d’abord seul·e à la question. Discute ensuite avec d’autres participant·es, puis vote une seconde fois. Envoie également ta réponse au second tour ; elle peut différer de la première.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">337,342</context>
+          <context context-type="linenumber">336,341</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6486,15 +6486,15 @@
         <target>Comment interpréter les résultats, le classement et les scores d’équipe ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">349</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
         <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung.</source>
-        <target>La personne qui anime décide quand les résultats deviennent visibles. Le classement, les scores d’équipe et les codes bonus n’apparaissent que s’ils sont activés pour la session. Ton auto-évaluation n’a aucun effet sur ton score ni sur ta position.</target>
+        <target>La personne qui anime décide quand les résultats deviennent visibles. Le classement, les scores d’équipe et les codes bonus n’apparaissent que s’ils sont activés pour la session. Ton degré de confiance autoévalué n’a aucun effet sur ton score ni sur ta position.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">356,360</context>
+          <context context-type="linenumber">355,359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6502,7 +6502,7 @@
         <target>Pour tout le monde</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6510,7 +6510,7 @@
         <target>Comment les données et les contenus sont-ils traités ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">375</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
@@ -6518,15 +6518,15 @@
         <target>Aucun compte n’est nécessaire. Les quiz de la personne qui anime sont d’abord stockés localement dans son navigateur ; pendant une session en direct, seules les données nécessaires à l’interaction sont échangées. arsnova.eu est open source et conçu pour un fonctionnement respectueux de la vie privée en Europe. Consulte la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Politique de confidentialité<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> pour en savoir plus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,386</context>
+          <context context-type="linenumber">378,385</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
-        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
-        <target>Comment utiliser arsnova.eu de façon accessible et comme application ?</target>
+        <source>Welche Barrierefreiheitsfunktionen gibt es, und wie installiere ich arsnova.eu als App?</source>
+        <target>Quelles options d’accessibilité sont disponibles et comment installer arsnova.eu comme application ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">393</context>
+          <context context-type="linenumber">392,393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -6363,7 +6363,7 @@
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
         <source> Neue Beiträge können zunächst zurückgehalten und erst nach deiner Freigabe veröffentlicht werden. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
-        <target>I nuovi contributi possono attendere l’approvazione prima di apparire. Puoi approvare, fissare in alto, archiviare o rimuovere le domande. Voti positivi e negativi e diverse modalità di ordinamento aiutano a stabilire le priorità; la nuvola di parole mette in evidenza i temi ricorrenti per la presentazione.</target>
+        <target>I nuovi contributi possono essere trattenuti e pubblicati solo dopo la tua approvazione. Puoi approvare, fissare in alto, archiviare o rimuovere le domande. Voti positivi e negativi e diverse modalità di ordinamento aiutano a stabilire le priorità; la nuvola di parole mette in evidenza i temi ricorrenti per la presentazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">189,195</context>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -359,16 +359,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="seo.titleHelp" datatype="html">
-        <source>So funktioniert’s – arsnova.eu</source>
-        <target>Come funziona – arsnova.eu</target>
+        <source>Hilfe &amp; Einstieg – arsnova.eu</source>
+        <target>Guida e primi passi – arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="seo.descHelp" datatype="html">
-        <source>Kurz erklärt: Live-Sessions, Quiz-Frageformate, Selbsteinschätzung, Blitzlicht, Q&amp;A und Moderationsabläufe auf arsnova.eu.</source>
-        <target>Guida rapida: sessioni live, formati di domanda, autovalutazione, sondaggio rapido, Q&amp;A e flussi di moderazione su arsnova.eu.</target>
+        <source>Hilfe für Veranstaltungsleitungen und Teilnehmende: Session starten, abstimmen, Q&amp;A und Blitzlicht nutzen, Ergebnisse auswerten und Funktionen nachschlagen.</source>
+        <target>Guida per chi conduce e chi partecipa: avviare una sessione, votare, usare Q&amp;A e sondaggio rapido, analizzare i risultati e scoprire le funzioni avanzate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">120</context>
@@ -6186,835 +6186,371 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.pageTitle" datatype="html">
-        <source> So funktioniert’s</source>
-        <target>Come funziona</target>
+        <source> Hilfe &amp; Einstieg</source>
+        <target>Guida e primi passi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">36,38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Diese Seite richtet sich an <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lehrende, Trainer:innen und Vortragende<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, die aus einer Präsentation eine echte Live-Situation machen wollen: kurze Checks, Diskussionen, Q&amp;A, Blitzlicht und Auswertung laufen in einer Session zusammen. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Ohne Pflichtkonto<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> für deine Gruppe: Code oder QR zeigen, Smartphones raus, loslegen.</source>
-        <target>Questa pagina è pensata per <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>docenti, formatrici e formatori, relatrici e relatori<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> che vogliono trasformare una presentazione in una vera situazione live: verifiche rapide, discussione, Q&amp;A, sondaggio rapido e restituzione stanno tutti nella stessa sessione. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Nessun account obbligatorio<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> per il gruppo: mostri codice o QR, smartphone alla mano, si parte.</target>
+        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen.</source>
+        <target>Scegli come usi arsnova.eu. Segui una breve introduzione oppure consulta direttamente una funzione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">41,47</context>
+          <context context-type="linenumber">41,44</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.uspTitle" datatype="html">
-        <source>Was arsnova.eu anders macht</source>
-        <target>Cosa rende arsnova.eu diverso</target>
+      <trans-unit id="help.roleNavAria" datatype="html">
+        <source>Rollenwahl</source>
+        <target>Scelta del ruolo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.usp1" datatype="html">
-        <source> arsnova.eu ist als <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Live-Regie für Unterricht, Training und Talks<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> gedacht: Du wechselst nicht zwischen Präsentation, Chat, Umfragetool und Quiz-App, sondern steuerst Interaktion, Beamer-Ansicht und Ergebnisfreigabe an einem Ort.</source>
-        <target>arsnova.eu è una <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>regia live per lezioni, formazione e talk<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: invece di passare tra slide, chat, strumenti di sondaggio e app per quiz, gestisci interazione, vista proiettore e pubblicazione dei risultati da un unico posto.</target>
+      <trans-unit id="help.roleHostTitle" datatype="html">
+        <source>Ich leite eine Veranstaltung</source>
+        <target>Conduco una sessione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">51,55</context>
+          <context context-type="linenumber">54</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.usp2" datatype="html">
-        <source> Der Fokus liegt auf <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>didaktischer Kontrolle und Datenschutz<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: Inhalte bleiben zunächst local-first im Browser, Teilnehmende brauchen kein Konto, das Projekt ist Open Source und für EU-orientierten Betrieb ausgelegt. Markdown und KaTeX machen fachliche Fragen präsentationstauglich, von MINT-Formeln bis zum kurzen Fallbeispiel.</source>
-        <target>Il focus è su <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>controllo didattico e protezione dei dati<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: i contenuti restano prima di tutto local-first nel browser, i partecipanti non hanno bisogno di un account, il progetto è open source ed è pensato per un uso orientato all’UE. Markdown e KaTeX rendono le domande disciplinari pronte per la presentazione, dalle formule STEM ai brevi casi pratici.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56,61</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsTitle" datatype="html">
-        <source> Frageformate: passend zum didaktischen Ziel</source>
-        <target>Formati di domanda: quello giusto per il tuo obiettivo didattico</target>
+      <trans-unit id="help.roleHostHint" datatype="html">
+        <source>Für Lehrende, Vortragende, Trainer:innen und Moderator:innen</source>
+        <target>Per docenti, relatori, formatori e moderatori</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsLead" datatype="html">
-        <source> Wähle das Format nach der Situation im Raum: Willst du Wissen prüfen, Haltungen sichtbar machen, Begriffe einsammeln oder Schätzungen diskutieren? Die Formate sind bewusst getrennt, damit Ergebnisanzeige, Bewertung und Moderation zum Einsatzzweck passen.</source>
-        <target>Scegli il formato in base alla situazione in aula: vuoi verificare conoscenze, rendere visibili opinioni, raccogliere concetti o discutere stime? I formati sono volutamente separati, così visualizzazione, valutazione e moderazione restano coerenti con lo scopo.</target>
+      <trans-unit id="help.roleParticipantTitle" datatype="html">
+        <source>Ich nehme an einer Veranstaltung teil</source>
+        <target>Partecipo a una sessione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">224</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsGridAria" datatype="html">
-        <source>Verfügbare Quiz-Frageformate</source>
-        <target>Formati di domande quiz disponibili</target>
+      <trans-unit id="help.roleParticipantHint" datatype="html">
+        <source>Für alle, die abstimmen, Fragen stellen oder Feedback geben</source>
+        <target>Per votare, fare domande o dare un feedback</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.newUserTitle" datatype="html">
+        <source>Neu bei arsnova.eu</source>
+        <target>Prima esperienza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">76</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
-        <source>Single Choice</source>
-        <target>Single Choice</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTag" datatype="html">
-        <source> eine richtige Option</source>
-        <target>una sola opzione corretta</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceBody" datatype="html">
-        <source> Für punktgenaue Verständnischecks: Eine Antwort ist korrekt, Ergebnis und Punkte sind sofort klar.</source>
-        <target>Per controlli di comprensione puntuali: una risposta è corretta, risultato e punti sono subito chiari.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
-        <source>Multiple Choice</source>
-        <target>Multiple Choice</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
-        <source> mehrere richtige Optionen</source>
-        <target>più opzioni corrette</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
-        <source> Für komplexere Konzepte, typische Fehlannahmen oder Fragen wie „Welche Aussagen stimmen?“ – mehrere Lösungen können zählen.</source>
-        <target>Per concetti più complessi, false credenze tipiche o domande come “Quali affermazioni sono corrette?” — possono contare più risposte.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTitle" datatype="html">
-        <source>Kurzantwort</source>
-        <target>Risposta breve</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTag" datatype="html">
-        <source> Musterlösung statt Auswahl</source>
-        <target>soluzione modello, non scelta guidata</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextBody" datatype="html">
-        <source> Teilnehmende formulieren kurz selbst. Du hinterlegst Musterlösungen; arsnova.eu kann Schreibvarianten, Toleranz und bei Bedarf Zahlen oder Einheiten auswerten.</source>
-        <target>Le persone partecipanti rispondono brevemente con parole proprie. Tu inserisci soluzioni modello; arsnova.eu può valutare varianti di scrittura, tolleranze e, se serve, numeri o unità.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTitle" datatype="html">
-        <source>Freitext</source>
-        <target>Testo libero</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTag" datatype="html">
-        <source> offene Antworten</source>
-        <target>risposte aperte</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextBody" datatype="html">
-        <source> Für Ideen, Reflexionen und Erwartungsabfragen. Keine automatische Bewertung; Antworten lassen sich sammeln und als Wortwolke sichtbar machen.</source>
-        <target>Per idee, riflessioni e aspettative. Nessuna valutazione automatica; le risposte possono essere raccolte e mostrate come nuvola di parole.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTitle" datatype="html">
-        <source>Umfrage</source>
-        <target>Sondaggio</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTag" datatype="html">
-        <source> Meinungsbild ohne richtig/falsch</source>
-        <target>quadro d’opinione senza giusto/sbagliato</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyBody" datatype="html">
-        <source> Für Prioritäten, Vorwissen oder Entscheidungen im Raum. Optionen werden gezählt, ohne Scorelogik.</source>
-        <target>Per priorità, conoscenze pregresse o decisioni in aula. Le opzioni vengono conteggiate senza logica di punteggio.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTitle" datatype="html">
-        <source>Bewertungsskala</source>
-        <target>Scala di valutazione</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTag" datatype="html">
-        <source> Skala mit eigenen Polen</source>
-        <target>scala con estremi personalizzati</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingBody" datatype="html">
-        <source> Für Zustimmung, Sicherheit, Tempo oder Feedback von niedrig bis hoch; optional mit benannten Endpunkten.</source>
-        <target>Per accordo, sicurezza, ritmo o feedback da basso ad alto, anche con estremi nominati.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
-        <source>Numerische Schätzfrage</source>
-        <target>Domanda di stima numerica</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTag" datatype="html">
-        <source> Zahlen schätzen, Streuung sehen</source>
-        <target>stimare numeri, vedere la dispersione</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateBody" datatype="html">
-        <source> Für Jahreszahlen, Größenordnungen, Messwerte und Wahrscheinlichkeiten. Mit Referenzwert, Toleranzband, Histogramm, Statistik und optionaler zweiter Runde.</source>
-        <target>Per anni, ordini di grandezza, misure e probabilità. Con valore di riferimento, banda di tolleranza, istogramma, statistiche e secondo turno opzionale.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatsBlitzNote" datatype="html">
-        <source> Blitzlicht ist davon getrennt: Es ist für spontane Live-Rückmeldungen gedacht, wenn du keine vollständige Quizfrage bauen willst.</source>
-        <target>Il sondaggio rapido è separato da questi formati: serve per feedback live spontanei quando non vuoi costruire una domanda quiz completa.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceTitle" datatype="html">
-        <source> Selbsteinschätzung bei bewertbaren Fragen</source>
-        <target>Autovalutazione per domande valutabili</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceLead" datatype="html">
-        <source> Die Selbsteinschätzung ist kein eigener Fragetyp, sondern eine optionale Zusatzabfrage nach Single Choice, Multiple Choice, Kurzantwort und numerischer Schätzfrage: Teilnehmende geben an, wie sicher sie bei ihrer Antwort sind (Skala 1–5). Das beeinflusst keine Punkte – hilft dir aber, Lernstand und Fehlkonzepte zu erkennen.</source>
-        <target>L&apos;autovalutazione non è un tipo di domanda separato, ma una domanda aggiuntiva facoltativa in base alla domanda a scelta singola, a scelta multipla, a risposta breve e con stima numerica: i partecipanti indicano quanto sono sicuri della loro risposta (scala 1–5). Ciò non influisce su nessun punto, ma ti aiuta a riconoscere il tuo livello di apprendimento e le tue idee sbagliate.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceListAria" datatype="html">
-        <source>Didaktische Funktionen der Selbsteinschätzung</source>
-        <target>Funzioni didattiche di autovalutazione</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
-        <source>Nach der Antwort abfragen</source>
-        <target>Dopo la risposta</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
-        <source> Progressive Disclosure: Erst Antwort wählen oder eingeben, dann die Selbsteinschätzung. Während der Abstimmung sieht niemand aggregierte Werte anderer Personen.</source>
-        <target>Divulgazione progressiva: prima seleziona o inserisci la risposta, poi l&apos;autovalutazione. Durante la votazione nessuno vede i valori aggregati degli altri.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorTitle" datatype="html">
-        <source>Im Editor konfigurieren</source>
-        <target>Configura nell&apos;editor</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorBody" datatype="html">
-        <source> Toggle pro Frage, optionale Labels für niedrige und hohe Antwortsicherheit und eine Live-Vorschau der Skala. Für neue bewertbare Fragen ist die Selbsteinschätzung standardmäßig aktiv.</source>
-        <target>Attiva/disattiva per domanda, etichette opzionali per confidenza della risposta bassa e alta e un&apos;anteprima in tempo reale della scala. L&apos;autovalutazione è attiva di default per le nuove domande valutabili.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceHostTitle" datatype="html">
-        <source>Host-Auswertung nach Freigabe</source>
-        <target>Valutazione host dopo la pubblicazione dei risultati</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">226</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceHostBody" datatype="html">
-        <source> Matrix aus Korrektheit und Antwortsicherheit mit Hervorhebung <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>selbstsicher falsch<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Bei Auswahlfragen siehst du, welche falschen Optionen mit hoher Antwortsicherheit gewählt wurden.</source>
-        <target>Matrice di correttezza e sicurezza nella risposta con evidenziazione delle risposte <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>sicure ma sbagliate<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Nelle domande a scelta vedi quali opzioni errate sono state scelte con alta sicurezza nella risposta.</target>
+      <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
+        <source>Was kann ich mit arsnova.eu machen?</source>
+        <target>Cosa posso fare con arsnova.eu?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportTitle" datatype="html">
-        <source>Abschluss und Export</source>
-        <target>Completamento ed esportazione</target>
+      <trans-unit id="help.hostCapabilitiesBody" datatype="html">
+        <source> Mit einem Quiz stellst du vorbereitete Wissens- oder Meinungsfragen. Im Q&amp;A sammelst und priorisierst du Fragen aus dem Publikum. Das Blitzlicht eignet sich für spontane Stimmungs-, Verständnis- und Tempoabfragen. Du kannst alle drei Bereiche in einer Live-Session verbinden.</source>
+        <target>Usa un quiz per domande di conoscenza o di opinione preparate in anticipo. Con il canale Q&amp;A raccogli e ordini per priorità le domande del pubblico. Il sondaggio rapido è adatto a riscontri spontanei su clima, comprensione e ritmo. Puoi riunire tutte e tre le funzioni in un’unica sessione dal vivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">88,93</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportBody" datatype="html">
-        <source> Nach Session-Ende fasst die Auswertung gefestigtes Wissen, Fehlkonzept-Hinweis und fragiles Wissen zusammen. Fragen mit weniger als 5 Antworten mit Selbsteinschätzung werden nicht aggregiert ausgewiesen. Der Nachbesprechungsplan (PDF) ist das empfohlene Format; CSV steht unter „Mehr“ für Excel zur Verfügung. In der Quiz-Sammlung findest du den Nachbesprechungsplan auf der Quizkarte.</source>
-        <target> Alla fine della sessione, la valutazione riassume le conoscenze consolidate, il rischio di concetti errati e le conoscenze fragili. Le domande con meno di 5 risposte con autovalutazione non vengono mostrate in forma aggregata. Il piano di debriefing (PDF) è il formato consigliato; il CSV è disponibile sotto «Altro» per Excel. Nella raccolta quiz trovi il piano di debriefing sulla scheda del quiz.</target>
+      <trans-unit id="help.hostFirstSessionTitle" datatype="html">
+        <source>Wie starte ich meine erste Session?</source>
+        <target>Come avvio la mia prima sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTitle" datatype="html">
-        <source>Demo-Quiz</source>
-        <target>Quiz dimostrativo</target>
+      <trans-unit id="help.hostFirstSessionBody" datatype="html">
+        <source> Öffne die Quiz-Sammlung und nutze das Demo-Quiz oder erstelle ein eigenes Quiz. Wähle „Starten“, lege Stil und Optionen fest und teile anschließend den sechsstelligen Code oder QR-Code. In der Host-Ansicht zeigst du die nächste Frage, startest die Antwortphase und gibst das Ergebnis frei. Tipp: Teste die Vorschau vor dem ersten Einsatz einmal auf einem zweiten Gerät.</source>
+        <target>Apri la raccolta dei quiz e usa il quiz dimostrativo oppure creane uno. Seleziona «Avvia», scegli lo stile e le opzioni, quindi condividi il codice di sei caratteri o il codice QR. Nella vista di conduzione, mostra la domanda successiva, avvia la fase di risposta e visualizza i risultati. Suggerimento: prova l’anteprima su un secondo dispositivo prima della prima sessione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">107,113</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoCardHint" datatype="html">
-        <source> Ein vorinstalliertes Beispiel-Quiz zeigt die Frageformate in konkreten Unterrichtsmomenten: Wissenscheck, Wortwolke, Kurzantwort, Schätzfrage, Bewertungsskala, Selbsteinschätzung, Formeln und Markdown. Du findest es in deiner Quiz-Sammlung und kannst es dort in der Vorschau öffnen.</source>
-        <target>Un quiz di esempio preinstallato mostra i formati di domanda in momenti didattici concreti: verifica rapida, nuvola di parole, risposta breve, stima, scala di valutazione, autovalutazione, formule e Markdown. Lo trovi nella tua raccolta quiz e puoi aprirlo in anteprima.</target>
+      <trans-unit id="help.hostFinishTitle" datatype="html">
+        <source>Wie beende und werte ich eine Session aus?</source>
+        <target>Come concludo e analizzo una sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTip" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tipp:&lt;/stro"/>Tipp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Öffne die Vorschau vor der ersten Live-Session einmal auf einem zweiten Gerät. So siehst du sofort, wie Host-Ansicht und Teilnehmenden-Screen zusammenspielen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Suggerimento:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> apri una volta l’anteprima su un secondo dispositivo prima della prima sessione live. Vedrai subito come lavorano insieme vista host e schermo dei partecipanti.</target>
+      <trans-unit id="help.hostFinishBody" datatype="html">
+        <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar.</source>
+        <target>Concludi la sessione dalla vista di conduzione. A quel punto sono disponibili i risultati riepilogativi. Usa il piano di debriefing in PDF per l’analisi didattica; l’esportazione CSV si trova sotto «Di più». Il piano resta accessibile dalla scheda del quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">124,129</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickstartTitle" datatype="html">
-        <source>Schnellstart</source>
-        <target>Avvio rapido</target>
+      <trans-unit id="help.experiencedUserTitle" datatype="html">
+        <source> Schon vertraut mit arsnova.eu</source>
+        <target>Conosco già arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">134,136</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart1" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Quiz anlegen:&lt;/"/>Quiz anlegen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> „Quiz-Sammlung öffnen&quot; wählen, neues Quiz erstellen und pro Frage das passende Format wählen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Crea quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> scegli “Apri raccolta quiz”, crea un nuovo quiz e scegli il formato giusto per ogni domanda.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart2" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Veranstaltung s"/>Veranstaltung starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Stil, Timer, Teams und Rangliste festlegen. Danach entsteht ein 6-stelliger Code, den du als Text oder QR-Code teilst.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Avvia evento:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> imposta stile, timer, team e classifica. Poi viene creato un codice a 6 caratteri, da condividere come testo o QR code.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart3" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Live moderieren"/>Live moderieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage zeigen, Antwortphase starten, Ergebnisse freigeben oder zurückhalten und bei Bedarf eine zweite Runde anschließen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Modera live:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> mostra la domanda, avvia la fase di risposta, pubblica o trattieni i risultati e aggiungi un secondo turno quando è utile.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostTitle" datatype="html">
-        <source>Veranstaltung leiten</source>
-        <target>Guida l&apos;evento</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLead" datatype="html">
-        <source> In der Host-Ansicht führst du durch die Session wie durch eine kleine Senderegie: Teilnehmende reinholen, Inhalte freigeben, Diskussion öffnen und Ergebnisse sichtbar machen.</source>
-        <target>Nella vista host guidi la sessione come una piccola regia: fai entrare i partecipanti, pubblichi i contenuti, apri la discussione e rendi visibili i risultati.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostStartStep" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Session starten:&lt;"/>Session starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> In deiner Quiz-Sammlung eine Veranstaltung starten und festlegen, ob sie mit Quiz oder Q&amp;A beginnt. Dann entsteht der Beitrittscode.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Avvia sessione:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> dalla tua raccolta quiz avvia un evento e scegli se iniziare con quiz o Q&amp;A. A quel punto viene creato il codice di accesso.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLobby" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Lobby:&lt;/stron"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Du siehst, wer beigetreten ist; ein QR-Code zum Beitritt wird angezeigt.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Vedi chi si è iscritto; verrà visualizzato un codice QR per partecipare.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostBeamer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beamer- und Pr"/>Beamer- und Presenter-Ansicht:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage, Antworten, Countdown und Ergebnisse erscheinen groß genug für Projektion, Stream oder zweiten Bildschirm.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vista proiettore e presentatore:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> domanda, risposte, conto alla rovescia e risultati sono abbastanza grandi per proiezione, streaming o secondo schermo.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSteuerung" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Steuerung:&lt;/stron"/>Steuerung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Nutze „Nächste Frage“, um den Inhalt einzublenden. Optional läuft zuerst eine Lesephase, danach startest du die Antwortphase und entscheidest, wann das Ergebnis auf den Screen kommt.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Controlli:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> usa “Domanda successiva” per portare il contenuto sullo schermo. Puoi iniziare con una fase di lettura, poi aprire la fase di risposta e decidere quando mostrare il risultato.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instruc"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Bei geeigneten Quizfragen, Schätzfragen und Blitzlicht-Runden: erst abstimmen lassen, Diskussion starten, dann erneut abstimmen. Der Vorher/Nachher-Vergleich macht Lernfortschritt sichtbar.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (doppi turni):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> per domande quiz adatte, domande di stima e sondaggi rapidi: prima si vota, poi si discute, quindi si vota di nuovo. Il confronto prima/dopo rende visibile il progresso di apprendimento.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSettings" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Einstellungen:&lt;/"/>Einstellungen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beim Start legst du Stil und Optionen fest: seriös oder spielerisch, mit oder ohne Rangliste, Sound, Lesephase, Team-Modus, Nicknamen und Timer.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Impostazioni:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> all’avvio scegli stile e opzioni: serio o giocoso, con o senza classifica, audio, fase di lettura, modalità team, nickname e timer.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallTitle" datatype="html">
-        <source> Fragenwand im Live-Kanal Q&amp;A</source>
-        <target> Bacheca delle domande nel canale live Q&amp;A </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLead" datatype="html">
-        <source> Q&amp;A soll nicht als Nebenchat verschwinden. Die Fragenwand macht Rückfragen sichtbar, priorisierbar und moderierbar: Du hältst den roten Faden, während die Gruppe gemeinsam zeigt, welche Punkte wirklich Klärung brauchen.</source>
-        <target> Il Q&amp;A non deve perdersi in una chat laterale. La bacheca delle domande rende gli interventi visibili, prioritizzabili e moderabili: mantieni il filo della sessione mentre il gruppo segnala insieme quali punti hanno davvero bisogno di chiarimento. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallListAria" datatype="html">
-        <source>Didaktische Funktionen der Q&amp;A-Fragenwand</source>
-        <target>Funzioni didattiche della bacheca Q&amp;A</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationTitle" datatype="html">
-        <source>Moderation mit pädagogischem Takt</source>
-        <target> Moderazione con ritmo didattico </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationBody" datatype="html">
-        <source> Auf Wunsch warten neue Fragen erst auf deine Freigabe. Du kannst Beiträge freigeben, anheften, archivieren oder entfernen und damit Schutzraum, Relevanz und Timing steuern: sofort beantworten, für später sammeln oder als Diskussionsspur markieren.</source>
-        <target> Se serve, le nuove domande attendono prima la tua approvazione. Puoi approvare, mettere in evidenza, archiviare o rimuovere i contributi e governare clima, rilevanza e tempi: rispondere subito, raccogliere per dopo o aprire una traccia di discussione. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingTitle" datatype="html">
-        <source>Kollektives Hoch- und Runtervoting</source>
-        <target> Upvote e downvote collettivi </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingBody" datatype="html">
-        <source> Teilnehmende gewichten Fragen gemeinsam. Positive und negative Stimmen zeigen nicht nur Popularität, sondern auch Unsicherheit, Widerspruch und Klärungsbedarf; Sortierungen wie „meist unterstützt“, „beste Fragen“ und „umstritten“ helfen dir, knappe Live-Zeit didaktisch zu setzen.</source>
-        <target> Partecipanti pesano insieme le domande. Voti positivi e negativi mostrano non solo popolarità, ma anche incertezza, dissenso e bisogno di chiarimento; ordinamenti come “più supportate”, “migliori domande” e “controverse” ti aiutano a usare il tempo live dove ha più senso didattico. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
-        <source>Q&amp;A-Wortwolke auf Themenebene</source>
-        <target> Word cloud Q&amp;A a livello di temi </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudBody" datatype="html">
-        <source> Die Word-Cloud verdichtet sichtbare Fragen zu Wörtern und Phrasen, gewichtet nach Unterstützung, belastbarer Zustimmung oder Kontroverse. Sie lässt sich einfrieren, nach Sortierlogik betrachten und in der Presenter-Ansicht zeigen – als schneller Blick auf Themencluster, nicht als dekorative Wortliste.</source>
-        <target> La word cloud condensa le domande visibili in parole e frasi, pesate per supporto, consenso robusto o controversia. Può essere congelata, letta secondo la logica di ordinamento e mostrata nella vista presentatore: una lettura rapida dei cluster tematici, non una lista decorativa di parole. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmTitle" datatype="html">
-        <source>Nächster Schritt: Moderationskompass</source>
-        <target>Prossimo passo: bussola di moderazione</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmBody" datatype="html">
-        <source> Geplant ist zuerst ein deterministischer Moderationskompass. Optional können später asynchrone Q&amp;A-NLP-Signale und quellengebundene Zusammenfassungen dazukommen – als datenschutzbewusste Moderationshilfe statt Blackbox-Bewertung.</source>
-        <target> Prima è prevista una bussola di moderazione deterministica. In seguito si potranno aggiungere in modo opzionale segnali Q&amp;A NLP asincroni e riepiloghi collegati alle fonti, come supporto alla moderazione attento ai dati invece di una valutazione black box. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.blitzTitle" datatype="html">
-        <source>Blitzlicht</source>
-        <target>Sondaggio rapido</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackIntro" datatype="html">
-        <source> Schnelle Stimmungs- und Wissensabfragen – z. B. vor der Pause, zum Einstieg oder für spontane Checks. Nutzbar im Host-Bereich deiner Live-Session oder direkt von der Startseite.</source>
-        <target>Sondaggi rapidi su clima e comprensione, prima della pausa, in apertura o per una verifica al volo. Disponibili nell’area host della sessione live o direttamente dalla pagina iniziale.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfMood" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stimmungsb"/>Stimmungsbild<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): Wie geht es den Teilnehmenden?</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Immagine dell&apos;atmosfera<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): Come stanno i partecipanti?</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfYesNoMaybe" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein / Viel"/>Ja / Nein / Vielleicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Schnelle Zustimmungsabfrage.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sì/No/Forse<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): richiesta rapida di consenso.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackYesNo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein&lt;/strong&gt; (👍"/>Ja / Nein<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): Klare Zwei-Optionen-Abfrage ohne Mittelweg.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sì / No<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): domanda binaria chiara, senza via di mezzo.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Wahr / Falsch / Weiß nicht&lt;/stron"/>Wahr / Falsch / Weiß nicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): Für schnelle Einschätzungen oder Wissenschecks.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vero / Falso / Non lo so<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): per valutazioni rapide o brevi verifiche di conoscenza.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Mehrstufige Schnellabfragen&lt;/s"/>Mehrstufige Schnellabfragen<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D): Drei oder vier feste Optionen für spontane Abstimmungen – ohne eine vollständige Quizfrage zu bauen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sondaggi rapidi in più fasi<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A-D): tre o quattro opzioni fisse per la votazione spontanea, senza creare una domanda del quiz completa.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTempo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tempo-Feedback&lt;/strong"/>Tempo-Feedback<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): Mit vier Icons meldet deine Gruppe laufend zurück, ob sie folgen kann. Teilnehmende können ihre Rückmeldung ändern; du siehst nur die aggregierte Tendenz.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Feedback sul ritmo<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): con quattro icone il gruppo indica continuamente se riesce a seguire. Le persone partecipanti possono cambiare risposta; tu vedi solo la tendenza aggregata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">283,285</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
-        <source> Du startest die Runde im Host-Bereich deiner Live-Session oder über die Blitzlicht-Karte „Live mit einem Klick&quot; auf der Startseite. Teilnehmende tippen eine Antwort; du siehst die Ergebnisse live als Balkendiagramm.</source>
-        <target>Avvii il turno dalla vista host della tua sessione live oppure direttamente dalla scheda «Sondaggio rapido» («In diretta con un clic») nella pagina iniziale. Le persone partecipanti votano con un tocco e tu vedi i risultati in tempo reale come grafico a barre.</target>
+      <trans-unit id="help.hostFormatsTitle" datatype="html">
+        <source>Fragetypen und Selbsteinschätzung</source>
+        <target>Tipi di domanda e autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">141</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instr"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Erste Runde – Ergebnis nicht auflösen – „Diskussionsphase&quot; starten („Diskutiert mit eurem Nachbarn&quot;) – „Zweite Abstimmung&quot;. Vorher/Nachher-Vergleich zeigt, wie sich das Stimmungsbild durch den Austausch verändert hat.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (doppi turni):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Primo turno - Non risolvere il risultato - Inizia la "fase di discussione" ("Discuti con il tuo vicino") - "Secondo voto". Il confronto prima/dopo mostra come cambia l’immagine dell’atmosfera grazie allo scambio.</target>
+      <trans-unit id="help.hostFormatsBody" datatype="html">
+        <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar.</source>
+        <target>Sono disponibili scelta singola, scelta multipla, risposta breve, testo libero, sondaggio, scala di valutazione e stima numerica. Le domande valutabili possono essere seguite da un’autovalutazione da 1 a 5. Non modifica il punteggio, ma evidenzia conoscenze consolidate, conoscenze fragili e possibili concezioni errate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">145,151</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfStop" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stopp:&lt;/st"/>Stopp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Abstimmung einfrieren – Teilnehmende sehen „Abstimmung ist pausiert&quot; und können nicht mehr abstimmen, bis du „Fortsetzen&quot; wählst.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Interrompi:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Blocca la votazione: i partecipanti vedono &quot;La votazione è in pausa&quot; e non possono più votare finché non scegli &quot;Riprendi&quot;.</target>
+      <trans-unit id="help.hostModerationTitle" datatype="html">
+        <source>Live moderieren und Peer Instruction nutzen</source>
+        <target>Moderare dal vivo e usare la Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfReset" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Zurücksetze"/>Zurücksetzen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Alle Stimmen löschen und erneut abstimmen lassen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Reimposta:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Elimina tutti i voti e lascia che votino di nuovo.</target>
+      <trans-unit id="help.hostModerationBody" datatype="html">
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.</source>
+        <target>Usa secondo le necessità la fase di lettura, il timer, la vista proiettore o presentatore e la visualizzazione differita dei risultati. Per la Peer Instruction, avvia una prima votazione, apri una fase di discussione e poi una seconda votazione. Il confronto prima-dopo rende visibili i cambiamenti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">162,167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfNewRound" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Neue Runde:&lt;/s"/>Neue Runde:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Neuen Code erzeugen und eine frische Runde starten.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Nuovo round:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Genera un nuovo codice e inizia un nuovo round.</target>
+      <trans-unit id="help.hostQaTitle" datatype="html">
+        <source>Die Q&amp;A-Fragenwand moderieren</source>
+        <target>Moderare la bacheca delle domande Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfCopyLink" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Link kopieren:"/>Link kopieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beitrittslink in die Zwischenablage kopieren, z. B. zum Teilen per Chat.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Copia link:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Copia il link di unione negli appunti, ad es. per la condivisione tramite chat.</target>
+      <trans-unit id="help.hostQaBody" datatype="html">
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation.</source>
+        <target>I nuovi contributi possono attendere l’approvazione prima di apparire. Puoi approvare, fissare in alto, archiviare o rimuovere le domande. Voti positivi e negativi e diverse modalità di ordinamento aiutano a stabilire le priorità; la nuvola di parole sintetizza i temi visibili per la presentazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">178,183</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsTitle" datatype="html">
-        <source>Für deine Teilnehmenden</source>
-        <target>Per i tuoi partecipanti</target>
+      <trans-unit id="help.hostPulseTitle" datatype="html">
+        <source>Blitzlicht und Tempo-Feedback einsetzen</source>
+        <target>Usare il sondaggio rapido e il feedback sul ritmo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsLead" datatype="html">
-        <source> Kurz erklärt, was du in deiner Veranstaltung weitergeben kannst:</source>
-        <target>In breve: cosa puoi condividere durante il tuo evento:</target>
+      <trans-unit id="help.hostPulseBody" datatype="html">
+        <source> Starte ein Blitzlicht aus der Live-Session oder über „Live mit einem Klick“ auf der Startseite. Du kannst die Abstimmung pausieren, fortsetzen, zurücksetzen oder als neue Runde starten. Beim Tempo-Feedback ändern Teilnehmende ihre Rückmeldung jederzeit; du siehst nur die aggregierte Tendenz.</source>
+        <target>Avvia un sondaggio rapido dalla sessione dal vivo oppure con «In diretta con un clic» nella pagina iniziale. Puoi metterlo in pausa, riprenderlo, azzerarlo o avviare un nuovo turno. Nel feedback sul ritmo, i partecipanti possono cambiare risposta in qualsiasi momento; tu vedi solo la tendenza aggregata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">194,199</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsJoin" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beitreten:&lt;/strong&gt;"/>Beitreten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> 6-stelligen Code auf arsnova.eu eingeben und „Los geht&apos;s&quot; – funktioniert für Quiz, Q&amp;A und Blitzlicht. Keine Anmeldung nötig.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Entrare:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Inserisci il codice a 6 cifre su arsnova.eu e «Si parte» — vale per quiz, Q&amp;A e sondaggio rapido. Nessuna registrazione.</target>
+      <trans-unit id="help.hostLibraryTitle" datatype="html">
+        <source>Quiz-Sammlung und Einstellungen verwalten</source>
+        <target>Gestire quiz e impostazioni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsNick" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Nicknamen:&lt;/strong&gt;"/>Nicknamen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Je nach deiner Einstellung vorgegebene Namen, eigener Name oder anonym.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Soprannomi:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> A seconda delle tue impostazioni, nomi predefiniti, il tuo nome o anonimo.</target>
+      <trans-unit id="help.hostLibraryBody" datatype="html">
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
+        <target>Nella raccolta dei quiz puoi modificare e riordinare le domande, controllare l’anteprima e importare o esportare quiz in formato JSON. Il link di sincronizzazione permette di condividere la raccolta o continuare su un altro dispositivo. I modelli di IA aiutano nella generazione e nella verifica senza inviare i contenuti ad arsnova.eu. All’avvio configuri, tra le altre cose, stile, classifica, suoni, squadre, nickname, timer e codici bonus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">210,217</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsVote" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Abstimmung:&lt;/strong&gt;"/>Abstimmung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage erscheint auf dem Gerät, Antwort wählen und absenden. Bei aktivierter Selbsteinschätzung folgt danach die Skala 1–5. Bei Zeitlimit läuft ein Countdown.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vota:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> La domanda appare sul dispositivo; scegli la risposta e invia. Se l'autovalutazione è attiva, segue la scala 1–5. Con limite di tempo, parte un conto alla rovescia.</target>
+      <trans-unit id="help.participantJoinTitle" datatype="html">
+        <source>Wie trete ich einer Session bei?</source>
+        <target>Come partecipo a una sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTitle" datatype="html">
-        <source>Deine Quiz-Sammlung</source>
-        <target>La tua raccolta quiz</target>
+      <trans-unit id="help.participantJoinBody" datatype="html">
+        <source> Scanne den QR-Code oder öffne arsnova.eu und gib den sechsstelligen Code ein. Du brauchst kein Konto. Je nach Einstellung der Veranstaltungsleitung nimmst du anonym, mit einem vorgegebenen Nickname oder mit einem selbst gewählten Namen teil.</source>
+        <target>Scansiona il codice QR oppure apri arsnova.eu e inserisci il codice di sei caratteri. Non serve un account. In base alle impostazioni di chi conduce, puoi partecipare in forma anonima, con un nickname predefinito o con un nome scelto da te.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">235,240</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionLead" datatype="html">
-        <source>Hier legst du deine Quizze an und bereitest sie vor.</source>
-        <target>Qui crei e prepari i tuoi quiz.</target>
+      <trans-unit id="help.participantAnswerTitle" datatype="html">
+        <source>Wie beantworte ich eine Quizfrage?</source>
+        <target>Come rispondo a una domanda del quiz?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">247</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionEditor" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Editor:&lt;/strong&gt; Fra"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Fragen per Drag-and-Drop sortieren, auf- und zuklappen, Vorschau prüfen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ordina le domande utilizzando il trascinamento della selezione, espandi e comprimi, controlla l'anteprima.</target>
+      <trans-unit id="help.participantAnswerBody" datatype="html">
+        <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
+        <target>Seleziona o inserisci una risposta, quindi inviala. Se l’autovalutazione è attiva, indica quanto sei sicuro su una scala da 1 a 5. Se è previsto un limite di tempo, un conto alla rovescia mostra il tempo rimanente. I risultati appaiono quando chi conduce li rende visibili.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">254,259</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTypes" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Fragetypen:&lt;/strong"/>Fragetypen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage – pro Frage optional mit Timer, Schwierigkeitsgrad und Selbsteinschätzung.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Tipi di domanda:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single choice, multiple choice, risposta breve, testo libero, sondaggio, scala di valutazione e domanda di stima numerica — ogni domanda può includere timer, difficoltà e autovalutazione opzionali.</target>
+      <trans-unit id="help.participantContributeTitle" datatype="html">
+        <source>Wie stelle ich eine Frage oder gebe Feedback?</source>
+        <target>Come faccio una domanda o do un feedback?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">266</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionImport" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Import / Export:&lt;/st"/>Import / Export:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Quiz als JSON importieren oder exportieren. Mit der Start- und Prüfvorlage kannst du anspruchsvolle Quizze mit deinem bevorzugten KI-Tool generieren, prüfen und direkt importieren – deine Inhalte und Präsentationen werden nicht an arsnova.eu gesendet; du nutzt dein eigenes KI-Tool.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Import / esportazione:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Importa o esporta quiz come JSON. Con i modelli di generazione e verifica puoi creare quiz di qualità con il tuo strumento IA preferito, verificarli e importarli direttamente. Contenuti e presentazioni non vengono inviati ad arsnova.eu; usi il tuo strumento IA.</target>
+      <trans-unit id="help.participantContributeBody" datatype="html">
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
+        <target>Nel canale Q&amp;A puoi inviare una domanda e votare positivamente o negativamente i contributi altrui. In base alla moderazione, la tua domanda potrebbe apparire solo dopo l’approvazione. Nel sondaggio rapido dai un riscontro spontaneo con un tocco. Puoi modificare il feedback sul ritmo finché il sondaggio è aperto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">273,278</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionSync" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Sync:&lt;/strong&gt; Mit"/>Sync:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit dem Sync-Link deine Quiz-Sammlung mit Kolleg:innen teilen oder auf anderen Geräten weiterarbeiten. Wer den Link hat, kann die Sammlung öffnen. Die Geräteangaben helfen nur bei der Orientierung.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sincronizzazione:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Usa il link sync per condividere la tua raccolta quiz o per continuare su altri dispositivi. Chiunque abbia il link può aprire la raccolta. I dati del dispositivo servono solo per orientarti.</target>
+      <trans-unit id="help.participantChannelsTitle" datatype="html">
+        <source>Wie nutze ich Quiz, Q&amp;A und Blitzlicht in einer Session?</source>
+        <target>Come uso quiz, Q&amp;A e sondaggio rapido in una sola sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">290</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoQuizHint" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Demo-Quiz:&lt;/stro"/>Demo-Quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ein vorinstalliertes Quiz zeigt alle Formate mit Beispielen inkl. KaTeX-Formeln und Markdown. In der Quiz-Sammlung in der Vorschau öffnen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Quiz dimostrativo:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> un quiz preinstallato mostra tutti i formati con esempi, incluse formule KaTeX e Markdown. Aprilo in anteprima dalla raccolta quiz.</target>
+      <trans-unit id="help.participantChannelsBody" datatype="html">
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung.</source>
+        <target>Una sessione dal vivo può combinare quiz, Q&amp;A e sondaggio rapido. Segui la vista attiva e le indicazioni sul tuo dispositivo. Se un canale non è attivo, attendi che chi conduce apra l’attività successiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">297,302</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesTitle" datatype="html">
-        <source>Seriös und Spielerisch</source>
-        <target>Serio e giocoso</target>
+      <trans-unit id="help.participantSecondRoundTitle" datatype="html">
+        <source>Was passiert bei einer zweiten Abstimmungsrunde?</source>
+        <target>Cosa succede in un secondo turno di votazione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesLead" datatype="html">
-        <source> Zwei Stile für unterschiedliche Situationen – wählbar auf der Startseite und beim Session-Start.</source>
-        <target>Due stili per situazioni diverse: selezionabili sulla home page e all&apos;inizio della sessione.</target>
+      <trans-unit id="help.participantSecondRoundBody" datatype="html">
+        <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden.</source>
+        <target>Nella Peer Instruction rispondi prima alla domanda in autonomia. Poi confrontati con altri partecipanti e vota una seconda volta. Invia la risposta anche nel secondo turno; può essere diversa dalla prima.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">316,321</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.styleSerious" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Seriös:&lt;/strong&gt;"/>Seriös:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonym, ohne Rangliste – ideal für formative Assessments, Prüfungsvorbereitung und sensible Themen.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Serio:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonimo, senza classifiche - ideale per valutazioni formative, preparazione agli esami e argomenti delicati.</target>
+      <trans-unit id="help.participantResultsTitle" datatype="html">
+        <source>Wie sind Ergebnisse, Rangliste und Teamwertung zu verstehen?</source>
+        <target>Come interpreto risultati, classifica e punteggi di squadra?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylePlayful" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Spielerisch:&lt;/st"/>Spielerisch:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit Rangliste, Sounds und Anfeuerung – ideal für Auflockerung, Wettbewerbe und motivierende Quizze.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Giocoso:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Con classifica, suoni e messaggi di incoraggiamento – ideale per alleggerire l’atmosfera, competizioni e quiz motivanti.</target>
+      <trans-unit id="help.participantResultsBody" datatype="html">
+        <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung.</source>
+        <target>Chi conduce decide quando rendere visibili i risultati. Classifica, punteggi di squadra e codici bonus compaiono solo se sono stati attivati per la sessione. L’autovalutazione non influisce sul punteggio né sulla posizione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">335,339</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesOptions" datatype="html">
-        <source> Alle Optionen (Rangliste, Sound, Lesephase, Team, Bonus) lassen sich einzeln an- und ausschalten.</source>
-        <target>Tutte le opzioni (classifica, suono, fase di lettura, squadra, bonus) possono essere attivate e disattivate individualmente.</target>
+      <trans-unit id="help.commonTitle" datatype="html">
+        <source>Für alle</source>
+        <target>Per tutti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">346</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTitle" datatype="html">
-        <source>Weitere Funktionen</source>
-        <target>Più funzionalità</target>
+      <trans-unit id="help.commonPrivacyTitle" datatype="html">
+        <source>Wie werden Daten und Inhalte behandelt?</source>
+        <target>Come vengono gestiti dati e contenuti?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">351</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreBonus" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Bonus-Codes:&lt;"/>Bonus-Codes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Top-Platzierte erhalten einen einlösbaren Code (z. B. für Bonuspunkte). Du siehst die Code-Liste; personenbezogene Daten werden nicht gespeichert.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Codici bonus:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> I primi classificati ricevono un codice riscattabile (ad esempio per punti bonus). Vedi l'elenco dei codici; I dati personali non vengono memorizzati.</target>
+      <trans-unit id="help.commonPrivacyBody" datatype="html">
+        <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target>Non serve un account. I quiz di chi conduce vengono memorizzati inizialmente nel browser; durante una sessione dal vivo vengono scambiati i dati necessari all’interazione. arsnova.eu è open source ed è progettato per un uso attento alla privacy in Europa. Per i dettagli consulta l’<x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Informativa sulla privacy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">355,362</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTeams" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Team-Modus:&lt;/"/>Team-Modus:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Deine Teilnehmenden spielen in Teams mit eigenem Team-Leaderboard – z. B. für Gruppenwettbewerbe im Seminar.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Modalità squadra:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> I tuoi partecipanti giocano in squadre con la propria classifica di squadra, ad es. per le gare collettive nei seminari.</target>
+      <trans-unit id="help.commonAccessibilityTitle" datatype="html">
+        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
+        <target>Come uso arsnova.eu in modo accessibile e come app?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreGamification" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Gamification:&lt;/stron"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sound-Effekte, Belohnungseffekte für Top-Plätze, Motivationsmeldungen – im Spielerisch-Modus.</source>
-        <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Effetti sonori, effetti di ricompensa per i primi posti, messaggi motivazionali - in modalità giocosa.</target>
+      <trans-unit id="help.commonAccessibilityBody" datatype="html">
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <target>arsnova.eu si può usare con la tastiera, con uno screen reader e con lo zoom. Se necessario, utilizza le opzioni di contrasto e tema dell’app o del sistema operativo. Puoi anche installare arsnova.eu come Progressive Web App. Per maggiori informazioni consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Dichiarazione di accessibilità<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">376,382</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyTitle" datatype="html">
-        <source>Datenschutz und Technik</source>
-        <target>Protezione dei dati e tecnologia</target>
+      <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
+        <source>Was kann ich bei technischen Problemen tun?</source>
+        <target>Cosa posso fare se qualcosa non funziona?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">389</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyBody" datatype="html">
-        <source> arsnova.eu ist kostenlos, Open Source und für den Einsatz an Schulen, Hochschulen und in Weiterbildung gedacht – mit Fokus auf Datenschutz (DSGVO). Quiz-Inhalte werden lokal im Browser gespeichert. Keine Anmeldung nötig, weder für dich noch für deine Teilnehmenden. Als App installierbar (PWA) – z. B. für schnelleren Start auf dem Smartphone. Oberfläche auf Deutsch, Englisch, Französisch, Spanisch und Italienisch.</source>
-        <target>arsnova.eu è gratuito, open source e destinato all&apos;uso nelle scuole, nelle università e nell&apos;istruzione superiore, con particolare attenzione alla protezione dei dati (GDPR). Il contenuto del quiz viene salvato localmente nel browser. Non è necessaria alcuna registrazione, né per te né per i tuoi partecipanti. Può essere installato come app (PWA) – ad es. B. per un avvio più rapido sullo smartphone. Interfaccia in tedesco, inglese, francese, spagnolo e italiano.</target>
+      <trans-unit id="help.commonTroubleshootingBody" datatype="html">
+        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
+        <target>Controlla innanzitutto il codice o il codice QR, la connessione Internet e che la sessione sia ancora attiva. Se non vedi ancora una domanda, la sessione potrebbe essere nella lobby, nella fase di lettura o in pausa. Dopo un’interruzione, riapri il link di partecipazione o inserisci di nuovo il codice. Rivolgiti a chi conduce se la sessione è già terminata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">396,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -6206,7 +6206,7 @@
         <target>Scelta del ruolo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostTitle" datatype="html">
@@ -6214,11 +6214,11 @@
         <target>Conduco una sessione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostHint" datatype="html">
@@ -6226,7 +6226,7 @@
         <target>Per docenti, relatori, formatori e moderatori</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantTitle" datatype="html">
@@ -6234,11 +6234,11 @@
         <target>Partecipo a una sessione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">71</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">224</context>
+          <context context-type="linenumber">241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
@@ -6246,7 +6246,7 @@
         <target>Per votare, fare domande o dare un feedback</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.newUserTitle" datatype="html">
@@ -6254,11 +6254,11 @@
         <target>Prima esperienza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">87</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">226</context>
+          <context context-type="linenumber">244</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
@@ -6266,7 +6266,7 @@
         <target>Cosa posso fare con arsnova.eu?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesBody" datatype="html">
@@ -6274,7 +6274,7 @@
         <target>Usa un quiz per domande di conoscenza o di opinione preparate in anticipo. Con il canale Q&amp;A raccogli e ordini per priorità le domande del pubblico. Il sondaggio rapido è adatto a riscontri spontanei su clima, comprensione e ritmo. Puoi riunire tutte e tre le funzioni in un’unica sessione dal vivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">88,93</context>
+          <context context-type="linenumber">99,104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionTitle" datatype="html">
@@ -6282,7 +6282,7 @@
         <target>Come avvio la mia prima sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionBody" datatype="html">
@@ -6290,7 +6290,7 @@
         <target>Apri la raccolta dei quiz e usa il quiz dimostrativo oppure creane uno. Seleziona «Avvia», scegli lo stile e le opzioni, quindi condividi il codice di sei caratteri o il codice QR. Nella vista di conduzione, mostra la domanda successiva, avvia la fase di risposta e visualizza i risultati. Suggerimento: prova l’anteprima su un secondo dispositivo prima della prima sessione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">107,113</context>
+          <context context-type="linenumber">118,124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishTitle" datatype="html">
@@ -6298,7 +6298,7 @@
         <target>Come concludo e analizzo una sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
@@ -6306,7 +6306,7 @@
         <target>Concludi la sessione dalla vista di conduzione. A quel punto sono disponibili i risultati riepilogativi. Usa il piano di debriefing in PDF per l’analisi didattica; l’esportazione CSV si trova sotto «Di più». Il piano resta accessibile dalla scheda del quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">124,129</context>
+          <context context-type="linenumber">135,140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.experiencedUserTitle" datatype="html">
@@ -6314,11 +6314,11 @@
         <target>Conosco già arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">134,136</context>
+          <context context-type="linenumber">145,147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">283,285</context>
+          <context context-type="linenumber">304,306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
@@ -6326,7 +6326,7 @@
         <target>Tipi di domanda e autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
@@ -6334,7 +6334,7 @@
         <target>Sono disponibili scelta singola, scelta multipla, risposta breve, testo libero, sondaggio, scala di valutazione e stima numerica. Le domande valutabili possono essere seguite da un’autovalutazione da 1 a 5. Non modifica il punteggio, ma evidenzia conoscenze consolidate, conoscenze fragili e possibili concezioni errate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">145,151</context>
+          <context context-type="linenumber">156,162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationTitle" datatype="html">
@@ -6342,7 +6342,7 @@
         <target>Moderare dal vivo e usare la Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
@@ -6350,7 +6350,7 @@
         <target>Usa secondo le necessità la fase di lettura, il timer, la vista proiettore o presentatore e la visualizzazione differita dei risultati. Per la Peer Instruction, avvia una prima votazione, apri una fase di discussione e poi una seconda votazione. Il confronto prima-dopo rende visibili i cambiamenti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,167</context>
+          <context context-type="linenumber">173,178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaTitle" datatype="html">
@@ -6358,7 +6358,7 @@
         <target>Moderare la bacheca delle domande Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
@@ -6366,7 +6366,7 @@
         <target>I nuovi contributi possono attendere l’approvazione prima di apparire. Puoi approvare, fissare in alto, archiviare o rimuovere le domande. Voti positivi e negativi e diverse modalità di ordinamento aiutano a stabilire le priorità; la nuvola di parole sintetizza i temi visibili per la presentazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">178,183</context>
+          <context context-type="linenumber">189,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
@@ -6374,7 +6374,7 @@
         <target>Usare il sondaggio rapido e il feedback sul ritmo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
@@ -6382,7 +6382,7 @@
         <target>Avvia un sondaggio rapido dalla sessione dal vivo oppure con «In diretta con un clic» nella pagina iniziale. Puoi metterlo in pausa, riprenderlo, azzerarlo o avviare un nuovo turno. Nel feedback sul ritmo, i partecipanti possono cambiare risposta in qualsiasi momento; tu vedi solo la tendenza aggregata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">194,199</context>
+          <context context-type="linenumber">205,210</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
@@ -6390,7 +6390,7 @@
         <target>Gestire quiz e impostazioni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">217</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
@@ -6398,7 +6398,7 @@
         <target>Nella raccolta dei quiz puoi modificare e riordinare le domande, controllare l’anteprima e importare o esportare quiz in formato JSON. Il link di sincronizzazione permette di condividere la raccolta o continuare su un altro dispositivo. I modelli di IA aiutano nella generazione e nella verifica senza inviare i contenuti ad arsnova.eu. All’avvio configuri, tra le altre cose, stile, classifica, suoni, squadre, nickname, timer e codici bonus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">210,217</context>
+          <context context-type="linenumber">221,228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
@@ -6406,7 +6406,7 @@
         <target>Come partecipo a una sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">231</context>
+          <context context-type="linenumber">249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
@@ -6414,7 +6414,7 @@
         <target>Scansiona il codice QR oppure apri arsnova.eu e inserisci il codice di sei caratteri. Non serve un account. In base alle impostazioni di chi conduce, puoi partecipare in forma anonima, con un nickname predefinito o con un nome scelto da te.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">235,240</context>
+          <context context-type="linenumber">256,261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
@@ -6422,7 +6422,7 @@
         <target>Come rispondo a una domanda del quiz?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">247</context>
+          <context context-type="linenumber">268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
@@ -6430,7 +6430,7 @@
         <target>Seleziona o inserisci una risposta, quindi inviala. Se l’autovalutazione è attiva, indica quanto sei sicuro su una scala da 1 a 5. Se è previsto un limite di tempo, un conto alla rovescia mostra il tempo rimanente. I risultati appaiono quando chi conduce li rende visibili.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">254,259</context>
+          <context context-type="linenumber">275,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
@@ -6438,7 +6438,7 @@
         <target>Come faccio una domanda o do un feedback?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">287</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
@@ -6446,7 +6446,7 @@
         <target>Nel canale Q&amp;A puoi inviare una domanda e votare positivamente o negativamente i contributi altrui. In base alla moderazione, la tua domanda potrebbe apparire solo dopo l’approvazione. Nel sondaggio rapido dai un riscontro spontaneo con un tocco. Puoi modificare il feedback sul ritmo finché il sondaggio è aperto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">273,278</context>
+          <context context-type="linenumber">294,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
@@ -6454,7 +6454,7 @@
         <target>Come uso quiz, Q&amp;A e sondaggio rapido in una sola sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">290</context>
+          <context context-type="linenumber">311</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
@@ -6462,7 +6462,7 @@
         <target>Una sessione dal vivo può combinare quiz, Q&amp;A e sondaggio rapido. Segui la vista attiva e le indicazioni sul tuo dispositivo. Se un canale non è attivo, attendi che chi conduce apra l’attività successiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">297,302</context>
+          <context context-type="linenumber">318,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6470,7 +6470,7 @@
         <target>Cosa succede in un secondo turno di votazione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
@@ -6478,7 +6478,7 @@
         <target>Nella Peer Instruction rispondi prima alla domanda in autonomia. Poi confrontati con altri partecipanti e vota una seconda volta. Invia la risposta anche nel secondo turno; può essere diversa dalla prima.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">316,321</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6486,7 +6486,7 @@
         <target>Come interpreto risultati, classifica e punteggi di squadra?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">328</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
@@ -6494,7 +6494,7 @@
         <target>Chi conduce decide quando rendere visibili i risultati. Classifica, punteggi di squadra e codici bonus compaiono solo se sono stati attivati per la sessione. L’autovalutazione non influisce sul punteggio né sulla posizione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">335,339</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6502,7 +6502,7 @@
         <target>Per tutti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6510,7 +6510,7 @@
         <target>Come vengono gestiti dati e contenuti?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">351</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
@@ -6518,7 +6518,7 @@
         <target>Non serve un account. I quiz di chi conduce vengono memorizzati inizialmente nel browser; durante una sessione dal vivo vengono scambiati i dati necessari all’interazione. arsnova.eu è open source ed è progettato per un uso attento alla privacy in Europa. Per i dettagli consulta l’<x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Informativa sulla privacy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,362</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
@@ -6526,15 +6526,17 @@
         <target>Come uso arsnova.eu in modo accessibile e come app?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
-        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;
+                    &gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a
+                  &gt;"/>.</source>
         <target>arsnova.eu si può usare con la tastiera, con uno screen reader e con lo zoom. Se necessario, utilizza le opzioni di contrasto e tema dell’app o del sistema operativo. Puoi anche installare arsnova.eu come Progressive Web App. Per maggiori informazioni consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Dichiarazione di accessibilità<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">376,382</context>
+          <context context-type="linenumber">400,408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
@@ -6542,7 +6544,7 @@
         <target>Cosa posso fare se qualcosa non funziona?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389</context>
+          <context context-type="linenumber">415</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
@@ -6550,7 +6552,7 @@
         <target>Controlla innanzitutto il codice o il codice QR, la connessione Internet e che la sessione sia ancora attiva. Se non vedi ancora una domanda, la sessione potrebbe essere nella lobby, nella fase di lettura o in pausa. Dopo un’interruzione, riapri il link di partecipazione o inserisci di nuovo il codice. Rivolgiti a chi conduce se la sessione è già terminata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">396,403</context>
+          <context context-type="linenumber">422,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -6194,8 +6194,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen.</source>
-        <target>Scegli come usi arsnova.eu. Segui una breve introduzione oppure consulta direttamente una funzione.</target>
+        <source> Wähle, in welcher Rolle du arsnova.eu nutzt. Hier findest du einen schnellen Einstieg und gezielte Hilfe zu einzelnen Funktionen.</source>
+        <target>Scegli il ruolo con cui usi arsnova.eu. Qui trovi un avvio rapido e un aiuto mirato per le singole funzioni.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">41,44</context>
@@ -6251,7 +6251,7 @@
       </trans-unit>
       <trans-unit id="help.newUserTitle" datatype="html">
         <source>Neu bei arsnova.eu</source>
-        <target>Prima esperienza</target>
+        <target>Prima volta su arsnova.eu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">87</context>
@@ -6303,7 +6303,7 @@
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
         <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar.</source>
-        <target>Concludi la sessione dalla vista di conduzione. A quel punto sono disponibili i risultati riepilogativi. Usa il piano di debriefing in PDF per l’analisi didattica; l’esportazione CSV si trova sotto «Di più». Il piano resta accessibile dalla scheda del quiz.</target>
+        <target>Concludi la sessione dalla vista di conduzione. A quel punto è disponibile il riepilogo dei risultati. Usa il piano per la discussione dei risultati in PDF per l’analisi didattica; l’esportazione CSV si trova sotto «Di più». Il piano resta accessibile dalla scheda del quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">135,140</context>
@@ -6323,7 +6323,7 @@
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
         <source>Fragetypen und Selbsteinschätzung</source>
-        <target>Tipi di domanda e autovalutazione</target>
+        <target>Tipi di domanda e sicurezza nella risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">152</context>
@@ -6331,7 +6331,7 @@
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
         <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar.</source>
-        <target>Sono disponibili scelta singola, scelta multipla, risposta breve, testo libero, sondaggio, scala di valutazione e stima numerica. Le domande valutabili possono essere seguite da un’autovalutazione da 1 a 5. Non modifica il punteggio, ma evidenzia conoscenze consolidate, conoscenze fragili e possibili concezioni errate.</target>
+        <target>Sono disponibili domande a risposta singola, domande a risposta multipla, risposta breve, testo libero, sondaggio, scala di valutazione e stima numerica. Le domande valutabili possono essere seguite da un’autovalutazione del grado di sicurezza su una scala da 1 a 5. Questa non modifica il punteggio, ma può evidenziare conoscenze consolidate, conoscenze non ancora consolidate e possibili concezioni errate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">156,162</context>
@@ -6346,7 +6346,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
-        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar.</source>
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-Nachher-Vergleich macht Veränderungen sichtbar.</source>
         <target>Usa secondo le necessità la fase di lettura, il timer, la vista proiettore o presentatore e la visualizzazione differita dei risultati. Per la Peer Instruction, avvia una prima votazione, apri una fase di discussione e poi una seconda votazione. Il confronto prima-dopo rende visibili i cambiamenti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
@@ -6362,8 +6362,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation.</source>
-        <target>I nuovi contributi possono attendere l’approvazione prima di apparire. Puoi approvare, fissare in alto, archiviare o rimuovere le domande. Voti positivi e negativi e diverse modalità di ordinamento aiutano a stabilire le priorità; la nuvola di parole sintetizza i temi visibili per la presentazione.</target>
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
+        <target>I nuovi contributi possono attendere l’approvazione prima di apparire. Puoi approvare, fissare in alto, archiviare o rimuovere le domande. Voti positivi e negativi e diverse modalità di ordinamento aiutano a stabilire le priorità; la nuvola di parole mette in evidenza i temi ricorrenti per la presentazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">189,194</context>
@@ -6394,8 +6394,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
-        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
-        <target>Nella raccolta dei quiz puoi modificare e riordinare le domande, controllare l’anteprima e importare o esportare quiz in formato JSON. Il link di sincronizzazione permette di condividere la raccolta o continuare su un altro dispositivo. I modelli di IA aiutano nella generazione e nella verifica senza inviare i contenuti ad arsnova.eu. All’avvio configuri, tra le altre cose, stile, classifica, suoni, squadre, nickname, timer e codici bonus.</target>
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen dich beim Erstellen und Prüfen von Quizzen, ohne dass Inhalte an arsnova.eu gesendet werden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes.</source>
+        <target>Nella raccolta dei quiz puoi modificare e riordinare le domande, controllare l’anteprima e importare o esportare quiz in formato JSON. Il link di sincronizzazione permette di condividere la raccolta o continuare su un altro dispositivo. I modelli di IA ti aiutano a creare e verificare i quiz senza inviare i contenuti ad arsnova.eu. All’avvio configuri, tra le altre cose, stile, classifica, suoni, squadre, nickname, timer e codici bonus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">221,228</context>
@@ -6427,7 +6427,7 @@
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
         <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
-        <target>Seleziona o inserisci una risposta, quindi inviala. Se l’autovalutazione è attiva, indica quanto sei sicuro su una scala da 1 a 5. Se è previsto un limite di tempo, un conto alla rovescia mostra il tempo rimanente. I risultati appaiono quando chi conduce li rende visibili.</target>
+        <target>Seleziona o inserisci una risposta, quindi inviala. Se l’autovalutazione del grado di sicurezza è attiva, indica quanto sei sicuro su una scala da 1 a 5. Se è previsto un limite di tempo, un conto alla rovescia mostra il tempo rimanente. I risultati appaiono quando chi conduce li rende visibili.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">275,280</context>
@@ -6458,11 +6458,11 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
-        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung.</source>
-        <target>Una sessione dal vivo può combinare quiz, Q&amp;A e sondaggio rapido. Segui la vista attiva e le indicazioni sul tuo dispositivo. Se un canale non è attivo, attendi che chi conduce apra l’attività successiva.</target>
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge den Hinweisen in der jeweils geöffneten Ansicht. Wenn ein Bereich gerade nicht aktiv ist, warte, bis die Veranstaltungsleitung die nächste Aktivität öffnet.</source>
+        <target>Una sessione dal vivo può combinare quiz, Q&amp;A e sondaggio rapido. Segui le indicazioni nella vista attualmente aperta. Se un canale non è attivo, attendi che chi conduce apra l’attività successiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,323</context>
+          <context context-type="linenumber">318,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6470,7 +6470,7 @@
         <target>Cosa succede in un secondo turno di votazione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
@@ -6478,7 +6478,7 @@
         <target>Nella Peer Instruction rispondi prima alla domanda in autonomia. Poi confrontati con altri partecipanti e vota una seconda volta. Invia la risposta anche nel secondo turno; può essere diversa dalla prima.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">337,342</context>
+          <context context-type="linenumber">336,341</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6486,15 +6486,15 @@
         <target>Come interpreto risultati, classifica e punteggi di squadra?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">349</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
         <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung.</source>
-        <target>Chi conduce decide quando rendere visibili i risultati. Classifica, punteggi di squadra e codici bonus compaiono solo se sono stati attivati per la sessione. L’autovalutazione non influisce sul punteggio né sulla posizione.</target>
+        <target>Chi conduce decide quando rendere visibili i risultati. Classifica, punteggi di squadra e codici bonus compaiono solo se sono stati attivati per la sessione. Il grado di sicurezza autovalutato non influisce sul punteggio né sulla posizione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">356,360</context>
+          <context context-type="linenumber">355,359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6502,7 +6502,7 @@
         <target>Per tutti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6510,23 +6510,23 @@
         <target>Come vengono gestiti dati e contenuti?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">375</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
         <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</source>
-        <target>Non serve un account. I quiz di chi conduce vengono memorizzati inizialmente nel browser; durante una sessione dal vivo vengono scambiati i dati necessari all’interazione. arsnova.eu è open source ed è progettato per un uso attento alla privacy in Europa. Per i dettagli consulta l’<x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Informativa sulla privacy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
+        <target>Non serve un account. I quiz di chi conduce vengono memorizzati inizialmente nel browser; durante una sessione dal vivo vengono scambiati i dati necessari all’interazione. arsnova.eu è open source ed è progettato per tutelare la privacy nel contesto europeo. Per i dettagli consulta l’<x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Informativa sulla privacy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,386</context>
+          <context context-type="linenumber">378,385</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
-        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
-        <target>Come uso arsnova.eu in modo accessibile e come app?</target>
+        <source>Welche Barrierefreiheitsfunktionen gibt es, und wie installiere ich arsnova.eu als App?</source>
+        <target>Quali opzioni di accessibilità sono disponibili e come posso installare arsnova.eu come app?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">393</context>
+          <context context-type="linenumber">392,393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -6195,7 +6195,7 @@
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
         <source> Wähle, in welcher Rolle du arsnova.eu nutzt. Hier findest du einen schnellen Einstieg und gezielte Hilfe zu einzelnen Funktionen.</source>
-        <target>Scegli il ruolo con cui usi arsnova.eu. Qui trovi un avvio rapido e un aiuto mirato per le singole funzioni.</target>
+        <target>Scegli il tuo ruolo su arsnova.eu. Qui trovi una guida rapida e indicazioni mirate sulle singole funzioni.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">41,44</context>
@@ -6238,7 +6238,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">241</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
@@ -6258,7 +6258,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244</context>
+          <context context-type="linenumber">245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
@@ -6271,7 +6271,7 @@
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesBody" datatype="html">
         <source> Mit einem Quiz stellst du vorbereitete Wissens- oder Meinungsfragen. Im Q&amp;A sammelst und priorisierst du Fragen aus dem Publikum. Das Blitzlicht eignet sich für spontane Stimmungs-, Verständnis- und Tempoabfragen. Du kannst alle drei Bereiche in einer Live-Session verbinden.</source>
-        <target>Usa un quiz per domande di conoscenza o di opinione preparate in anticipo. Con il canale Q&amp;A raccogli e ordini per priorità le domande del pubblico. Il sondaggio rapido è adatto a riscontri spontanei su clima, comprensione e ritmo. Puoi riunire tutte e tre le funzioni in un’unica sessione dal vivo.</target>
+        <target>Usa un quiz per domande di conoscenza o di opinione preparate in anticipo. Con il canale Q&amp;A raccogli e dai priorità alle domande del pubblico. Il sondaggio rapido è adatto a riscontri spontanei su clima, comprensione e ritmo. Puoi riunire tutte e tre le funzioni in un’unica sessione dal vivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">99,104</context>
@@ -6318,7 +6318,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">304,306</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
@@ -6362,11 +6362,11 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
+        <source> Neue Beiträge können zunächst zurückgehalten und erst nach deiner Freigabe veröffentlicht werden. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar.</source>
         <target>I nuovi contributi possono attendere l’approvazione prima di apparire. Puoi approvare, fissare in alto, archiviare o rimuovere le domande. Voti positivi e negativi e diverse modalità di ordinamento aiutano a stabilire le priorità; la nuvola di parole mette in evidenza i temi ricorrenti per la presentazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">189,194</context>
+          <context context-type="linenumber">189,195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
@@ -6374,7 +6374,7 @@
         <target>Usare il sondaggio rapido e il feedback sul ritmo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
@@ -6382,7 +6382,7 @@
         <target>Avvia un sondaggio rapido dalla sessione dal vivo oppure con «In diretta con un clic» nella pagina iniziale. Puoi metterlo in pausa, riprenderlo, azzerarlo o avviare un nuovo turno. Nel feedback sul ritmo, i partecipanti possono cambiare risposta in qualsiasi momento; tu vedi solo la tendenza aggregata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">205,210</context>
+          <context context-type="linenumber">206,211</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
@@ -6390,7 +6390,7 @@
         <target>Gestire quiz e impostazioni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">217</context>
+          <context context-type="linenumber">218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
@@ -6398,7 +6398,7 @@
         <target>Nella raccolta dei quiz puoi modificare e riordinare le domande, controllare l’anteprima e importare o esportare quiz in formato JSON. Il link di sincronizzazione permette di condividere la raccolta o continuare su un altro dispositivo. I modelli di IA ti aiutano a creare e verificare i quiz senza inviare i contenuti ad arsnova.eu. All’avvio configuri, tra le altre cose, stile, classifica, suoni, squadre, nickname, timer e codici bonus.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">221,228</context>
+          <context context-type="linenumber">222,229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
@@ -6406,7 +6406,7 @@
         <target>Come partecipo a una sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">249</context>
+          <context context-type="linenumber">250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
@@ -6414,7 +6414,7 @@
         <target>Scansiona il codice QR oppure apri arsnova.eu e inserisci il codice di sei caratteri. Non serve un account. In base alle impostazioni di chi conduce, puoi partecipare in forma anonima, con un nickname predefinito o con un nome scelto da te.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">256,261</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
@@ -6422,15 +6422,15 @@
         <target>Come rispondo a una domanda del quiz?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">268</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
         <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt.</source>
-        <target>Seleziona o inserisci una risposta, quindi inviala. Se l’autovalutazione del grado di sicurezza è attiva, indica quanto sei sicuro su una scala da 1 a 5. Se è previsto un limite di tempo, un conto alla rovescia mostra il tempo rimanente. I risultati appaiono quando chi conduce li rende visibili.</target>
+        <target>Seleziona o inserisci una risposta, quindi inviala. Se l’autovalutazione del grado di sicurezza è attiva, indica il tuo grado di sicurezza su una scala da 1 a 5. Se è previsto un limite di tempo, un conto alla rovescia mostra il tempo rimanente. I risultati appaiono quando chi conduce li rende visibili.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">275,280</context>
+          <context context-type="linenumber">276,281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
@@ -6438,15 +6438,15 @@
         <target>Come faccio una domanda o do un feedback?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">287</context>
+          <context context-type="linenumber">288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
-        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
-        <target>Nel canale Q&amp;A puoi inviare una domanda e votare positivamente o negativamente i contributi altrui. In base alla moderazione, la tua domanda potrebbe apparire solo dopo l’approvazione. Nel sondaggio rapido dai un riscontro spontaneo con un tocco. Puoi modificare il feedback sul ritmo finché il sondaggio è aperto.</target>
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen positiv oder negativ bewerten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern.</source>
+        <target>Nel canale Q&amp;A puoi inviare una domanda e assegnare un voto positivo o negativo ai contributi altrui. In base alla moderazione, la tua domanda potrebbe apparire solo dopo l’approvazione. Nel sondaggio rapido dai un riscontro spontaneo con un tocco. Puoi modificare il feedback sul ritmo finché il sondaggio è aperto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">294,299</context>
+          <context context-type="linenumber">295,300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
@@ -6454,7 +6454,7 @@
         <target>Come uso quiz, Q&amp;A e sondaggio rapido in una sola sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">311</context>
+          <context context-type="linenumber">312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
@@ -6462,7 +6462,7 @@
         <target>Una sessione dal vivo può combinare quiz, Q&amp;A e sondaggio rapido. Segui le indicazioni nella vista attualmente aperta. Se un canale non è attivo, attendi che chi conduce apra l’attività successiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,322</context>
+          <context context-type="linenumber">319,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
@@ -6470,7 +6470,7 @@
         <target>Cosa succede in un secondo turno di votazione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">329</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
@@ -6478,7 +6478,7 @@
         <target>Nella Peer Instruction rispondi prima alla domanda in autonomia. Poi confrontati con altri partecipanti e vota una seconda volta. Invia la risposta anche nel secondo turno; può essere diversa dalla prima.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">336,341</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
@@ -6486,7 +6486,7 @@
         <target>Come interpreto risultati, classifica e punteggi di squadra?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">348</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
@@ -6494,7 +6494,7 @@
         <target>Chi conduce decide quando rendere visibili i risultati. Classifica, punteggi di squadra e codici bonus compaiono solo se sono stati attivati per la sessione. Il grado di sicurezza autovalutato non influisce sul punteggio né sulla posizione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,359</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
@@ -6502,7 +6502,7 @@
         <target>Per tutti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">368</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
@@ -6510,7 +6510,7 @@
         <target>Come vengono gestiti dati e contenuti?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">374</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
@@ -6518,7 +6518,7 @@
         <target>Non serve un account. I quiz di chi conduce vengono memorizzati inizialmente nel browser; durante una sessione dal vivo vengono scambiati i dati necessari all’interazione. arsnova.eu è open source ed è progettato per tutelare la privacy nel contesto europeo. Per i dettagli consulta l’<x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Informativa sulla privacy<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378,385</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
@@ -6526,7 +6526,7 @@
         <target>Quali opzioni di accessibilità sono disponibili e come posso installare arsnova.eu come app?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">393,394</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
@@ -6536,7 +6536,7 @@
         <target>arsnova.eu si può usare con la tastiera, con uno screen reader e con lo zoom. Se necessario, utilizza le opzioni di contrasto e tema dell’app o del sistema operativo. Puoi anche installare arsnova.eu come Progressive Web App. Per maggiori informazioni consulta la <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>Dichiarazione di accessibilità<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">400,408</context>
+          <context context-type="linenumber">401,409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
@@ -6544,15 +6544,15 @@
         <target>Cosa posso fare se qualcosa non funziona?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415</context>
+          <context context-type="linenumber">416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
-        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
-        <target>Controlla innanzitutto il codice o il codice QR, la connessione Internet e che la sessione sia ancora attiva. Se non vedi ancora una domanda, la sessione potrebbe essere nella lobby, nella fase di lettura o in pausa. Dopo un’interruzione, riapri il link di partecipazione o inserisci di nuovo il codice. Rivolgiti a chi conduce se la sessione è già terminata.</target>
+        <source> Prüfe zuerst den Code oder QR-Code und deine Internetverbindung. Vergewissere dich außerdem, dass die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde.</source>
+        <target>Controlla innanzitutto il codice o il codice QR e la connessione Internet, quindi verifica che la sessione sia ancora attiva. Se non vedi ancora una domanda, la sessione potrebbe essere nella lobby, nella fase di lettura o in pausa. Dopo un’interruzione, riapri il link di partecipazione o inserisci di nuovo il codice. Rivolgiti a chi conduce se la sessione è già terminata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">422,429</context>
+          <context context-type="linenumber">423,430</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -5468,310 +5468,312 @@
         <source>Rollenwahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostTitle" datatype="html">
         <source>Ich leite eine Veranstaltung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">54</context>
+          <context context-type="linenumber">55</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleHostHint" datatype="html">
         <source>Für Lehrende, Vortragende, Trainer:innen und Moderator:innen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantTitle" datatype="html">
         <source>Ich nehme an einer Veranstaltung teil</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">71</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">224</context>
+          <context context-type="linenumber">241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
         <source>Für alle, die abstimmen, Fragen stellen oder Feedback geben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.newUserTitle" datatype="html">
         <source>Neu bei arsnova.eu</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">87</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">226</context>
+          <context context-type="linenumber">244</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
         <source>Was kann ich mit arsnova.eu machen?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">81</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesBody" datatype="html">
         <source> Mit einem Quiz stellst du vorbereitete Wissens- oder Meinungsfragen. Im Q&amp;A sammelst und priorisierst du Fragen aus dem Publikum. Das Blitzlicht eignet sich für spontane Stimmungs-, Verständnis- und Tempoabfragen. Du kannst alle drei Bereiche in einer Live-Session verbinden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">88,93</context>
+          <context context-type="linenumber">99,104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionTitle" datatype="html">
         <source>Wie starte ich meine erste Session?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFirstSessionBody" datatype="html">
         <source> Öffne die Quiz-Sammlung und nutze das Demo-Quiz oder erstelle ein eigenes Quiz. Wähle „Starten“, lege Stil und Optionen fest und teile anschließend den sechsstelligen Code oder QR-Code. In der Host-Ansicht zeigst du die nächste Frage, startest die Antwortphase und gibst das Ergebnis frei. Tipp: Teste die Vorschau vor dem ersten Einsatz einmal auf einem zweiten Gerät. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">107,113</context>
+          <context context-type="linenumber">118,124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishTitle" datatype="html">
         <source>Wie beende und werte ich eine Session aus?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFinishBody" datatype="html">
         <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">124,129</context>
+          <context context-type="linenumber">135,140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.experiencedUserTitle" datatype="html">
         <source> Schon vertraut mit arsnova.eu </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">134,136</context>
+          <context context-type="linenumber">145,147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">283,285</context>
+          <context context-type="linenumber">304,306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
         <source>Fragetypen und Selbsteinschätzung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">141</context>
+          <context context-type="linenumber">152</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsBody" datatype="html">
         <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">145,151</context>
+          <context context-type="linenumber">156,162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationTitle" datatype="html">
         <source>Live moderieren und Peer Instruction nutzen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">169</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
         <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,167</context>
+          <context context-type="linenumber">173,178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaTitle" datatype="html">
         <source>Die Q&amp;A-Fragenwand moderieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">174</context>
+          <context context-type="linenumber">185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
         <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">178,183</context>
+          <context context-type="linenumber">189,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
         <source>Blitzlicht und Tempo-Feedback einsetzen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
         <source> Starte ein Blitzlicht aus der Live-Session oder über „Live mit einem Klick“ auf der Startseite. Du kannst die Abstimmung pausieren, fortsetzen, zurücksetzen oder als neue Runde starten. Beim Tempo-Feedback ändern Teilnehmende ihre Rückmeldung jederzeit; du siehst nur die aggregierte Tendenz. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">194,199</context>
+          <context context-type="linenumber">205,210</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
         <source>Quiz-Sammlung und Einstellungen verwalten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">217</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
         <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">210,217</context>
+          <context context-type="linenumber">221,228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
         <source>Wie trete ich einer Session bei?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">231</context>
+          <context context-type="linenumber">249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
         <source> Scanne den QR-Code oder öffne arsnova.eu und gib den sechsstelligen Code ein. Du brauchst kein Konto. Je nach Einstellung der Veranstaltungsleitung nimmst du anonym, mit einem vorgegebenen Nickname oder mit einem selbst gewählten Namen teil. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">235,240</context>
+          <context context-type="linenumber">256,261</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
         <source>Wie beantworte ich eine Quizfrage?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">247</context>
+          <context context-type="linenumber">268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
         <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">254,259</context>
+          <context context-type="linenumber">275,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
         <source>Wie stelle ich eine Frage oder gebe Feedback?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">266</context>
+          <context context-type="linenumber">287</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
         <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">273,278</context>
+          <context context-type="linenumber">294,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
         <source>Wie nutze ich Quiz, Q&amp;A und Blitzlicht in einer Session?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">290</context>
+          <context context-type="linenumber">311</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
         <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">297,302</context>
+          <context context-type="linenumber">318,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
         <source>Was passiert bei einer zweiten Abstimmungsrunde?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">309</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
         <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">316,321</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
         <source>Wie sind Ergebnisse, Rangliste und Teamwertung zu verstehen?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">328</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
         <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">335,339</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
         <source>Für alle</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
         <source>Wie werden Daten und Inhalte behandelt?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">351</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
         <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,362</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
         <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
-        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;
+                    &gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a
+                  &gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">376,382</context>
+          <context context-type="linenumber">400,408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
         <source>Was kann ich bei technischen Problemen tun?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389</context>
+          <context context-type="linenumber">415</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
         <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">396,403</context>
+          <context context-type="linenumber">422,429</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -5458,7 +5458,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen. </source>
+        <source> Wähle, in welcher Rolle du arsnova.eu nutzt. Hier findest du einen schnellen Einstieg und gezielte Hilfe zu einzelnen Funktionen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">41,44</context>
@@ -5593,7 +5593,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostModerationBody" datatype="html">
-        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar. </source>
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-Nachher-Vergleich macht Veränderungen sichtbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">173,178</context>
@@ -5607,7 +5607,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation. </source>
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">189,194</context>
@@ -5635,7 +5635,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
-        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes. </source>
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen dich beim Erstellen und Prüfen von Quizzen, ohne dass Inhalte an arsnova.eu gesendet werden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">221,228</context>
@@ -5691,66 +5691,66 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
-        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung. </source>
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge den Hinweisen in der jeweils geöffneten Ansicht. Wenn ein Bereich gerade nicht aktiv ist, warte, bis die Veranstaltungsleitung die nächste Aktivität öffnet. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,323</context>
+          <context context-type="linenumber">318,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
         <source>Was passiert bei einer zweiten Abstimmungsrunde?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
         <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">337,342</context>
+          <context context-type="linenumber">336,341</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
         <source>Wie sind Ergebnisse, Rangliste und Teamwertung zu verstehen?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">349</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
         <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">356,360</context>
+          <context context-type="linenumber">355,359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
         <source>Für alle</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">369</context>
+          <context context-type="linenumber">368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
         <source>Wie werden Daten und Inhalte behandelt?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">375</context>
+          <context context-type="linenumber">374</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
         <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,386</context>
+          <context context-type="linenumber">378,385</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
-        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
+        <source>Welche Barrierefreiheitsfunktionen gibt es, und wie installiere ich arsnova.eu als App?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">393</context>
+          <context context-type="linenumber">392,393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -5497,7 +5497,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">241</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.roleParticipantHint" datatype="html">
@@ -5515,7 +5515,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244</context>
+          <context context-type="linenumber">245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
@@ -5568,7 +5568,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">304,306</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostFormatsTitle" datatype="html">
@@ -5607,150 +5607,150 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostQaBody" datatype="html">
-        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar. </source>
+        <source> Neue Beiträge können zunächst zurückgehalten und erst nach deiner Freigabe veröffentlicht werden. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Positive und negative Bewertungen sowie verschiedene Sortierungen helfen dir bei der Priorisierung; die Wortwolke macht wiederkehrende Themen für die Präsentation sichtbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">189,194</context>
+          <context context-type="linenumber">189,195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseTitle" datatype="html">
         <source>Blitzlicht und Tempo-Feedback einsetzen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">201</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPulseBody" datatype="html">
         <source> Starte ein Blitzlicht aus der Live-Session oder über „Live mit einem Klick“ auf der Startseite. Du kannst die Abstimmung pausieren, fortsetzen, zurücksetzen oder als neue Runde starten. Beim Tempo-Feedback ändern Teilnehmende ihre Rückmeldung jederzeit; du siehst nur die aggregierte Tendenz. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">205,210</context>
+          <context context-type="linenumber">206,211</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryTitle" datatype="html">
         <source>Quiz-Sammlung und Einstellungen verwalten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">217</context>
+          <context context-type="linenumber">218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLibraryBody" datatype="html">
         <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen dich beim Erstellen und Prüfen von Quizzen, ohne dass Inhalte an arsnova.eu gesendet werden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">221,228</context>
+          <context context-type="linenumber">222,229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinTitle" datatype="html">
         <source>Wie trete ich einer Session bei?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">249</context>
+          <context context-type="linenumber">250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantJoinBody" datatype="html">
         <source> Scanne den QR-Code oder öffne arsnova.eu und gib den sechsstelligen Code ein. Du brauchst kein Konto. Je nach Einstellung der Veranstaltungsleitung nimmst du anonym, mit einem vorgegebenen Nickname oder mit einem selbst gewählten Namen teil. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">256,261</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerTitle" datatype="html">
         <source>Wie beantworte ich eine Quizfrage?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">268</context>
+          <context context-type="linenumber">269</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantAnswerBody" datatype="html">
         <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">275,280</context>
+          <context context-type="linenumber">276,281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeTitle" datatype="html">
         <source>Wie stelle ich eine Frage oder gebe Feedback?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">287</context>
+          <context context-type="linenumber">288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantContributeBody" datatype="html">
-        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern. </source>
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen positiv oder negativ bewerten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">294,299</context>
+          <context context-type="linenumber">295,300</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsTitle" datatype="html">
         <source>Wie nutze ich Quiz, Q&amp;A und Blitzlicht in einer Session?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">311</context>
+          <context context-type="linenumber">312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantChannelsBody" datatype="html">
         <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge den Hinweisen in der jeweils geöffneten Ansicht. Wenn ein Bereich gerade nicht aktiv ist, warte, bis die Veranstaltungsleitung die nächste Aktivität öffnet. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">318,322</context>
+          <context context-type="linenumber">319,323</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundTitle" datatype="html">
         <source>Was passiert bei einer zweiten Abstimmungsrunde?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">329</context>
+          <context context-type="linenumber">330</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantSecondRoundBody" datatype="html">
         <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">336,341</context>
+          <context context-type="linenumber">337,342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsTitle" datatype="html">
         <source>Wie sind Ergebnisse, Rangliste und Teamwertung zu verstehen?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">348</context>
+          <context context-type="linenumber">349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantResultsBody" datatype="html">
         <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,359</context>
+          <context context-type="linenumber">356,360</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTitle" datatype="html">
         <source>Für alle</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">368</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyTitle" datatype="html">
         <source>Wie werden Daten und Inhalte behandelt?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">374</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonPrivacyBody" datatype="html">
         <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378,385</context>
+          <context context-type="linenumber">379,386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityTitle" datatype="html">
         <source>Welche Barrierefreiheitsfunktionen gibt es, und wie installiere ich arsnova.eu als App?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">393,394</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonAccessibilityBody" datatype="html">
@@ -5759,21 +5759,21 @@
                   &gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">400,408</context>
+          <context context-type="linenumber">401,409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
         <source>Was kann ich bei technischen Problemen tun?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415</context>
+          <context context-type="linenumber">416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.commonTroubleshootingBody" datatype="html">
-        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde. </source>
+        <source> Prüfe zuerst den Code oder QR-Code und deine Internetverbindung. Vergewissere dich außerdem, dass die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">422,429</context>
+          <context context-type="linenumber">423,430</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -316,14 +316,14 @@
         </context-group>
       </trans-unit>
       <trans-unit id="seo.titleHelp" datatype="html">
-        <source>So funktioniert’s – arsnova.eu</source>
+        <source>Hilfe &amp; Einstieg – arsnova.eu</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="seo.descHelp" datatype="html">
-        <source>Kurz erklärt: Live-Sessions, Quiz-Frageformate, Selbsteinschätzung, Blitzlicht, Q&amp;A und Moderationsabläufe auf arsnova.eu.</source>
+        <source>Hilfe für Veranstaltungsleitungen und Teilnehmende: Session starten, abstimmen, Q&amp;A und Blitzlicht nutzen, Ergebnisse auswerten und Funktionen nachschlagen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/seo-route-meta.ts</context>
           <context context-type="linenumber">120</context>
@@ -5451,731 +5451,327 @@
         </context-group>
       </trans-unit>
       <trans-unit id="help.pageTitle" datatype="html">
-        <source> So funktioniert’s </source>
+        <source> Hilfe &amp; Einstieg </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">36,38</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.intro" datatype="html">
-        <source> Diese Seite richtet sich an <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lehrende, Trainer:innen und Vortragende<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>, die aus einer Präsentation eine echte Live-Situation machen wollen: kurze Checks, Diskussionen, Q&amp;A, Blitzlicht und Auswertung laufen in einer Session zusammen. <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Ohne Pflichtkonto<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> für deine Gruppe: Code oder QR zeigen, Smartphones raus, loslegen. </source>
+        <source> Wähle, wie du arsnova.eu nutzt. Du erhältst einen kurzen Einstieg oder kannst gezielt Funktionen nachschlagen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">41,47</context>
+          <context context-type="linenumber">41,44</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.uspTitle" datatype="html">
-        <source>Was arsnova.eu anders macht</source>
+      <trans-unit id="help.roleNavAria" datatype="html">
+        <source>Rollenwahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.usp1" datatype="html">
-        <source> arsnova.eu ist als <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Live-Regie für Unterricht, Training und Talks<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> gedacht: Du wechselst nicht zwischen Präsentation, Chat, Umfragetool und Quiz-App, sondern steuerst Interaktion, Beamer-Ansicht und Ergebnisfreigabe an einem Ort. </source>
+      <trans-unit id="help.roleHostTitle" datatype="html">
+        <source>Ich leite eine Veranstaltung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">51,55</context>
+          <context context-type="linenumber">54</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.usp2" datatype="html">
-        <source> Der Fokus liegt auf <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>didaktischer Kontrolle und Datenschutz<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>: Inhalte bleiben zunächst local-first im Browser, Teilnehmende brauchen kein Konto, das Projekt ist Open Source und für EU-orientierten Betrieb ausgelegt. Markdown und KaTeX machen fachliche Fragen präsentationstauglich, von MINT-Formeln bis zum kurzen Fallbeispiel. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">56,61</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsTitle" datatype="html">
-        <source> Frageformate: passend zum didaktischen Ziel </source>
+      <trans-unit id="help.roleHostHint" datatype="html">
+        <source>Für Lehrende, Vortragende, Trainer:innen und Moderator:innen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsLead" datatype="html">
-        <source> Wähle das Format nach der Situation im Raum: Willst du Wissen prüfen, Haltungen sichtbar machen, Begriffe einsammeln oder Schätzungen diskutieren? Die Formate sind bewusst getrennt, damit Ergebnisanzeige, Bewertung und Moderation zum Einsatzzweck passen. </source>
+      <trans-unit id="help.roleParticipantTitle" datatype="html">
+        <source>Ich nehme an einer Veranstaltung teil</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">224</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.formatsGridAria" datatype="html">
-        <source>Verfügbare Quiz-Frageformate</source>
+      <trans-unit id="help.roleParticipantHint" datatype="html">
+        <source>Für alle, die abstimmen, Fragen stellen oder Feedback geben</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.newUserTitle" datatype="html">
+        <source>Neu bei arsnova.eu</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
           <context context-type="linenumber">76</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
-        <source>Single Choice</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceTag" datatype="html">
-        <source> eine richtige Option </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSingleChoiceBody" datatype="html">
-        <source> Für punktgenaue Verständnischecks: Eine Antwort ist korrekt, Ergebnis und Punkte sind sofort klar. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
-        <source>Multiple Choice</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
-        <source> mehrere richtige Optionen </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
-        <source> Für komplexere Konzepte, typische Fehlannahmen oder Fragen wie „Welche Aussagen stimmen?“ – mehrere Lösungen können zählen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTitle" datatype="html">
-        <source>Kurzantwort</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextTag" datatype="html">
-        <source> Musterlösung statt Auswahl </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatShortTextBody" datatype="html">
-        <source> Teilnehmende formulieren kurz selbst. Du hinterlegst Musterlösungen; arsnova.eu kann Schreibvarianten, Toleranz und bei Bedarf Zahlen oder Einheiten auswerten. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTitle" datatype="html">
-        <source>Freitext</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextTag" datatype="html">
-        <source> offene Antworten </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatFreeTextBody" datatype="html">
-        <source> Für Ideen, Reflexionen und Erwartungsabfragen. Keine automatische Bewertung; Antworten lassen sich sammeln und als Wortwolke sichtbar machen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTitle" datatype="html">
-        <source>Umfrage</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyTag" datatype="html">
-        <source> Meinungsbild ohne richtig/falsch </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatSurveyBody" datatype="html">
-        <source> Für Prioritäten, Vorwissen oder Entscheidungen im Raum. Optionen werden gezählt, ohne Scorelogik. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTitle" datatype="html">
-        <source>Bewertungsskala</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingTag" datatype="html">
-        <source> Skala mit eigenen Polen </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatRatingBody" datatype="html">
-        <source> Für Zustimmung, Sicherheit, Tempo oder Feedback von niedrig bis hoch; optional mit benannten Endpunkten. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
-        <source>Numerische Schätzfrage</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateTag" datatype="html">
-        <source> Zahlen schätzen, Streuung sehen </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatNumericEstimateBody" datatype="html">
-        <source> Für Jahreszahlen, Größenordnungen, Messwerte und Wahrscheinlichkeiten. Mit Referenzwert, Toleranzband, Histogramm, Statistik und optionaler zweiter Runde. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.formatsBlitzNote" datatype="html">
-        <source> Blitzlicht ist davon getrennt: Es ist für spontane Live-Rückmeldungen gedacht, wenn du keine vollständige Quizfrage bauen willst. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceTitle" datatype="html">
-        <source> Selbsteinschätzung bei bewertbaren Fragen </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceLead" datatype="html">
-        <source> Die Selbsteinschätzung ist kein eigener Fragetyp, sondern eine optionale Zusatzabfrage nach Single Choice, Multiple Choice, Kurzantwort und numerischer Schätzfrage: Teilnehmende geben an, wie sicher sie bei ihrer Antwort sind (Skala 1–5). Das beeinflusst keine Punkte – hilft dir aber, Lernstand und Fehlkonzepte zu erkennen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceListAria" datatype="html">
-        <source>Didaktische Funktionen der Selbsteinschätzung</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
-        <source>Nach der Antwort abfragen</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
-        <source> Progressive Disclosure: Erst Antwort wählen oder eingeben, dann die Selbsteinschätzung. Während der Abstimmung sieht niemand aggregierte Werte anderer Personen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorTitle" datatype="html">
-        <source>Im Editor konfigurieren</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceEditorBody" datatype="html">
-        <source> Toggle pro Frage, optionale Labels für niedrige und hohe Antwortsicherheit und eine Live-Vorschau der Skala. Für neue bewertbare Fragen ist die Selbsteinschätzung standardmäßig aktiv. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.confidenceHostTitle" datatype="html">
-        <source>Host-Auswertung nach Freigabe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">226</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceHostBody" datatype="html">
-        <source> Matrix aus Korrektheit und Antwortsicherheit mit Hervorhebung <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>selbstsicher falsch<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Bei Auswahlfragen siehst du, welche falschen Optionen mit hoher Antwortsicherheit gewählt wurden. </source>
+      <trans-unit id="help.hostCapabilitiesTitle" datatype="html">
+        <source>Was kann ich mit arsnova.eu machen?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportTitle" datatype="html">
-        <source>Abschluss und Export</source>
+      <trans-unit id="help.hostCapabilitiesBody" datatype="html">
+        <source> Mit einem Quiz stellst du vorbereitete Wissens- oder Meinungsfragen. Im Q&amp;A sammelst und priorisierst du Fragen aus dem Publikum. Das Blitzlicht eignet sich für spontane Stimmungs-, Verständnis- und Tempoabfragen. Du kannst alle drei Bereiche in einer Live-Session verbinden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">88,93</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.confidenceExportBody" datatype="html">
-        <source> Nach Session-Ende fasst die Auswertung gefestigtes Wissen, Fehlkonzept-Hinweis und fragiles Wissen zusammen. Fragen mit weniger als 5 Antworten mit Selbsteinschätzung werden nicht aggregiert ausgewiesen. Der Nachbesprechungsplan (PDF) ist das empfohlene Format; CSV steht unter „Mehr“ für Excel zur Verfügung. In der Quiz-Sammlung findest du den Nachbesprechungsplan auf der Quizkarte. </source>
+      <trans-unit id="help.hostFirstSessionTitle" datatype="html">
+        <source>Wie starte ich meine erste Session?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTitle" datatype="html">
-        <source>Demo-Quiz</source>
+      <trans-unit id="help.hostFirstSessionBody" datatype="html">
+        <source> Öffne die Quiz-Sammlung und nutze das Demo-Quiz oder erstelle ein eigenes Quiz. Wähle „Starten“, lege Stil und Optionen fest und teile anschließend den sechsstelligen Code oder QR-Code. In der Host-Ansicht zeigst du die nächste Frage, startest die Antwortphase und gibst das Ergebnis frei. Tipp: Teste die Vorschau vor dem ersten Einsatz einmal auf einem zweiten Gerät. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">107,113</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoCardHint" datatype="html">
-        <source> Ein vorinstalliertes Beispiel-Quiz zeigt die Frageformate in konkreten Unterrichtsmomenten: Wissenscheck, Wortwolke, Kurzantwort, Schätzfrage, Bewertungsskala, Selbsteinschätzung, Formeln und Markdown. Du findest es in deiner Quiz-Sammlung und kannst es dort in der Vorschau öffnen. </source>
+      <trans-unit id="help.hostFinishTitle" datatype="html">
+        <source>Wie beende und werte ich eine Session aus?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoTip" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tipp:&lt;/stro"/>Tipp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Öffne die Vorschau vor der ersten Live-Session einmal auf einem zweiten Gerät. So siehst du sofort, wie Host-Ansicht und Teilnehmenden-Screen zusammenspielen. </source>
+      <trans-unit id="help.hostFinishBody" datatype="html">
+        <source> Beende die Session in der Host-Ansicht. Danach stehen die zusammengefassten Ergebnisse zur Verfügung. Nutze den Nachbesprechungsplan als PDF für die didaktische Auswertung; den CSV-Export findest du unter „Mehr“. Der Nachbesprechungsplan bleibt über die Quizkarte erreichbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">124,129</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickstartTitle" datatype="html">
-        <source>Schnellstart</source>
+      <trans-unit id="help.experiencedUserTitle" datatype="html">
+        <source> Schon vertraut mit arsnova.eu </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">134,136</context>
         </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart1" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Quiz anlegen:&lt;/"/>Quiz anlegen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> „Quiz-Sammlung öffnen&quot; wählen, neues Quiz erstellen und pro Frage das passende Format wählen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart2" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Veranstaltung s"/>Veranstaltung starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Stil, Timer, Teams und Rangliste festlegen. Danach entsteht ein 6-stelliger Code, den du als Text oder QR-Code teilst. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickstart3" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Live moderieren"/>Live moderieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage zeigen, Antwortphase starten, Ergebnisse freigeben oder zurückhalten und bei Bedarf eine zweite Runde anschließen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostTitle" datatype="html">
-        <source>Veranstaltung leiten</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLead" datatype="html">
-        <source> In der Host-Ansicht führst du durch die Session wie durch eine kleine Senderegie: Teilnehmende reinholen, Inhalte freigeben, Diskussion öffnen und Ergebnisse sichtbar machen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostStartStep" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Session starten:&lt;"/>Session starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> In deiner Quiz-Sammlung eine Veranstaltung starten und festlegen, ob sie mit Quiz oder Q&amp;A beginnt. Dann entsteht der Beitrittscode. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostLobby" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Lobby:&lt;/stron"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Du siehst, wer beigetreten ist; ein QR-Code zum Beitritt wird angezeigt. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostBeamer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beamer- und Pr"/>Beamer- und Presenter-Ansicht:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage, Antworten, Countdown und Ergebnisse erscheinen groß genug für Projektion, Stream oder zweiten Bildschirm. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSteuerung" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Steuerung:&lt;/stron"/>Steuerung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Nutze „Nächste Frage“, um den Inhalt einzublenden. Optional läuft zuerst eine Lesephase, danach startest du die Antwortphase und entscheidest, wann das Ergebnis auf den Screen kommt. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instruc"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Bei geeigneten Quizfragen, Schätzfragen und Blitzlicht-Runden: erst abstimmen lassen, Diskussion starten, dann erneut abstimmen. Der Vorher/Nachher-Vergleich macht Lernfortschritt sichtbar. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.hostSettings" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Einstellungen:&lt;/"/>Einstellungen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beim Start legst du Stil und Optionen fest: seriös oder spielerisch, mit oder ohne Rangliste, Sound, Lesephase, Team-Modus, Nicknamen und Timer. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallTitle" datatype="html">
-        <source> Fragenwand im Live-Kanal Q&amp;A </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLead" datatype="html">
-        <source> Q&amp;A soll nicht als Nebenchat verschwinden. Die Fragenwand macht Rückfragen sichtbar, priorisierbar und moderierbar: Du hältst den roten Faden, während die Gruppe gemeinsam zeigt, welche Punkte wirklich Klärung brauchen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallListAria" datatype="html">
-        <source>Didaktische Funktionen der Q&amp;A-Fragenwand</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationTitle" datatype="html">
-        <source>Moderation mit pädagogischem Takt</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallModerationBody" datatype="html">
-        <source> Auf Wunsch warten neue Fragen erst auf deine Freigabe. Du kannst Beiträge freigeben, anheften, archivieren oder entfernen und damit Schutzraum, Relevanz und Timing steuern: sofort beantworten, für später sammeln oder als Diskussionsspur markieren. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingTitle" datatype="html">
-        <source>Kollektives Hoch- und Runtervoting</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallVotingBody" datatype="html">
-        <source> Teilnehmende gewichten Fragen gemeinsam. Positive und negative Stimmen zeigen nicht nur Popularität, sondern auch Unsicherheit, Widerspruch und Klärungsbedarf; Sortierungen wie „meist unterstützt“, „beste Fragen“ und „umstritten“ helfen dir, knappe Live-Zeit didaktisch zu setzen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
-        <source>Q&amp;A-Wortwolke auf Themenebene</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallWordCloudBody" datatype="html">
-        <source> Die Word-Cloud verdichtet sichtbare Fragen zu Wörtern und Phrasen, gewichtet nach Unterstützung, belastbarer Zustimmung oder Kontroverse. Sie lässt sich einfrieren, nach Sortierlogik betrachten und in der Presenter-Ansicht zeigen – als schneller Blick auf Themencluster, nicht als dekorative Wortliste. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmTitle" datatype="html">
-        <source>Nächster Schritt: Moderationskompass</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qaWallLlmBody" datatype="html">
-        <source> Geplant ist zuerst ein deterministischer Moderationskompass. Optional können später asynchrone Q&amp;A-NLP-Signale und quellengebundene Zusammenfassungen dazukommen – als datenschutzbewusste Moderationshilfe statt Blackbox-Bewertung. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.blitzTitle" datatype="html">
-        <source>Blitzlicht</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackIntro" datatype="html">
-        <source> Schnelle Stimmungs- und Wissensabfragen – z. B. vor der Pause, zum Einstieg oder für spontane Checks. Nutzbar im Host-Bereich deiner Live-Session oder direkt von der Startseite. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfMood" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stimmungsb"/>Stimmungsbild<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): Wie geht es den Teilnehmenden? </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.qfYesNoMaybe" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein / Viel"/>Ja / Nein / Vielleicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Schnelle Zustimmungsabfrage. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackYesNo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein&lt;/strong&gt; (👍"/>Ja / Nein<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): Klare Zwei-Optionen-Abfrage ohne Mittelweg. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Wahr / Falsch / Weiß nicht&lt;/stron"/>Wahr / Falsch / Weiß nicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): Für schnelle Einschätzungen oder Wissenschecks. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Mehrstufige Schnellabfragen&lt;/s"/>Mehrstufige Schnellabfragen<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D): Drei oder vier feste Optionen für spontane Abstimmungen – ohne eine vollständige Quizfrage zu bauen. </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="help.quickFeedbackTempo" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tempo-Feedback&lt;/strong"/>Tempo-Feedback<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): Mit vier Icons meldet deine Gruppe laufend zurück, ob sie folgen kann. Teilnehmende können ihre Rückmeldung ändern; du siehst nur die aggregierte Tendenz. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">283,285</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
-        <source> Du startest die Runde im Host-Bereich deiner Live-Session oder über die Blitzlicht-Karte „Live mit einem Klick&quot; auf der Startseite. Teilnehmende tippen eine Antwort; du siehst die Ergebnisse live als Balkendiagramm. </source>
+      <trans-unit id="help.hostFormatsTitle" datatype="html">
+        <source>Fragetypen und Selbsteinschätzung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">141</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfPeer" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instr"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Erste Runde – Ergebnis nicht auflösen – „Diskussionsphase&quot; starten („Diskutiert mit eurem Nachbarn&quot;) – „Zweite Abstimmung&quot;. Vorher/Nachher-Vergleich zeigt, wie sich das Stimmungsbild durch den Austausch verändert hat. </source>
+      <trans-unit id="help.hostFormatsBody" datatype="html">
+        <source> Zur Verfügung stehen Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage. Bei bewertbaren Fragen kann anschließend eine Selbsteinschätzung auf einer Skala von 1 bis 5 folgen. Sie verändert die Punktzahl nicht, macht aber gefestigtes Wissen, fragiles Wissen und mögliche Fehlkonzepte sichtbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">145,151</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfStop" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stopp:&lt;/st"/>Stopp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Abstimmung einfrieren – Teilnehmende sehen „Abstimmung ist pausiert&quot; und können nicht mehr abstimmen, bis du „Fortsetzen&quot; wählst. </source>
+      <trans-unit id="help.hostModerationTitle" datatype="html">
+        <source>Live moderieren und Peer Instruction nutzen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfReset" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Zurücksetze"/>Zurücksetzen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Alle Stimmen löschen und erneut abstimmen lassen. </source>
+      <trans-unit id="help.hostModerationBody" datatype="html">
+        <source> Nutze je nach Situation Lesephase, Timer, Beamer- oder Presenter-Ansicht und eine verzögerte Ergebnisfreigabe. Für Peer Instruction lässt du zuerst abstimmen, startest eine Diskussionsphase und öffnest anschließend eine zweite Abstimmung. Der Vorher-nachher-Vergleich macht Veränderungen sichtbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">162,167</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfNewRound" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Neue Runde:&lt;/s"/>Neue Runde:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Neuen Code erzeugen und eine frische Runde starten. </source>
+      <trans-unit id="help.hostQaTitle" datatype="html">
+        <source>Die Q&amp;A-Fragenwand moderieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.qfCopyLink" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Link kopieren:"/>Link kopieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beitrittslink in die Zwischenablage kopieren, z. B. zum Teilen per Chat. </source>
+      <trans-unit id="help.hostQaBody" datatype="html">
+        <source> Neue Beiträge können vor der Veröffentlichung auf Freigabe warten. Du kannst Fragen freigeben, anheften, archivieren oder entfernen. Hoch- und Runtervotes sowie verschiedene Sortierungen helfen bei der Priorisierung; die Wortwolke verdichtet sichtbare Themen für die Präsentation. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">178,183</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsTitle" datatype="html">
-        <source>Für deine Teilnehmenden</source>
+      <trans-unit id="help.hostPulseTitle" datatype="html">
+        <source>Blitzlicht und Tempo-Feedback einsetzen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">190</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsLead" datatype="html">
-        <source> Kurz erklärt, was du in deiner Veranstaltung weitergeben kannst: </source>
+      <trans-unit id="help.hostPulseBody" datatype="html">
+        <source> Starte ein Blitzlicht aus der Live-Session oder über „Live mit einem Klick“ auf der Startseite. Du kannst die Abstimmung pausieren, fortsetzen, zurücksetzen oder als neue Runde starten. Beim Tempo-Feedback ändern Teilnehmende ihre Rückmeldung jederzeit; du siehst nur die aggregierte Tendenz. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">194,199</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsJoin" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beitreten:&lt;/strong&gt;"/>Beitreten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> 6-stelligen Code auf arsnova.eu eingeben und „Los geht&apos;s&quot; – funktioniert für Quiz, Q&amp;A und Blitzlicht. Keine Anmeldung nötig. </source>
+      <trans-unit id="help.hostLibraryTitle" datatype="html">
+        <source>Quiz-Sammlung und Einstellungen verwalten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">206</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsNick" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Nicknamen:&lt;/strong&gt;"/>Nicknamen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Je nach deiner Einstellung vorgegebene Namen, eigener Name oder anonym. </source>
+      <trans-unit id="help.hostLibraryBody" datatype="html">
+        <source> In der Quiz-Sammlung bearbeitest und sortierst du Fragen, prüfst die Vorschau und importierst oder exportierst Quizze als JSON. Über den Sync-Link kannst du die Sammlung teilen oder auf einem anderen Gerät fortsetzen. KI-Vorlagen unterstützen Erzeugung und Prüfung, ohne Inhalte an arsnova.eu zu senden. Beim Session-Start konfigurierst du unter anderem Stil, Rangliste, Sound, Teams, Nicknamen, Timer und Bonus-Codes. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">210,217</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.participantsVote" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Abstimmung:&lt;/strong&gt;"/>Abstimmung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage erscheint auf dem Gerät, Antwort wählen und absenden. Bei aktivierter Selbsteinschätzung folgt danach die Skala 1–5. Bei Zeitlimit läuft ein Countdown. </source>
+      <trans-unit id="help.participantJoinTitle" datatype="html">
+        <source>Wie trete ich einer Session bei?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTitle" datatype="html">
-        <source>Deine Quiz-Sammlung</source>
+      <trans-unit id="help.participantJoinBody" datatype="html">
+        <source> Scanne den QR-Code oder öffne arsnova.eu und gib den sechsstelligen Code ein. Du brauchst kein Konto. Je nach Einstellung der Veranstaltungsleitung nimmst du anonym, mit einem vorgegebenen Nickname oder mit einem selbst gewählten Namen teil. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">235,240</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionLead" datatype="html">
-        <source>Hier legst du deine Quizze an und bereitest sie vor.</source>
+      <trans-unit id="help.participantAnswerTitle" datatype="html">
+        <source>Wie beantworte ich eine Quizfrage?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">247</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionEditor" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Editor:&lt;/strong&gt; Fra"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Fragen per Drag-and-Drop sortieren, auf- und zuklappen, Vorschau prüfen. </source>
+      <trans-unit id="help.participantAnswerBody" datatype="html">
+        <source> Wähle eine Antwort oder gib sie ein und sende sie ab. Ist die Selbsteinschätzung aktiviert, bewertest du anschließend auf einer Skala von 1 bis 5, wie sicher du dir bist. Bei einem Zeitlimit zeigt dir ein Countdown die verbleibende Zeit. Das Ergebnis erscheint, sobald die Veranstaltungsleitung es freigibt. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">254,259</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionTypes" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Fragetypen:&lt;/strong"/>Fragetypen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage – pro Frage optional mit Timer, Schwierigkeitsgrad und Selbsteinschätzung. </source>
+      <trans-unit id="help.participantContributeTitle" datatype="html">
+        <source>Wie stelle ich eine Frage oder gebe Feedback?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">266</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionImport" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Import / Export:&lt;/st"/>Import / Export:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Quiz als JSON importieren oder exportieren. Mit der Start- und Prüfvorlage kannst du anspruchsvolle Quizze mit deinem bevorzugten KI-Tool generieren, prüfen und direkt importieren – deine Inhalte und Präsentationen werden nicht an arsnova.eu gesendet; du nutzt dein eigenes KI-Tool. </source>
+      <trans-unit id="help.participantContributeBody" datatype="html">
+        <source> Im Q&amp;A kannst du eine eigene Frage senden und Beiträge anderer Personen hoch- oder runtervoten. Je nach Moderation erscheint deine Frage erst nach der Freigabe. Im Blitzlicht gibst du mit einem Tippen eine spontane Rückmeldung. Dein Tempo-Feedback kannst du während der laufenden Abfrage ändern. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">273,278</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.collectionSync" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Sync:&lt;/strong&gt; Mit"/>Sync:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit dem Sync-Link deine Quiz-Sammlung mit Kolleg:innen teilen oder auf anderen Geräten weiterarbeiten. Wer den Link hat, kann die Sammlung öffnen. Die Geräteangaben helfen nur bei der Orientierung. </source>
+      <trans-unit id="help.participantChannelsTitle" datatype="html">
+        <source>Wie nutze ich Quiz, Q&amp;A und Blitzlicht in einer Session?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">290</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.demoQuizHint" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Demo-Quiz:&lt;/stro"/>Demo-Quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ein vorinstalliertes Quiz zeigt alle Formate mit Beispielen inkl. KaTeX-Formeln und Markdown. In der Quiz-Sammlung in der Vorschau öffnen. </source>
+      <trans-unit id="help.participantChannelsBody" datatype="html">
+        <source> Eine Live-Session kann Quiz, Q&amp;A und Blitzlicht miteinander verbinden. Folge der jeweils geöffneten Ansicht und den Hinweisen auf deinem Gerät. Wenn ein Bereich gerade nicht aktiv ist, warte auf die nächste Freigabe durch die Veranstaltungsleitung. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">297,302</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesTitle" datatype="html">
-        <source>Seriös und Spielerisch</source>
+      <trans-unit id="help.participantSecondRoundTitle" datatype="html">
+        <source>Was passiert bei einer zweiten Abstimmungsrunde?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">309</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesLead" datatype="html">
-        <source> Zwei Stile für unterschiedliche Situationen – wählbar auf der Startseite und beim Session-Start. </source>
+      <trans-unit id="help.participantSecondRoundBody" datatype="html">
+        <source> Bei Peer Instruction beantwortest du die Frage zunächst allein. Anschließend diskutierst du mit anderen Teilnehmenden und stimmst ein zweites Mal ab. Sende deine Antwort auch in der zweiten Runde erneut ab; sie darf sich von deiner ersten Antwort unterscheiden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">316,321</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.styleSerious" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Seriös:&lt;/strong&gt;"/>Seriös:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonym, ohne Rangliste – ideal für formative Assessments, Prüfungsvorbereitung und sensible Themen. </source>
+      <trans-unit id="help.participantResultsTitle" datatype="html">
+        <source>Wie sind Ergebnisse, Rangliste und Teamwertung zu verstehen?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylePlayful" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Spielerisch:&lt;/st"/>Spielerisch:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit Rangliste, Sounds und Anfeuerung – ideal für Auflockerung, Wettbewerbe und motivierende Quizze. </source>
+      <trans-unit id="help.participantResultsBody" datatype="html">
+        <source> Die Veranstaltungsleitung entscheidet, wann Ergebnisse sichtbar werden. Rangliste, Teamwertung und Bonus-Codes erscheinen nur, wenn sie für die Session aktiviert wurden. Deine Selbsteinschätzung hat keinen Einfluss auf Punkte oder Platzierung. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">335,339</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.stylesOptions" datatype="html">
-        <source> Alle Optionen (Rangliste, Sound, Lesephase, Team, Bonus) lassen sich einzeln an- und ausschalten. </source>
+      <trans-unit id="help.commonTitle" datatype="html">
+        <source>Für alle</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">346</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTitle" datatype="html">
-        <source>Weitere Funktionen</source>
+      <trans-unit id="help.commonPrivacyTitle" datatype="html">
+        <source>Wie werden Daten und Inhalte behandelt?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">351</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreBonus" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Bonus-Codes:&lt;"/>Bonus-Codes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Top-Platzierte erhalten einen einlösbaren Code (z. B. für Bonuspunkte). Du siehst die Code-Liste; personenbezogene Daten werden nicht gespeichert. </source>
+      <trans-unit id="help.commonPrivacyBody" datatype="html">
+        <source> Für die Nutzung ist kein Konto erforderlich. Quiz-Inhalte der Veranstaltungsleitung werden zunächst lokal im Browser gespeichert; während einer Live-Session werden die für die Interaktion notwendigen Daten ausgetauscht. arsnova.eu ist Open Source und für einen datenschutzorientierten Betrieb in Europa ausgelegt. Einzelheiten findest du in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/privacy&apos;)&quot;&gt;"/>Datenschutzerklärung<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">355,362</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreTeams" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Team-Modus:&lt;/"/>Team-Modus:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Deine Teilnehmenden spielen in Teams mit eigenem Team-Leaderboard – z. B. für Gruppenwettbewerbe im Seminar. </source>
+      <trans-unit id="help.commonAccessibilityTitle" datatype="html">
+        <source>Wie nutze ich arsnova.eu barrierefrei und als App?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">369</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.moreGamification" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Gamification:&lt;/stron"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sound-Effekte, Belohnungseffekte für Top-Plätze, Motivationsmeldungen – im Spielerisch-Modus. </source>
+      <trans-unit id="help.commonAccessibilityBody" datatype="html">
+        <source> arsnova.eu lässt sich mit Tastatur, Screenreader und vergrößerter Darstellung bedienen. Nutze bei Bedarf die Kontrast- und Farbschemaoptionen der App oder deines Betriebssystems. Du kannst arsnova.eu außerdem als Progressive Web App installieren. Weitere Hinweise stehen in der <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;localizedPath(&apos;/legal/accessibility&apos;)&quot;&gt;"/>Erklärung zur Barrierefreiheit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">376,382</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyTitle" datatype="html">
-        <source>Datenschutz und Technik</source>
+      <trans-unit id="help.commonTroubleshootingTitle" datatype="html">
+        <source>Was kann ich bei technischen Problemen tun?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">389</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="help.privacyBody" datatype="html">
-        <source> arsnova.eu ist kostenlos, Open Source und für den Einsatz an Schulen, Hochschulen und in Weiterbildung gedacht – mit Fokus auf Datenschutz (DSGVO). Quiz-Inhalte werden lokal im Browser gespeichert. Keine Anmeldung nötig, weder für dich noch für deine Teilnehmenden. Als App installierbar (PWA) – z. B. für schnelleren Start auf dem Smartphone. Oberfläche auf Deutsch, Englisch, Französisch, Spanisch und Italienisch. </source>
+      <trans-unit id="help.commonTroubleshootingBody" datatype="html">
+        <source> Prüfe zuerst den Code oder QR-Code, deine Internetverbindung und ob die Session noch aktiv ist. Wenn noch keine Frage sichtbar ist, kann sich die Session in der Lobby, einer Lesephase oder einer Pause befinden. Öffne nach einer Verbindungsunterbrechung den Beitrittslink erneut oder gib den Code noch einmal ein. Wende dich an die Veranstaltungsleitung, wenn die Session bereits beendet wurde. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">396,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Die Hilfeseite `/help` war eine lange, überwiegend host-zentrierte Seite ohne Progressive Disclosure; Teilnehmende, Einsteiger und erfahrene Nutzende fanden sich schlecht zurecht, und Roadmap-Inhalte waren als Hilfe dargestellt.
- **Lösung:** Rollenwahl per Ankerkarten, getrennte Bereiche für Host/Teilnahme/„Für alle“, flache Material-Akkordeons für Einstieg und Referenz sowie Copy-Deck in `de`/`en`/`fr`/`es`/`it` inkl. angepasster SEO-Metadaten.
- **Bewusste Nicht-Ziele:** Keine Suche, keine Panel-Detailrouten, kein persistierter Akkordeonzustand, keine Änderungen an Session-/Quiz-/Q&A-/Blitzlicht-Funktionalität.

Closes #190

## Risiko und Verträge

- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Issue #190 (verbindliche Informationsarchitektur und Copy-Deck), bestehendes Content-Page-Rahmenverhalten (Zurück/Escape/Fokusfalle), MOTD-Akkordeon-`inert`-Muster, ADR-0008/i18n (Quellsprache DE, alle Locales synchron).

**Betroffene externe Verträge:**

Keine.

## Implementierung

- Help-Seite auf H1, Einleitung und zwei Anker-Rollenkarten (`#help-host`, `#help-participant`) umgestellt.
- Pro Erfahrungsgruppe flaches `mat-accordion [multi]="true"`; erstes Anfängerpanel je Rolle initial geöffnet; Referenzpanels geschlossen; keine verschachtelten Panels.
- Geschlossene Panelinhalte mit Links nutzen `inert` analog zum MOTD-Archiv.
- Roadmap-Texte (Moderationskompass, asynchrone Q&A-NLP-Signale) entfernt; produktive Inhalte in die neuen Panels migriert.
- SEO-Titel/-Description sowie i18n-Kataloge für alle fünf Locales aktualisiert.
- Zitierte UI-Aktionen an sichtbare Labels angeglichen (z. B. DE „Starten“, FR „Feedback express“ / „Feedback instantané en un clic“, IT «Di più»).

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [ ] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

Akkordeon öffnen/schließen inkl. `aria-expanded` und `inert` für Link-Inhalte; Content-Page Escape/Backdrop/Fokusfalle unverändert.

## Validierung

- [x] `npm run typecheck` (via Pre-Commit-Hook)
- [x] `npm test` (via Pre-Commit-Hook; Frontend 1103/1103)
- [x] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
      (`npm run build:localize -w @arsnova/frontend`)
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run test -w @arsnova/frontend` | bestanden (1103 Tests) |
| `npm run check:i18n -w @arsnova/frontend` | bestanden (2434 Einheiten) |
| `npm run build:localize -w @arsnova/frontend` | bestanden |
| `npm run lint` | bestanden |
| Pre-Commit `typecheck` + `npm test` | bestanden |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Nur Frontend-Hilfeseite und SEO-Meta für `/help`; keine API-/DB-/Redis-Änderung.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Standard-Frontend-Deploy.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen.
- **Rollback:** Vorherigen Frontend-Stand ausrollen.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Automatisierte Regressionen in `help.component.spec.ts` und `seo-route-meta.spec.ts`.
- Manuell im lokalisierten Build (`dist/browser/{de,en,fr,it,es}`) Struktur und Texte gegen Copy-Deck/UI-Labels geprüft.
- Tastatur-/Akkordeon-Verhalten und Content-Page Escape/Backdrop per Unit-Tests abgesichert; sichtbarer Fokus und Light/Dark über bestehende M3-Tokens.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Realtime, Migrationen, Last, Sicherheitsgrenzen – reine Frontend-Hilfe/i18n/SEO.
- **Verbleibende Risiken:** Vollständiger Screenreader-Kurztest und Viewport-Checks auf physischem Gerät sollten im Review noch einmal kurz bestätigt werden. Pre-Commit scheiterte einmal an einem flaky, unzugehörigen `session-vote`-Timer-Test und lief beim Retry grün.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)