### PR TITLE
feat(landing,frontend): info.arsnova.eu fünfsprachig und kontextuell aus der App verlinken (#192)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,10 @@ jobs:
           BASE_PATH: /
         run: npm run build:landing
 
+      - name: Landing i18n contract
+        if: needs.changes.outputs.docs_only != 'true'
+        run: npm run test:i18n -w @arsnova/landing
+
       - name: Landing accessibility gate
         if: needs.changes.outputs.docs_only != 'true'
         run: |
@@ -445,6 +449,7 @@ jobs:
             sleep 1
           done
           BASE_URL="http://localhost:4321" npm run test:a11y -w @arsnova/landing
+          BASE_URL="http://localhost:4321" npm run test:language-switcher -w @arsnova/landing
 
   # Explizites `npm run typecheck` (Backend + Frontend, --noEmit) — ergänzt die
   # tsc-Schritte im build-Job; eigener Check in der PR-Übersicht, parallel zu build.

--- a/apps/frontend/src/app/app.component.html
+++ b/apps/frontend/src/app/app.component.html
@@ -181,6 +181,7 @@
               </a>
               <a
                 matButton
+                class="app-footer__link--external"
                 [href]="infoLandingFeaturesUrl"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -191,7 +192,12 @@
                 <span class="app-footer__link-text" i18n="@@app.footer.infoLanding"
                   >Was arsnova.eu kann</span
                 >
-                <mat-icon class="app-footer__icon" aria-hidden="true">open_in_new</mat-icon>
+                <mat-icon
+                  class="app-footer__icon app-footer__icon--external"
+                  iconPositionEnd
+                  aria-hidden="true"
+                  >open_in_new</mat-icon
+                >
               </a>
               <a matButton [routerLink]="localizedPath('/legal/imprint')">
                 <mat-icon class="app-footer__icon">gavel</mat-icon>

--- a/apps/frontend/src/app/app.component.html
+++ b/apps/frontend/src/app/app.component.html
@@ -179,6 +179,20 @@
                   >So funktioniert’s</span
                 >
               </a>
+              <a
+                matButton
+                [href]="infoLandingFeaturesUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                i18n-aria-label="@@app.footer.infoLandingAria"
+                aria-label="Was arsnova.eu kann (öffnet in neuem Tab)"
+              >
+                <mat-icon class="app-footer__icon">info</mat-icon>
+                <span class="app-footer__link-text" i18n="@@app.footer.infoLanding"
+                  >Was arsnova.eu kann</span
+                >
+                <mat-icon class="app-footer__icon" aria-hidden="true">open_in_new</mat-icon>
+              </a>
               <a matButton [routerLink]="localizedPath('/legal/imprint')">
                 <mat-icon class="app-footer__icon">gavel</mat-icon>
                 <span class="app-footer__link-text" i18n>Impressum</span>

--- a/apps/frontend/src/app/app.component.scss
+++ b/apps/frontend/src/app/app.component.scss
@@ -320,6 +320,11 @@
   line-height: 1;
 }
 
+/* Trailing external affordance: Material icon-offset/spacing zurücknehmen (Footer nutzt eigenes Gap). */
+.app-footer__links .mat-mdc-button-base .app-footer__icon--external {
+  margin-inline: 0;
+}
+
 /* Schmale Viewports: nur Icons (Text per Clip aus dem sichtbaren Layout, bleibt für Screenreader). */
 @media (max-width: 599px) {
   .app-footer__links {
@@ -343,6 +348,11 @@
     clip-path: inset(50%);
     white-space: nowrap;
     border: 0;
+  }
+
+  /* Wie die anderen Footer-Links nur ein Lead-Icon; neuer Tab steht im aria-label. */
+  .app-footer__link--external .app-footer__icon--external {
+    display: none;
   }
 }
 

--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -404,6 +404,25 @@ describe('AppComponent', () => {
     fixture.destroy();
   });
 
+  it('setzt das externe Footer-Icon von Was arsnova.eu kann als Trailing-Icon', async () => {
+    configureAppTestBed();
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const link = (fixture.nativeElement as HTMLElement).querySelector(
+      'a.app-footer__link--external',
+    ) as HTMLAnchorElement | null;
+    const trailing = link?.querySelector('mat-icon.app-footer__icon--external[iconPositionEnd]');
+
+    expect(link?.textContent ?? '').toContain('Was arsnova.eu kann');
+    expect(trailing?.textContent?.trim()).toBe('open_in_new');
+    expect(link?.querySelectorAll('mat-icon:not([iconPositionEnd])')).toHaveLength(1);
+
+    fixture.destroy();
+  });
+
   it('füllt leere Tageshistorien lokal im Dev-Modus für die visuelle Prüfung mit Demo-Werten', async () => {
     TestBed.configureTestingModule({
       imports: [AppComponent],

--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -396,6 +396,7 @@ describe('AppComponent', () => {
 
     expect(text).not.toContain('News-Archiv');
     expect(text).not.toContain('So funktioniert’s');
+    expect(text).not.toContain('Was arsnova.eu kann');
     expect(text).not.toContain('Impressum');
     expect(text).not.toContain('Datenschutz');
     expect(text).not.toContain('Barrierefreiheit');

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -31,6 +31,7 @@ import { trpc } from './core/trpc.client';
 import type { FooterStatusDTO, ServerStatsDTO } from '@arsnova/shared-types';
 import { ServerStatusWidgetComponent } from './shared/server-status-widget/server-status-widget.component';
 import { localizePath } from './core/locale-router';
+import { INFO_LANDING_ANCHORS, infoLandingUrl } from './core/info-landing-url';
 import { HostDisplayModeService } from './core/host-display-mode.service';
 import { SeoService } from './core/seo.service';
 import { MotdHeaderStateService } from './core/motd-header-state.service';
@@ -94,6 +95,8 @@ class ConnectionBannerHostDirective {
 })
 export class AppComponent implements OnInit, OnDestroy {
   readonly localizedPath = localizePath;
+  /** Footer-Deep-Link zur Informationsseite (Features). */
+  readonly infoLandingFeaturesUrl = infoLandingUrl(INFO_LANDING_ANCHORS.features);
   isOnline = signal(true);
   updateAvailable = signal(false);
   updateReloading = signal(false);

--- a/apps/frontend/src/app/core/info-landing-url.spec.ts
+++ b/apps/frontend/src/app/core/info-landing-url.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { INFO_LANDING_ANCHORS, infoLandingUrl } from './info-landing-url';
+
+describe('infoLandingUrl', () => {
+  it('baut immer einen Locale-Pfad und nie nur die Domainwurzel', () => {
+    expect(infoLandingUrl(null, 'de')).toBe('https://info.arsnova.eu/de/');
+    expect(infoLandingUrl(INFO_LANDING_ANCHORS.features, 'en')).toBe(
+      'https://info.arsnova.eu/en/#features',
+    );
+    expect(infoLandingUrl(INFO_LANDING_ANCHORS.workflow, 'fr')).toBe(
+      'https://info.arsnova.eu/fr/#workflow',
+    );
+    expect(infoLandingUrl(INFO_LANDING_ANCHORS.qaWall, 'it')).toBe(
+      'https://info.arsnova.eu/it/#qa-wall',
+    );
+    expect(infoLandingUrl(INFO_LANDING_ANCHORS.confidence, 'es')).toBe(
+      'https://info.arsnova.eu/es/#confidence',
+    );
+  });
+});

--- a/apps/frontend/src/app/core/info-landing-url.ts
+++ b/apps/frontend/src/app/core/info-landing-url.ts
@@ -1,0 +1,34 @@
+import { getEffectiveLocale, type SupportedLocale } from './locale-from-path';
+
+/** Öffentliche Informationsseite (Astro Landing). */
+export const INFO_LANDING_ORIGIN = 'https://info.arsnova.eu';
+
+/** Kanonische Deep-Link-Anker (Issue #192); sprachneutral und in allen Locales identisch. */
+export const INFO_LANDING_ANCHORS = {
+  workflow: 'workflow',
+  numericEstimate: 'numeric-estimate',
+  confidence: 'confidence',
+  qaWall: 'qa-wall',
+  features: 'features',
+  accessibility: 'accessibility',
+  trust: 'trust',
+  comparison: 'comparison',
+  faq: 'faq',
+} as const;
+
+export type InfoLandingAnchor = (typeof INFO_LANDING_ANCHORS)[keyof typeof INFO_LANDING_ANCHORS];
+
+/**
+ * Locale-sichere URL zur Informationsseite.
+ * Niemals nur die Domainwurzel — immer `/{locale}/` (+ optionaler kanonischer Hash).
+ */
+export function infoLandingUrl(
+  anchor?: InfoLandingAnchor | null,
+  locale: SupportedLocale = getEffectiveLocale(),
+): string {
+  const path = `${INFO_LANDING_ORIGIN.replace(/\/$/, '')}/${locale}/`;
+  if (!anchor) {
+    return path;
+  }
+  return `${path}#${anchor}`;
+}

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -59,6 +59,23 @@
             ist Open Source und für EU-orientierten Betrieb ausgelegt. Markdown und KaTeX machen
             fachliche Fragen präsentationstauglich, von MINT-Formeln bis zum kurzen Fallbeispiel.
           </p>
+          <aside class="help-info-landing" aria-labelledby="help-info-landing-title">
+            <h3
+              id="help-info-landing-title"
+              class="help-info-landing__title"
+              i18n="@@help.infoLandingTitle"
+            >
+              Mehr zu Nutzen und Hintergründen
+            </h3>
+            <p class="help-info-landing__body" i18n="@@help.infoLandingBody">
+              Auf der Informationsseite findest du Einsatzmöglichkeiten, Hinweise zu Datenschutz und
+              Barrierefreiheit sowie die Abgrenzung zu anderen Audience-Response-Systemen.
+            </p>
+            <app-info-landing-link
+              [anchor]="infoLandingFeaturesAnchor"
+              [label]="infoLandingFeaturesLabel"
+            />
+          </aside>
         </section>
 
         <section class="help-section--formats" aria-labelledby="help-formats-title">

--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -44,13 +44,13 @@
         </p>
 
         <aside class="help-info-landing" aria-labelledby="help-info-landing-title">
-          <h3
+          <h2
             id="help-info-landing-title"
             class="help-info-landing__title"
             i18n="@@help.infoLandingTitle"
           >
             Mehr zu Nutzen und Hintergründen
-          </h3>
+          </h2>
           <p class="help-info-landing__body" i18n="@@help.infoLandingBody">
             Auf der Informationsseite findest du Einsatzmöglichkeiten, Hinweise zu Datenschutz und
             Barrierefreiheit sowie die Abgrenzung zu anderen Audience-Response-Systemen.

--- a/apps/frontend/src/app/features/help/help.component.scss
+++ b/apps/frontend/src/app/features/help/help.component.scss
@@ -301,3 +301,23 @@
   justify-content: center;
   font-size: 0.875rem;
 }
+
+.help-info-landing {
+  margin-top: 1.5rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--mat-sys-corner-medium);
+  background: color-mix(in srgb, var(--mat-sys-surface-container-low) 80%, transparent);
+}
+
+.help-info-landing__title {
+  margin: 0 0 0.5rem;
+  font: var(--mat-sys-title-small);
+  color: var(--mat-sys-on-surface);
+}
+
+.help-info-landing__body {
+  margin: 0 0 0.75rem;
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+}

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -288,6 +288,25 @@ describe('HelpComponent', () => {
     expect(text.match(/Schon vertraut mit arsnova\.eu/g)?.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('hält die Überschriftenreihenfolge für die Info-Landing-Aside ein', async () => {
+    const fixture = await createFixture();
+    const root = fixture.nativeElement as HTMLElement;
+    const headings = Array.from(root.querySelectorAll('h1, h2, h3')).map((el) => ({
+      level: Number(el.tagName.slice(1)),
+      id: el.id || null,
+    }));
+
+    expect(headings[0]).toEqual({ level: 1, id: 'help-page-title' });
+    expect(headings[1]).toEqual({ level: 2, id: 'help-info-landing-title' });
+    expect(root.querySelector('aside.help-info-landing app-info-landing-link')).toBeTruthy();
+
+    let previous = headings[0]!.level;
+    for (const heading of headings.slice(1)) {
+      expect(heading.level).toBeLessThanOrEqual(previous + 1);
+      previous = heading.level;
+    }
+  });
+
   it('rendert die erwarteten Akkordeonpanels ohne Verschachtelung', async () => {
     const fixture = await createFixture();
     const root = fixture.nativeElement as HTMLElement;

--- a/apps/frontend/src/app/features/help/help.component.ts
+++ b/apps/frontend/src/app/features/help/help.component.ts
@@ -6,13 +6,15 @@ import { MatButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import { dismissContentPage, shouldDeferContentPageEscape } from '../../shared/content-page-nav';
+import { InfoLandingLinkComponent } from '../../shared/info-landing-link/info-landing-link.component';
+import { INFO_LANDING_ANCHORS } from '../../core/info-landing-url';
 
 /**
  * „So funktioniert’s“: Nutzerorientierte Anleitung, Layout und Stil wie Legal-Seiten.
  */
 @Component({
   selector: 'app-help',
-  imports: [MatButton, MatIcon, CdkTrapFocus],
+  imports: [MatButton, MatIcon, CdkTrapFocus, InfoLandingLinkComponent],
   templateUrl: './help.component.html',
   styleUrls: [
     '../../shared/styles/dialog-title-header.scss',
@@ -24,6 +26,9 @@ export class HelpComponent {
   private readonly location = inject(Location);
   private readonly router = inject(Router);
   private readonly dialog = inject(MatDialog);
+
+  readonly infoLandingFeaturesAnchor = INFO_LANDING_ANCHORS.features;
+  readonly infoLandingFeaturesLabel = $localize`:@@help.infoLandingLink:Hintergründe und Einsatzmöglichkeiten`;
 
   @HostListener('document:keydown.escape', ['$event'])
   onEscape(event: Event): void {

--- a/apps/frontend/src/app/features/home/home.component.html
+++ b/apps/frontend/src/app/features/home/home.component.html
@@ -440,6 +440,12 @@
             <mat-icon class="home-cta__icon">devices</mat-icon>
             <span i18n="@@homeHostCard.syncPanelCta">Zwischen Geräten wechseln</span>
           </button>
+          <app-info-landing-link
+            class="home-card__info-landing"
+            [anchor]="infoLandingWorkflowAnchor"
+            [label]="infoLandingWorkflowLabel"
+            [dense]="true"
+          />
         </div>
         @if (syncLinkVisible()) {
           <div class="home-sync-entry">

--- a/apps/frontend/src/app/features/home/home.component.scss
+++ b/apps/frontend/src/app/features/home/home.component.scss
@@ -932,6 +932,11 @@ mat-card-actions.l-stack {
   --mdc-text-button-container-height: 2rem;
 }
 
+.home-card__info-landing {
+  align-self: center;
+  max-width: 100%;
+}
+
 .home-sync-entry {
   width: 100%;
   display: flex;

--- a/apps/frontend/src/app/features/home/home.component.ts
+++ b/apps/frontend/src/app/features/home/home.component.ts
@@ -73,6 +73,8 @@ import {
   renderMarkdownWithoutKatex,
 } from '../../shared/markdown-katex.util';
 import { MarkdownImageLightboxDirective } from '../../shared/markdown-image-lightbox/markdown-image-lightbox.directive';
+import { InfoLandingLinkComponent } from '../../shared/info-landing-link/info-landing-link.component';
+import { INFO_LANDING_ANCHORS } from '../../core/info-landing-url';
 
 @Component({
   selector: 'app-home',
@@ -92,6 +94,7 @@ import { MarkdownImageLightboxDirective } from '../../shared/markdown-image-ligh
     MatTooltip,
     CdkTrapFocus,
     MarkdownImageLightboxDirective,
+    InfoLandingLinkComponent,
   ],
   templateUrl: './home.component.html',
   styleUrls: ['../../shared/styles/dialog-title-header.scss', './home.component.scss'],
@@ -99,6 +102,8 @@ import { MarkdownImageLightboxDirective } from '../../shared/markdown-image-ligh
 export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly localizedCommands = localizeCommands;
   readonly localizedPath = localizePath;
+  readonly infoLandingWorkflowAnchor = INFO_LANDING_ANCHORS.workflow;
+  readonly infoLandingWorkflowLabel = $localize`:@@homeHostCard.infoLanding:Einsatzmöglichkeiten entdecken`;
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly snackBar = inject(MatSnackBar);

--- a/apps/frontend/src/app/features/quiz/quiz-edit/quiz-edit.component.html
+++ b/apps/frontend/src/app/features/quiz/quiz-edit/quiz-edit.component.html
@@ -563,6 +563,14 @@
             </mat-form-field>
           }
         </div>
+        @if (isNumericEstimateType()) {
+          <app-info-landing-link
+            class="quiz-edit-form__info-landing"
+            [anchor]="infoLandingEstimateAnchor"
+            [label]="infoLandingEstimateLabel"
+            [dense]="true"
+          />
+        }
 
         <fieldset class="quiz-edit-form__fieldset">
           <legend class="quiz-edit-form__legend" i18n="@@quiz.edit.questionTimerSectionLegend">
@@ -613,6 +621,12 @@
               Teilnehmende geben nach ihrer Antwort an, wie sicher sie sind. Beeinflusst nicht die
               Punktevergabe.
             </p>
+            <app-info-landing-link
+              class="quiz-edit-form__info-landing"
+              [anchor]="infoLandingConfidenceAnchor"
+              [label]="infoLandingConfidenceLabel"
+              [dense]="true"
+            />
             <mat-slide-toggle
               formControlName="confidenceEnabled"
               (change)="onConfidenceEnabledChanged()"

--- a/apps/frontend/src/app/features/quiz/quiz-edit/quiz-edit.component.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-edit/quiz-edit.component.ts
@@ -111,6 +111,8 @@ import { MarkdownKatexEditorComponent } from '../../../shared/markdown-katex-edi
 import { decorateLeadingAnswerEmoji } from '../../../shared/leading-answer-emoji.util';
 import { answerOptionColor, answerOptionShape } from '../../../shared/answer-option-badge.util';
 import { AnswerOptionBadgeComponent } from '../../../shared/answer-option-badge/answer-option-badge.component';
+import { InfoLandingLinkComponent } from '../../../shared/info-landing-link/info-landing-link.component';
+import { INFO_LANDING_ANCHORS } from '../../../core/info-landing-url';
 import { replaceEmojiShortcodes } from '../../../shared/emoji-shortcode.util';
 import {
   focusAndScrollElement,
@@ -330,11 +332,17 @@ type QuizMetadataComparable = {
     MarkdownImageLightboxDirective,
     MarkdownKatexEditorComponent,
     AnswerOptionBadgeComponent,
+    InfoLandingLinkComponent,
   ],
   templateUrl: './quiz-edit.component.html',
   styleUrls: ['../../../shared/styles/dialog-title-header.scss', './quiz-edit.component.scss'],
 })
 export class QuizEditComponent implements OnDestroy {
+  readonly infoLandingEstimateAnchor = INFO_LANDING_ANCHORS.numericEstimate;
+  readonly infoLandingEstimateLabel = $localize`:@@quizEdit.infoLandingEstimate:Schätzfragen didaktisch einsetzen`;
+  readonly infoLandingConfidenceAnchor = INFO_LANDING_ANCHORS.confidence;
+  readonly infoLandingConfidenceLabel = $localize`:@@quizEdit.infoLandingConfidence:Selbsteinschätzung und Nachbesprechung verstehen`;
+
   private readonly document = inject(DOCUMENT);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -498,6 +498,14 @@
                       <span i18n>Erste Frage starten</span>
                     }
                   </button>
+                  @if (isQaSession()) {
+                    <app-info-landing-link
+                      class="session-host__info-landing session-host__info-landing--lobby"
+                      [anchor]="infoLandingQaAnchor"
+                      [label]="infoLandingQaLabel"
+                      [dense]="true"
+                    />
+                  }
                 </div>
               </section>
             }
@@ -1191,12 +1199,6 @@
                     Session beendet
                   </h1>
                   <p class="session-host__finished-sub" i18n>Alle Ergebnisse sind gespeichert.</p>
-                  <app-info-landing-link
-                    class="session-host__info-landing"
-                    [anchor]="infoLandingConfidenceAnchor"
-                    [label]="infoLandingConfidenceLabel"
-                    [dense]="true"
-                  />
                   <div class="session-host__export-actions">
                     <div class="session-host__export-pdf">
                       @let exportPdfPriorityCount =
@@ -1311,6 +1313,12 @@
                       <p class="session-host__export-hint" role="status">{{ status }}</p>
                     }
                   </div>
+                  <app-info-landing-link
+                    class="session-host__info-landing session-host__info-landing--finished"
+                    [anchor]="infoLandingConfidenceAnchor"
+                    [label]="infoLandingConfidenceLabel"
+                    [dense]="true"
+                  />
                 </header>
               </div>
             } @else {
@@ -3066,12 +3074,6 @@
                 >
                 <div class="session-host__qa-title-block">
                   <p class="session-channel-card__eyebrow">{{ channelLabel('qa') }}</p>
-                  <app-info-landing-link
-                    class="session-host__info-landing"
-                    [anchor]="infoLandingQaAnchor"
-                    [label]="infoLandingQaLabel"
-                    [dense]="true"
-                  />
                   @if (!qaTitleEditing()) {
                     <div class="session-host__qa-title-view">
                       <h2 class="session-channel-card__title session-host__qa-title-heading">

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -1191,6 +1191,12 @@
                     Session beendet
                   </h1>
                   <p class="session-host__finished-sub" i18n>Alle Ergebnisse sind gespeichert.</p>
+                  <app-info-landing-link
+                    class="session-host__info-landing"
+                    [anchor]="infoLandingConfidenceAnchor"
+                    [label]="infoLandingConfidenceLabel"
+                    [dense]="true"
+                  />
                   <div class="session-host__export-actions">
                     <div class="session-host__export-pdf">
                       @let exportPdfPriorityCount =
@@ -3060,6 +3066,12 @@
                 >
                 <div class="session-host__qa-title-block">
                   <p class="session-channel-card__eyebrow">{{ channelLabel('qa') }}</p>
+                  <app-info-landing-link
+                    class="session-host__info-landing"
+                    [anchor]="infoLandingQaAnchor"
+                    [label]="infoLandingQaLabel"
+                    [dense]="true"
+                  />
                   @if (!qaTitleEditing()) {
                     <div class="session-host__qa-title-view">
                       <h2 class="session-channel-card__title session-host__qa-title-heading">

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -1412,6 +1412,95 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     const text = fixture.nativeElement.textContent ?? '';
     expect(text).toContain('Offene Fragen');
     expect(text).toContain('Fragerunde starten');
+    expect(
+      fixture.nativeElement.querySelector(
+        '.session-host__info-landing--lobby app-info-landing-link, app-info-landing-link.session-host__info-landing--lobby',
+      ),
+    ).toBeTruthy();
+    expect(text).toContain('Warum die Fragenwand mehr als ein Chat ist');
+    fixture.destroy();
+  });
+
+  it('blendet den Q&A-Info-Landing-Link im aktiven Q&A-Kanal aus', async () => {
+    getInfoQueryMock.mockResolvedValue({
+      ...defaultSession,
+      status: 'ACTIVE',
+      channels: {
+        quiz: { enabled: true },
+        qa: { enabled: true, open: true, title: 'Offene Fragen', moderationMode: true },
+        quickFeedback: { enabled: false, open: false },
+      },
+    });
+
+    const fixture = setup([
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          parent: {
+            snapshot: {
+              paramMap: convertToParamMap({ code: 'ABC123' }),
+            },
+          },
+          snapshot: {
+            queryParamMap: convertToParamMap({ tab: 'qa' }),
+            paramMap: convertToParamMap({}),
+          },
+          queryParamMap: of(convertToParamMap({ tab: 'qa' })),
+        },
+      },
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent ?? '';
+    expect(text).toContain('Offene Fragen');
+    expect(text).not.toContain('Warum die Fragenwand mehr als ein Chat ist');
+    expect(
+      fixture.nativeElement.querySelector(
+        '.session-host__channel--qa app-info-landing-link, .session-host__qa-panel app-info-landing-link',
+      ),
+    ).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector(
+        'app-info-landing-link.session-host__info-landing--lobby',
+      ),
+    ).toBeNull();
+    fixture.destroy();
+  });
+
+  it('zeigt den Confidence-Info-Link im Finished-State nach den Export-Aktionen', async () => {
+    getInfoQueryMock.mockResolvedValue({
+      ...defaultSession,
+      status: 'FINISHED',
+    });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'FINISHED', currentQuestion: null });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+
+    const exportActions = fixture.nativeElement.querySelector(
+      '.session-host__export-actions',
+    ) as HTMLElement | null;
+    const infoLink = fixture.nativeElement.querySelector(
+      'app-info-landing-link.session-host__info-landing--finished, .session-host__info-landing--finished',
+    ) as HTMLElement | null;
+
+    expect(exportActions).toBeTruthy();
+    expect(infoLink).toBeTruthy();
+    expect(fixture.nativeElement.textContent ?? '').toContain(
+      'Selbsteinschätzung und Nachbesprechung verstehen',
+    );
+
+    const position = exportActions!.compareDocumentPosition(infoLink!);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     fixture.destroy();
   });
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -66,6 +66,8 @@ import {
   showQuestionTypeIndicator,
 } from '../../../shared/answer-option-badge.util';
 import { AnswerOptionBadgeComponent } from '../../../shared/answer-option-badge/answer-option-badge.component';
+import { InfoLandingLinkComponent } from '../../../shared/info-landing-link/info-landing-link.component';
+import { INFO_LANDING_ANCHORS } from '../../../core/info-landing-url';
 import { ThemePresetService } from '../../../core/theme-preset.service';
 import { SoundService } from '../../../core/sound.service';
 import { HostDisplayModeService } from '../../../core/host-display-mode.service';
@@ -408,12 +410,17 @@ function musicTracksForPhase(
     FoyerEntranceLayerComponent,
     AnswerOptionBadgeComponent,
     CdkTrapFocus,
+    InfoLandingLinkComponent,
   ],
   templateUrl: './session-host.component.html',
   styleUrls: ['../../../shared/styles/dialog-title-header.scss', './session-host.component.scss'],
 })
 export class SessionHostComponent implements OnInit, OnDestroy {
   readonly localizedPath = localizePath;
+  readonly infoLandingQaAnchor = INFO_LANDING_ANCHORS.qaWall;
+  readonly infoLandingQaLabel = $localize`:@@sessionHost.infoLandingQa:Warum die Fragenwand mehr als ein Chat ist`;
+  readonly infoLandingConfidenceAnchor = INFO_LANDING_ANCHORS.confidence;
+  readonly infoLandingConfidenceLabel = $localize`:@@sessionHost.infoLandingConfidence:Selbsteinschätzung und Nachbesprechung verstehen`;
   session = signal<SessionInfoDTO | null>(null);
   readonly sessionUnavailable = signal(false);
   /** Lobby: Live-Teilnehmerliste (Story 2.2). */

--- a/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.html
+++ b/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.html
@@ -1,0 +1,13 @@
+<a
+  class="info-landing-link"
+  [class.info-landing-link--dense]="dense()"
+  [href]="href()"
+  target="_blank"
+  rel="noopener noreferrer"
+  [attr.aria-label]="label() + ' (' + newTabHint + ')'"
+>
+  <mat-icon class="info-landing-link__lead-icon" aria-hidden="true">info</mat-icon>
+  <span class="info-landing-link__label">{{ label() }}</span>
+  <mat-icon class="info-landing-link__external-icon" aria-hidden="true">open_in_new</mat-icon>
+  <span class="sr-only">{{ newTabHint }}</span>
+</a>

--- a/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.scss
+++ b/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.scss
@@ -1,0 +1,53 @@
+.info-landing-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: 100%;
+  min-height: 2.75rem;
+  padding: 0.25rem 0;
+  color: var(--mat-sys-primary);
+  font: inherit;
+  font-size: var(--mat-sys-body-medium-size, 0.875rem);
+  line-height: var(--mat-sys-body-medium-line-height, 1.25rem);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  border-radius: var(--mat-sys-corner-extra-small, 4px);
+}
+
+.info-landing-link:hover {
+  color: var(--mat-sys-on-primary-container, var(--mat-sys-primary));
+}
+
+.info-landing-link:focus-visible {
+  outline: 2px solid var(--mat-sys-primary);
+  outline-offset: 2px;
+}
+
+.info-landing-link--dense {
+  min-height: 2.5rem;
+  font-size: var(--mat-sys-label-large-size, 0.875rem);
+}
+
+.info-landing-link__lead-icon,
+.info-landing-link__external-icon {
+  flex-shrink: 0;
+  width: 1.125rem;
+  height: 1.125rem;
+  font-size: 1.125rem;
+}
+
+.info-landing-link__label {
+  min-width: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.ts
+++ b/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.ts
@@ -1,0 +1,26 @@
+import { Component, computed, input } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+import { infoLandingUrl, type InfoLandingAnchor } from '../../core/info-landing-url';
+
+/**
+ * Kontextueller Link zur mehrsprachigen Informationsseite (Issue #192).
+ * Öffnet immer in neuem Tab; kein Tracking.
+ */
+@Component({
+  selector: 'app-info-landing-link',
+  imports: [MatIcon],
+  templateUrl: './info-landing-link.component.html',
+  styleUrl: './info-landing-link.component.scss',
+})
+export class InfoLandingLinkComponent {
+  /** Kanonischer Anker ohne `#`. */
+  readonly anchor = input.required<InfoLandingAnchor>();
+  /** Sichtbarer Linktext (lokalisiert vom Aufrufer). */
+  readonly label = input.required<string>();
+  /** Optional dichtere Darstellung (z. B. unter Formularfeldern). */
+  readonly dense = input(false);
+
+  protected readonly href = computed(() => infoLandingUrl(this.anchor()));
+
+  protected readonly newTabHint = $localize`:@@infoLanding.openInNewTab:öffnet in neuem Tab`;
+}

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -14398,7 +14398,7 @@
       </trans-unit>
       <trans-unit id="sessionHost.infoLandingQa" datatype="html">
         <source>Warum die Fragenwand mehr als ein Chat ist</source>
-        <target>Why the Q&A wall is more than a chat</target>
+        <target>Why the Q&amp;A wall is more than a chat</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">421</context>

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -110,12 +110,28 @@
           <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.infoLandingAria" datatype="html">
+        <source>Was arsnova.eu kann (öffnet in neuem Tab)</source>
+        <target>What arsnova.eu can do (opens in a new tab)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">188</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.infoLanding" datatype="html">
+        <source>Was arsnova.eu kann</source>
+        <target>What arsnova.eu can do</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">192</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <target>Legal notice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
@@ -123,7 +139,7 @@
         <target>Privacy</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">188</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">
@@ -131,7 +147,7 @@
         <target>Accessibility</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibility" datatype="html">
@@ -139,7 +155,7 @@
         <target>Accessibility</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7981911571029514989" datatype="html">
@@ -147,7 +163,7 @@
         <target>Now even faster and smoother!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1136696335453039978" datatype="html">
@@ -155,7 +171,7 @@
         <target>Preset: Business</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6151253518820826531" datatype="html">
@@ -163,7 +179,7 @@
         <target>Preset: Gamification</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2911090466936872230" datatype="html">
@@ -171,7 +187,7 @@
         <target>Connecting…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/feedback/feedback-host.component.html</context>
@@ -187,7 +203,7 @@
         <target>Try again</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAria" datatype="html">
@@ -195,7 +211,7 @@
         <target>Open news archive</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
@@ -203,7 +219,7 @@
         <target>Open news archive, one unread message</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
@@ -211,7 +227,7 @@
         <target>Open news archive, <x id="INTERPOLATION" equiv-text="{{ n }}"/> unread messages</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">227</context>
+          <context context-type="linenumber">230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.notFound" datatype="html">
@@ -1902,7 +1918,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">402</context>
+          <context context-type="linenumber">410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -1942,7 +1958,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">397</context>
+          <context context-type="linenumber">405</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -4878,7 +4894,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4690</context>
+          <context context-type="linenumber">4697</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -4930,7 +4946,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3633</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -5374,7 +5390,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1899</context>
+          <context context-type="linenumber">1906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -5386,7 +5402,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1904</context>
+          <context context-type="linenumber">1911</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -5410,7 +5426,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -5422,7 +5438,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -6230,12 +6246,28 @@
           <context context-type="linenumber">56,61</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.infoLandingTitle" datatype="html">
+        <source> Mehr zu Nutzen und Hintergründen</source>
+        <target>More about benefits and background</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">63,65</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingBody" datatype="html">
+        <source> Auf der Informationsseite findest du Einsatzmöglichkeiten, Hinweise zu Datenschutz und Barrierefreiheit sowie die Abgrenzung zu anderen Audience-Response-Systemen.</source>
+        <target>On the information site you will find use cases, notes on privacy and accessibility, and how arsnova.eu differs from other audience response systems.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66,69</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.formatsTitle" datatype="html">
         <source> Frageformate: passend zum didaktischen Ziel</source>
         <target>Question formats: match the teaching goal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">78,80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsLead" datatype="html">
@@ -6243,7 +6275,7 @@
         <target>Choose the format that fits the room: are you checking knowledge, surfacing attitudes, collecting terms, or discussing estimates? The formats are deliberately separate so result display, scoring, and moderation fit the purpose.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">81,85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsGridAria" datatype="html">
@@ -6251,7 +6283,7 @@
         <target>Available quiz question formats</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
@@ -6259,7 +6291,7 @@
         <target>Single Choice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTag" datatype="html">
@@ -6267,7 +6299,7 @@
         <target>one correct option</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
+          <context context-type="linenumber">97,99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceBody" datatype="html">
@@ -6275,7 +6307,7 @@
         <target>For precise understanding checks: one answer is correct, and results and points are immediately clear.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
+          <context context-type="linenumber">100,103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
@@ -6283,7 +6315,7 @@
         <target>Multiple Choice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
@@ -6291,7 +6323,7 @@
         <target>several correct options</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
@@ -6299,7 +6331,7 @@
         <target>For more complex concepts, common misconceptions, or questions like “Which statements are true?” — several answers can count.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
+          <context context-type="linenumber">113,116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTitle" datatype="html">
@@ -6307,7 +6339,7 @@
         <target>Short answer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTag" datatype="html">
@@ -6315,7 +6347,7 @@
         <target>model answer, not a menu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
+          <context context-type="linenumber">123,125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextBody" datatype="html">
@@ -6323,7 +6355,7 @@
         <target>Participants answer briefly in their own words. You provide model answers; arsnova.eu can evaluate spelling variants, tolerance, and, when needed, numbers or units.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
+          <context context-type="linenumber">126,129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTitle" datatype="html">
@@ -6331,7 +6363,7 @@
         <target>Free text</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">135</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTag" datatype="html">
@@ -6339,7 +6371,7 @@
         <target>open responses</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
+          <context context-type="linenumber">136,138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextBody" datatype="html">
@@ -6347,7 +6379,7 @@
         <target>For ideas, reflections, and expectation checks. No automatic scoring; responses can be collected and shown as a word cloud.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
+          <context context-type="linenumber">139,142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTitle" datatype="html">
@@ -6355,7 +6387,7 @@
         <target>Survey</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTag" datatype="html">
@@ -6363,7 +6395,7 @@
         <target>opinion snapshot, no right/wrong</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
+          <context context-type="linenumber">149,151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyBody" datatype="html">
@@ -6371,7 +6403,7 @@
         <target>For priorities, prior knowledge, or decisions in the room. Options are counted without score logic.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
+          <context context-type="linenumber">152,155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTitle" datatype="html">
@@ -6379,7 +6411,7 @@
         <target>Rating scale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTag" datatype="html">
@@ -6387,7 +6419,7 @@
         <target>scale with custom endpoints</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
+          <context context-type="linenumber">162,164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingBody" datatype="html">
@@ -6395,7 +6427,7 @@
         <target>For agreement, confidence, pace, or feedback from low to high, optionally with named endpoints.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
+          <context context-type="linenumber">165,168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
@@ -6403,7 +6435,7 @@
         <target>Numerical estimate question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTag" datatype="html">
@@ -6411,7 +6443,7 @@
         <target>estimate numbers, see the spread</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
+          <context context-type="linenumber">175,177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateBody" datatype="html">
@@ -6419,7 +6451,7 @@
         <target>For years, orders of magnitude, measurements, and probabilities. Includes reference value, tolerance band, histogram, statistics, and an optional second round.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
+          <context context-type="linenumber">178,181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsBlitzNote" datatype="html">
@@ -6427,7 +6459,7 @@
         <target>Pulse Check is separate from these formats: it is for spontaneous live feedback when you do not want to build a full quiz question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
+          <context context-type="linenumber">185,188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceTitle" datatype="html">
@@ -6435,7 +6467,7 @@
         <target>Self-assessment for evaluable questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
+          <context context-type="linenumber">192,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceLead" datatype="html">
@@ -6443,7 +6475,7 @@
         <target>The self-assessment is not a separate question type, but an optional additional question according to single choice, multiple choice, short answer and numerical estimation question: Participants indicate how confident they are in their answer (scale 1–5). This doesn&apos;t affect any points - but it does help you recognize your level of learning and misconceptions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
+          <context context-type="linenumber">195,200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceListAria" datatype="html">
@@ -6451,7 +6483,7 @@
         <target>Didactic functions of self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
@@ -6459,7 +6491,7 @@
         <target>Ask after the answer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
@@ -6467,7 +6499,7 @@
         <target>Progressive Disclosure: First select or enter the answer, then the self-assessment. During voting, no one sees other people&apos;s aggregated values.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
+          <context context-type="linenumber">210,214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorTitle" datatype="html">
@@ -6475,7 +6507,7 @@
         <target>Configure in the editor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorBody" datatype="html">
@@ -6483,7 +6515,7 @@
         <target>Toggle per question, optional labels for low and high response confidence, and a live preview of the scale. Self-assessment is active by default for new assessable questions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
+          <context context-type="linenumber">221,225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostTitle" datatype="html">
@@ -6491,7 +6523,7 @@
         <target>Host evaluation after results release</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostBody" datatype="html">
@@ -6499,7 +6531,7 @@
         <target>Matrix of correctness and response confidence highlighting <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>confidently wrong<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. For choice questions, you can see which incorrect options were selected with high response confidence.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">232,236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportTitle" datatype="html">
@@ -6507,7 +6539,7 @@
         <target>Completion and export</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportBody" datatype="html">
@@ -6515,7 +6547,7 @@
         <target> At the end of the session, the evaluation summarizes consolidated knowledge, misconception risk and fragile knowledge. Questions with fewer than 5 responses with a self-assessment are not shown in aggregate. The debrief plan (PDF) is the recommended format; CSV is available under “More” for Excel. In the quiz collection you will find the debrief plan on the quiz card.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">243,249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTitle" datatype="html">
@@ -6523,7 +6555,7 @@
         <target>Demo Quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">256</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoCardHint" datatype="html">
@@ -6531,7 +6563,7 @@
         <target>A preinstalled demo quiz shows the question formats in concrete teaching moments: knowledge check, word cloud, short answer, estimate, rating scale, self-assessment, formulas, and Markdown. You can find it in your quiz library and open it in preview.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTip" datatype="html">
@@ -6539,7 +6571,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Tip:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Open the preview once on a second device before your first live session. You will immediately see how the host view and participant screen work together.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">264,267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstartTitle" datatype="html">
@@ -6547,7 +6579,7 @@
         <target>Quick start</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart1" datatype="html">
@@ -6555,7 +6587,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Create a quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Choose “Open quiz library”, create a new quiz, and choose the right format for each question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
+          <context context-type="linenumber">274,276</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart2" datatype="html">
@@ -6563,7 +6595,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Start a session:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Choose style, timers, teams, and leaderboard. Then a 6-character code is created, which you share as text or QR code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
+          <context context-type="linenumber">278,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart3" datatype="html">
@@ -6571,7 +6603,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Moderate live:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Show the question, start the answer phase, reveal or hold back results, and add a second round when useful.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
+          <context context-type="linenumber">282,284</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostTitle" datatype="html">
@@ -6579,7 +6611,7 @@
         <target>Host your session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
+          <context context-type="linenumber">289</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLead" datatype="html">
@@ -6587,7 +6619,7 @@
         <target>In the host view, you run the session like a small control room: bring participants in, reveal content, open discussion, and make results visible.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
+          <context context-type="linenumber">290,294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostStartStep" datatype="html">
@@ -6595,7 +6627,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Start session:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> From your quiz library, start a session and choose whether it opens with a quiz or Q&amp;A. Then the join code is created.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
+          <context context-type="linenumber">297,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLobby" datatype="html">
@@ -6603,7 +6635,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> You see who has joined; a QR code for joining is shown.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
+          <context context-type="linenumber">301,303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostBeamer" datatype="html">
@@ -6611,7 +6643,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Projector and presenter view:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Question, answers, countdown, and results are large enough for projection, stream, or second screen.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSteuerung" datatype="html">
@@ -6619,7 +6651,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Controls:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Use “Next question” to bring content on screen. You can start with a reading phase, then open the answer phase and decide when results appear on the screen.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
+          <context context-type="linenumber">309,312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPeer" datatype="html">
@@ -6627,7 +6659,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (double rounds):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> For suitable quiz questions, estimate questions, and Pulse Check rounds: vote first, discuss, then vote again. The before/after comparison makes learning progress visible.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
+          <context context-type="linenumber">314,317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSettings" datatype="html">
@@ -6635,7 +6667,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Settings:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> At the start, choose style and options: business or playful, with or without leaderboard, sound, reading phase, team mode, nicknames, and timer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
+          <context context-type="linenumber">319,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallTitle" datatype="html">
@@ -6643,7 +6675,7 @@
         <target> Question wall in the live Q&amp;A channel </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
+          <context context-type="linenumber">327,329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLead" datatype="html">
@@ -6651,7 +6683,7 @@
         <target> Q&amp;A should not disappear into a side chat. The question wall makes audience questions visible, prioritizable, and easy to moderate: you keep the thread of the session while the group collectively signals which points really need clarification. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
+          <context context-type="linenumber">330,334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallListAria" datatype="html">
@@ -6659,7 +6691,7 @@
         <target>Teaching functions of the Q&amp;A question wall</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
+          <context context-type="linenumber">338</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationTitle" datatype="html">
@@ -6667,7 +6699,7 @@
         <target> Moderation with pedagogical timing </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">343</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationBody" datatype="html">
@@ -6675,7 +6707,7 @@
         <target> When needed, new questions wait for your approval first. You can approve, pin, archive, or remove contributions and steer psychological safety, relevance, and timing: answer now, collect for later, or mark as a discussion thread. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
+          <context context-type="linenumber">344,349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingTitle" datatype="html">
@@ -6683,7 +6715,7 @@
         <target> Collective upvoting and downvoting </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingBody" datatype="html">
@@ -6691,7 +6723,7 @@
         <target> Participants weight questions together. Positive and negative votes show more than popularity: they surface uncertainty, disagreement, and need for clarification. Sort modes such as “most supported”, “best questions”, and “controversial” help you spend limited live time where it matters didactically. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
+          <context context-type="linenumber">356,361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
@@ -6699,7 +6731,7 @@
         <target> Q&amp;A word cloud at theme level </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
+          <context context-type="linenumber">367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudBody" datatype="html">
@@ -6707,7 +6739,7 @@
         <target> The word cloud condenses visible questions into words and phrases, weighted by support, robust agreement, or controversy. It can be frozen, viewed through the current sort logic, and shown in Presenter View: a fast read on topic clusters, not a decorative word list. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
+          <context context-type="linenumber">368,373</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmTitle" datatype="html">
@@ -6715,7 +6747,7 @@
         <target>Next step: moderation compass</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
+          <context context-type="linenumber">379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmBody" datatype="html">
@@ -6723,7 +6755,7 @@
         <target> Planned first is a deterministic moderation compass. Later, asynchronous Q&amp;A NLP signals and source-bound summaries can be added optionally, as a privacy-conscious moderation aid rather than black-box grading. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
+          <context context-type="linenumber">380,384</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.blitzTitle" datatype="html">
@@ -6731,7 +6763,7 @@
         <target>Pulse Check</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
+          <context context-type="linenumber">391</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackIntro" datatype="html">
@@ -6739,7 +6771,7 @@
         <target>Quick pulse and comprehension checks, whether before a break, as a warm-up, or when you need an instant read. Available from the host view of your live session or straight from the home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
+          <context context-type="linenumber">392,396</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfMood" datatype="html">
@@ -6747,7 +6779,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Mood<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): How are participants doing?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
+          <context context-type="linenumber">399,400</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfYesNoMaybe" datatype="html">
@@ -6755,7 +6787,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Yes / No / Maybe<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Quick pulse check.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
+          <context context-type="linenumber">402,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackYesNo" datatype="html">
@@ -6763,7 +6795,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Yes / No<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): Clear two-option poll with no middle ground.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">405,406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
@@ -6771,7 +6803,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>True / False / Don&apos;t know<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): For quick assessments or knowledge checks.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
+          <context context-type="linenumber">408,410</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
@@ -6779,7 +6811,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lettered quick polls<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D): Three or four preset choices for on-the-fly votes—no full quiz question required.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
+          <context context-type="linenumber">412,414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTempo" datatype="html">
@@ -6787,7 +6819,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Tempo feedback<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): Four icons let your group continuously show whether they can follow. Participants can change their feedback; you only see the aggregated trend.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">416,419</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
@@ -6795,7 +6827,7 @@
         <target>You start the round in the host area of your live session or directly via the Pulse Check card “Live in one click” on the home page. Participants vote with one tap, and you see the results live as a bar chart.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">421,425</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfPeer" datatype="html">
@@ -6803,7 +6835,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (double rounds):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Round one: don&apos;t reveal results yet → start the “discussion phase” (“talk to someone next to you”) → “second vote.” The before/after view shows how the mood snapshot shifts after discussion.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">428,432</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfStop" datatype="html">
@@ -6811,7 +6843,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Stop:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Freeze the poll – participants see “Poll is paused” and cannot vote until you choose “Resume”.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">434,436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfReset" datatype="html">
@@ -6819,7 +6851,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Reset:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Clear all votes and run the poll again.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">438,439</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfNewRound" datatype="html">
@@ -6827,7 +6859,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>New round:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Generate a new code and start a fresh round.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">441,442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfCopyLink" datatype="html">
@@ -6835,7 +6867,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Copy link:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Copy the join link to the clipboard, e.g. to share via chat.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">444,446</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsTitle" datatype="html">
@@ -6843,7 +6875,7 @@
         <target>For your participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsLead" datatype="html">
@@ -6851,7 +6883,7 @@
         <target>In short: what you can share with people in your session:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">452,454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsJoin" datatype="html">
@@ -6859,7 +6891,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Join:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Enter the 6-character code on arsnova.eu and tap “Let&apos;s go”—works for quiz, Q&amp;A, and Pulse Check. No sign-up required.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">457,459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsNick" datatype="html">
@@ -6867,7 +6899,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Nicknames:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Depending on your settings, participants will use predefined names, their own names, or stay entirely anonymous.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">461,463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsVote" datatype="html">
@@ -6875,7 +6907,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Voting:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> The question appears on their device; they select an answer and submit. When self-assessment is enabled, the 1–5 scale follows. With a time limit, a countdown runs.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">465,468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTitle" datatype="html">
@@ -6883,7 +6915,7 @@
         <target>Your quiz library</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionLead" datatype="html">
@@ -6891,7 +6923,7 @@
         <target>Here you create and prepare your quizzes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionEditor" datatype="html">
@@ -6899,7 +6931,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sort questions using drag and drop, expand and collapse, check preview.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">477,479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTypes" datatype="html">
@@ -6907,7 +6939,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Question types:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single choice, multiple choice, short answer, free text, survey, rating scale, and numerical estimate question — each question can optionally include a timer, difficulty, and self-assessment.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">481,484</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionImport" datatype="html">
@@ -6915,7 +6947,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Import / Export:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Import or export quizzes as JSON. Use the generation and review templates to create high-quality quizzes with your preferred AI tool, review them, and import them directly. Your content and presentations are not sent to arsnova.eu; you use your own AI tool.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">486,490</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionSync" datatype="html">
@@ -6923,7 +6955,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sync:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Use the sync link to share your quiz library with colleagues or continue on other devices. Anyone with the link can open the library. Device details are only there to help you get your bearings.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">492,495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoQuizHint" datatype="html">
@@ -6931,7 +6963,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Demo quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> A preinstalled quiz shows all formats with examples, including KaTeX formulas and Markdown. Open it from the quiz library in preview.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">497,500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesTitle" datatype="html">
@@ -6939,7 +6971,7 @@
         <target>Business and gamification</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesLead" datatype="html">
@@ -6947,7 +6979,7 @@
         <target>Two styles for different situations—selectable on the home page and at session start.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">506,509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.styleSerious" datatype="html">
@@ -6955,7 +6987,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Business:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonymous, no leaderboard—ideal for formative assessments, exam prep, and sensitive topics.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">512,514</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylePlayful" datatype="html">
@@ -6963,7 +6995,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Leaderboard, sound effects, and energy—great for icebreakers, team competitions, and high-energy quizzes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">516,518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesOptions" datatype="html">
@@ -6971,7 +7003,7 @@
         <target>All options (leaderboard, sound, reading phase, team, bonus) can be turned on or off individually.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">520,523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTitle" datatype="html">
@@ -6979,7 +7011,7 @@
         <target>More features</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreBonus" datatype="html">
@@ -6987,7 +7019,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Bonus codes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Top finishers get a redeemable code (e.g. for bonus points). You see the code list; we don&apos;t store personal data.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">530,533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTeams" datatype="html">
@@ -6995,7 +7027,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Team mode:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Your participants play in teams with their own team leaderboard—e.g. for group competitions in seminars.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">535,537</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreGamification" datatype="html">
@@ -7003,7 +7035,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sound effects, rewards for top finishers, and on-screen encouragement—when you use the gamification style.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">539,541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyTitle" datatype="html">
@@ -7011,7 +7043,7 @@
         <target>Privacy and technology</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyBody" datatype="html">
@@ -7019,7 +7051,15 @@
         <target>arsnova.eu is free, open source, and built for schools, universities, and workplace training—with a strong focus on privacy (GDPR). Quiz content stays in your browser first. No sign-up for you or your participants. Installable as a PWA for a faster start on phones. UI in German, English, French, Spanish, and Italian.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">547,553</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingLink" datatype="html">
+        <source>Hintergründe und Einsatzmöglichkeiten</source>
+        <target>Background and use cases</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.ts</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">
@@ -7103,11 +7143,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">408</context>
+          <context context-type="linenumber">416</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">864</context>
+          <context context-type="linenumber">872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -7143,11 +7183,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">409</context>
+          <context context-type="linenumber">417</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">865</context>
+          <context context-type="linenumber">873</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -7415,7 +7455,7 @@
         <target>Share with others or use the same library on a second device:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">447,449</context>
+          <context context-type="linenumber">453,455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareAria" datatype="html">
@@ -7423,7 +7463,7 @@
         <target>Show sync link</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">456</context>
+          <context context-type="linenumber">462</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareLink" datatype="html">
@@ -7431,7 +7471,7 @@
         <target>Show sync link</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">459</context>
+          <context context-type="linenumber">465</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncOpenHint" datatype="html">
@@ -7439,7 +7479,7 @@
         <target>Paste the sync link you received:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">465,467</context>
+          <context context-type="linenumber">471,473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkLabel" datatype="html">
@@ -7447,7 +7487,7 @@
         <target>Sync link</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkPlaceholder" datatype="html">
@@ -7455,7 +7495,7 @@
         <target>sync-room-12345678</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">483</context>
+          <context context-type="linenumber">489</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkInputAria" datatype="html">
@@ -7463,7 +7503,7 @@
         <target>Enter or paste sync link</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">489</context>
+          <context context-type="linenumber">495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkSubmit" datatype="html">
@@ -7471,7 +7511,7 @@
         <target>Open</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">497,499</context>
+          <context context-type="linenumber">503,505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkedHintWithOrigin" datatype="html">
@@ -7479,7 +7519,7 @@
         <target>Quizzes are shared with <x id="INTERPOLATION" equiv-text="{{ originSummary }}"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">513,515</context>
+          <context context-type="linenumber">519,521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkCta" datatype="html">
@@ -7487,7 +7527,7 @@
         <target>Unlink</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayTitle" datatype="html">
@@ -7495,7 +7535,7 @@
         <target>Current news</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">567,569</context>
+          <context context-type="linenumber">573,575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayCloseAria" datatype="html">
@@ -7503,7 +7543,7 @@
         <target>Close message</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">585</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.ack" datatype="html">
@@ -7511,7 +7551,7 @@
         <target>Got it!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">593,595</context>
+          <context context-type="linenumber">599,601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbGroupAria" datatype="html">
@@ -7519,7 +7559,7 @@
         <target>Rate this message</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">599</context>
+          <context context-type="linenumber">605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpTooltip" datatype="html">
@@ -7527,7 +7567,7 @@
         <target>Helpful — tap again to remove your vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">609</context>
+          <context context-type="linenumber">615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpAria" datatype="html">
@@ -7535,7 +7575,7 @@
         <target>Helpful, tap again to remove your vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">611</context>
+          <context context-type="linenumber">617</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownTooltip" datatype="html">
@@ -7543,7 +7583,7 @@
         <target>Not helpful — tap again to remove your vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">623</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownAria" datatype="html">
@@ -7551,7 +7591,15 @@
         <target>Not helpful, tap again to remove your vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">625</context>
+          <context context-type="linenumber">631</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="homeHostCard.infoLanding" datatype="html">
+        <source>Einsatzmöglichkeiten entdecken</source>
+        <target>Explore use cases</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.syncOrigin" datatype="html">
@@ -7559,11 +7607,11 @@
         <target><x id="browser" equiv-text="peer.browserLabel"/> on <x id="device" equiv-text="peer.deviceLabel"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2862374619655540985" datatype="html">
@@ -7571,11 +7619,11 @@
         <target>just now</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">470</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5002</context>
+          <context context-type="linenumber">5009</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7587,11 +7635,11 @@
         <target><x id="PH" equiv-text="minutes"/> mins ago</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">467</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5004</context>
+          <context context-type="linenumber">5011</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7603,11 +7651,11 @@
         <target>1 hour ago</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7619,11 +7667,11 @@
         <target><x id="PH" equiv-text="hours"/> hrs ago</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7635,11 +7683,11 @@
         <target>1 day ago</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7651,11 +7699,11 @@
         <target><x id="PH" equiv-text="days"/> days ago</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7667,7 +7715,7 @@
         <target>Remove session <x id="PH"/> from list</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">477</context>
+          <context context-type="linenumber">482</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.heroChipStartError" datatype="html">
@@ -7675,7 +7723,7 @@
         <target>Could not start the channel. Please try again.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">586</context>
+          <context context-type="linenumber">591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkError" datatype="html">
@@ -7683,7 +7731,7 @@
         <target>Please enter a valid sync link.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">645</context>
+          <context context-type="linenumber">650</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkConfirmPrompt" datatype="html">
@@ -7691,7 +7739,7 @@
         <target>Really remove the link? The current quiz library will stay on this device.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">666</context>
+          <context context-type="linenumber">671</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkSuccess" datatype="html">
@@ -7699,7 +7747,7 @@
         <target>Link removed. The quiz library is now only active on this device.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">674</context>
+          <context context-type="linenumber">679</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeFeedbackCard.startError" datatype="html">
@@ -7707,7 +7755,7 @@
         <target>Couldn&apos;t start Pulse Check. Try again.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">700</context>
+          <context context-type="linenumber">705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6627607898679527757" datatype="html">
@@ -7715,7 +7763,7 @@
         <target>Please enter the 6-character code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">730</context>
+          <context context-type="linenumber">735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2422920312042178920" datatype="html">
@@ -7723,7 +7771,7 @@
         <target>This session has already ended.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">787</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/join/join.component.ts</context>
@@ -7911,7 +7959,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7931,7 +7979,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -8027,7 +8075,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2939</context>
+          <context context-type="linenumber">2946</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -8677,7 +8725,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1882</context>
+          <context context-type="linenumber">1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.previewSaveAndOpen" datatype="html">
@@ -8689,7 +8737,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1886</context>
+          <context context-type="linenumber">1900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1736772795054152455" datatype="html">
@@ -8889,7 +8937,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">595</context>
+          <context context-type="linenumber">603</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -9416,7 +9464,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1599,1602</context>
+          <context context-type="linenumber">1613,1616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionEditSaveHint" datatype="html">
@@ -9492,7 +9540,7 @@
         <target>Time for this question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">568,570</context>
+          <context context-type="linenumber">576,578</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9504,7 +9552,7 @@
         <target>The default is the time limit from the quiz settings. You can set your own limit per question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">571,574</context>
+          <context context-type="linenumber">579,582</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9516,7 +9564,7 @@
         <target>Use quiz time limit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">587</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9528,7 +9576,7 @@
         <target>Seconds for this question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">585</context>
+          <context context-type="linenumber">593</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9540,7 +9588,7 @@
         <target>Seconds for this question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">590</context>
+          <context context-type="linenumber">598</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9552,7 +9600,7 @@
         <target>No reading phase for this question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">602,604</context>
+          <context context-type="linenumber">610,612</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9564,7 +9612,7 @@
         <target>Self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">609,611</context>
+          <context context-type="linenumber">617,619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceConfigHint" datatype="html">
@@ -9572,7 +9620,7 @@
         <target>After their answer, participants indicate how confident they are. Does not affect the scoring.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">612,615</context>
+          <context context-type="linenumber">620,623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceEnabledToggle" datatype="html">
@@ -9580,7 +9628,7 @@
         <target>Self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">620,622</context>
+          <context context-type="linenumber">634,636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelLowField" datatype="html">
@@ -9588,7 +9636,7 @@
         <target>Low answer confidence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">632</context>
+          <context context-type="linenumber">646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelHighField" datatype="html">
@@ -9596,7 +9644,7 @@
         <target>High answer confidence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">652</context>
+          <context context-type="linenumber">666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewLabel" datatype="html">
@@ -9604,7 +9652,7 @@
         <target>Preview for participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">676,678</context>
+          <context context-type="linenumber">690,692</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8205020163645016790" datatype="html">
@@ -9613,7 +9661,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">715</context>
+          <context context-type="linenumber">729</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.quickFormatAria" datatype="html">
@@ -9621,7 +9669,7 @@
         <target>Select quick format</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">720</context>
+          <context context-type="linenumber">734</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7287117104463920417" datatype="html">
@@ -9630,7 +9678,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">726</context>
+          <context context-type="linenumber">740</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetSection" datatype="html">
@@ -9638,7 +9686,7 @@
         <target>Quick start</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">731,733</context>
+          <context context-type="linenumber">745,747</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetGroupAria" datatype="html">
@@ -9646,7 +9694,7 @@
         <target>Select estimation question template</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">738</context>
+          <context context-type="linenumber">752</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8648957206736539595" datatype="html">
@@ -9654,7 +9702,7 @@
         <target>Input type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">756</context>
+          <context context-type="linenumber">770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateInputTypeLabel" datatype="html">
@@ -9662,7 +9710,7 @@
         <target>Number type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">759</context>
+          <context context-type="linenumber">773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntegerOption" datatype="html">
@@ -9670,7 +9718,7 @@
         <target>Integer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">762</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalOption" datatype="html">
@@ -9678,7 +9726,7 @@
         <target>Decimal number</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">765</context>
+          <context context-type="linenumber">779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalPlacesLabel" datatype="html">
@@ -9686,7 +9734,7 @@
         <target>Max. decimal places</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">772</context>
+          <context context-type="linenumber">786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceSection" datatype="html">
@@ -9694,7 +9742,7 @@
         <target>Tolerance mode</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">788,790</context>
+          <context context-type="linenumber">802,804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceModeLabel" datatype="html">
@@ -9702,7 +9750,7 @@
         <target>mode</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">792</context>
+          <context context-type="linenumber">806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteIntervalOption" datatype="html">
@@ -9710,7 +9758,7 @@
         <target>Absolute interval [L, R]</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">797</context>
+          <context context-type="linenumber">811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateRelativePercentOption" datatype="html">
@@ -9718,7 +9766,7 @@
         <target>Relative tolerance band (V ± p%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">802</context>
+          <context context-type="linenumber">816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalLeftLabel" datatype="html">
@@ -9726,7 +9774,7 @@
         <target>Left border L</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">811</context>
+          <context context-type="linenumber">825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalRightLabel" datatype="html">
@@ -9734,7 +9782,7 @@
         <target>Right border R</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">817</context>
+          <context context-type="linenumber">831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueLabel" datatype="html">
@@ -9742,7 +9790,7 @@
         <target>Reference value for analysis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">824</context>
+          <context context-type="linenumber">838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueHint" datatype="html">
@@ -9750,7 +9798,7 @@
         <target>Optional for reference line, error metric and round comparison</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">828</context>
+          <context context-type="linenumber">842</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueLabel" datatype="html">
@@ -9758,7 +9806,7 @@
         <target>Reference value V</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueHint" datatype="html">
@@ -9766,7 +9814,7 @@
         <target>Must be ≠ 0</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">840</context>
+          <context context-type="linenumber">854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTolerancePercentLabel" datatype="html">
@@ -9774,7 +9822,7 @@
         <target>Tolerance p (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">845</context>
+          <context context-type="linenumber">859</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateBoundsSection" datatype="html">
@@ -9782,7 +9830,7 @@
         <target>Plausibility limits (optional)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">858,860</context>
+          <context context-type="linenumber">872,874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMinLabel" datatype="html">
@@ -9790,7 +9838,7 @@
         <target>Min input</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">863</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMaxLabel" datatype="html">
@@ -9798,7 +9846,7 @@
         <target>Max input</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">867</context>
+          <context context-type="linenumber">881</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewAria" datatype="html">
@@ -9806,7 +9854,7 @@
         <target>Preview of the estimation question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">876</context>
+          <context context-type="linenumber">890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewTitle" datatype="html">
@@ -9814,7 +9862,7 @@
         <target>Band preview</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">881</context>
+          <context context-type="linenumber">895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTwoRoundsToggle" datatype="html">
@@ -9822,7 +9870,7 @@
         <target>Two rounds of voting (peer instruction)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">937,939</context>
+          <context context-type="linenumber">951,953</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8259238864102475814" datatype="html">
@@ -9831,7 +9879,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">945</context>
+          <context context-type="linenumber">959</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.ratingScaleAria" datatype="html">
@@ -9839,7 +9887,7 @@
         <target>Select rating scale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">949</context>
+          <context context-type="linenumber">963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4298652859209119138" datatype="html">
@@ -9847,7 +9895,7 @@
         <target>Left end label (optional)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3739377380076895717" datatype="html">
@@ -9855,7 +9903,7 @@
         <target>Right end label (optional)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">985</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigLegend" datatype="html">
@@ -9863,7 +9911,7 @@
         <target>Typos and spelling variants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">983,985</context>
+          <context context-type="linenumber">997,999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigHint" datatype="html">
@@ -9871,7 +9919,7 @@
         <target>Choose which typos still count. The preview below shows whether they lead to full points, partial credit, or no credit.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">989,992</context>
+          <context context-type="linenumber">1003,1006</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindFieldLabel" datatype="html">
@@ -9879,7 +9927,7 @@
         <target>Answer type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">996</context>
+          <context context-type="linenumber">1010</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthFieldLabel" datatype="html">
@@ -9887,7 +9935,7 @@
         <target>Maximum answer length</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1010</context>
+          <context context-type="linenumber">1024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthHint" datatype="html">
@@ -9895,7 +9943,7 @@
         <target>1 to 500 characters</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationModeFieldLabel" datatype="html">
@@ -9903,7 +9951,7 @@
         <target>Evaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1025</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceFieldLabel" datatype="html">
@@ -9911,7 +9959,7 @@
         <target>Tolerance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceHint" datatype="html">
@@ -9919,7 +9967,7 @@
         <target>The percentages describe the allowed deviation from the model answer, not the score. Low ≈ 10%, medium ≈ 20%, generous ≈ 30%. The same level feels stricter for short terms.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1042,1044</context>
+          <context context-type="linenumber">1056,1058</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextAllowPartialCreditToggle" datatype="html">
@@ -9927,7 +9975,7 @@
         <target>Award partial credit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1066,1068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextCaseSensitiveToggle" datatype="html">
@@ -9935,7 +9983,7 @@
         <target>Match letter case</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1058,1060</context>
+          <context context-type="linenumber">1072,1074</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindFieldLabel" datatype="html">
@@ -9943,7 +9991,7 @@
         <target>Number format</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1064</context>
+          <context context-type="linenumber">1078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeFieldLabel" datatype="html">
@@ -9951,7 +9999,7 @@
         <target>Numeric tolerance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1074</context>
+          <context context-type="linenumber">1088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeHint" datatype="html">
@@ -9959,7 +10007,7 @@
         <target>Exact mode requires the same numeric value. Absolute tolerance uses a fixed ± range, relative tolerance uses a percentage around the model answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1082,1083</context>
+          <context context-type="linenumber">1096,1097</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceFieldLabel" datatype="html">
@@ -9967,7 +10015,7 @@
         <target>Absolute tolerance (±)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1090</context>
+          <context context-type="linenumber">1104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceHint" datatype="html">
@@ -9975,7 +10023,7 @@
         <target>Example: with 10 and ±0.5, answers from 9.5 to 10.5 are accepted.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1100</context>
+          <context context-type="linenumber">1114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceFieldLabel" datatype="html">
@@ -9983,7 +10031,7 @@
         <target>Relative tolerance (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1108</context>
+          <context context-type="linenumber">1122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceHint" datatype="html">
@@ -9991,7 +10039,7 @@
         <target>Example: with 200 and 5%, answers from 190 to 210 are accepted.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1118</context>
+          <context context-type="linenumber">1132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyFieldLabel" datatype="html">
@@ -9999,7 +10047,7 @@
         <target>Unit family</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1126</context>
+          <context context-type="linenumber">1140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitToggle" datatype="html">
@@ -10007,7 +10055,7 @@
         <target> Require unit </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1139,1141</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAcceptEquivalentUnitsToggle" datatype="html">
@@ -10015,7 +10063,7 @@
         <target> Accept equivalent units </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1159,1161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLegend" datatype="html">
@@ -10023,7 +10071,7 @@
         <target>How grading behaves</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1154,1156</context>
+          <context context-type="linenumber">1168,1170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningLabel" datatype="html">
@@ -10031,7 +10079,7 @@
         <target>Teaching note:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1200</context>
+          <context context-type="linenumber">1214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsToggle" datatype="html">
@@ -10039,7 +10087,7 @@
         <target>Show technical details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1208,1210</context>
+          <context context-type="linenumber">1222,1224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsIntro" datatype="html">
@@ -10047,7 +10095,7 @@
         <target>Auto combines exact matches, Hamming, Damerau-Levenshtein, and Levenshtein. Hamming works for single incorrect characters in same-length answers, Damerau-Levenshtein additionally handles swapped neighboring letters, and Levenshtein also covers missing or extra characters.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1215,1220</context>
+          <context context-type="linenumber">1229,1234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTrimWhitespaceToggle" datatype="html">
@@ -10055,7 +10103,7 @@
         <target>Ignore whitespace at the start and end</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1225,1227</context>
+          <context context-type="linenumber">1239,1241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextNormalizeWhitespaceToggle" datatype="html">
@@ -10063,7 +10111,7 @@
         <target>Collapse repeated spaces</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1231,1233</context>
+          <context context-type="linenumber">1245,1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextValidSolutionHint" datatype="html">
@@ -10071,7 +10119,7 @@
         <target>Valid</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1272,1274</context>
+          <context context-type="linenumber">1286,1288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8021687558521014030" datatype="html">
@@ -10080,7 +10128,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1276</context>
+          <context context-type="linenumber">1290</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6278157135662238363" datatype="html">
@@ -10089,7 +10137,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2650319028885568688" datatype="html">
@@ -10098,7 +10146,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2525684207823121577" datatype="html">
@@ -10106,7 +10154,7 @@
         <target>Participants answer freely here – no predefined answers needed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1332,1334</context>
+          <context context-type="linenumber">1346,1348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.livePreviewCardTitle" datatype="html">
@@ -10114,7 +10162,7 @@
         <target>Full preview</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1357,1359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7492260970005034710" datatype="html">
@@ -10122,7 +10170,7 @@
         <target>Formula error: <x id="INTERPOLATION" equiv-text="{{ previewKatexError() }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1350,1352</context>
+          <context context-type="linenumber">1364,1366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2863483573986908286" datatype="html">
@@ -10131,7 +10179,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1355</context>
+          <context context-type="linenumber">1369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10144,7 +10192,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1429</context>
+          <context context-type="linenumber">1443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionsListTitle" datatype="html">
@@ -10153,7 +10201,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1437,1439</context>
+          <context context-type="linenumber">1451,1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8122550761270535954" datatype="html">
@@ -10162,7 +10210,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1441</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3827964072457808965" datatype="html">
@@ -10171,7 +10219,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1451</context>
+          <context context-type="linenumber">1465</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -10183,7 +10231,7 @@
         <target>Add your first question above to get started.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1452,1454</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionListPosition" datatype="html">
@@ -10191,7 +10239,7 @@
         <target>Question <x id="INTERPOLATION" equiv-text="{{ question.order + 1 }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1514,1515</context>
+          <context context-type="linenumber">1528,1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionDisabledBadge" datatype="html">
@@ -10199,7 +10247,7 @@
         <target>Disabled</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1539</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineDisabledHint" datatype="html">
@@ -10207,7 +10255,7 @@
         <target>This question is disabled and does not appear in the preview and live quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1565,1568</context>
+          <context context-type="linenumber">1579,1582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.activateQuestion" datatype="html">
@@ -10215,15 +10263,15 @@
         <target>Activate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1575</context>
+          <context context-type="linenumber">1589</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1772</context>
+          <context context-type="linenumber">1786</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineEditEyebrow" datatype="html">
@@ -10231,7 +10279,7 @@
         <target>Edit mode</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1587,1589</context>
+          <context context-type="linenumber">1601,1603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.editQuestionTitle" datatype="html">
@@ -10239,7 +10287,7 @@
         <target>Edit this question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1593,1595</context>
+          <context context-type="linenumber">1607,1609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.freeTextWordCloudHint" datatype="html">
@@ -10247,7 +10295,7 @@
         <target>Free text answer as a word cloud</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1617,1619</context>
+          <context context-type="linenumber">1631,1633</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10259,7 +10307,7 @@
         <target>Short answer with automatic matching against sample solutions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1624,1626</context>
+          <context context-type="linenumber">1638,1640</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10271,7 +10319,7 @@
         <target>Self-assessment is collected after the answer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1715,1717</context>
+          <context context-type="linenumber">1729,1731</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6920196637619975735" datatype="html">
@@ -10279,11 +10327,11 @@
         <target>Edit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1754</context>
+          <context context-type="linenumber">1768</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1802</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10295,11 +10343,11 @@
         <target>Disable</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1763</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1797</context>
+          <context context-type="linenumber">1811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4580399730639224598" datatype="html">
@@ -10308,11 +10356,11 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1791</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1811</context>
+          <context context-type="linenumber">1825</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -10324,11 +10372,11 @@
         <target>Back to quiz list</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1843</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1900</context>
+          <context context-type="linenumber">1914</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -10344,7 +10392,7 @@
         <target>Back</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1832</context>
+          <context context-type="linenumber">1846</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -10356,11 +10404,11 @@
         <target>Discard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1842</context>
+          <context context-type="linenumber">1856</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1846</context>
+          <context context-type="linenumber">1860</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButtonAria" datatype="html">
@@ -10368,7 +10416,7 @@
         <target>Add another question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1869</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButton" datatype="html">
@@ -10376,7 +10424,7 @@
         <target>Another question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1859</context>
+          <context context-type="linenumber">1873</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.saveAllButton" datatype="html">
@@ -10384,11 +10432,11 @@
         <target>Save changes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1869</context>
+          <context context-type="linenumber">1883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1873</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7620597678842046410" datatype="html">
@@ -10397,7 +10445,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1895</context>
+          <context context-type="linenumber">1909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6672916435220201136" datatype="html">
@@ -10406,7 +10454,23 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1903</context>
+          <context context-type="linenumber">1917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingEstimate" datatype="html">
+        <source>Schätzfragen didaktisch einsetzen</source>
+        <target>Use estimation questions for learning</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <target>Understand confidence ratings and follow-up</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="924826286502636331" datatype="html">
@@ -10415,7 +10479,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">399</context>
+          <context context-type="linenumber">407</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4737017620429217247" datatype="html">
@@ -10424,7 +10488,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">400</context>
+          <context context-type="linenumber">408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="493996564238682027" datatype="html">
@@ -10432,7 +10496,7 @@
         <target>Free text</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">401</context>
+          <context context-type="linenumber">409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8680267345873464947" datatype="html">
@@ -10440,7 +10504,7 @@
         <target>Survey</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">403</context>
+          <context context-type="linenumber">411</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5472460529727499985" datatype="html">
@@ -10448,7 +10512,7 @@
         <target>Rating (1-5 / 1-10)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">404</context>
+          <context context-type="linenumber">412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearLabel" datatype="html">
@@ -10456,7 +10520,7 @@
         <target>year</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">427</context>
+          <context context-type="linenumber">435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearHint" datatype="html">
@@ -10464,7 +10528,7 @@
         <target>Integer, 1500-2000 plausible, 1700-1900 accepted, two rounds.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">428</context>
+          <context context-type="linenumber">436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementLabel" datatype="html">
@@ -10472,7 +10536,7 @@
         <target>Measured value</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">433</context>
+          <context context-type="linenumber">441</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementHint" datatype="html">
@@ -10480,7 +10544,7 @@
         <target>Decimal value with one decimal place and a narrow absolute tolerance band.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">434</context>
+          <context context-type="linenumber">442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentLabel" datatype="html">
@@ -10488,7 +10552,7 @@
         <target>Percentage</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">439</context>
+          <context context-type="linenumber">447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentHint" datatype="html">
@@ -10496,7 +10560,7 @@
         <target>Integer from 0 to 100 with ten percentage points tolerance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">440</context>
+          <context context-type="linenumber">448</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeLabel" datatype="html">
@@ -10504,7 +10568,7 @@
         <target>Magnitude</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">445</context>
+          <context context-type="linenumber">453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeHint" datatype="html">
@@ -10512,7 +10576,7 @@
         <target>Large integer with relative tolerance band for order of magnitude estimates.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">446</context>
+          <context context-type="linenumber">454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.easy" datatype="html">
@@ -10520,7 +10584,7 @@
         <target>Easy</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">452</context>
+          <context context-type="linenumber">460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10528,7 +10592,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4673</context>
+          <context context-type="linenumber">4680</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10540,7 +10604,7 @@
         <target>Medium</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">453</context>
+          <context context-type="linenumber">461</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10548,7 +10612,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4675</context>
+          <context context-type="linenumber">4682</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10560,7 +10624,7 @@
         <target>Hard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">454</context>
+          <context context-type="linenumber">462</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10568,7 +10632,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4677</context>
+          <context context-type="linenumber">4684</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10580,7 +10644,7 @@
         <target>Exact match only</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">464</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10592,7 +10656,7 @@
         <target>Only accepts identical spelling.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeAutoLabel" datatype="html">
@@ -10600,7 +10664,7 @@
         <target>Allow small typos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">469</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10612,7 +10676,7 @@
         <target>Best for most technical terms: handles exact matches, small typos, letter swaps, and missing characters.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeHammingLabel" datatype="html">
@@ -10620,7 +10684,7 @@
         <target>Same length, small letter swaps</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">474</context>
+          <context context-type="linenumber">482</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10632,7 +10696,7 @@
         <target>Best for terms of the same length with one wrong or swapped letter.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">475</context>
+          <context context-type="linenumber">483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeLevenshteinLabel" datatype="html">
@@ -10640,7 +10704,7 @@
         <target>Also allow missing or extra characters</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">479</context>
+          <context context-type="linenumber">487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10652,7 +10716,7 @@
         <target>Best for terms with a missing or extra character.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">480</context>
+          <context context-type="linenumber">488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindText" datatype="html">
@@ -10660,7 +10724,7 @@
         <target>Evaluate with text similarity</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">491</context>
+          <context context-type="linenumber">499</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindTextHint" datatype="html">
@@ -10668,7 +10732,7 @@
         <target>Suitable for technical terms and fixed spellings with minor typos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumeric" datatype="html">
@@ -10676,7 +10740,7 @@
         <target>Evaluate numbers</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">496</context>
+          <context context-type="linenumber">504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericHint" datatype="html">
@@ -10684,7 +10748,7 @@
         <target>Evaluates numeric values instead of text similarity and supports exact, absolute, or relative tolerances.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">497</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnit" datatype="html">
@@ -10692,7 +10756,7 @@
         <target>Evaluate numbers and units</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">501</context>
+          <context context-type="linenumber">509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnitHint" datatype="html">
@@ -10700,7 +10764,7 @@
         <target>Checks numeric values together with a curated unit family and explains missing or differing units.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">502</context>
+          <context context-type="linenumber">510</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindInteger" datatype="html">
@@ -10708,7 +10772,7 @@
         <target>Integer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">507</context>
+          <context context-type="linenumber">515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindDecimal" datatype="html">
@@ -10716,7 +10780,7 @@
         <target>Decimal number</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">508</context>
+          <context context-type="linenumber">516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceExact" datatype="html">
@@ -10724,7 +10788,7 @@
         <target>Exact value</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">512</context>
+          <context context-type="linenumber">520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceAbsolute" datatype="html">
@@ -10732,7 +10796,7 @@
         <target>Absolute tolerance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">515</context>
+          <context context-type="linenumber">523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelative" datatype="html">
@@ -10740,7 +10804,7 @@
         <target>Relative tolerance (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">519</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyLength" datatype="html">
@@ -10748,7 +10812,7 @@
         <target>Length</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">524</context>
+          <context context-type="linenumber">532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyMass" datatype="html">
@@ -10756,7 +10820,7 @@
         <target>Mass</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">525</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyTime" datatype="html">
@@ -10764,7 +10828,7 @@
         <target>Time</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">526</context>
+          <context context-type="linenumber">534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyVolume" datatype="html">
@@ -10772,7 +10836,7 @@
         <target>Volume</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceNone" datatype="html">
@@ -10780,7 +10844,7 @@
         <target>No tolerance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">531</context>
+          <context context-type="linenumber">539</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10792,7 +10856,7 @@
         <target>Low</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">532</context>
+          <context context-type="linenumber">540</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10804,7 +10868,7 @@
         <target>Medium</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">541</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10816,7 +10880,7 @@
         <target>Generous</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">534</context>
+          <context context-type="linenumber">542</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10828,7 +10892,7 @@
         <target>Nobel Prize</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">538</context>
+          <context context-type="linenumber">546</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10844,7 +10908,7 @@
         <target>Kindergarten (animal emojis)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">541</context>
+          <context context-type="linenumber">549</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10860,7 +10924,7 @@
         <target>Primary school</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">551</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10876,7 +10940,7 @@
         <target>Middle school</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">552</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10892,7 +10956,7 @@
         <target>Upper secondary</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">545</context>
+          <context context-type="linenumber">553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10908,7 +10972,7 @@
         <target>Quiz standard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">768</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4668229613641280742" datatype="html">
@@ -10916,7 +10980,7 @@
         <target>Custom</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">866</context>
+          <context context-type="linenumber">874</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10928,7 +10992,7 @@
         <target>Five-level scale from 1 to 5, low: <x id="low" equiv-text="low"/>, high: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">980</context>
+          <context context-type="linenumber">988</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithLow" datatype="html">
@@ -10936,7 +11000,7 @@
         <target>Five-level scale from 1 to 5, low: <x id="low" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">983</context>
+          <context context-type="linenumber">991</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithHigh" datatype="html">
@@ -10944,7 +11008,7 @@
         <target>Five-level scale from 1 to 5, high: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">986</context>
+          <context context-type="linenumber">994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAria" datatype="html">
@@ -10952,7 +11016,7 @@
         <target>Five-level scale from 1 to 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">988</context>
+          <context context-type="linenumber">996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceLabel" datatype="html">
@@ -10964,7 +11028,7 @@
           )"/> to <x id="right" equiv-text="this.formatNumericEstimateEditorValue(band.right)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReferenceLabel" datatype="html">
@@ -10976,7 +11040,7 @@
             )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1152,1154</context>
+          <context context-type="linenumber">1160,1162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewIncomplete" datatype="html">
@@ -10984,7 +11048,7 @@
         <target>Tolerance band is displayed once limits or reference and percentage are complete.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1168</context>
+          <context context-type="linenumber">1176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceOutside" datatype="html">
@@ -10992,7 +11056,7 @@
         <target>Plausibility limits and tolerance ranges do not yet match. Values ​​in the band should also be enterable.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1177</context>
+          <context context-type="linenumber">1185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReady" datatype="html">
@@ -11000,7 +11064,7 @@
         <target>Plausibility limits permitted entries; the tolerance band decides points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1179</context>
+          <context context-type="linenumber">1187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityRange" datatype="html">
@@ -11012,7 +11076,7 @@
       )"/> to <x id="max" equiv-text="this.formatNumericEstimateEditorValue(max)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1186,1188</context>
+          <context context-type="linenumber">1194,1196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMin" datatype="html">
@@ -11024,7 +11088,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1191,1193</context>
+          <context context-type="linenumber">1199,1201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMax" datatype="html">
@@ -11036,7 +11100,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1196,1198</context>
+          <context context-type="linenumber">1204,1206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionLabel" datatype="html">
@@ -11044,7 +11108,7 @@
         <target>Sample solution <x id="solutionNumber" equiv-text="index + 1"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1286</context>
+          <context context-type="linenumber">1294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.answerLabel" datatype="html">
@@ -11052,7 +11116,7 @@
         <target>Answer <x id="answerNumber" equiv-text="index + 1"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1289</context>
+          <context context-type="linenumber">1297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.markAnswerCorrectAria" datatype="html">
@@ -11060,7 +11124,7 @@
         <target>Mark answer <x id="answerNumber" equiv-text="answerNumber"/> as correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1293</context>
+          <context context-type="linenumber">1301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.toggleAnswerCorrectAria" datatype="html">
@@ -11068,7 +11132,7 @@
         <target>Answer <x id="answerNumber" equiv-text="answerNumber"/> correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1297</context>
+          <context context-type="linenumber">1305</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.removeAnswerAria" datatype="html">
@@ -11076,7 +11140,7 @@
         <target>Remove answer <x id="answerNumber" equiv-text="answerNumber"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.collapseQuestionAria" datatype="html">
@@ -11084,7 +11148,7 @@
         <target>Collapse question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1306</context>
+          <context context-type="linenumber">1314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.expandQuestionAria" datatype="html">
@@ -11092,7 +11156,7 @@
         <target>Expand question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsPreviewLabel" datatype="html">
@@ -11100,7 +11164,7 @@
         <target>Sample solutions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.livePreviewAnswersLabel" datatype="html">
@@ -11108,7 +11172,7 @@
         <target>Answers</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1313</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.addShortTextSolution" datatype="html">
@@ -11116,7 +11180,7 @@
         <target>Add another sample solution</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1318</context>
+          <context context-type="linenumber">1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8266267788371304686" datatype="html">
@@ -11125,7 +11189,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1319</context>
+          <context context-type="linenumber">1327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthSummary" datatype="html">
@@ -11133,11 +11197,11 @@
         <target>Max. <x id="maxLength" equiv-text="resolveShortTextMaxLength(question.shortTextMaxLength)"/> characters</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1436</context>
+          <context context-type="linenumber">1444</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1479</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11149,7 +11213,7 @@
         <target>±{$tolerance} absolute</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelativeSummary" datatype="html">
@@ -11157,7 +11221,7 @@
         <target>±{$tolerance}% relative</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1455</context>
+          <context context-type="linenumber">1463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilySummary" datatype="html">
@@ -11165,7 +11229,7 @@
         <target>Units: {$unitFamily}</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1469</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitSummary" datatype="html">
@@ -11173,7 +11237,7 @@
         <target>Unit required</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitOptionalSummary" datatype="html">
@@ -11181,7 +11245,7 @@
         <target>Unit optional</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1466</context>
+          <context context-type="linenumber">1474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEquivalentUnitsSummary" datatype="html">
@@ -11189,7 +11253,7 @@
         <target>Equivalent units allowed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1470</context>
+          <context context-type="linenumber">1478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericExactUnitsSummary" datatype="html">
@@ -11197,7 +11261,7 @@
         <target>Only exact configured unit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1471</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceSummary" datatype="html">
@@ -11205,7 +11269,7 @@
         <target>Tolerance: <x id="tolerance" equiv-text="this.shortTextToleranceLabel(question.shortTextToleranceLevel)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1484</context>
+          <context context-type="linenumber">1492</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11217,7 +11281,7 @@
         <target>Case-sensitive matching</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1488</context>
+          <context context-type="linenumber">1496</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11229,7 +11293,7 @@
         <target>Full points only</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1491</context>
+          <context context-type="linenumber">1499</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11241,7 +11305,7 @@
         <target>Whitespace is checked strictly</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1498</context>
+          <context context-type="linenumber">1506</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11253,7 +11317,7 @@
         <target>Define at least one reference answer with a unit, keep the unit set small, and require units only when the unit itself should be graded.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1507</context>
+          <context context-type="linenumber">1515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningNumeric" datatype="html">
@@ -11261,7 +11325,7 @@
         <target>Define at least one clear reference value and choose tolerance so it allows calculation imprecision while clearly excluding scientifically wrong values.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1508</context>
+          <context context-type="linenumber">1516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarning" datatype="html">
@@ -11269,7 +11333,7 @@
         <target>Use tolerant grading only for clearly defined technical terms. For open wording, multiple sample solutions are usually fairer than high tolerance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11281,7 +11345,7 @@
         <target>Add between one and ten reference answers with a supported unit, for example “2 m”.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1521</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHintNumeric" datatype="html">
@@ -11289,7 +11353,7 @@
         <target>Add between one and ten numeric reference answers, for example “3.5”.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1530</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHint" datatype="html">
@@ -11297,7 +11361,7 @@
         <target>Add between one and ten sample solutions. Every variant counts as a correct short answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewExactLabel" datatype="html">
@@ -11305,11 +11369,11 @@
         <target>Exact entry</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1621</context>
+          <context context-type="linenumber">1629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLengthLabel" datatype="html">
@@ -11317,7 +11381,7 @@
         <target>Missing or extra character</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1553</context>
+          <context context-type="linenumber">1561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewWrongLabel" datatype="html">
@@ -11325,11 +11389,11 @@
         <target>Different term</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1557</context>
+          <context context-type="linenumber">1565</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1658</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeFull" datatype="html">
@@ -11337,11 +11401,11 @@
         <target>Full points</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1592</context>
+          <context context-type="linenumber">1600</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeAccepted" datatype="html">
@@ -11349,11 +11413,11 @@
         <target>Accepted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1593</context>
+          <context context-type="linenumber">1601</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1669</context>
+          <context context-type="linenumber">1677</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomePartial" datatype="html">
@@ -11361,11 +11425,11 @@
         <target>Partial credit (<x id="points" equiv-text="result.points"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1596</context>
+          <context context-type="linenumber">1604</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1672</context>
+          <context context-type="linenumber">1680</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeRejected" datatype="html">
@@ -11373,11 +11437,11 @@
         <target>Not accepted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1599</context>
+          <context context-type="linenumber">1607</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1683</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewNumericToleranceLabel" datatype="html">
@@ -11385,7 +11449,7 @@
         <target>Within tolerance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1629</context>
+          <context context-type="linenumber">1637</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewEquivalentUnitLabel" datatype="html">
@@ -11393,7 +11457,7 @@
         <target>Equivalent unit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewMissingUnitLabel" datatype="html">
@@ -11401,7 +11465,7 @@
         <target>Missing unit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1644</context>
+          <context context-type="linenumber">1652</context>
         </context-group>
       </trans-unit>
       <trans-unit id="705009069021941649" datatype="html">
@@ -11409,7 +11473,7 @@
         <target>Select exactly one correct answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2025</context>
+          <context context-type="linenumber">2033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5903298630443190027" datatype="html">
@@ -11417,7 +11481,7 @@
         <target>Select at least one correct answer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2037</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2211937330568533798" datatype="html">
@@ -11425,7 +11489,7 @@
         <target>Save failed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2148</context>
+          <context context-type="linenumber">2156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5746363347338638819" datatype="html">
@@ -11433,7 +11497,7 @@
         <target>Couldn&apos;t save settings.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2165</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3347548161086861397" datatype="html">
@@ -11441,7 +11505,7 @@
         <target>Question could not be updated.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.saveConfirmation" datatype="html">
@@ -11449,7 +11513,7 @@
         <target>Changes saved. The question, quiz details, and settings are now included in the preview and live quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2284</context>
+          <context context-type="linenumber">2292</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogTitle" datatype="html">
@@ -11457,7 +11521,7 @@
         <target>Delete question?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2312</context>
+          <context context-type="linenumber">2320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogMessage" datatype="html">
@@ -11465,7 +11529,7 @@
         <target>Question <x id="PH" equiv-text="position"/> will be permanently removed from the quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2313</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.deleteIrreversible" datatype="html">
@@ -11473,7 +11537,7 @@
         <target>This cannot be undone.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2315</context>
+          <context context-type="linenumber">2323</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -11485,7 +11549,7 @@
         <target>Delete</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionCancel" datatype="html">
@@ -11493,7 +11557,7 @@
         <target>Cancel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2318</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4357290152640831712" datatype="html">
@@ -11501,7 +11565,7 @@
         <target>Delete failed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2335</context>
+          <context context-type="linenumber">2343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -11513,11 +11577,11 @@
         <target>Move failed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2356</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionUp" datatype="html">
@@ -11525,7 +11589,7 @@
         <target>Move question <x id="position" equiv-text="position"/> up</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2370</context>
+          <context context-type="linenumber">2378</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionDown" datatype="html">
@@ -11533,7 +11597,7 @@
         <target>Move question <x id="position" equiv-text="position"/> down</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2374</context>
+          <context context-type="linenumber">2382</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.dragQuestion" datatype="html">
@@ -11541,7 +11605,7 @@
         <target>Move question <x id="position" equiv-text="position"/> by dragging</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2378</context>
+          <context context-type="linenumber">2386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionMovedAnnouncement" datatype="html">
@@ -11549,7 +11613,7 @@
         <target>Question <x id="previousPosition" equiv-text="previousPosition"/> has been moved to position <x id="currentPosition" equiv-text="currentPosition"/> of <x id="total" equiv-text="total"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2385</context>
+          <context context-type="linenumber">2393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesDialogHeading" datatype="html">
@@ -13346,7 +13410,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3010</context>
+          <context context-type="linenumber">3016</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -13358,7 +13422,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3013</context>
+          <context context-type="linenumber">3019</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -13370,7 +13434,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3018</context>
+          <context context-type="linenumber">3024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -13382,7 +13446,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3208</context>
+          <context context-type="linenumber">3220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -13394,7 +13458,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3212</context>
+          <context context-type="linenumber">3224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -13406,7 +13470,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3215</context>
+          <context context-type="linenumber">3227</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -13418,7 +13482,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3218</context>
+          <context context-type="linenumber">3230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -13574,7 +13638,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2718</context>
+          <context context-type="linenumber">2724</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -13594,7 +13658,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2981</context>
+          <context context-type="linenumber">2987</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -13798,7 +13862,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2951</context>
+          <context context-type="linenumber">2957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -13854,7 +13918,7 @@
         <target>View debrief plan</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1212</context>
+          <context context-type="linenumber">1218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuVisual" datatype="html">
@@ -13862,7 +13926,7 @@
         <target>Standard (with diagrams)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1230</context>
+          <context context-type="linenumber">1236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuPdfUa" datatype="html">
@@ -13870,7 +13934,7 @@
         <target>Barrier-free (PDF/UA-1)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1241</context>
+          <context context-type="linenumber">1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
@@ -13878,7 +13942,7 @@
         <target>More export options</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1258</context>
+          <context context-type="linenumber">1264</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButton" datatype="html">
@@ -13886,7 +13950,7 @@
         <target>More</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1261</context>
+          <context context-type="linenumber">1267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7070792224026857010" datatype="html">
@@ -13894,7 +13958,7 @@
         <target>To home</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1265</context>
+          <context context-type="linenumber">1271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelTooltip" datatype="html">
@@ -13902,7 +13966,7 @@
         <target>Tabular raw data for spreadsheets – less detail than the debrief plan.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1275</context>
+          <context context-type="linenumber">1281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelMenuItem" datatype="html">
@@ -13910,7 +13974,7 @@
         <target>Export raw data as CSV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1280</context>
+          <context context-type="linenumber">1286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressAria" datatype="html">
@@ -13918,7 +13982,7 @@
         <target>Export is running</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1290</context>
+          <context context-type="linenumber">1296</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
@@ -13926,7 +13990,7 @@
         <target>Exporting…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1295,1297</context>
+          <context context-type="linenumber">1301,1303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
@@ -13934,7 +13998,7 @@
         <target>Briefly compare notes with someone next to you</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1323,1325</context>
+          <context context-type="linenumber">1329,1331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1952538840507841358" datatype="html">
@@ -13942,7 +14006,7 @@
         <target>Same answer? Great. Different view? Convince each other.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1326,1328</context>
+          <context context-type="linenumber">1332,1334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5596291527944555255" datatype="html">
@@ -13950,7 +14014,7 @@
         <target>Second vote follows shortly.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1329,1331</context>
+          <context context-type="linenumber">1335,1337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveLabel" datatype="html">
@@ -13958,7 +14022,7 @@
         <target>Q&amp;A round is live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1339,1341</context>
+          <context context-type="linenumber">1345,1347</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveHint" datatype="html">
@@ -13966,7 +14030,7 @@
         <target>Participants can now join with the session code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1349,1351</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionCounter" datatype="html">
@@ -13974,7 +14038,7 @@
         <target>Question <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/> / <x id="INTERPOLATION_1" equiv-text="{{ q.totalQuestions }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1358,1359</context>
+          <context context-type="linenumber">1364,1365</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionNumber" datatype="html">
@@ -13982,7 +14046,7 @@
         <target>Question <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1361,1362</context>
+          <context context-type="linenumber">1367,1368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1017989655370592681" datatype="html">
@@ -13990,7 +14054,7 @@
         <target>Last question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1364</context>
+          <context context-type="linenumber">1370</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7135032209126516357" datatype="html">
@@ -13998,7 +14062,7 @@
         <target>All have voted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1403</context>
+          <context context-type="linenumber">1409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
@@ -14006,7 +14070,7 @@
         <target>Participants can extend or turn off their personal deadline if needed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1424,1427</context>
+          <context context-type="linenumber">1430,1433</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.questionMetadataAria" datatype="html">
@@ -14014,7 +14078,7 @@
         <target>Question metadata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1439</context>
+          <context context-type="linenumber">1445</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
@@ -14034,7 +14098,7 @@
         <target>Reading phase</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1464</context>
+          <context context-type="linenumber">1470</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
@@ -14042,7 +14106,7 @@
         <target>Answers will follow shortly.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1465,1467</context>
+          <context context-type="linenumber">1471,1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
@@ -14050,7 +14114,7 @@
         <target>Rating scale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
@@ -14058,7 +14122,7 @@
         <target>Rating distribution</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1551</context>
+          <context context-type="linenumber">1557</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
@@ -14066,7 +14130,7 @@
         <target>Waiting for estimates…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1590,1592</context>
+          <context context-type="linenumber">1596,1598</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
@@ -14074,7 +14138,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ q.totalVotes }}"/> answers received</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1598,1600</context>
+          <context context-type="linenumber">1604,1606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
@@ -14082,11 +14146,11 @@
         <target>Statistics summary</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1610</context>
+          <context context-type="linenumber">1616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2043</context>
+          <context context-type="linenumber">2049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
@@ -14094,7 +14158,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615</context>
+          <context context-type="linenumber">1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
@@ -14102,11 +14166,11 @@
         <target>Accepted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1633</context>
+          <context context-type="linenumber">1639</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2063</context>
+          <context context-type="linenumber">2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
@@ -14114,7 +14178,7 @@
         <target>Round comparison</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1653</context>
+          <context context-type="linenumber">1659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
@@ -14122,7 +14186,7 @@
         <target>shift</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
@@ -14130,7 +14194,7 @@
         <target>Round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1695</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
@@ -14138,7 +14202,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1694</context>
+          <context context-type="linenumber">1700</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
@@ -14146,11 +14210,11 @@
         <target>Show statistical details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2180</context>
+          <context context-type="linenumber">2186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
@@ -14158,7 +14222,7 @@
         <target>Round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1895,1897</context>
+          <context context-type="linenumber">1901,1903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
@@ -14166,7 +14230,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1923,1925</context>
+          <context context-type="linenumber">1929,1931</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
@@ -14174,7 +14238,7 @@
         <target>Paired Δ: <x id="INTERPOLATION" equiv-text="{{ rc.pairedAnalysis.closerCount }}"/> closer, <x id="INTERPOLATION_1" equiv-text="{{ rc.pairedAnalysis.fartherCount }}"/> farther, <x id="INTERPOLATION_2" equiv-text="{{ rc.pairedAnalysis.unchangedCount }}"/> unchanged (<x id="INTERPOLATION_3" equiv-text="{{ rc.pairedAnalysis.pairedCount }}"/> pairs)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1954,1962</context>
+          <context context-type="linenumber">1960,1968</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
@@ -14182,7 +14246,7 @@
         <target>Δx distribution</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1972</context>
+          <context context-type="linenumber">1978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
@@ -14190,7 +14254,7 @@
         <target>smaller is closer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2086</context>
+          <context context-type="linenumber">2092</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
@@ -14198,7 +14262,7 @@
         <target>Results round</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2193,2195</context>
+          <context context-type="linenumber">2199,2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
@@ -14206,7 +14270,7 @@
         <target>No estimates received.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2220,2222</context>
+          <context context-type="linenumber">2226,2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
@@ -14214,7 +14278,7 @@
         <target>Before/after comparison Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2232</context>
+          <context context-type="linenumber">2238</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
@@ -14222,7 +14286,7 @@
         <target>Round 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> vote)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2240</context>
+          <context context-type="linenumber">2246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
@@ -14230,7 +14294,7 @@
         <target>Round 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> votes)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2246</context>
+          <context context-type="linenumber">2252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
@@ -14238,7 +14302,7 @@
         <target>Round 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> vote)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2254</context>
+          <context context-type="linenumber">2260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
@@ -14246,7 +14310,7 @@
         <target>Round 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> votes)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2260</context>
+          <context context-type="linenumber">2266</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
@@ -14254,7 +14318,7 @@
         <target>Correct: <x id="INTERPOLATION" equiv-text="{{ q.roundComparison.round1CorrectCount }}"/> in round 1, then <x id="INTERPOLATION_1" equiv-text="{{ q.roundComparison.round2CorrectCount }}"/> in round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2272,2276</context>
+          <context context-type="linenumber">2278,2282</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
@@ -14262,7 +14326,7 @@
         <target>Peer instruction recommended</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2519,2521</context>
+          <context context-type="linenumber">2525,2527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
@@ -14270,7 +14334,7 @@
         <target>35–70% fully correct—second round fits.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2526,2528</context>
+          <context context-type="linenumber">2532,2534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
@@ -14278,7 +14342,7 @@
         <target>Round 1 still hidden until you continue.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2533,2535</context>
+          <context context-type="linenumber">2539,2541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
@@ -14286,7 +14350,7 @@
         <target>Start discussion or show results.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2540,2542</context>
+          <context context-type="linenumber">2546,2548</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
@@ -14294,7 +14358,7 @@
         <target>Self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2598,2600</context>
+          <context context-type="linenumber">2604,2606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
@@ -14302,7 +14366,7 @@
         <target> Right or wrong—and how confident? Especially important: wrong despite high answer confidence. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2604,2607</context>
+          <context context-type="linenumber">2610,2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
@@ -14310,7 +14374,7 @@
         <target>Correctness and self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2634</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
@@ -14318,7 +14382,7 @@
         <target> Often wrong with high answer confidence </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2682,2684</context>
+          <context context-type="linenumber">2688,2690</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
@@ -14326,7 +14390,7 @@
         <target>Updating question …</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2727,2729</context>
+          <context context-type="linenumber">2733,2735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
@@ -14334,7 +14398,7 @@
         <target>No question is live yet—tap “Next question” to begin.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2731,2733</context>
+          <context context-type="linenumber">2737,2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -14342,7 +14406,7 @@
         <target>Live reactions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2751</context>
+          <context context-type="linenumber">2757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
@@ -14350,7 +14414,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2757</context>
+          <context context-type="linenumber">2763</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
@@ -14358,7 +14422,7 @@
         <target>new</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2765</context>
+          <context context-type="linenumber">2771</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
@@ -14366,7 +14430,7 @@
         <target>No reactions yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2788</context>
+          <context context-type="linenumber">2794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
@@ -14375,7 +14439,7 @@
         </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2801</context>
+          <context context-type="linenumber">2807</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
@@ -14383,7 +14447,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ entry.totalScore | number }}"/> pts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2868</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
@@ -14391,7 +14455,7 @@
         <target>Tie: response time counts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2877</context>
+          <context context-type="linenumber">2883</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
@@ -14399,7 +14463,7 @@
         <target>Team standings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2895</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
@@ -14407,7 +14471,7 @@
         <target>pts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2942</context>
+          <context context-type="linenumber">2948</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
@@ -14415,7 +14479,7 @@
         <target>Switch quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2971</context>
+          <context context-type="linenumber">2977</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
@@ -14423,7 +14487,7 @@
         <target>Edit Q&amp;A title</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3074</context>
+          <context context-type="linenumber">3086</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
@@ -14431,7 +14495,7 @@
         <target>Q&amp;A title</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3087</context>
+          <context context-type="linenumber">3099</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
@@ -14439,15 +14503,15 @@
         <target>Ask something about this session...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3098</context>
+          <context context-type="linenumber">3110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">886</context>
+          <context context-type="linenumber">893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">898</context>
+          <context context-type="linenumber">905</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14459,7 +14523,7 @@
         <target>Save title</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3110</context>
+          <context context-type="linenumber">3122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
@@ -14467,7 +14531,7 @@
         <target>Cancel editing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3121</context>
+          <context context-type="linenumber">3133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
@@ -14475,7 +14539,7 @@
         <target>Pre-moderation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3140,3142</context>
+          <context context-type="linenumber">3152,3154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
@@ -14483,7 +14547,7 @@
         <target>Pre-moderation is on. New questions wait for your approval.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3144,3146</context>
+          <context context-type="linenumber">3156,3158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
@@ -14491,7 +14555,7 @@
         <target>No questions yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3153,3155</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
@@ -14499,7 +14563,7 @@
         <target>Total: <x id="INTERPOLATION" equiv-text="qaQuestions().length"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3165,3166</context>
+          <context context-type="linenumber">3177,3178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
@@ -14507,7 +14571,7 @@
         <target>Waiting for approval: <x id="INTERPOLATION" equiv-text="qaPendingCount()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3174,3175</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
@@ -14515,7 +14579,7 @@
         <target>Show all questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3227</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
@@ -14523,7 +14587,7 @@
         <target>Show all</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3230</context>
+          <context context-type="linenumber">3242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
@@ -14531,7 +14595,7 @@
         <target>Show pinned questions only</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3238</context>
+          <context context-type="linenumber">3250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
@@ -14539,7 +14603,7 @@
         <target>Pinned only</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3241</context>
+          <context context-type="linenumber">3253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
@@ -14547,7 +14611,7 @@
         <target>Show new questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3253</context>
+          <context context-type="linenumber">3265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
@@ -14555,7 +14619,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ qaUnseenCount() }}"/> new questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3259</context>
+          <context context-type="linenumber">3271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
@@ -14563,7 +14627,7 @@
         <target>Export questions as CSV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3291</context>
+          <context context-type="linenumber">3303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
@@ -14571,7 +14635,7 @@
         <target>Export questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3294</context>
+          <context context-type="linenumber">3306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
@@ -14579,7 +14643,7 @@
         <target>Exporting…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3302,3304</context>
+          <context context-type="linenumber">3314,3316</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
@@ -14587,7 +14651,7 @@
         <target>Controversial</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3371</context>
+          <context context-type="linenumber">3383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
@@ -14595,7 +14659,7 @@
         <target><x id="INTERPOLATION" equiv-text="question.positiveVoteCount"/> positive · <x id="INTERPOLATION_1" equiv-text="question.negativeVoteCount"/> negative</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3399,3400</context>
+          <context context-type="linenumber">3411,3412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
@@ -14603,7 +14667,7 @@
         <target>Reliable approval <x id="INTERPOLATION" equiv-text="formatQaPercent(question.bestScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3407,3408</context>
+          <context context-type="linenumber">3419,3420</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
@@ -14611,7 +14675,7 @@
         <target>Split reactions <x id="INTERPOLATION" equiv-text="formatQaPercent(question.controversyScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3417,3419</context>
+          <context context-type="linenumber">3429,3431</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
@@ -14619,7 +14683,7 @@
         <target>Pinned-only view active – no pinned questions yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3460,3462</context>
+          <context context-type="linenumber">3472,3474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
@@ -14627,7 +14691,7 @@
         <target>Reveal answer options</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3513</context>
+          <context context-type="linenumber">3525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
@@ -14635,7 +14699,7 @@
         <target>Start discussion phase—talk it over before round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3549</context>
+          <context context-type="linenumber">3561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
@@ -14643,7 +14707,7 @@
         <target>Discussion phase</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3552</context>
+          <context context-type="linenumber">3564</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
@@ -14651,11 +14715,11 @@
         <target>Release anyway</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3579</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3589</context>
+          <context context-type="linenumber">3601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
@@ -14663,7 +14727,7 @@
         <target>Show result anyway</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3570</context>
+          <context context-type="linenumber">3582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
@@ -14671,7 +14735,7 @@
         <target>Show results</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3591</context>
+          <context context-type="linenumber">3603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
@@ -14679,7 +14743,7 @@
         <target>Next question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3607,3609</context>
+          <context context-type="linenumber">3619,3621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
@@ -14687,7 +14751,7 @@
         <target>On to the next question without a second vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3630</context>
+          <context context-type="linenumber">3642</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
@@ -14695,7 +14759,7 @@
         <target>On to the next question without a second vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3633</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
@@ -14703,7 +14767,7 @@
         <target>Shows the previous question again with its result and correct answer (without a new vote).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650</context>
+          <context context-type="linenumber">3662</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
@@ -14711,7 +14775,7 @@
         <target>Show previous result again</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3652,3654</context>
+          <context context-type="linenumber">3664,3666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
@@ -14719,7 +14783,7 @@
         <target>End session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3662,3664</context>
+          <context context-type="linenumber">3674,3676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -14727,7 +14791,7 @@
         <target>Host view for lobby and control.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3670</context>
+          <context context-type="linenumber">3682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
@@ -14735,7 +14799,7 @@
         <target>Lobby · Warm</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">322</context>
+          <context context-type="linenumber">324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyArrival" datatype="html">
@@ -14743,7 +14807,7 @@
         <target>Lobby · Arriving</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyCalm" datatype="html">
@@ -14751,7 +14815,7 @@
         <target>Lobby · Calm</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyPulse" datatype="html">
@@ -14759,7 +14823,7 @@
         <target>Lobby · Pulse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">334</context>
+          <context context-type="linenumber">336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackReadingBuild" datatype="html">
@@ -14767,7 +14831,7 @@
         <target>Reading · Build-up</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">338</context>
+          <context context-type="linenumber">340</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownFocus" datatype="html">
@@ -14775,7 +14839,7 @@
         <target>Countdown · Focus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownTempo" datatype="html">
@@ -14783,7 +14847,7 @@
         <target>Countdown · Pace</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownIntense" datatype="html">
@@ -14791,7 +14855,23 @@
         <target>Countdown · Intense</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">350</context>
+          <context context-type="linenumber">352</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingQa" datatype="html">
+        <source>Warum die Fragenwand mehr als ein Chat ist</source>
+        <target>Why the Q&A wall is more than a chat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">421</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <target>Understand confidence ratings and follow-up</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">423</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4017389878545296254" datatype="html">
@@ -14799,7 +14879,7 @@
         <target>Waiting for live free-text data…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">500</context>
+          <context context-type="linenumber">507</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14811,7 +14891,7 @@
         <target>Live free text</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">503</context>
+          <context context-type="linenumber">510</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14823,7 +14903,7 @@
         <target>Frequent words from the answers.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">504</context>
+          <context context-type="linenumber">511</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14835,7 +14915,7 @@
         <target>Q&amp;A analysis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">505</context>
+          <context context-type="linenumber">512</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14847,7 +14927,7 @@
         <target>Shows which words and phrases dominate the visible Q&amp;A questions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">506</context>
+          <context context-type="linenumber">513</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14859,7 +14939,7 @@
         <target>Hide word cloud</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">647</context>
+          <context context-type="linenumber">654</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudShow" datatype="html">
@@ -14867,7 +14947,7 @@
         <target>Show word cloud</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">648</context>
+          <context context-type="linenumber">655</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudResume" datatype="html">
@@ -14875,11 +14955,11 @@
         <target>Resume live updates</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">653</context>
+          <context context-type="linenumber">660</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1036</context>
+          <context context-type="linenumber">1043</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFreeze" datatype="html">
@@ -14887,11 +14967,11 @@
         <target>Freeze word cloud</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">654</context>
+          <context context-type="linenumber">661</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1037</context>
+          <context context-type="linenumber">1044</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFrozenInfo" datatype="html">
@@ -14899,7 +14979,7 @@
         <target>Word cloud frozen.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">679</context>
+          <context context-type="linenumber">686</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobbyShort" datatype="html">
@@ -14907,7 +14987,7 @@
         <target>Lobby</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseConnectingShort" datatype="html">
@@ -14915,7 +14995,7 @@
         <target>Reading</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">837</context>
+          <context context-type="linenumber">844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseRunningShort" datatype="html">
@@ -14923,7 +15003,7 @@
         <target>Countdown</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">838</context>
+          <context context-type="linenumber">845</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicLabelOff" datatype="html">
@@ -14931,7 +15011,7 @@
         <target>Music off</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">870</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
@@ -14939,7 +15019,7 @@
         <target>Quiz session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">891</context>
+          <context context-type="linenumber">898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricBest" datatype="html">
@@ -14947,7 +15027,7 @@
         <target>reliable approval</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">958</context>
+          <context context-type="linenumber">965</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricControversial" datatype="html">
@@ -14955,7 +15035,7 @@
         <target>controversy</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">960</context>
+          <context context-type="linenumber">967</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricTop" datatype="html">
@@ -14963,7 +15043,7 @@
         <target>positive votes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">969</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudTitle" datatype="html">
@@ -14971,7 +15051,7 @@
         <target>Q&amp;A word cloud</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">965</context>
+          <context context-type="linenumber">972</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14983,7 +15063,7 @@
         <target>Large words and phrases come from questions with strong approval and enough votes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">969</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintControversial" datatype="html">
@@ -14991,7 +15071,7 @@
         <target>Large words and phrases come from questions with opposing reactions. Hover to see the related questions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintTop" datatype="html">
@@ -14999,7 +15079,7 @@
         <target>Large words and phrases come from questions with many positive votes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">973</context>
+          <context context-type="linenumber">980</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudThemeFallbackHint" datatype="html">
@@ -15007,7 +15087,7 @@
         <target>Individual words are shown until word groups and phrases are reliable.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1026</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintBest" datatype="html">
@@ -15015,7 +15095,7 @@
         <target>Shows questions with strong approval and enough votes first. Pinned questions are marked, not promoted.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1024</context>
+          <context context-type="linenumber">1031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintControversial" datatype="html">
@@ -15023,7 +15103,7 @@
         <target>Shows questions with mixed reactions first. Pinned questions are marked, not promoted.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1026</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintTop" datatype="html">
@@ -15031,7 +15111,7 @@
         <target>Shows questions with the most positive votes first. Pinned questions are marked, not promoted.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1028</context>
+          <context context-type="linenumber">1035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudShow" datatype="html">
@@ -15039,7 +15119,7 @@
         <target>Show word cloud</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1032</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountOneMetric" datatype="html">
@@ -15047,7 +15127,7 @@
         <target>1 visible question · Size of words and phrases: <x id="metric" equiv-text="metric"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1043</context>
+          <context context-type="linenumber">1050</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountManyMetric" datatype="html">
@@ -15055,7 +15135,7 @@
         <target><x id="count" equiv-text="count"/> visible questions · Size of words and phrases: <x id="metric" equiv-text="metric"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1045</context>
+          <context context-type="linenumber">1052</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountOne" datatype="html">
@@ -15063,7 +15143,7 @@
         <target>1 answer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1552</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
@@ -15071,7 +15151,7 @@
         <target><x id="count" equiv-text="count"/> answers</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1546</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
@@ -15079,7 +15159,7 @@
         <target>Low · <x id="label" equiv-text="q.confidenceLabelLow"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1637</context>
+          <context context-type="linenumber">1644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
@@ -15087,7 +15167,7 @@
         <target>Low (1–2)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
@@ -15095,7 +15175,7 @@
         <target>Medium (3)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1642</context>
+          <context context-type="linenumber">1649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
@@ -15103,7 +15183,7 @@
         <target>High · <x id="label" equiv-text="q.confidenceLabelHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1674</context>
+          <context context-type="linenumber">1681</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
@@ -15111,7 +15191,7 @@
         <target>High (4–5)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
@@ -15119,7 +15199,7 @@
         <target>Correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1696</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
@@ -15127,7 +15207,7 @@
         <target>Incorrect</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1696</context>
+          <context context-type="linenumber">1703</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
@@ -15135,7 +15215,7 @@
         <target><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
@@ -15143,7 +15223,7 @@
         <target>1 confident wrong answer – possible misconception</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1793</context>
+          <context context-type="linenumber">1800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
@@ -15151,7 +15231,7 @@
         <target><x id="count" equiv-text="count"/> confident wrong answers – possible misconceptions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1794</context>
+          <context context-type="linenumber">1801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
@@ -15159,7 +15239,7 @@
         <target>Correct+high <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · Wrong+high <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1805</context>
+          <context context-type="linenumber">1812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
@@ -15167,7 +15247,7 @@
         <target>2 (Peer Instruction)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1825</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
@@ -15175,7 +15255,7 @@
         <target>Round 1: <x id="r1" equiv-text="round1Count"/> votes · Aggregated: Round 2 with <x id="r2" equiv-text="round2Count"/> votes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1843</context>
+          <context context-type="linenumber">1850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
@@ -15183,7 +15263,7 @@
         <target>Aggregation Round 2 (Peer Instruction)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1845</context>
+          <context context-type="linenumber">1852</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
@@ -15191,7 +15271,7 @@
         <target>Aggregation round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1848</context>
+          <context context-type="linenumber">1855</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
@@ -15199,7 +15279,7 @@
         <target>That didn’t quite go through</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2452</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
@@ -15207,7 +15287,7 @@
         <target>No worries — this happens sometimes (a quick blip or flaky Wi‑Fi). Give it a couple of seconds, then tap Try again — that usually does the trick.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2453</context>
+          <context context-type="linenumber">2460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
@@ -15215,7 +15295,7 @@
         <target>Your Q&amp;A board isn’t playing along right now</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2460</context>
+          <context context-type="linenumber">2467</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
@@ -15223,7 +15303,7 @@
         <target>Nothing’s broken — it just didn’t work that once. Take a breath, wait 2–3 seconds, tap Try again, and it’ll usually snap back.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2461</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
@@ -15231,7 +15311,7 @@
         <target>Export isn’t ready yet</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2468</context>
+          <context context-type="linenumber">2475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
@@ -15239,7 +15319,7 @@
         <target>PDF or Excel export didn’t go through that time. Wait a few seconds, tap Try again — a second try usually sorts it.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2469</context>
+          <context context-type="linenumber">2476</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
@@ -15247,7 +15327,7 @@
         <target>Participants and the presentation view are redirected to the home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2610</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
@@ -15255,7 +15335,7 @@
         <target>The session ends for everyone; it is not possible to continue with the same code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
@@ -15263,7 +15343,7 @@
         <target><x id="participantCount" equiv-text="participants"/> Participants are still in the session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2608</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
@@ -15271,7 +15351,7 @@
         <target>You already have results. After ending, you can export them or review feedback in the finished view.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2613</context>
+          <context context-type="linenumber">2620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
@@ -15279,7 +15359,7 @@
         <target>There are no usable results yet. After ending, you will be taken directly to the home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2617</context>
+          <context context-type="linenumber">2624</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
@@ -15287,7 +15367,7 @@
         <target>For bonus codes: Advise participants to copy their personal code now (clipboard) before they leave the page - otherwise they can easily lose it.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2622</context>
+          <context context-type="linenumber">2629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
@@ -15295,7 +15375,7 @@
         <target>Leave session?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
@@ -15303,7 +15383,7 @@
         <target>Your session is still active.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2629</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
@@ -15311,7 +15391,7 @@
         <target>Leave anyway</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2631</context>
+          <context context-type="linenumber">2638</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
@@ -15319,7 +15399,7 @@
         <target>Back to session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2632</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
@@ -15327,7 +15407,7 @@
         <target>Stop preview</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2823</context>
+          <context context-type="linenumber">2830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
@@ -15335,7 +15415,7 @@
         <target>Preview track (max. 12 seconds)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2824</context>
+          <context context-type="linenumber">2831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
@@ -15343,7 +15423,7 @@
         <target>Sound on</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2836</context>
+          <context context-type="linenumber">2843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
@@ -15351,7 +15431,7 @@
         <target>Sound off</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2837</context>
+          <context context-type="linenumber">2844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
@@ -15359,7 +15439,7 @@
         <target>Participant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
@@ -15367,7 +15447,7 @@
         <target>Participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2898</context>
+          <context context-type="linenumber">2905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
@@ -15375,7 +15455,7 @@
         <target>1 live participant connected</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
@@ -15383,7 +15463,7 @@
         <target><x id="connectedCount" equiv-text="connectedCount"/> live participants connected</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2917</context>
+          <context context-type="linenumber">2924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
@@ -15391,7 +15471,7 @@
         <target>No one is in this team yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2943</context>
+          <context context-type="linenumber">2950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
@@ -15399,7 +15479,7 @@
         <target>Rating</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3759</context>
+          <context context-type="linenumber">3766</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
@@ -15407,7 +15487,7 @@
         <target>Ratings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3763</context>
+          <context context-type="linenumber">3770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
@@ -15415,11 +15495,11 @@
         <target>Results are in.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3768</context>
+          <context context-type="linenumber">3775</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3775</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
@@ -15427,11 +15507,11 @@
         <target>Time&apos;s up.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3769</context>
+          <context context-type="linenumber">3776</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3776</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
@@ -15439,7 +15519,7 @@
         <target>Waiting for ratings…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3770</context>
+          <context context-type="linenumber">3777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
@@ -15447,7 +15527,7 @@
         <target>Waiting for answers…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
@@ -15455,7 +15535,7 @@
         <target><x id="PH" equiv-text="votes"/> of <x id="PH_1" equiv-text="participants"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3781</context>
+          <context context-type="linenumber">3788</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
@@ -15463,7 +15543,7 @@
         <target>One person is still using their 10× time. “Release anyway” ends their personal window.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3788</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
@@ -15471,7 +15551,7 @@
         <target>One person is still using their 10× time. Wait for the room countdown or until the 10× time ends.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3789</context>
+          <context context-type="linenumber">3796</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
@@ -15479,7 +15559,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> people are still using their 10× time. “Release anyway” ends their personal windows.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3793</context>
+          <context context-type="linenumber">3800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
@@ -15487,7 +15567,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> people are still using their 10× time. Wait for the room countdown or until the 10× time ends.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3794</context>
+          <context context-type="linenumber">3801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
@@ -15495,7 +15575,7 @@
         <target>One person is answering without a personal deadline. “Show results” ends their input.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3797</context>
+          <context context-type="linenumber">3804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
@@ -15503,7 +15583,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> people are answering without a personal deadline. “Show results” ends their input.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3799</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
@@ -15511,7 +15591,7 @@
         <target><x id="votes" equiv-text="votes"/> of <x id="participants" equiv-text="participants"/> participants voted. <x id="percentage" equiv-text="percentage"/> percent reached.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3805</context>
+          <context context-type="linenumber">3812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
@@ -15519,7 +15599,7 @@
         <target><x id="votes" equiv-text="votes"/> of <x id="participants" equiv-text="participants"/> participants have voted. <x id="percentage" equiv-text="percentage"/> percent reached.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3807</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
@@ -15527,7 +15607,7 @@
         <target><x id="voteCount"/> out of <x id="participantTotal"/> has voted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3818</context>
+          <context context-type="linenumber">3825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
@@ -15535,7 +15615,7 @@
         <target><x id="voteCount"/> out of <x id="participantTotal"/> have voted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3827</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
@@ -15543,7 +15623,7 @@
         <target><x id="voteCount"/> out of <x id="participantTotal"/> has rated</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3831</context>
+          <context context-type="linenumber">3838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
@@ -15551,7 +15631,7 @@
         <target><x id="voteCount"/> out of <x id="participantTotal"/> have rated</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3833</context>
+          <context context-type="linenumber">3840</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
@@ -15559,7 +15639,7 @@
         <target><x id="correctCount"/> out of <x id="voteTotal"/> fully correct answers (<x id="percentage"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3839</context>
+          <context context-type="linenumber">3846</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
@@ -15567,7 +15647,7 @@
         <target><x id="changed"/> out of <x id="both"/> (<x id="pct"/>%) changed their mind</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3843</context>
+          <context context-type="linenumber">3850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
@@ -15575,7 +15655,7 @@
         <target>↑ <x id="count"/> wrong → correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3847</context>
+          <context context-type="linenumber">3854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
@@ -15583,7 +15663,7 @@
         <target>↓ <x id="count"/> correct → wrong</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3851</context>
+          <context context-type="linenumber">3858</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
@@ -15591,7 +15671,7 @@
         <target>Average <x id="avg"/> out of 5 stars</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3857</context>
+          <context context-type="linenumber">3864</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
@@ -15599,7 +15679,7 @@
         <target><x id="PH" equiv-text="total"/> reaction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
@@ -15607,7 +15687,7 @@
         <target><x id="PH" equiv-text="total"/> reactions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
@@ -15615,7 +15695,7 @@
         <target>Lobby – participants can join</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3917</context>
+          <context context-type="linenumber">3924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
@@ -15623,7 +15703,7 @@
         <target>Q&amp;A is getting ready</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3918</context>
+          <context context-type="linenumber">3925</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
@@ -15631,15 +15711,15 @@
         <target>Q&amp;A is live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3919</context>
+          <context context-type="linenumber">3926</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3921</context>
+          <context context-type="linenumber">3928</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3922</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
@@ -15647,7 +15727,7 @@
         <target>Paused</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3920</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
@@ -15655,7 +15735,7 @@
         <target>Q&amp;A ended</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3923</context>
+          <context context-type="linenumber">3930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
@@ -15663,7 +15743,7 @@
         <target>Voting ended – waiting for results</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3928</context>
+          <context context-type="linenumber">3935</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
@@ -15671,7 +15751,7 @@
         <target>Lobby – participants can join</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3931</context>
+          <context context-type="linenumber">3938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
@@ -15679,7 +15759,7 @@
         <target>Reading phase – answers are locked</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3932</context>
+          <context context-type="linenumber">3939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
@@ -15687,7 +15767,7 @@
         <target>Voting is live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3933</context>
+          <context context-type="linenumber">3940</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
@@ -15695,7 +15775,7 @@
         <target>Paused</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3934</context>
+          <context context-type="linenumber">3941</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
@@ -15703,7 +15783,7 @@
         <target>Showing results</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3935</context>
+          <context context-type="linenumber">3942</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
@@ -15711,7 +15791,7 @@
         <target>Discussion – exchange before second round</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3936</context>
+          <context context-type="linenumber">3943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
@@ -15719,7 +15799,7 @@
         <target>Session ended</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3937</context>
+          <context context-type="linenumber">3944</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
@@ -15727,7 +15807,7 @@
         <target><x id="readyCount" equiv-text="readyCount"/> of <x id="connectedCount" equiv-text="connectedCount"/> ready</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3948</context>
+          <context context-type="linenumber">3955</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
@@ -15735,7 +15815,7 @@
         <target><x id="PH" equiv-text="readyCount"/> of <x id="PH_1" equiv-text="connectedCount"/> connected participants ready · <x id="PH_2" equiv-text="totalParticipantCount"/> total</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3950</context>
+          <context context-type="linenumber">3957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
@@ -15743,7 +15823,7 @@
         <target>All participants are ready – answer options can be revealed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3955</context>
+          <context context-type="linenumber">3962</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
@@ -15751,7 +15831,7 @@
         <target>All connected participants are ready – answer options can be revealed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3957</context>
+          <context context-type="linenumber">3964</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
@@ -15759,7 +15839,7 @@
         <target>1 second remaining</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3988</context>
+          <context context-type="linenumber">3995</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
@@ -15767,7 +15847,7 @@
         <target><x id="seconds" equiv-text="seconds"/> seconds remaining</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3989</context>
+          <context context-type="linenumber">3996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -15781,7 +15861,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4113,4116</context>
+          <context context-type="linenumber">4120,4123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -15795,7 +15875,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4158,4161</context>
+          <context context-type="linenumber">4165,4168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -15809,7 +15889,7 @@
       )"/> to <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4163,4166</context>
+          <context context-type="linenumber">4170,4173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -15823,7 +15903,7 @@
     )"/> to <x id="right" equiv-text="this.formatNumericHostValue(band.right, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4168,4171</context>
+          <context context-type="linenumber">4175,4178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
@@ -15831,7 +15911,7 @@
         <target>Median <x id="median" equiv-text="formatNumber(stats.median, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4286</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
@@ -15839,7 +15919,7 @@
         <target>Estimates</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4319</context>
+          <context context-type="linenumber">4326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
@@ -15847,7 +15927,7 @@
         <target>valid answers</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
@@ -15855,7 +15935,7 @@
         <target>Mean</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4327</context>
+          <context context-type="linenumber">4334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
@@ -15863,7 +15943,7 @@
         <target>Average of all estimates</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4329</context>
+          <context context-type="linenumber">4336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
@@ -15871,7 +15951,7 @@
         <target>Median</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4335</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
@@ -15879,7 +15959,7 @@
         <target>Middle sorted value</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4337</context>
+          <context context-type="linenumber">4344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
@@ -15887,7 +15967,7 @@
         <target>Spread</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4343</context>
+          <context context-type="linenumber">4350</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
@@ -15895,7 +15975,7 @@
         <target>Standard deviation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4345</context>
+          <context context-type="linenumber">4352</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
@@ -15903,7 +15983,7 @@
         <target>Middle 50%</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4351</context>
+          <context context-type="linenumber">4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -15918,7 +15998,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4356,4359</context>
+          <context context-type="linenumber">4363,4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
@@ -15926,7 +16006,7 @@
         <target>Range</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4365</context>
+          <context context-type="linenumber">4372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
@@ -15934,7 +16014,7 @@
         <target>smallest to largest estimate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4370</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
@@ -15942,7 +16022,7 @@
         <target>In range</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4376</context>
+          <context context-type="linenumber">4383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -15958,7 +16038,7 @@
         )"/>% accepted</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4382,4386</context>
+          <context context-type="linenumber">4389,4393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
@@ -15966,7 +16046,7 @@
         <target>Avg. distance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4392</context>
+          <context context-type="linenumber">4399</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
@@ -15974,7 +16054,7 @@
         <target>to reference</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394</context>
+          <context context-type="linenumber">4401</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
@@ -15982,7 +16062,7 @@
         <target>Median</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4402</context>
+          <context context-type="linenumber">4409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
@@ -15990,7 +16070,7 @@
         <target>Mean</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4405</context>
+          <context context-type="linenumber">4412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
@@ -15998,7 +16078,7 @@
         <target>Estimates</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4407</context>
+          <context context-type="linenumber">4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -16014,7 +16094,7 @@
     )"/> % in the accepted range</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4438,4442</context>
+          <context context-type="linenumber">4445,4449</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
@@ -16022,7 +16102,7 @@
         <target>Average distance to reference</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4456</context>
+          <context context-type="linenumber">4463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
@@ -16030,7 +16110,7 @@
         <target>closer to the reference value</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4470</context>
+          <context context-type="linenumber">4477</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
@@ -16038,7 +16118,7 @@
         <target>Median change</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4487</context>
+          <context context-type="linenumber">4494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
@@ -16046,7 +16126,7 @@
         <target>Mean change</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4488</context>
+          <context context-type="linenumber">4495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -16061,7 +16141,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4499,4502</context>
+          <context context-type="linenumber">4506,4509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -16076,7 +16156,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4511</context>
+          <context context-type="linenumber">4515,4518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -16092,7 +16172,7 @@
         )"/> percentage points</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520,4524</context>
+          <context context-type="linenumber">4527,4531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -16116,7 +16196,7 @@
           )"/> comparable estimates have improved.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4540,4548</context>
+          <context context-type="linenumber">4547,4555</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -16140,7 +16220,7 @@
           )"/> comparable estimates are further away.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4552,4560</context>
+          <context context-type="linenumber">4559,4567</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
@@ -16148,7 +16228,7 @@
         <target>Round 2 is mixed: closer and more distant estimates are balanced in the pair comparison.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4564</context>
+          <context context-type="linenumber">4571</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -16162,7 +16242,7 @@
           )"/> in round 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4576,4579</context>
+          <context context-type="linenumber">4583,4586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -16176,7 +16256,7 @@
           )"/> larger in round 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4583,4586</context>
+          <context context-type="linenumber">4590,4593</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -16192,7 +16272,7 @@
         )"/> percentage points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4598,4602</context>
+          <context context-type="linenumber">4605,4609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -16216,7 +16296,7 @@
         )"/> estimates are within the tolerance band.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4617,4625</context>
+          <context context-type="linenumber">4624,4632</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -16230,7 +16310,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4630,4633</context>
+          <context context-type="linenumber">4637,4640</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -16244,7 +16324,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4637,4640</context>
+          <context context-type="linenumber">4644,4647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
@@ -16252,7 +16332,7 @@
         <target>Quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4686</context>
+          <context context-type="linenumber">4693</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16264,7 +16344,7 @@
         <target>Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4688</context>
+          <context context-type="linenumber">4695</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16276,11 +16356,11 @@
         <target><x id="count" equiv-text="this.qaUnseenCount()"/> new</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4696</context>
+          <context context-type="linenumber">4703</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4713</context>
+          <context context-type="linenumber">4720</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelInactive" datatype="html">
@@ -16288,7 +16368,7 @@
         <target>Off</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4813</context>
+          <context context-type="linenumber">4820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelClosed" datatype="html">
@@ -16296,7 +16376,7 @@
         <target>Closed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4816</context>
+          <context context-type="linenumber">4823</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16308,7 +16388,7 @@
         <target>Question from <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16320,7 +16400,7 @@
         <target>Question from the audience</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16332,7 +16412,7 @@
         <target>Deselect <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4879</context>
+          <context context-type="linenumber">4886</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16348,7 +16428,7 @@
         <target>Highlight all questions from <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4880</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16364,7 +16444,7 @@
         <target>Being answered</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4909</context>
+          <context context-type="linenumber">4916</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16376,7 +16456,7 @@
         <target>Open</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4911</context>
+          <context context-type="linenumber">4918</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16388,7 +16468,7 @@
         <target>Waiting for approval</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4913</context>
+          <context context-type="linenumber">4920</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16400,7 +16480,7 @@
         <target>Answered</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4915</context>
+          <context context-type="linenumber">4922</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16412,7 +16492,7 @@
         <target>Removed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4917</context>
+          <context context-type="linenumber">4924</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16424,7 +16504,7 @@
         <target>Approve</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5018</context>
+          <context context-type="linenumber">5025</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
@@ -16432,7 +16512,7 @@
         <target>Highlight</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5020</context>
+          <context context-type="linenumber">5027</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
@@ -16440,7 +16520,7 @@
         <target>Remove highlight</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5022</context>
+          <context context-type="linenumber">5029</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
@@ -16448,7 +16528,7 @@
         <target>Archive</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5024</context>
+          <context context-type="linenumber">5031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
@@ -16456,7 +16536,7 @@
         <target>Remove permanently</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5027</context>
+          <context context-type="linenumber">5034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
@@ -16464,7 +16544,7 @@
         <target>Delete</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5028</context>
+          <context context-type="linenumber">5035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
@@ -16472,7 +16552,7 @@
         <target>Close channel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5372</context>
+          <context context-type="linenumber">5379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
@@ -16480,7 +16560,7 @@
         <target>Reopen channel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5373</context>
+          <context context-type="linenumber">5380</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
@@ -16488,7 +16568,7 @@
         <target>Pre-moderation enabled.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5787</context>
+          <context context-type="linenumber">5794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
@@ -16496,7 +16576,7 @@
         <target>Pre-moderation disabled.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5788</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
@@ -16504,7 +16584,7 @@
         <target>Question approved.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5821</context>
+          <context context-type="linenumber">5828</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
@@ -16512,7 +16592,7 @@
         <target>Question highlighted.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5823</context>
+          <context context-type="linenumber">5830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
@@ -16520,7 +16600,7 @@
         <target>Question archived.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5825</context>
+          <context context-type="linenumber">5832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
@@ -16528,7 +16608,7 @@
         <target>Question removed.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5826</context>
+          <context context-type="linenumber">5833</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
@@ -16536,7 +16616,7 @@
         <target>This person’s open personal 10× deadline ends immediately.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5927</context>
+          <context context-type="linenumber">5934</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
@@ -16544,11 +16624,11 @@
         <target>No further answers will be possible afterwards.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5928</context>
+          <context context-type="linenumber">5935</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5932</context>
+          <context context-type="linenumber">5939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
@@ -16556,7 +16636,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> open personal 10× deadlines end immediately.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5931</context>
+          <context context-type="linenumber">5938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
@@ -16564,7 +16644,7 @@
         <target>End personal deadlines?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5936</context>
+          <context context-type="linenumber">5943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
@@ -16572,7 +16652,7 @@
         <target>You are starting the discussion phase while personal timers are still running.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5939</context>
+          <context context-type="linenumber">5946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
@@ -16580,7 +16660,7 @@
         <target>You are showing the result while personal timers are still running.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5940</context>
+          <context context-type="linenumber">5947</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
@@ -16588,7 +16668,7 @@
         <target>Release anyway</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5942</context>
+          <context context-type="linenumber">5949</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
@@ -16596,7 +16676,7 @@
         <target>Keep waiting</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5943</context>
+          <context context-type="linenumber">5950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
@@ -16604,7 +16684,7 @@
         <target>Question no.;Question text;Type;Participants;Aggregation round;Avg. points;Self-assessment n;Solid;Misconception risk;Fragile;Detected gap;Undecided;Most common incorrect high-confidence answer;Details</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6089</context>
+          <context context-type="linenumber">6096</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
@@ -16612,7 +16692,7 @@
         <target>Learning status and self-assessment</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6143</context>
+          <context context-type="linenumber">6150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
@@ -16620,7 +16700,7 @@
         <target>Valid answers;Evaluated questions;Not aggregated (&lt;5 responses with self-assessment);Solid;Misconception risk;Fragile;Identified knowledge gap;Undecided</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
@@ -16628,7 +16708,7 @@
         <target>Team leaderboard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6167</context>
+          <context context-type="linenumber">6174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
@@ -16636,7 +16716,7 @@
         <target>Rank;Team;Color;Members;Team points;Avg. points per member</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6169</context>
+          <context context-type="linenumber">6176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
@@ -16644,7 +16724,7 @@
         <target>Bonus codes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6187</context>
+          <context context-type="linenumber">6194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
@@ -16652,7 +16732,7 @@
         <target>Rank;Nickname;Code;Points;Generated at</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6189</context>
+          <context context-type="linenumber">6196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
@@ -16660,7 +16740,7 @@
         <target>Result CSV exported.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6197</context>
+          <context context-type="linenumber">6204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
@@ -16668,7 +16748,7 @@
         <target>View debrief plan as PDF – 1 question for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6209</context>
+          <context context-type="linenumber">6216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
@@ -16676,7 +16756,7 @@
         <target>View debrief plan as PDF – <x id="count" equiv-text="count"/> questions for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6212</context>
+          <context context-type="linenumber">6219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
@@ -16684,7 +16764,7 @@
         <target>View debrief plan as PDF</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6214</context>
+          <context context-type="linenumber">6221</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
@@ -16692,7 +16772,7 @@
         <target>1 question recommended for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6219</context>
+          <context context-type="linenumber">6226</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
@@ -16700,7 +16780,7 @@
         <target><x id="count" equiv-text="count"/> questions recommended for debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6221</context>
+          <context context-type="linenumber">6228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
@@ -16708,7 +16788,7 @@
         <target>PDF is created (<x id="PH" equiv-text="exportData.questions.length"/> questions)…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6233</context>
+          <context context-type="linenumber">6240</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
@@ -16716,7 +16796,7 @@
         <target>Results PDF downloaded.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6239</context>
+          <context context-type="linenumber">6246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
@@ -16724,7 +16804,7 @@
         <target>Result PDF opened for saving.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6240</context>
+          <context context-type="linenumber">6247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
@@ -16732,7 +16812,7 @@
         <target>No.;Question ID;Status;Question;Score;Positive votes;Negative votes;Total votes;Wilson score;Controversy score;Controversial;Created at</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6267</context>
+          <context context-type="linenumber">6274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
@@ -16740,7 +16820,7 @@
         <target>Q&amp;A CSV exported.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6290</context>
+          <context context-type="linenumber">6297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
@@ -16748,11 +16828,11 @@
         <target>Question <x id="questionNumber" equiv-text="data.questionOrder + 1"/>: <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6453</context>
+          <context context-type="linenumber">6460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6461</context>
+          <context context-type="linenumber">6468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16768,7 +16848,7 @@
         <target>Live free-text is being updated.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6456</context>
+          <context context-type="linenumber">6463</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16780,7 +16860,7 @@
         <target>Current question is not a free-text question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6464</context>
+          <context context-type="linenumber">6471</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16792,7 +16872,7 @@
         <target>No active question yet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6467</context>
+          <context context-type="linenumber">6474</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16804,7 +16884,7 @@
         <target>Could not load live free-text data.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6471</context>
+          <context context-type="linenumber">6478</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -20346,6 +20426,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/countdown-fingers/countdown-fingers.component.ts</context>
           <context context-type="linenumber">126</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="infoLanding.openInNewTab" datatype="html">
+        <source>öffnet in neuem Tab</source>
+        <target>opens in a new tab</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/info-landing-link/info-landing-link.component.ts</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="markdown.copyCode" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -110,12 +110,28 @@
           <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.infoLandingAria" datatype="html">
+        <source>Was arsnova.eu kann (öffnet in neuem Tab)</source>
+        <target>Qué ofrece arsnova.eu (se abre en una pestaña nueva)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">188</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.infoLanding" datatype="html">
+        <source>Was arsnova.eu kann</source>
+        <target>Qué ofrece arsnova.eu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">192</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <target>Aviso legal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
@@ -123,7 +139,7 @@
         <target>Privacidad</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">188</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">
@@ -131,7 +147,7 @@
         <target>Accesibilidad</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibility" datatype="html">
@@ -139,7 +155,7 @@
         <target>Accesibilidad</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7981911571029514989" datatype="html">
@@ -147,7 +163,7 @@
         <target>¡Ahora aún más rápido y fluido!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1136696335453039978" datatype="html">
@@ -155,7 +171,7 @@
         <target>Ajuste: Profesional</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6151253518820826531" datatype="html">
@@ -163,7 +179,7 @@
         <target>Ajuste: Lúdico</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2911090466936872230" datatype="html">
@@ -171,7 +187,7 @@
         <target>Conectar…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/feedback/feedback-host.component.html</context>
@@ -187,7 +203,7 @@
         <target>Intentar otra vez</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAria" datatype="html">
@@ -195,7 +211,7 @@
         <target>Abrir archivo de noticias</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
@@ -203,7 +219,7 @@
         <target>Abrir archivo de noticias, un mensaje sin leer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
@@ -211,7 +227,7 @@
         <target>Abrir archivo de noticias, <x id="INTERPOLATION" equiv-text="{{ n }}"/> mensajes sin leer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">227</context>
+          <context context-type="linenumber">230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.notFound" datatype="html">
@@ -1899,7 +1915,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">402</context>
+          <context context-type="linenumber">410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -1939,7 +1955,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">397</context>
+          <context context-type="linenumber">405</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -4876,7 +4892,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4690</context>
+          <context context-type="linenumber">4697</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -4928,7 +4944,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3633</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -5370,7 +5386,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1899</context>
+          <context context-type="linenumber">1906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -5382,7 +5398,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1904</context>
+          <context context-type="linenumber">1911</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -5406,7 +5422,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -5418,7 +5434,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -6225,12 +6241,28 @@
           <context context-type="linenumber">56,61</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.infoLandingTitle" datatype="html">
+        <source> Mehr zu Nutzen und Hintergründen</source>
+        <target>Más sobre beneficios y contexto</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">63,65</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingBody" datatype="html">
+        <source> Auf der Informationsseite findest du Einsatzmöglichkeiten, Hinweise zu Datenschutz und Barrierefreiheit sowie die Abgrenzung zu anderen Audience-Response-Systemen.</source>
+        <target>En la página de información encontrarás casos de uso, información sobre privacidad y accesibilidad, y la comparación con otros sistemas de respuesta del público.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66,69</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.formatsTitle" datatype="html">
         <source> Frageformate: passend zum didaktischen Ziel</source>
         <target>Formatos de pregunta: cada objetivo didáctico con su formato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">78,80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsLead" datatype="html">
@@ -6238,7 +6270,7 @@
         <target>Elige el formato según lo que ocurre en la sala: ¿quieres comprobar conocimientos, hacer visibles posturas, recoger conceptos o discutir estimaciones? Los formatos están separados a propósito para que la visualización, la evaluación y la moderación encajen con el uso.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">81,85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsGridAria" datatype="html">
@@ -6246,7 +6278,7 @@
         <target>Formatos de preguntas de quiz disponibles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
@@ -6254,7 +6286,7 @@
         <target>Single Choice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTag" datatype="html">
@@ -6262,7 +6294,7 @@
         <target>una única opción correcta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
+          <context context-type="linenumber">97,99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceBody" datatype="html">
@@ -6270,7 +6302,7 @@
         <target>Para comprobaciones de comprensión precisas: una respuesta es correcta, y resultado y puntos quedan claros al instante.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
+          <context context-type="linenumber">100,103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
@@ -6278,7 +6310,7 @@
         <target>Multiple Choice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
@@ -6286,7 +6318,7 @@
         <target>varias opciones correctas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
@@ -6294,7 +6326,7 @@
         <target>Para conceptos más complejos, malentendidos típicos o preguntas como “¿Qué afirmaciones son correctas?” — pueden contar varias respuestas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
+          <context context-type="linenumber">113,116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTitle" datatype="html">
@@ -6302,7 +6334,7 @@
         <target>Respuesta corta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTag" datatype="html">
@@ -6310,7 +6342,7 @@
         <target>solución modelo, no menú de opciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
+          <context context-type="linenumber">123,125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextBody" datatype="html">
@@ -6318,7 +6350,7 @@
         <target>Los participantes responden brevemente con sus propias palabras. Tú defines soluciones modelo; arsnova.eu puede evaluar variantes de escritura, tolerancias y, si hace falta, números o unidades.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
+          <context context-type="linenumber">126,129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTitle" datatype="html">
@@ -6326,7 +6358,7 @@
         <target>Texto libre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">135</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTag" datatype="html">
@@ -6334,7 +6366,7 @@
         <target>respuestas abiertas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
+          <context context-type="linenumber">136,138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextBody" datatype="html">
@@ -6342,7 +6374,7 @@
         <target>Para ideas, reflexiones y expectativas. Sin evaluación automática; las respuestas se pueden recoger y mostrar como nube de palabras.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
+          <context context-type="linenumber">139,142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTitle" datatype="html">
@@ -6350,7 +6382,7 @@
         <target>Encuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTag" datatype="html">
@@ -6358,7 +6390,7 @@
         <target>mapa de opinión sin correcto/incorrecto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
+          <context context-type="linenumber">149,151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyBody" datatype="html">
@@ -6366,7 +6398,7 @@
         <target>Para prioridades, conocimientos previos o decisiones en la sala. Las opciones se cuentan sin lógica de puntuación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
+          <context context-type="linenumber">152,155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTitle" datatype="html">
@@ -6374,7 +6406,7 @@
         <target>Escala de valoración</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTag" datatype="html">
@@ -6382,7 +6414,7 @@
         <target>escala con extremos propios</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
+          <context context-type="linenumber">162,164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingBody" datatype="html">
@@ -6390,7 +6422,7 @@
         <target>Para acuerdo, seguridad, ritmo o feedback de bajo a alto, opcionalmente con extremos nombrados.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
+          <context context-type="linenumber">165,168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
@@ -6398,7 +6430,7 @@
         <target>Pregunta de estimación numérica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTag" datatype="html">
@@ -6406,7 +6438,7 @@
         <target>estimar números, ver la dispersión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
+          <context context-type="linenumber">175,177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateBody" datatype="html">
@@ -6414,7 +6446,7 @@
         <target>Para años, órdenes de magnitud, medidas y probabilidades. Con valor de referencia, banda de tolerancia, histograma, estadísticas y segunda ronda opcional.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
+          <context context-type="linenumber">178,181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsBlitzNote" datatype="html">
@@ -6422,7 +6454,7 @@
         <target>El sondeo rápido va aparte de estos formatos: sirve para feedback espontáneo en directo cuando no quieres crear una pregunta de quiz completa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
+          <context context-type="linenumber">185,188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceTitle" datatype="html">
@@ -6430,7 +6462,7 @@
         <target>Autoevaluación para preguntas evaluables</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
+          <context context-type="linenumber">192,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceLead" datatype="html">
@@ -6438,7 +6470,7 @@
         <target>La autoevaluación no es un tipo de pregunta separada, sino una pregunta adicional opcional de opción única, opción múltiple, respuesta corta y pregunta de estimación numérica: los participantes indican qué tan seguros están en su respuesta (escala 1-5). Esto no afecta ningún punto, pero le ayuda a reconocer su nivel de aprendizaje y sus ideas erróneas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
+          <context context-type="linenumber">195,200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceListAria" datatype="html">
@@ -6446,7 +6478,7 @@
         <target>Funciones didácticas de la autoevaluación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
@@ -6454,7 +6486,7 @@
         <target>Después de la respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
@@ -6462,7 +6494,7 @@
         <target>Divulgación progresiva: Primero seleccione o ingrese la respuesta, luego la autoevaluación. Durante la votación, nadie ve los valores agregados de otras personas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
+          <context context-type="linenumber">210,214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorTitle" datatype="html">
@@ -6470,7 +6502,7 @@
         <target>Configurar en el editor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorBody" datatype="html">
@@ -6478,7 +6510,7 @@
         <target>Alternar por pregunta, etiquetas opcionales para confianza de respuesta alta y baja y una vista previa en vivo de la escala. La autoevaluación está activa por defecto para nuevas preguntas evaluables.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
+          <context context-type="linenumber">221,225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostTitle" datatype="html">
@@ -6486,7 +6518,7 @@
         <target>Evaluación en la vista host tras publicar resultados</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostBody" datatype="html">
@@ -6494,7 +6526,7 @@
         <target>Matriz de corrección y confianza en la respuesta con resaltado de respuestas <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>falsas y muy seguras<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. En preguntas de opción ves qué opciones incorrectas se eligieron con alta confianza en la respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">232,236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportTitle" datatype="html">
@@ -6502,7 +6534,7 @@
         <target>Finalización y exportación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportBody" datatype="html">
@@ -6510,7 +6542,7 @@
         <target> Al final de la sesión, la evaluación resume los conocimientos consolidados, el riesgo de malentendidos y los conocimientos frágiles. Las preguntas con menos de 5 respuestas con autoevaluación no se muestran de forma agregada. El plan de debriefing (PDF) es el formato recomendado; el CSV está disponible en «Más» para Excel. En la colección de quizzes encontrarás el plan de debriefing en la tarjeta del quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">243,249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTitle" datatype="html">
@@ -6518,7 +6550,7 @@
         <target>Prueba de demostración</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">256</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoCardHint" datatype="html">
@@ -6526,7 +6558,7 @@
         <target>Un quiz de ejemplo preinstalado muestra los formatos de pregunta en momentos didácticos concretos: comprobación de conocimientos, nube de palabras, respuesta corta, estimación, escala de valoración, autoevaluación, fórmulas y Markdown. Lo encuentras en tu colección de quizzes y puedes abrirlo en vista previa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTip" datatype="html">
@@ -6534,7 +6566,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Consejo:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> abre la vista previa una vez en un segundo dispositivo antes de tu primera sesión en directo. Verás enseguida cómo encajan la vista de host y la pantalla de participantes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">264,267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstartTitle" datatype="html">
@@ -6542,7 +6574,7 @@
         <target>Inicio rápido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart1" datatype="html">
@@ -6550,7 +6582,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Crear quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> elige “Abrir colección de quizzes”, crea un nuevo quiz y elige el formato adecuado para cada pregunta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
+          <context context-type="linenumber">274,276</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart2" datatype="html">
@@ -6558,7 +6590,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Iniciar evento:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> define estilo, temporizadores, equipos y ranking. Después se crea un código de 6 caracteres, que puedes compartir como texto o QR.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
+          <context context-type="linenumber">278,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart3" datatype="html">
@@ -6566,7 +6598,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Moderar en directo:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> muestra la pregunta, inicia la fase de respuesta, publica o reserva los resultados y añade una segunda ronda cuando aporte valor.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
+          <context context-type="linenumber">282,284</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostTitle" datatype="html">
@@ -6574,7 +6606,7 @@
         <target>Liderar el evento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
+          <context context-type="linenumber">289</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLead" datatype="html">
@@ -6582,7 +6614,7 @@
         <target>En la vista de host diriges la sesión como una pequeña mesa de control: das entrada a participantes, muestras contenidos, abres el debate y haces visibles los resultados.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
+          <context context-type="linenumber">290,294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostStartStep" datatype="html">
@@ -6590,7 +6622,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Iniciar sesión:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> desde tu colección de quizzes, inicia un evento y elige si empieza con quiz o con Q&amp;A. Entonces se crea el código de acceso.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
+          <context context-type="linenumber">297,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLobby" datatype="html">
@@ -6598,7 +6630,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ves quién se ha unido; se muestra un código QR para unirse.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
+          <context context-type="linenumber">301,303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostBeamer" datatype="html">
@@ -6606,7 +6638,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vista de proyección y presentación:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> pregunta, respuestas, cuenta atrás y resultados aparecen con tamaño suficiente para proyector, emisión o segunda pantalla.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSteuerung" datatype="html">
@@ -6614,7 +6646,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Controles:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> usa “Siguiente pregunta” para llevar el contenido a pantalla. Puedes empezar con una fase de lectura, abrir después la fase de respuesta y decidir cuándo aparece el resultado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
+          <context context-type="linenumber">309,312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPeer" datatype="html">
@@ -6622,7 +6654,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (rondas dobles):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> para preguntas de quiz adecuadas, estimaciones y sondeos rápidos: primero se vota, luego se debate y después se vuelve a votar. La comparación antes/después hace visible el avance de aprendizaje.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
+          <context context-type="linenumber">314,317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSettings" datatype="html">
@@ -6630,7 +6662,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Ajustes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> al iniciar eliges estilo y opciones: serio o lúdico, con o sin ranking, sonido, fase de lectura, modo equipo, apodos y temporizador.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
+          <context context-type="linenumber">319,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallTitle" datatype="html">
@@ -6638,7 +6670,7 @@
         <target> Muro de preguntas en el canal Q&amp;A en directo </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
+          <context context-type="linenumber">327,329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLead" datatype="html">
@@ -6646,7 +6678,7 @@
         <target> El Q&amp;A no debería perderse en un chat paralelo. El muro de preguntas hace visibles, priorizables y moderables las dudas: mantienes el hilo de la sesión mientras el grupo señala de forma colectiva qué puntos necesitan aclaración. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
+          <context context-type="linenumber">330,334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallListAria" datatype="html">
@@ -6654,7 +6686,7 @@
         <target>Funciones didácticas del muro de preguntas Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
+          <context context-type="linenumber">338</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationTitle" datatype="html">
@@ -6662,7 +6694,7 @@
         <target> Moderación con criterio didáctico </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">343</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationBody" datatype="html">
@@ -6670,7 +6702,7 @@
         <target> Si lo necesitas, las nuevas preguntas esperan primero tu aprobación. Puedes aprobar, fijar, archivar o retirar aportaciones y cuidar el espacio, la relevancia y el momento: responder ahora, guardar para después o abrir una línea de debate. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
+          <context context-type="linenumber">344,349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingTitle" datatype="html">
@@ -6678,7 +6710,7 @@
         <target> Voto colectivo a favor y en contra </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingBody" datatype="html">
@@ -6686,7 +6718,7 @@
         <target> Las personas participantes ponderan juntas las preguntas. Los votos positivos y negativos muestran algo más que popularidad: sacan a la luz incertidumbre, desacuerdo y necesidad de aclaración. Ordenaciones como «más apoyadas», «mejores preguntas» y «controvertidas» te ayudan a dedicar el tiempo en directo donde tiene más sentido didáctico. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
+          <context context-type="linenumber">356,361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
@@ -6694,7 +6726,7 @@
         <target> Nube de palabras Q&amp;A a nivel temático </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
+          <context context-type="linenumber">367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudBody" datatype="html">
@@ -6702,7 +6734,7 @@
         <target> La nube de palabras condensa las preguntas visibles en palabras y frases, ponderadas por apoyo, acuerdo sólido o controversia. Puede congelarse, leerse según la lógica de ordenación y mostrarse en la vista de presentación: una lectura rápida de grupos temáticos, no una lista decorativa de palabras. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
+          <context context-type="linenumber">368,373</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmTitle" datatype="html">
@@ -6710,7 +6742,7 @@
         <target>Siguiente paso: brújula de moderación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
+          <context context-type="linenumber">379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmBody" datatype="html">
@@ -6718,7 +6750,7 @@
         <target> Primero se prevé una brújula de moderación determinista. Más adelante se podrán añadir de forma opcional señales Q&amp;A NLP asíncronas y resúmenes vinculados a las fuentes, como ayuda de moderación respetuosa con los datos en lugar de una valoración de caja negra. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
+          <context context-type="linenumber">380,384</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.blitzTitle" datatype="html">
@@ -6726,7 +6758,7 @@
         <target>Sondeo rápido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
+          <context context-type="linenumber">391</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackIntro" datatype="html">
@@ -6734,7 +6766,7 @@
         <target>Sondeos rápidos sobre ánimo y comprensión, antes de una pausa, al arrancar o para tomar el pulso en el momento. Disponibles en la vista de anfitrión de tu sesión en directo o desde la página de inicio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
+          <context context-type="linenumber">392,396</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfMood" datatype="html">
@@ -6742,7 +6774,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Imagen del estado de ánimo<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): ¿Cómo les va a los participantes?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
+          <context context-type="linenumber">399,400</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfYesNoMaybe" datatype="html">
@@ -6750,7 +6782,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sí / No / Quizás<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Consulta de consentimiento rápido.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
+          <context context-type="linenumber">402,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackYesNo" datatype="html">
@@ -6758,7 +6790,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sí / No<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): pregunta binaria clara, sin término medio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">405,406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
@@ -6766,7 +6798,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Verdadero / Falso / No lo sé<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): para valoraciones rápidas o comprobaciones de conocimiento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
+          <context context-type="linenumber">408,410</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
@@ -6774,7 +6806,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Encuestas rápidas de varias etapas<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A-D): tres o cuatro opciones fijas para la votación espontánea, sin crear una pregunta de prueba completa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
+          <context context-type="linenumber">412,414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTempo" datatype="html">
@@ -6782,7 +6814,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Feedback de ritmo<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): con cuatro iconos, tu grupo indica en todo momento si puede seguir. Las personas participantes pueden cambiar su respuesta; tú solo ves la tendencia agregada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">416,419</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
@@ -6790,7 +6822,7 @@
         <target>Inicias la ronda en la vista de anfitrión de tu sesión en directo o directamente desde la tarjeta «Sondeo rápido» («En vivo con un clic») en la página de inicio. Las personas participantes votan con un toque y ves los resultados al instante en un gráfico de barras.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">421,425</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfPeer" datatype="html">
@@ -6798,7 +6830,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Instrucción entre pares (rondas dobles):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Primera ronda - No resolver el resultado - Iniciar la "fase de discusión" ("Discute con tu vecino") - "Segunda votación". La comparación antes/después muestra cómo cambia el estado de ánimo tras el intercambio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">428,432</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfStop" datatype="html">
@@ -6806,7 +6838,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Detener:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Congelar la votación: los participantes ven &quot;La votación está en pausa&quot; y ya no pueden votar hasta que elijas &quot;Reanudar&quot;.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">434,436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfReset" datatype="html">
@@ -6814,7 +6846,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Restablecer:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Elimina todos los votos y déjalos votar nuevamente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">438,439</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfNewRound" datatype="html">
@@ -6822,7 +6854,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Nueva ronda:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Genera nuevo código y comienza una nueva ronda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">441,442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfCopyLink" datatype="html">
@@ -6830,7 +6862,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Copiar enlace:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Copiar enlace de unión al portapapeles, p. ej. para compartir a través del chat.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">444,446</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsTitle" datatype="html">
@@ -6838,7 +6870,7 @@
         <target>Para tus participantes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsLead" datatype="html">
@@ -6846,7 +6878,7 @@
         <target>En pocas palabras, qué puedes compartir en tu evento:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">452,454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsJoin" datatype="html">
@@ -6854,7 +6886,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Unirse:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Introduce el código de 6 dígitos en arsnova.eu y «Vamos» — vale para cuestionario, Q&amp;A y sondeo rápido. Sin registro.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">457,459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsNick" datatype="html">
@@ -6862,7 +6894,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Apodos:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Dependiendo de tu configuración, nombres predefinidos, tu propio nombre o anónimo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">461,463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsVote" datatype="html">
@@ -6870,7 +6902,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vota:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> La pregunta aparece en el dispositivo; elige la respuesta y envíala. Si la autoevaluación está activada, sigue la escala 1–5. Con límite de tiempo, hay una cuenta atrás.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">465,468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTitle" datatype="html">
@@ -6878,7 +6910,7 @@
         <target>Tu colección de quizzes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionLead" datatype="html">
@@ -6886,7 +6918,7 @@
         <target>Aquí creas y preparas tus cuestionarios.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionEditor" datatype="html">
@@ -6894,7 +6926,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ordene las preguntas arrastrando y soltando, expandiendo y contrayendo, verifique la vista previa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">477,479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTypes" datatype="html">
@@ -6902,7 +6934,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Tipos de pregunta:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single choice, multiple choice, respuesta corta, texto libre, encuesta, escala de valoración y pregunta de estimación numérica — cada pregunta puede incluir temporizador, dificultad y autoevaluación opcionales.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">481,484</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionImport" datatype="html">
@@ -6910,7 +6942,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Importar / exportar:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Importa o exporta quizzes como JSON. Usa las plantillas de generación y revisión para crear quizzes de calidad con tu herramienta de IA preferida, revisarlos e importarlos directamente. Tus contenidos y presentaciones no se envían a arsnova.eu; usas tu propia herramienta de IA.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">486,490</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionSync" datatype="html">
@@ -6918,7 +6950,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sincronización:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Usa el enlace de sync para compartir tu colección de quizzes o continuar en otros dispositivos. Quien tenga el enlace puede abrir la colección. Los datos del dispositivo solo sirven para orientarte.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">492,495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoQuizHint" datatype="html">
@@ -6926,7 +6958,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Quiz de demostración:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> un quiz preinstalado muestra todos los formatos con ejemplos, incluidas fórmulas KaTeX y Markdown. Ábrelo desde la colección de quizzes en vista previa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">497,500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesTitle" datatype="html">
@@ -6934,7 +6966,7 @@
         <target>Serio y juguetón</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesLead" datatype="html">
@@ -6942,7 +6974,7 @@
         <target>Dos estilos para diferentes situaciones: seleccionables en la página de inicio y al inicio de la sesión.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">506,509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.styleSerious" datatype="html">
@@ -6950,7 +6982,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Serio:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anónimo, sin clasificaciones: ideal para evaluaciones formativas, preparación de exámenes y temas delicados.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">512,514</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylePlayful" datatype="html">
@@ -6958,7 +6990,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Juguetón:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Con clasificación, sonidos y mensajes de ánimo: ideal para romper el hielo, competir y hacer cuestionarios motivadores.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">516,518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesOptions" datatype="html">
@@ -6966,7 +6998,7 @@
         <target>Todas las opciones (clasificaciones, sonido, fase de lectura, equipo, bonificación) se pueden activar y desactivar individualmente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">520,523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTitle" datatype="html">
@@ -6974,7 +7006,7 @@
         <target>Más funciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreBonus" datatype="html">
@@ -6982,7 +7014,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Códigos de bonificación:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Los primeros lugares reciben un código canjeable (por ejemplo, por puntos de bonificación). Verá la lista de códigos; Los datos personales no se almacenan.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">530,533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTeams" datatype="html">
@@ -6990,7 +7022,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Modo de equipo:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Tus participantes juegan en equipos con su propia tabla de clasificación de equipos, p. ej. para competiciones grupales en seminarios.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">535,537</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreGamification" datatype="html">
@@ -6998,7 +7030,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamificación:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Efectos de sonido, efectos de recompensa para los mejores lugares, mensajes motivadores, en modo lúdico.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">539,541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyTitle" datatype="html">
@@ -7006,7 +7038,7 @@
         <target>Protección de datos y tecnología</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyBody" datatype="html">
@@ -7014,7 +7046,15 @@
         <target>arsnova.eu es gratuito, de código abierto y está destinado a su uso en escuelas, universidades y educación superior, centrándose en la protección de datos (GDPR). El contenido del cuestionario se guarda localmente en el navegador. No es necesario registrarse, ni para usted ni para sus participantes. Se puede instalar como una aplicación (PWA), p. B. para un inicio más rápido en el teléfono inteligente. Interfaz en alemán, inglés, francés, español e italiano.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">547,553</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingLink" datatype="html">
+        <source>Hintergründe und Einsatzmöglichkeiten</source>
+        <target>Contexto y casos de uso</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.ts</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">
@@ -7098,11 +7138,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">408</context>
+          <context context-type="linenumber">416</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">864</context>
+          <context context-type="linenumber">872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -7138,11 +7178,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">409</context>
+          <context context-type="linenumber">417</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">865</context>
+          <context context-type="linenumber">873</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -7410,7 +7450,7 @@
         <target>Compartir con otras personas o usar la misma colección en un segundo dispositivo:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">447,449</context>
+          <context context-type="linenumber">453,455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareAria" datatype="html">
@@ -7418,7 +7458,7 @@
         <target>Mostrar enlace de sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">456</context>
+          <context context-type="linenumber">462</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareLink" datatype="html">
@@ -7426,7 +7466,7 @@
         <target>Mostrar enlace de sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">459</context>
+          <context context-type="linenumber">465</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncOpenHint" datatype="html">
@@ -7434,7 +7474,7 @@
         <target>Pega aquí el enlace de sync recibido:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">465,467</context>
+          <context context-type="linenumber">471,473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkLabel" datatype="html">
@@ -7442,7 +7482,7 @@
         <target>Enlace de sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkPlaceholder" datatype="html">
@@ -7450,7 +7490,7 @@
         <target>sync-room-12345678</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">483</context>
+          <context context-type="linenumber">489</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkInputAria" datatype="html">
@@ -7458,7 +7498,7 @@
         <target>Introducir enlace de sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">489</context>
+          <context context-type="linenumber">495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkSubmit" datatype="html">
@@ -7466,7 +7506,7 @@
         <target>Abrir</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">497,499</context>
+          <context context-type="linenumber">503,505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkedHintWithOrigin" datatype="html">
@@ -7474,7 +7514,7 @@
         <target>Los quizzes se comparten con <x id="INTERPOLATION" equiv-text="{{ originSummary }}"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">513,515</context>
+          <context context-type="linenumber">519,521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkCta" datatype="html">
@@ -7482,7 +7522,7 @@
         <target>Quitar vínculo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayTitle" datatype="html">
@@ -7490,7 +7530,7 @@
         <target>noticias actuales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">567,569</context>
+          <context context-type="linenumber">573,575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayCloseAria" datatype="html">
@@ -7498,7 +7538,7 @@
         <target>Cerrar mensaje</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">585</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.ack" datatype="html">
@@ -7506,7 +7546,7 @@
         <target>¡Entendido!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">593,595</context>
+          <context context-type="linenumber">599,601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbGroupAria" datatype="html">
@@ -7514,7 +7554,7 @@
         <target>Valorar el mensaje</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">599</context>
+          <context context-type="linenumber">605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpTooltip" datatype="html">
@@ -7522,7 +7562,7 @@
         <target>Útil — pulsa de nuevo para quitar tu voto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">609</context>
+          <context context-type="linenumber">615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpAria" datatype="html">
@@ -7530,7 +7570,7 @@
         <target>Útil, pulsa de nuevo para quitar tu voto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">611</context>
+          <context context-type="linenumber">617</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownTooltip" datatype="html">
@@ -7538,7 +7578,7 @@
         <target>No es útil — pulsa de nuevo para quitar tu voto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">623</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownAria" datatype="html">
@@ -7546,7 +7586,15 @@
         <target>No es útil, pulsa de nuevo para quitar tu voto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">625</context>
+          <context context-type="linenumber">631</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="homeHostCard.infoLanding" datatype="html">
+        <source>Einsatzmöglichkeiten entdecken</source>
+        <target>Explorar casos de uso</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.syncOrigin" datatype="html">
@@ -7554,11 +7602,11 @@
         <target><x id="browser" equiv-text="peer.browserLabel"/> en <x id="device" equiv-text="peer.deviceLabel"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2862374619655540985" datatype="html">
@@ -7566,11 +7614,11 @@
         <target>En este momento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">470</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5002</context>
+          <context context-type="linenumber">5009</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7582,11 +7630,11 @@
         <target>Hace <x id="PH" equiv-text="minutes"/> minutos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">467</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5004</context>
+          <context context-type="linenumber">5011</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7598,11 +7646,11 @@
         <target>Hace 1 hora</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7614,11 +7662,11 @@
         <target>Hace <x id="PH" equiv-text="hours"/> horas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7630,11 +7678,11 @@
         <target>Hace 1 día</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7646,11 +7694,11 @@
         <target>Hace <x id="PH" equiv-text="days"/> días</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7662,7 +7710,7 @@
         <target>Eliminar la sesión <x id="PH" equiv-text="code"/> de la lista</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">477</context>
+          <context context-type="linenumber">482</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.heroChipStartError" datatype="html">
@@ -7670,7 +7718,7 @@
         <target>No se pudo iniciar el canal. Inténtalo de nuevo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">586</context>
+          <context context-type="linenumber">591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkError" datatype="html">
@@ -7678,7 +7726,7 @@
         <target>Introduce un enlace de sync válido.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">645</context>
+          <context context-type="linenumber">650</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkConfirmPrompt" datatype="html">
@@ -7686,7 +7734,7 @@
         <target>¿Quitar el vínculo de verdad? La biblioteca de quizzes actual se mantendrá en este dispositivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">666</context>
+          <context context-type="linenumber">671</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkSuccess" datatype="html">
@@ -7694,7 +7742,7 @@
         <target>Vínculo quitado. La biblioteca de quizzes ahora solo está activa en este dispositivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">674</context>
+          <context context-type="linenumber">679</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeFeedbackCard.startError" datatype="html">
@@ -7702,7 +7750,7 @@
         <target>No se pudo iniciar el sondeo rápido. Vuelve a intentarlo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">700</context>
+          <context context-type="linenumber">705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6627607898679527757" datatype="html">
@@ -7710,7 +7758,7 @@
         <target>Introduce el código de 6 caracteres.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">730</context>
+          <context context-type="linenumber">735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2422920312042178920" datatype="html">
@@ -7718,7 +7766,7 @@
         <target>Esta sesión ya ha terminado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">787</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/join/join.component.ts</context>
@@ -7906,7 +7954,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7926,7 +7974,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -8022,7 +8070,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2939</context>
+          <context context-type="linenumber">2946</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -8666,7 +8714,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1882</context>
+          <context context-type="linenumber">1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.previewSaveAndOpen" datatype="html">
@@ -8678,7 +8726,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1886</context>
+          <context context-type="linenumber">1900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1736772795054152455" datatype="html">
@@ -8874,7 +8922,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">595</context>
+          <context context-type="linenumber">603</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -9386,7 +9434,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1599,1602</context>
+          <context context-type="linenumber">1613,1616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionEditSaveHint" datatype="html">
@@ -9458,7 +9506,7 @@
         <target>Es hora de esta pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">568,570</context>
+          <context context-type="linenumber">576,578</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9470,7 +9518,7 @@
         <target>El valor predeterminado es el límite de tiempo de la configuración del cuestionario. Puedes establecer tu propio límite por pregunta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">571,574</context>
+          <context context-type="linenumber">579,582</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9482,7 +9530,7 @@
         <target>Usar límite de tiempo de prueba</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">587</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9494,7 +9542,7 @@
         <target>Segundos para esta pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">585</context>
+          <context context-type="linenumber">593</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9506,7 +9554,7 @@
         <target>Segundos para esta pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">590</context>
+          <context context-type="linenumber">598</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9518,7 +9566,7 @@
         <target>Sin fase de lectura para esta pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">602,604</context>
+          <context context-type="linenumber">610,612</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9530,7 +9578,7 @@
         <target>Autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">609,611</context>
+          <context context-type="linenumber">617,619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceConfigHint" datatype="html">
@@ -9538,7 +9586,7 @@
         <target>Después de su respuesta, los participantes indican su confianza. No afecta la puntuación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">612,615</context>
+          <context context-type="linenumber">620,623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceEnabledToggle" datatype="html">
@@ -9546,7 +9594,7 @@
         <target>Autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">620,622</context>
+          <context context-type="linenumber">634,636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelLowField" datatype="html">
@@ -9554,7 +9602,7 @@
         <target>Baja seguridad de respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">632</context>
+          <context context-type="linenumber">646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelHighField" datatype="html">
@@ -9562,7 +9610,7 @@
         <target>Alta seguridad de respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">652</context>
+          <context context-type="linenumber">666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewLabel" datatype="html">
@@ -9570,7 +9618,7 @@
         <target>Vista previa para los participantes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">676,678</context>
+          <context context-type="linenumber">690,692</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8205020163645016790" datatype="html">
@@ -9578,7 +9626,7 @@
         <target>formato rápido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">715</context>
+          <context context-type="linenumber">729</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.quickFormatAria" datatype="html">
@@ -9586,7 +9634,7 @@
         <target>Elija formato rápido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">720</context>
+          <context context-type="linenumber">734</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7287117104463920417" datatype="html">
@@ -9594,7 +9642,7 @@
         <target>Sobrescribe las respuestas existentes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">726</context>
+          <context context-type="linenumber">740</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetSection" datatype="html">
@@ -9602,7 +9650,7 @@
         <target>Inicio rápido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">731,733</context>
+          <context context-type="linenumber">745,747</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetGroupAria" datatype="html">
@@ -9610,7 +9658,7 @@
         <target>Seleccionar plantilla de pregunta de estimación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">738</context>
+          <context context-type="linenumber">752</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8648957206736539595" datatype="html">
@@ -9618,7 +9666,7 @@
         <target>Tipo de entrada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">756</context>
+          <context context-type="linenumber">770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateInputTypeLabel" datatype="html">
@@ -9626,7 +9674,7 @@
         <target>Tipo de número</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">759</context>
+          <context context-type="linenumber">773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntegerOption" datatype="html">
@@ -9634,7 +9682,7 @@
         <target>Número entero</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">762</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalOption" datatype="html">
@@ -9642,7 +9690,7 @@
         <target>Número decimal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">765</context>
+          <context context-type="linenumber">779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalPlacesLabel" datatype="html">
@@ -9650,7 +9698,7 @@
         <target>Máx. decimales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">772</context>
+          <context context-type="linenumber">786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceSection" datatype="html">
@@ -9658,7 +9706,7 @@
         <target>Modo de tolerancia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">788,790</context>
+          <context context-type="linenumber">802,804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceModeLabel" datatype="html">
@@ -9666,7 +9714,7 @@
         <target>modo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">792</context>
+          <context context-type="linenumber">806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteIntervalOption" datatype="html">
@@ -9674,7 +9722,7 @@
         <target>Intervalo absoluto [L, R]</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">797</context>
+          <context context-type="linenumber">811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateRelativePercentOption" datatype="html">
@@ -9682,7 +9730,7 @@
         <target>Banda de tolerancia relativa (V ± p%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">802</context>
+          <context context-type="linenumber">816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalLeftLabel" datatype="html">
@@ -9690,7 +9738,7 @@
         <target>Borde izquierdo L</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">811</context>
+          <context context-type="linenumber">825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalRightLabel" datatype="html">
@@ -9698,7 +9746,7 @@
         <target>Borde derecho R</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">817</context>
+          <context context-type="linenumber">831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueLabel" datatype="html">
@@ -9706,7 +9754,7 @@
         <target>Valor de referencia para el análisis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">824</context>
+          <context context-type="linenumber">838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueHint" datatype="html">
@@ -9714,7 +9762,7 @@
         <target>Opcional para línea de referencia, métrica de error y comparación de rondas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">828</context>
+          <context context-type="linenumber">842</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueLabel" datatype="html">
@@ -9722,7 +9770,7 @@
         <target>Valor de referencia V</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueHint" datatype="html">
@@ -9730,7 +9778,7 @@
         <target>Debe ser ≠ 0</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">840</context>
+          <context context-type="linenumber">854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTolerancePercentLabel" datatype="html">
@@ -9738,7 +9786,7 @@
         <target>Tolerancia p (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">845</context>
+          <context context-type="linenumber">859</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateBoundsSection" datatype="html">
@@ -9746,7 +9794,7 @@
         <target>Límites de plausibilidad (opcional)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">858,860</context>
+          <context context-type="linenumber">872,874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMinLabel" datatype="html">
@@ -9754,7 +9802,7 @@
         <target>Entrada mínima</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">863</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMaxLabel" datatype="html">
@@ -9762,7 +9810,7 @@
         <target>Entrada máxima</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">867</context>
+          <context context-type="linenumber">881</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewAria" datatype="html">
@@ -9770,7 +9818,7 @@
         <target>Vista previa de la pregunta de estimación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">876</context>
+          <context context-type="linenumber">890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewTitle" datatype="html">
@@ -9778,7 +9826,7 @@
         <target>Vista previa de la banda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">881</context>
+          <context context-type="linenumber">895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTwoRoundsToggle" datatype="html">
@@ -9786,7 +9834,7 @@
         <target>Dos rondas de votación (instrucción entre pares)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">937,939</context>
+          <context context-type="linenumber">951,953</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8259238864102475814" datatype="html">
@@ -9794,7 +9842,7 @@
         <target>escala</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">945</context>
+          <context context-type="linenumber">959</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.ratingScaleAria" datatype="html">
@@ -9802,7 +9850,7 @@
         <target>Seleccionar escala de calificación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">949</context>
+          <context context-type="linenumber">963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4298652859209119138" datatype="html">
@@ -9810,7 +9858,7 @@
         <target>Borde izquierdo (opcional)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3739377380076895717" datatype="html">
@@ -9818,7 +9866,7 @@
         <target>Borde derecho (opcional)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">985</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigLegend" datatype="html">
@@ -9826,7 +9874,7 @@
         <target>Errores tipográficos y variantes de escritura</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">983,985</context>
+          <context context-type="linenumber">997,999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigHint" datatype="html">
@@ -9834,7 +9882,7 @@
         <target>Decide qué errores tipográficos siguen contando. La vista previa de abajo muestra si eso da puntuación completa, puntos parciales o ningún punto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">989,992</context>
+          <context context-type="linenumber">1003,1006</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindFieldLabel" datatype="html">
@@ -9842,7 +9890,7 @@
         <target>Tipo de respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">996</context>
+          <context context-type="linenumber">1010</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthFieldLabel" datatype="html">
@@ -9850,7 +9898,7 @@
         <target>Longitud máxima de la respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1010</context>
+          <context context-type="linenumber">1024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthHint" datatype="html">
@@ -9858,7 +9906,7 @@
         <target>1 a 500 caracteres</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationModeFieldLabel" datatype="html">
@@ -9866,7 +9914,7 @@
         <target>Evaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1025</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceFieldLabel" datatype="html">
@@ -9874,7 +9922,7 @@
         <target>Tolerancia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceHint" datatype="html">
@@ -9882,7 +9930,7 @@
         <target>Los porcentajes describen la desviación permitida respecto a la solución modelo, no la puntuación. Baja ≈ 10 %, media ≈ 20 %, amplia ≈ 30 %. En términos cortos, el mismo nivel resulta más estricto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1042,1044</context>
+          <context context-type="linenumber">1056,1058</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextAllowPartialCreditToggle" datatype="html">
@@ -9890,7 +9938,7 @@
         <target>Conceder puntos parciales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1066,1068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextCaseSensitiveToggle" datatype="html">
@@ -9898,7 +9946,7 @@
         <target>Distinguir mayúsculas y minúsculas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1058,1060</context>
+          <context context-type="linenumber">1072,1074</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindFieldLabel" datatype="html">
@@ -9906,7 +9954,7 @@
         <target>Formato numérico</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1064</context>
+          <context context-type="linenumber">1078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeFieldLabel" datatype="html">
@@ -9914,7 +9962,7 @@
         <target>Tolerancia numérica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1074</context>
+          <context context-type="linenumber">1088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeHint" datatype="html">
@@ -9922,7 +9970,7 @@
         <target>El modo exacto exige el mismo valor numérico. La tolerancia absoluta usa un rango fijo ± y la relativa usa un porcentaje alrededor de la respuesta modelo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1082,1083</context>
+          <context context-type="linenumber">1096,1097</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceFieldLabel" datatype="html">
@@ -9930,7 +9978,7 @@
         <target>Tolerancia absoluta (±)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1090</context>
+          <context context-type="linenumber">1104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceHint" datatype="html">
@@ -9938,7 +9986,7 @@
         <target>Ejemplo: con 10 y ±0,5 se aceptan respuestas entre 9,5 y 10,5.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1100</context>
+          <context context-type="linenumber">1114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceFieldLabel" datatype="html">
@@ -9946,7 +9994,7 @@
         <target>Tolerancia relativa (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1108</context>
+          <context context-type="linenumber">1122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceHint" datatype="html">
@@ -9954,7 +10002,7 @@
         <target>Ejemplo: con 200 y 5 % se aceptan respuestas entre 190 y 210.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1118</context>
+          <context context-type="linenumber">1132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyFieldLabel" datatype="html">
@@ -9962,7 +10010,7 @@
         <target>Familia de unidades</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1126</context>
+          <context context-type="linenumber">1140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitToggle" datatype="html">
@@ -9970,7 +10018,7 @@
         <target> Hacer obligatoria la unidad </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1139,1141</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAcceptEquivalentUnitsToggle" datatype="html">
@@ -9978,7 +10026,7 @@
         <target> Aceptar unidades equivalentes </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1159,1161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLegend" datatype="html">
@@ -9986,7 +10034,7 @@
         <target>Así actúa la evaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1154,1156</context>
+          <context context-type="linenumber">1168,1170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningLabel" datatype="html">
@@ -9994,7 +10042,7 @@
         <target>Nota didáctica:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1200</context>
+          <context context-type="linenumber">1214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsToggle" datatype="html">
@@ -10002,7 +10050,7 @@
         <target>Mostrar detalles técnicos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1208,1210</context>
+          <context context-type="linenumber">1222,1224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsIntro" datatype="html">
@@ -10010,7 +10058,7 @@
         <target>El modo automático combina coincidencia exacta, Hamming, Damerau-Levenshtein y Levenshtein. Hamming sirve para un solo carácter incorrecto con la misma longitud, Damerau-Levenshtein además maneja letras vecinas intercambiadas, y Levenshtein también cubre caracteres faltantes o extra.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1215,1220</context>
+          <context context-type="linenumber">1229,1234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTrimWhitespaceToggle" datatype="html">
@@ -10018,7 +10066,7 @@
         <target>Ignorar espacios al principio y al final</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1225,1227</context>
+          <context context-type="linenumber">1239,1241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextNormalizeWhitespaceToggle" datatype="html">
@@ -10026,7 +10074,7 @@
         <target>Unir espacios repetidos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1231,1233</context>
+          <context context-type="linenumber">1245,1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextValidSolutionHint" datatype="html">
@@ -10034,7 +10082,7 @@
         <target>Válida</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1272,1274</context>
+          <context context-type="linenumber">1286,1288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8021687558521014030" datatype="html">
@@ -10042,7 +10090,7 @@
         <target>opción</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1276</context>
+          <context context-type="linenumber">1290</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6278157135662238363" datatype="html">
@@ -10050,7 +10098,7 @@
         <target>Ingrese un texto de respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2650319028885568688" datatype="html">
@@ -10058,7 +10106,7 @@
         <target>Máximo 500 caracteres.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2525684207823121577" datatype="html">
@@ -10066,7 +10114,7 @@
         <target>Aquí, los participantes responden libremente, no se necesitan respuestas predeterminadas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1332,1334</context>
+          <context context-type="linenumber">1346,1348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.livePreviewCardTitle" datatype="html">
@@ -10074,7 +10122,7 @@
         <target>Vista previa completa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1357,1359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7492260970005034710" datatype="html">
@@ -10082,7 +10130,7 @@
         <target>Error de fórmula: <x id="INTERPOLATION" equiv-text="{{ previewKatexError() }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1350,1352</context>
+          <context context-type="linenumber">1364,1366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2863483573986908286" datatype="html">
@@ -10090,7 +10138,7 @@
         <target>Preguntar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1355</context>
+          <context context-type="linenumber">1369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10102,7 +10150,7 @@
         <target>Lista de preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1429</context>
+          <context context-type="linenumber">1443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionsListTitle" datatype="html">
@@ -10110,7 +10158,7 @@
         <target>Preguntas en el cuestionario</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1437,1439</context>
+          <context context-type="linenumber">1451,1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8122550761270535954" datatype="html">
@@ -10118,7 +10166,7 @@
         <target>Agregado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1441</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3827964072457808965" datatype="html">
@@ -10126,7 +10174,7 @@
         <target>Aún no hay preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1451</context>
+          <context context-type="linenumber">1465</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -10138,7 +10186,7 @@
         <target>Añade arriba tu primera pregunta para empezar.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1452,1454</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionListPosition" datatype="html">
@@ -10146,7 +10194,7 @@
         <target>Pregunta <x id="INTERPOLATION" equiv-text="{{ question.order + 1 }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1514,1515</context>
+          <context context-type="linenumber">1528,1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionDisabledBadge" datatype="html">
@@ -10154,7 +10202,7 @@
         <target>Desactivado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1539</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineDisabledHint" datatype="html">
@@ -10162,7 +10210,7 @@
         <target>Esta pregunta está deshabilitada y no aparece en la vista previa ni en el cuestionario en vivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1565,1568</context>
+          <context context-type="linenumber">1579,1582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.activateQuestion" datatype="html">
@@ -10170,15 +10218,15 @@
         <target>Activar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1575</context>
+          <context context-type="linenumber">1589</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1772</context>
+          <context context-type="linenumber">1786</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineEditEyebrow" datatype="html">
@@ -10186,7 +10234,7 @@
         <target>Modo de edición</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1587,1589</context>
+          <context context-type="linenumber">1601,1603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.editQuestionTitle" datatype="html">
@@ -10194,7 +10242,7 @@
         <target>Editar esta pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1593,1595</context>
+          <context context-type="linenumber">1607,1609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.freeTextWordCloudHint" datatype="html">
@@ -10202,7 +10250,7 @@
         <target>Respuesta de texto libre como una nube de palabras</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1617,1619</context>
+          <context context-type="linenumber">1631,1633</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10214,7 +10262,7 @@
         <target>Respuesta corta con comparación automática con soluciones modelo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1624,1626</context>
+          <context context-type="linenumber">1638,1640</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10226,7 +10274,7 @@
         <target>La autoevaluación se solicita tras la respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1715,1717</context>
+          <context context-type="linenumber">1729,1731</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6920196637619975735" datatype="html">
@@ -10234,11 +10282,11 @@
         <target>Editar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1754</context>
+          <context context-type="linenumber">1768</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1802</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10250,11 +10298,11 @@
         <target>Desactivar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1763</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1797</context>
+          <context context-type="linenumber">1811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4580399730639224598" datatype="html">
@@ -10262,11 +10310,11 @@
         <target>Borrar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1791</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1811</context>
+          <context context-type="linenumber">1825</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -10278,11 +10326,11 @@
         <target>Volver a la lista de cuestionarios</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1843</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1900</context>
+          <context context-type="linenumber">1914</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -10298,7 +10346,7 @@
         <target>Atrás</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1832</context>
+          <context context-type="linenumber">1846</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -10310,11 +10358,11 @@
         <target>Descartar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1842</context>
+          <context context-type="linenumber">1856</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1846</context>
+          <context context-type="linenumber">1860</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButtonAria" datatype="html">
@@ -10322,7 +10370,7 @@
         <target>Agrega otra pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1869</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButton" datatype="html">
@@ -10330,7 +10378,7 @@
         <target>Otra pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1859</context>
+          <context context-type="linenumber">1873</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.saveAllButton" datatype="html">
@@ -10338,11 +10386,11 @@
         <target>Guardar cambios</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1869</context>
+          <context context-type="linenumber">1883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1873</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7620597678842046410" datatype="html">
@@ -10350,7 +10398,7 @@
         <target>Prueba no encontrada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1895</context>
+          <context context-type="linenumber">1909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6672916435220201136" datatype="html">
@@ -10358,7 +10406,23 @@
         <target>Volver a la lista</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1903</context>
+          <context context-type="linenumber">1917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingEstimate" datatype="html">
+        <source>Schätzfragen didaktisch einsetzen</source>
+        <target>Usar preguntas de estimación con fines didácticos</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <target>Comprender la autoevaluación y el análisis posterior</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="924826286502636331" datatype="html">
@@ -10366,7 +10430,7 @@
         <target>elección única</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">399</context>
+          <context context-type="linenumber">407</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4737017620429217247" datatype="html">
@@ -10374,7 +10438,7 @@
         <target>opción múltiple</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">400</context>
+          <context context-type="linenumber">408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="493996564238682027" datatype="html">
@@ -10382,7 +10446,7 @@
         <target>texto libre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">401</context>
+          <context context-type="linenumber">409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8680267345873464947" datatype="html">
@@ -10390,7 +10454,7 @@
         <target>Encuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">403</context>
+          <context context-type="linenumber">411</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5472460529727499985" datatype="html">
@@ -10398,7 +10462,7 @@
         <target>Calificación (1-5 / 1-10)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">404</context>
+          <context context-type="linenumber">412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearLabel" datatype="html">
@@ -10406,7 +10470,7 @@
         <target>año</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">427</context>
+          <context context-type="linenumber">435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearHint" datatype="html">
@@ -10414,7 +10478,7 @@
         <target>Entero, 1500-2000 plausible, 1700-1900 aceptado, dos rondas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">428</context>
+          <context context-type="linenumber">436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementLabel" datatype="html">
@@ -10422,7 +10486,7 @@
         <target>Valor medido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">433</context>
+          <context context-type="linenumber">441</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementHint" datatype="html">
@@ -10430,7 +10494,7 @@
         <target>Valor decimal con un decimal y una estrecha banda de tolerancia absoluta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">434</context>
+          <context context-type="linenumber">442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentLabel" datatype="html">
@@ -10438,7 +10502,7 @@
         <target>Porcentaje</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">439</context>
+          <context context-type="linenumber">447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentHint" datatype="html">
@@ -10446,7 +10510,7 @@
         <target>Entero de 0 a 100 con una tolerancia de diez puntos porcentuales.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">440</context>
+          <context context-type="linenumber">448</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeLabel" datatype="html">
@@ -10454,7 +10518,7 @@
         <target>Magnitud</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">445</context>
+          <context context-type="linenumber">453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeHint" datatype="html">
@@ -10462,7 +10526,7 @@
         <target>Entero grande con banda de tolerancia relativa para estimaciones de orden de magnitud.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">446</context>
+          <context context-type="linenumber">454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.easy" datatype="html">
@@ -10470,7 +10534,7 @@
         <target>Fácil</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">452</context>
+          <context context-type="linenumber">460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10478,7 +10542,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4673</context>
+          <context context-type="linenumber">4680</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10490,7 +10554,7 @@
         <target>Medio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">453</context>
+          <context context-type="linenumber">461</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10498,7 +10562,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4675</context>
+          <context context-type="linenumber">4682</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10510,7 +10574,7 @@
         <target>Difícil</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">454</context>
+          <context context-type="linenumber">462</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10518,7 +10582,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4677</context>
+          <context context-type="linenumber">4684</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10530,7 +10594,7 @@
         <target>Solo coincidencia exacta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">464</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10542,7 +10606,7 @@
         <target>Solo acepta escrituras idénticas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeAutoLabel" datatype="html">
@@ -10550,7 +10614,7 @@
         <target>Permitir pequeños errores tipográficos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">469</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10562,7 +10626,7 @@
         <target>Para la mayoría de los términos técnicos: tiene en cuenta coincidencias exactas, pequeños errores tipográficos, letras transpuestas y caracteres faltantes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeHammingLabel" datatype="html">
@@ -10570,7 +10634,7 @@
         <target>Misma longitud, pequeños cambios de letras</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">474</context>
+          <context context-type="linenumber">482</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10582,7 +10646,7 @@
         <target>Para términos de la misma longitud con una letra incorrecta o intercambiada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">475</context>
+          <context context-type="linenumber">483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeLevenshteinLabel" datatype="html">
@@ -10590,7 +10654,7 @@
         <target>Permitir también caracteres faltantes o adicionales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">479</context>
+          <context context-type="linenumber">487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10602,7 +10666,7 @@
         <target>Para términos con un carácter faltante o adicional.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">480</context>
+          <context context-type="linenumber">488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindText" datatype="html">
@@ -10610,7 +10674,7 @@
         <target>Evaluar por similitud de texto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">491</context>
+          <context context-type="linenumber">499</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindTextHint" datatype="html">
@@ -10618,7 +10682,7 @@
         <target>Adecuado para términos técnicos y grafías fijas con pequeños errores tipográficos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumeric" datatype="html">
@@ -10626,7 +10690,7 @@
         <target>Evaluar números</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">496</context>
+          <context context-type="linenumber">504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericHint" datatype="html">
@@ -10634,7 +10698,7 @@
         <target>Evalúa valores numéricos en lugar de similitud de texto y admite tolerancias exactas, absolutas o relativas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">497</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnit" datatype="html">
@@ -10642,7 +10706,7 @@
         <target>Evaluar números y unidades</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">501</context>
+          <context context-type="linenumber">509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnitHint" datatype="html">
@@ -10650,7 +10714,7 @@
         <target>Comprueba valores numéricos junto con una familia de unidades seleccionada y explica unidades faltantes o diferentes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">502</context>
+          <context context-type="linenumber">510</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindInteger" datatype="html">
@@ -10658,7 +10722,7 @@
         <target>Número entero</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">507</context>
+          <context context-type="linenumber">515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindDecimal" datatype="html">
@@ -10666,7 +10730,7 @@
         <target>Número decimal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">508</context>
+          <context context-type="linenumber">516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceExact" datatype="html">
@@ -10674,7 +10738,7 @@
         <target>Valor exacto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">512</context>
+          <context context-type="linenumber">520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceAbsolute" datatype="html">
@@ -10682,7 +10746,7 @@
         <target>Tolerancia absoluta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">515</context>
+          <context context-type="linenumber">523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelative" datatype="html">
@@ -10690,7 +10754,7 @@
         <target>Tolerancia relativa (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">519</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyLength" datatype="html">
@@ -10698,7 +10762,7 @@
         <target>Longitud</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">524</context>
+          <context context-type="linenumber">532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyMass" datatype="html">
@@ -10706,7 +10770,7 @@
         <target>Masa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">525</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyTime" datatype="html">
@@ -10714,7 +10778,7 @@
         <target>Tiempo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">526</context>
+          <context context-type="linenumber">534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyVolume" datatype="html">
@@ -10722,7 +10786,7 @@
         <target>Volumen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceNone" datatype="html">
@@ -10730,7 +10794,7 @@
         <target>Sin tolerancia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">531</context>
+          <context context-type="linenumber">539</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10742,7 +10806,7 @@
         <target>Baja</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">532</context>
+          <context context-type="linenumber">540</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10754,7 +10818,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">541</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10766,7 +10830,7 @@
         <target>Amplia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">534</context>
+          <context context-type="linenumber">542</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10778,7 +10842,7 @@
         <target>Premio Nobel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">538</context>
+          <context context-type="linenumber">546</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10794,7 +10858,7 @@
         <target>Jardín de infancia (emojis de animales)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">541</context>
+          <context context-type="linenumber">549</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10810,7 +10874,7 @@
         <target>Escuela primaria</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">551</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10826,7 +10890,7 @@
         <target>Secundaria</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">552</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10842,7 +10906,7 @@
         <target>Escuela secundaria</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">545</context>
+          <context context-type="linenumber">553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10858,7 +10922,7 @@
         <target>Estándar de prueba</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">768</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4668229613641280742" datatype="html">
@@ -10866,7 +10930,7 @@
         <target>Costumbre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">866</context>
+          <context context-type="linenumber">874</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10878,7 +10942,7 @@
         <target>Escala de cinco niveles del 1 al 5, bajo: <x id="low" equiv-text="low"/>, alto: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">980</context>
+          <context context-type="linenumber">988</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithLow" datatype="html">
@@ -10886,7 +10950,7 @@
         <target>Escala de cinco niveles de 1 a 5, baja: <x id="low" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">983</context>
+          <context context-type="linenumber">991</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithHigh" datatype="html">
@@ -10894,7 +10958,7 @@
         <target>Escala de cinco niveles del 1 al 5, alto: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">986</context>
+          <context context-type="linenumber">994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAria" datatype="html">
@@ -10902,7 +10966,7 @@
         <target>Escala de cinco niveles de 1 a 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">988</context>
+          <context context-type="linenumber">996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceLabel" datatype="html">
@@ -10914,7 +10978,7 @@
           )"/> a <x id="right" equiv-text="this.formatNumericEstimateEditorValue(band.right)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReferenceLabel" datatype="html">
@@ -10926,7 +10990,7 @@
             )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1152,1154</context>
+          <context context-type="linenumber">1160,1162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewIncomplete" datatype="html">
@@ -10934,7 +10998,7 @@
         <target>La banda de tolerancia se muestra una vez que se completan los límites o la referencia y el porcentaje.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1168</context>
+          <context context-type="linenumber">1176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceOutside" datatype="html">
@@ -10942,7 +11006,7 @@
         <target>Los límites de plausibilidad y los rangos de tolerancia aún no coinciden. También se deben poder introducir los valores en la banda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1177</context>
+          <context context-type="linenumber">1185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReady" datatype="html">
@@ -10950,7 +11014,7 @@
         <target>Límites de plausibilidad de las entradas permitidas; la banda de tolerancia decide los puntos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1179</context>
+          <context context-type="linenumber">1187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityRange" datatype="html">
@@ -10962,7 +11026,7 @@
       )"/> a <x id="max" equiv-text="this.formatNumericEstimateEditorValue(max)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1186,1188</context>
+          <context context-type="linenumber">1194,1196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMin" datatype="html">
@@ -10974,7 +11038,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1191,1193</context>
+          <context context-type="linenumber">1199,1201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMax" datatype="html">
@@ -10986,7 +11050,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1196,1198</context>
+          <context context-type="linenumber">1204,1206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionLabel" datatype="html">
@@ -10994,7 +11058,7 @@
         <target>Solución modelo <x id="solutionNumber" equiv-text="index + 1"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1286</context>
+          <context context-type="linenumber">1294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.answerLabel" datatype="html">
@@ -11002,7 +11066,7 @@
         <target>Respuesta <x id="answerNumber" equiv-text="index + 1"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1289</context>
+          <context context-type="linenumber">1297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.markAnswerCorrectAria" datatype="html">
@@ -11010,7 +11074,7 @@
         <target>Marcar la respuesta <x id="answerNumber" equiv-text="answerNumber"/> como correcta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1293</context>
+          <context context-type="linenumber">1301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.toggleAnswerCorrectAria" datatype="html">
@@ -11018,7 +11082,7 @@
         <target>Respuesta <x id="answerNumber" equiv-text="answerNumber"/> correcta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1297</context>
+          <context context-type="linenumber">1305</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.removeAnswerAria" datatype="html">
@@ -11026,7 +11090,7 @@
         <target>Eliminar respuesta <x id="answerNumber" equiv-text="answerNumber"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.collapseQuestionAria" datatype="html">
@@ -11034,7 +11098,7 @@
         <target>Contraer pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1306</context>
+          <context context-type="linenumber">1314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.expandQuestionAria" datatype="html">
@@ -11042,7 +11106,7 @@
         <target>Expandir pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsPreviewLabel" datatype="html">
@@ -11050,7 +11114,7 @@
         <target>Soluciones modelo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.livePreviewAnswersLabel" datatype="html">
@@ -11058,7 +11122,7 @@
         <target>Respuestas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1313</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.addShortTextSolution" datatype="html">
@@ -11066,7 +11130,7 @@
         <target>Añadir otra solución modelo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1318</context>
+          <context context-type="linenumber">1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8266267788371304686" datatype="html">
@@ -11074,7 +11138,7 @@
         <target>Otra respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1319</context>
+          <context context-type="linenumber">1327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthSummary" datatype="html">
@@ -11082,11 +11146,11 @@
         <target>Máx. <x id="maxLength" equiv-text="resolveShortTextMaxLength(question.shortTextMaxLength)"/> caracteres</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1436</context>
+          <context context-type="linenumber">1444</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1479</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11098,7 +11162,7 @@
         <target>±{$tolerance} absoluto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelativeSummary" datatype="html">
@@ -11106,7 +11170,7 @@
         <target>±{$tolerance} % relativo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1455</context>
+          <context context-type="linenumber">1463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilySummary" datatype="html">
@@ -11114,7 +11178,7 @@
         <target>Unidades: {$unitFamily}</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1469</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitSummary" datatype="html">
@@ -11122,7 +11186,7 @@
         <target>Unidad obligatoria</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitOptionalSummary" datatype="html">
@@ -11130,7 +11194,7 @@
         <target>Unidad opcional</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1466</context>
+          <context context-type="linenumber">1474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEquivalentUnitsSummary" datatype="html">
@@ -11138,7 +11202,7 @@
         <target>Unidades equivalentes permitidas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1470</context>
+          <context context-type="linenumber">1478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericExactUnitsSummary" datatype="html">
@@ -11146,7 +11210,7 @@
         <target>Solo la unidad exacta configurada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1471</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceSummary" datatype="html">
@@ -11154,7 +11218,7 @@
         <target>Tolerancia: <x id="tolerance" equiv-text="this.shortTextToleranceLabel(question.shortTextToleranceLevel)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1484</context>
+          <context context-type="linenumber">1492</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11166,7 +11230,7 @@
         <target>Se distinguen mayúsculas y minúsculas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1488</context>
+          <context context-type="linenumber">1496</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11178,7 +11242,7 @@
         <target>Solo puntos completos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1491</context>
+          <context context-type="linenumber">1499</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11190,7 +11254,7 @@
         <target>Los espacios se comprueban estrictamente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1498</context>
+          <context context-type="linenumber">1506</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11202,7 +11266,7 @@
         <target>Define al menos una respuesta de referencia con unidad, mantén pequeño el conjunto de unidades y activa unidades obligatorias solo cuando la unidad deba evaluarse de verdad.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1507</context>
+          <context context-type="linenumber">1515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningNumeric" datatype="html">
@@ -11210,7 +11274,7 @@
         <target>Define al menos un valor de referencia claro y elige una tolerancia que permita imprecisiones de cálculo, pero que excluya claramente valores científicamente erróneos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1508</context>
+          <context context-type="linenumber">1516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarning" datatype="html">
@@ -11218,7 +11282,7 @@
         <target>Usa la evaluación tolerante solo con términos técnicos claramente definidos. Para formulaciones abiertas, varias soluciones modelo suelen ser más justas que una tolerancia alta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11230,7 +11294,7 @@
         <target>Añade entre una y diez respuestas de referencia con una unidad admitida, por ejemplo «2 m».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1521</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHintNumeric" datatype="html">
@@ -11238,7 +11302,7 @@
         <target>Añade entre una y diez respuestas de referencia como número, por ejemplo «3,5».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1530</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHint" datatype="html">
@@ -11246,7 +11310,7 @@
         <target>Añade entre una y diez soluciones modelo. Todas las variantes cuentan como respuesta corta correcta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewExactLabel" datatype="html">
@@ -11254,11 +11318,11 @@
         <target>Entrada exacta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1621</context>
+          <context context-type="linenumber">1629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLengthLabel" datatype="html">
@@ -11266,7 +11330,7 @@
         <target>Carácter faltante o adicional</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1553</context>
+          <context context-type="linenumber">1561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewWrongLabel" datatype="html">
@@ -11274,11 +11338,11 @@
         <target>Término diferente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1557</context>
+          <context context-type="linenumber">1565</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1658</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeFull" datatype="html">
@@ -11286,11 +11350,11 @@
         <target>Puntuación completa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1592</context>
+          <context context-type="linenumber">1600</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeAccepted" datatype="html">
@@ -11298,11 +11362,11 @@
         <target>Aceptada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1593</context>
+          <context context-type="linenumber">1601</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1669</context>
+          <context context-type="linenumber">1677</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomePartial" datatype="html">
@@ -11310,11 +11374,11 @@
         <target>Puntos parciales (<x id="points" equiv-text="result.points"/> %)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1596</context>
+          <context context-type="linenumber">1604</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1672</context>
+          <context context-type="linenumber">1680</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeRejected" datatype="html">
@@ -11322,11 +11386,11 @@
         <target>No aceptada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1599</context>
+          <context context-type="linenumber">1607</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1683</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewNumericToleranceLabel" datatype="html">
@@ -11334,7 +11398,7 @@
         <target>Dentro de la tolerancia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1629</context>
+          <context context-type="linenumber">1637</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewEquivalentUnitLabel" datatype="html">
@@ -11342,7 +11406,7 @@
         <target>Unidad equivalente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewMissingUnitLabel" datatype="html">
@@ -11350,7 +11414,7 @@
         <target>Unidad faltante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1644</context>
+          <context context-type="linenumber">1652</context>
         </context-group>
       </trans-unit>
       <trans-unit id="705009069021941649" datatype="html">
@@ -11358,7 +11422,7 @@
         <target>Elija exactamente una respuesta correcta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2025</context>
+          <context context-type="linenumber">2033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5903298630443190027" datatype="html">
@@ -11366,7 +11430,7 @@
         <target>Elija al menos una respuesta correcta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2037</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2211937330568533798" datatype="html">
@@ -11374,7 +11438,7 @@
         <target>Error al guardar.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2148</context>
+          <context context-type="linenumber">2156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5746363347338638819" datatype="html">
@@ -11382,7 +11446,7 @@
         <target>No se pudieron guardar los ajustes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2165</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3347548161086861397" datatype="html">
@@ -11390,7 +11454,7 @@
         <target>La pregunta no se pudo actualizar.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.saveConfirmation" datatype="html">
@@ -11398,7 +11462,7 @@
         <target>Cambios guardados. La pregunta, los datos del quiz y los ajustes ya están incluidos en la vista previa y en el quiz en vivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2284</context>
+          <context context-type="linenumber">2292</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogTitle" datatype="html">
@@ -11406,7 +11470,7 @@
         <target>¿Eliminar pregunta?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2312</context>
+          <context context-type="linenumber">2320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogMessage" datatype="html">
@@ -11414,7 +11478,7 @@
         <target>La pregunta <x id="PH" equiv-text="position"/> se eliminará permanentemente del cuestionario.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2313</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.deleteIrreversible" datatype="html">
@@ -11422,7 +11486,7 @@
         <target>Esto no se puede deshacer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2315</context>
+          <context context-type="linenumber">2323</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -11434,7 +11498,7 @@
         <target>Borrar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionCancel" datatype="html">
@@ -11442,7 +11506,7 @@
         <target>Cancelar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2318</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4357290152640831712" datatype="html">
@@ -11450,7 +11514,7 @@
         <target>Error al eliminar.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2335</context>
+          <context context-type="linenumber">2343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -11462,11 +11526,11 @@
         <target>El movimiento falló.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2356</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionUp" datatype="html">
@@ -11474,7 +11538,7 @@
         <target>Mover la pregunta <x id="position" equiv-text="position"/> hacia arriba</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2370</context>
+          <context context-type="linenumber">2378</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionDown" datatype="html">
@@ -11482,7 +11546,7 @@
         <target>Mover la pregunta <x id="position" equiv-text="position"/> hacia abajo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2374</context>
+          <context context-type="linenumber">2382</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.dragQuestion" datatype="html">
@@ -11490,7 +11554,7 @@
         <target>Mover la pregunta <x id="position" equiv-text="position"/> arrastrándola</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2378</context>
+          <context context-type="linenumber">2386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionMovedAnnouncement" datatype="html">
@@ -11498,7 +11562,7 @@
         <target>La pregunta <x id="previousPosition" equiv-text="previousPosition"/> se movió a la posición <x id="currentPosition" equiv-text="currentPosition"/> de <x id="total" equiv-text="total"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2385</context>
+          <context context-type="linenumber">2393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesDialogHeading" datatype="html">
@@ -13290,7 +13354,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3010</context>
+          <context context-type="linenumber">3016</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -13302,7 +13366,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3013</context>
+          <context context-type="linenumber">3019</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -13314,7 +13378,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3018</context>
+          <context context-type="linenumber">3024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -13326,7 +13390,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3208</context>
+          <context context-type="linenumber">3220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -13338,7 +13402,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3212</context>
+          <context context-type="linenumber">3224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -13350,7 +13414,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3215</context>
+          <context context-type="linenumber">3227</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -13362,7 +13426,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3218</context>
+          <context context-type="linenumber">3230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -13518,7 +13582,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2718</context>
+          <context context-type="linenumber">2724</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -13538,7 +13602,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2981</context>
+          <context context-type="linenumber">2987</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -13742,7 +13806,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2951</context>
+          <context context-type="linenumber">2957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -13798,7 +13862,7 @@
         <target>Ver el plan de debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1212</context>
+          <context context-type="linenumber">1218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuVisual" datatype="html">
@@ -13806,7 +13870,7 @@
         <target>Estándar (con diagramas)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1230</context>
+          <context context-type="linenumber">1236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuPdfUa" datatype="html">
@@ -13814,7 +13878,7 @@
         <target>Sin barreras (PDF/UA-1)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1241</context>
+          <context context-type="linenumber">1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
@@ -13822,7 +13886,7 @@
         <target>Más opciones de exportación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1258</context>
+          <context context-type="linenumber">1264</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButton" datatype="html">
@@ -13830,7 +13894,7 @@
         <target>Más</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1261</context>
+          <context context-type="linenumber">1267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7070792224026857010" datatype="html">
@@ -13838,7 +13902,7 @@
         <target>A la pagina de inicio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1265</context>
+          <context context-type="linenumber">1271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelTooltip" datatype="html">
@@ -13846,7 +13910,7 @@
         <target>Datos tabulares sin procesar para hoja de cálculo – menos detalles que el plan de debriefing.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1275</context>
+          <context context-type="linenumber">1281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelMenuItem" datatype="html">
@@ -13854,7 +13918,7 @@
         <target>Exportar datos en bruto (CSV)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1280</context>
+          <context context-type="linenumber">1286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressAria" datatype="html">
@@ -13862,7 +13926,7 @@
         <target>La exportación está en marcha</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1290</context>
+          <context context-type="linenumber">1296</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
@@ -13870,7 +13934,7 @@
         <target>Se exportará...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1295,1297</context>
+          <context context-type="linenumber">1301,1303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
@@ -13878,7 +13942,7 @@
         <target>Charla rápidamente con tu vecino.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1323,1325</context>
+          <context context-type="linenumber">1329,1331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1952538840507841358" datatype="html">
@@ -13886,7 +13950,7 @@
         <target>¿La misma respuesta? Excelente. ¿Opinión diferente? Convencerse unos a otros.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1326,1328</context>
+          <context context-type="linenumber">1332,1334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5596291527944555255" datatype="html">
@@ -13894,7 +13958,7 @@
         <target>Pronto llegará la segunda votación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1329,1331</context>
+          <context context-type="linenumber">1335,1337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveLabel" datatype="html">
@@ -13902,7 +13966,7 @@
         <target>La ronda de preguntas está en marcha</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1339,1341</context>
+          <context context-type="linenumber">1345,1347</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveHint" datatype="html">
@@ -13910,7 +13974,7 @@
         <target>Ahora las personas participantes pueden entrar con el código de la sesión.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1349,1351</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionCounter" datatype="html">
@@ -13918,7 +13982,7 @@
         <target>Pregunta <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/> / <x id="INTERPOLATION_1" equiv-text="{{ q.totalQuestions }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1358,1359</context>
+          <context context-type="linenumber">1364,1365</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionNumber" datatype="html">
@@ -13926,7 +13990,7 @@
         <target>Pregunta <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1361,1362</context>
+          <context context-type="linenumber">1367,1368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1017989655370592681" datatype="html">
@@ -13934,7 +13998,7 @@
         <target>Última pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1364</context>
+          <context context-type="linenumber">1370</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7135032209126516357" datatype="html">
@@ -13942,7 +14006,7 @@
         <target>Todos votaron</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1403</context>
+          <context context-type="linenumber">1409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
@@ -13950,7 +14014,7 @@
         <target>Los participantes pueden ampliar o desactivar su plazo personal si es necesario.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1424,1427</context>
+          <context context-type="linenumber">1430,1433</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.questionMetadataAria" datatype="html">
@@ -13958,7 +14022,7 @@
         <target>Metadatos de la pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1439</context>
+          <context context-type="linenumber">1445</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
@@ -13978,7 +14042,7 @@
         <target>Fase de lectura</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1464</context>
+          <context context-type="linenumber">1470</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
@@ -13986,7 +14050,7 @@
         <target>Las respuestas llegarán enseguida.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1465,1467</context>
+          <context context-type="linenumber">1471,1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
@@ -13994,7 +14058,7 @@
         <target>Escala de valoración</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
@@ -14002,7 +14066,7 @@
         <target>Distribución de las valoraciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1551</context>
+          <context context-type="linenumber">1557</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
@@ -14010,7 +14074,7 @@
         <target>Esperando estimaciones…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1590,1592</context>
+          <context context-type="linenumber">1596,1598</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
@@ -14018,7 +14082,7 @@
         <target><x id="INTERPOLATION"/> respuestas recibidas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1598,1600</context>
+          <context context-type="linenumber">1604,1606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
@@ -14026,11 +14090,11 @@
         <target>Resumen de estadísticas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1610</context>
+          <context context-type="linenumber">1616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2043</context>
+          <context context-type="linenumber">2049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
@@ -14038,7 +14102,7 @@
         <target>Ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615</context>
+          <context context-type="linenumber">1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
@@ -14046,11 +14110,11 @@
         <target>Aceptada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1633</context>
+          <context context-type="linenumber">1639</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2063</context>
+          <context context-type="linenumber">2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
@@ -14058,7 +14122,7 @@
         <target>Comparación redonda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1653</context>
+          <context context-type="linenumber">1659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
@@ -14066,7 +14130,7 @@
         <target>cambio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
@@ -14074,7 +14138,7 @@
         <target>Ronda 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1695</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
@@ -14082,7 +14146,7 @@
         <target>Ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1694</context>
+          <context context-type="linenumber">1700</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
@@ -14090,11 +14154,11 @@
         <target>Mostrar detalles estadísticos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2180</context>
+          <context context-type="linenumber">2186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
@@ -14102,7 +14166,7 @@
         <target>Ronda 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1895,1897</context>
+          <context context-type="linenumber">1901,1903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
@@ -14110,7 +14174,7 @@
         <target>Ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1923,1925</context>
+          <context context-type="linenumber">1929,1931</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
@@ -14118,7 +14182,7 @@
         <target>Δ por pares: <x id="INTERPOLATION"/> más cerca, <x id="INTERPOLATION_1"/> más lejos, <x id="INTERPOLATION_2"/> sin cambios (<x id="INTERPOLATION_3"/> pares)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1954,1962</context>
+          <context context-type="linenumber">1960,1968</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
@@ -14126,7 +14190,7 @@
         <target>Distribución Δx</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1972</context>
+          <context context-type="linenumber">1978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
@@ -14134,7 +14198,7 @@
         <target>más pequeño está más cerca</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2086</context>
+          <context context-type="linenumber">2092</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
@@ -14142,7 +14206,7 @@
         <target>Ronda de resultados</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2193,2195</context>
+          <context context-type="linenumber">2199,2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
@@ -14150,7 +14214,7 @@
         <target>No se han recibido estimaciones.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2220,2222</context>
+          <context context-type="linenumber">2226,2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
@@ -14158,7 +14222,7 @@
         <target>Comparación antes y después de la votación Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2232</context>
+          <context context-type="linenumber">2238</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
@@ -14166,7 +14230,7 @@
         <target>Ronda 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> voto)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2240</context>
+          <context context-type="linenumber">2246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
@@ -14174,7 +14238,7 @@
         <target>Ronda 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> votos)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2246</context>
+          <context context-type="linenumber">2252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
@@ -14182,7 +14246,7 @@
         <target>Ronda 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> voto)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2254</context>
+          <context context-type="linenumber">2260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
@@ -14190,7 +14254,7 @@
         <target>Ronda 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> votos)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2260</context>
+          <context context-type="linenumber">2266</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
@@ -14198,7 +14262,7 @@
         <target>Correctas: <x id="INTERPOLATION" equiv-text="{{ q.roundComparison.round1CorrectCount }}"/> en la ronda 1, después <x id="INTERPOLATION_1" equiv-text="{{ q.roundComparison.round2CorrectCount }}"/> en la ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2272,2276</context>
+          <context context-type="linenumber">2278,2282</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
@@ -14206,7 +14270,7 @@
         <target>Se recomienda Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2519,2521</context>
+          <context context-type="linenumber">2525,2527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
@@ -14214,7 +14278,7 @@
         <target>35–70 % totalmente correctos: 2.ª ronda encaja.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2526,2528</context>
+          <context context-type="linenumber">2532,2534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
@@ -14222,7 +14286,7 @@
         <target>1.ª ronda sigue oculta hasta que decidas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2533,2535</context>
+          <context context-type="linenumber">2539,2541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
@@ -14230,7 +14294,7 @@
         <target>Iniciar discusión o mostrar resultado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2540,2542</context>
+          <context context-type="linenumber">2546,2548</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
@@ -14238,7 +14302,7 @@
         <target>Autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2598,2600</context>
+          <context context-type="linenumber">2604,2606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
@@ -14246,7 +14310,7 @@
         <target> ¿Correcto o incorrecto — y con qué seguridad? Especialmente importante: incorrecto pese a alta seguridad de respuesta. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2604,2607</context>
+          <context context-type="linenumber">2610,2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
@@ -14254,7 +14318,7 @@
         <target>Corrección y autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2634</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
@@ -14262,7 +14326,7 @@
         <target> A menudo incorrecto con alta seguridad de respuesta </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2682,2684</context>
+          <context context-type="linenumber">2688,2690</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
@@ -14270,7 +14334,7 @@
         <target>Actualizando la pregunta …</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2727,2729</context>
+          <context context-type="linenumber">2733,2735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
@@ -14278,7 +14342,7 @@
         <target>Ninguna pregunta activa. Comience con &quot;Siguiente pregunta&quot;.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2731,2733</context>
+          <context context-type="linenumber">2737,2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -14286,7 +14350,7 @@
         <target>Reacciones de las personas participantes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2751</context>
+          <context context-type="linenumber">2757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
@@ -14294,7 +14358,7 @@
         <target>Ronda 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2757</context>
+          <context context-type="linenumber">2763</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
@@ -14302,7 +14366,7 @@
         <target>nuevo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2765</context>
+          <context context-type="linenumber">2771</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
@@ -14310,7 +14374,7 @@
         <target>Aún no hay reacciones.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2788</context>
+          <context context-type="linenumber">2794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
@@ -14318,7 +14382,7 @@
         <target>5 mejores</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2801</context>
+          <context context-type="linenumber">2807</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
@@ -14326,7 +14390,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ entry.totalScore | number }}"/> puntos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2868</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
@@ -14334,7 +14398,7 @@
         <target>Empate: cuenta el tiempo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2877</context>
+          <context context-type="linenumber">2883</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
@@ -14342,7 +14406,7 @@
         <target>Puntuación por equipos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2895</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
@@ -14350,7 +14414,7 @@
         <target>puntos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2942</context>
+          <context context-type="linenumber">2948</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
@@ -14358,7 +14422,7 @@
         <target>Cambiar cuestionario</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2971</context>
+          <context context-type="linenumber">2977</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
@@ -14366,7 +14430,7 @@
         <target>Editar título de Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3074</context>
+          <context context-type="linenumber">3086</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
@@ -14374,7 +14438,7 @@
         <target>Título de Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3087</context>
+          <context context-type="linenumber">3099</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
@@ -14382,15 +14446,15 @@
         <target>Preguntas sobre el evento...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3098</context>
+          <context context-type="linenumber">3110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">886</context>
+          <context context-type="linenumber">893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">898</context>
+          <context context-type="linenumber">905</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14402,7 +14466,7 @@
         <target>Guardar título</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3110</context>
+          <context context-type="linenumber">3122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
@@ -14410,7 +14474,7 @@
         <target>Cancelar edición</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3121</context>
+          <context context-type="linenumber">3133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
@@ -14418,7 +14482,7 @@
         <target>Pre-moderación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3140,3142</context>
+          <context context-type="linenumber">3152,3154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
@@ -14426,7 +14490,7 @@
         <target>La moderación previa está activa. Las nuevas preguntas esperan primero tu aprobación.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3144,3146</context>
+          <context context-type="linenumber">3156,3158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
@@ -14434,7 +14498,7 @@
         <target>Aún no hay preguntas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3153,3155</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
@@ -14442,7 +14506,7 @@
         <target>Total: <x id="INTERPOLATION" equiv-text="qaQuestions().length"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3165,3166</context>
+          <context context-type="linenumber">3177,3178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
@@ -14450,7 +14514,7 @@
         <target>Esperando aprobación: <x id="INTERPOLATION" equiv-text="qaPendingCount()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3174,3175</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
@@ -14458,7 +14522,7 @@
         <target>Mostrar todas las preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3227</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
@@ -14466,7 +14530,7 @@
         <target>Mostrar todas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3230</context>
+          <context context-type="linenumber">3242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
@@ -14474,7 +14538,7 @@
         <target>Mostrar solo preguntas fijadas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3238</context>
+          <context context-type="linenumber">3250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
@@ -14482,7 +14546,7 @@
         <target>Solo fijadas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3241</context>
+          <context context-type="linenumber">3253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
@@ -14490,7 +14554,7 @@
         <target>Mostrar nuevas preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3253</context>
+          <context context-type="linenumber">3265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
@@ -14498,7 +14562,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ qaUnseenCount() }}"/> preguntas nuevas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3259</context>
+          <context context-type="linenumber">3271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
@@ -14506,7 +14570,7 @@
         <target>Exportar preguntas como CSV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3291</context>
+          <context context-type="linenumber">3303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
@@ -14514,7 +14578,7 @@
         <target>Exportar preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3294</context>
+          <context context-type="linenumber">3306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
@@ -14522,7 +14586,7 @@
         <target>Exportando…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3302,3304</context>
+          <context context-type="linenumber">3314,3316</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
@@ -14530,7 +14594,7 @@
         <target>Polémica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3371</context>
+          <context context-type="linenumber">3383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
@@ -14538,7 +14602,7 @@
         <target><x id="INTERPOLATION" equiv-text="question.positiveVoteCount"/> positivas · <x id="INTERPOLATION_1" equiv-text="question.negativeVoteCount"/> negativas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3399,3400</context>
+          <context context-type="linenumber">3411,3412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
@@ -14546,7 +14610,7 @@
         <target>Aprobación fiable <x id="INTERPOLATION" equiv-text="formatQaPercent(question.bestScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3407,3408</context>
+          <context context-type="linenumber">3419,3420</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
@@ -14554,7 +14618,7 @@
         <target>Reacciones divididas <x id="INTERPOLATION" equiv-text="formatQaPercent(question.controversyScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3417,3419</context>
+          <context context-type="linenumber">3429,3431</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
@@ -14562,7 +14626,7 @@
         <target>Vista de fijadas activa – todavía no hay preguntas fijadas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3460,3462</context>
+          <context context-type="linenumber">3472,3474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
@@ -14570,7 +14634,7 @@
         <target>Mostrar opciones de respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3513</context>
+          <context context-type="linenumber">3525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
@@ -14578,7 +14642,7 @@
         <target>Iniciar fase de discusión: intercambio antes de la segunda votación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3549</context>
+          <context context-type="linenumber">3561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
@@ -14586,7 +14650,7 @@
         <target>Fase de discusión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3552</context>
+          <context context-type="linenumber">3564</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
@@ -14594,11 +14658,11 @@
         <target>Publicar de todos modos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3579</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3589</context>
+          <context context-type="linenumber">3601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
@@ -14606,7 +14670,7 @@
         <target>Mostrar el resultado de todos modos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3570</context>
+          <context context-type="linenumber">3582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
@@ -14614,7 +14678,7 @@
         <target>Mostrar resultado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3591</context>
+          <context context-type="linenumber">3603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
@@ -14622,7 +14686,7 @@
         <target>Siguiente pregunta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3607,3609</context>
+          <context context-type="linenumber">3619,3621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
@@ -14630,7 +14694,7 @@
         <target>A la siguiente pregunta sin segunda votación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3630</context>
+          <context context-type="linenumber">3642</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
@@ -14638,7 +14702,7 @@
         <target>A la siguiente pregunta sin segunda votación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3633</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
@@ -14646,7 +14710,7 @@
         <target>Vuelve a mostrar la pregunta anterior con su resultado y la respuesta correcta (sin nueva votación).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650</context>
+          <context context-type="linenumber">3662</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
@@ -14654,7 +14718,7 @@
         <target>Mostrar de nuevo el resultado anterior</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3652,3654</context>
+          <context context-type="linenumber">3664,3666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
@@ -14662,7 +14726,7 @@
         <target>Terminar sesión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3662,3664</context>
+          <context context-type="linenumber">3674,3676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -14670,7 +14734,7 @@
         <target>Vista de host para lobby y control.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3670</context>
+          <context context-type="linenumber">3682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
@@ -14678,7 +14742,7 @@
         <target>Lobby · Cálido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">322</context>
+          <context context-type="linenumber">324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyArrival" datatype="html">
@@ -14686,7 +14750,7 @@
         <target>Lobby · Llegada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyCalm" datatype="html">
@@ -14694,7 +14758,7 @@
         <target>Lobby · Calma</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyPulse" datatype="html">
@@ -14702,7 +14766,7 @@
         <target>Lobby · Pulso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">334</context>
+          <context context-type="linenumber">336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackReadingBuild" datatype="html">
@@ -14710,7 +14774,7 @@
         <target>Lectura · Preparación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">338</context>
+          <context context-type="linenumber">340</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownFocus" datatype="html">
@@ -14718,7 +14782,7 @@
         <target>Cuenta atrás · Enfoque</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownTempo" datatype="html">
@@ -14726,7 +14790,7 @@
         <target>Cuenta atrás · Ritmo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownIntense" datatype="html">
@@ -14734,7 +14798,23 @@
         <target>Cuenta atrás · Intensidad</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">350</context>
+          <context context-type="linenumber">352</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingQa" datatype="html">
+        <source>Warum die Fragenwand mehr als ein Chat ist</source>
+        <target>Por qué el muro de preguntas es más que un chat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">421</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <target>Comprender la autoevaluación y el análisis posterior</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">423</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4017389878545296254" datatype="html">
@@ -14742,7 +14822,7 @@
         <target>Esperando respuestas abiertas en directo...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">500</context>
+          <context context-type="linenumber">507</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14754,7 +14834,7 @@
         <target>Texto libre en vivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">503</context>
+          <context context-type="linenumber">510</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14766,7 +14846,7 @@
         <target>Palabras frecuentes de las respuestas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">504</context>
+          <context context-type="linenumber">511</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14778,7 +14858,7 @@
         <target>Análisis Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">505</context>
+          <context context-type="linenumber">512</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14790,7 +14870,7 @@
         <target>Muestra qué palabras y frases dominan en las preguntas Q&amp;A visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">506</context>
+          <context context-type="linenumber">513</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14802,7 +14882,7 @@
         <target>Ocultar nube de palabras</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">647</context>
+          <context context-type="linenumber">654</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudShow" datatype="html">
@@ -14810,7 +14890,7 @@
         <target>Mostrar nube de palabras</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">648</context>
+          <context context-type="linenumber">655</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudResume" datatype="html">
@@ -14818,11 +14898,11 @@
         <target>Reanudar actualización en directo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">653</context>
+          <context context-type="linenumber">660</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1036</context>
+          <context context-type="linenumber">1043</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFreeze" datatype="html">
@@ -14830,11 +14910,11 @@
         <target>Congelar nube de palabras</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">654</context>
+          <context context-type="linenumber">661</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1037</context>
+          <context context-type="linenumber">1044</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFrozenInfo" datatype="html">
@@ -14842,7 +14922,7 @@
         <target>Nube de palabras congelada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">679</context>
+          <context context-type="linenumber">686</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobbyShort" datatype="html">
@@ -14850,7 +14930,7 @@
         <target>Lobby</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseConnectingShort" datatype="html">
@@ -14858,7 +14938,7 @@
         <target>Lectura</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">837</context>
+          <context context-type="linenumber">844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseRunningShort" datatype="html">
@@ -14866,7 +14946,7 @@
         <target>Cuenta atrás</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">838</context>
+          <context context-type="linenumber">845</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicLabelOff" datatype="html">
@@ -14874,7 +14954,7 @@
         <target>Música desactivada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">870</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
@@ -14882,7 +14962,7 @@
         <target>Sesión de cuestionario</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">891</context>
+          <context context-type="linenumber">898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricBest" datatype="html">
@@ -14890,7 +14970,7 @@
         <target>aprobación fiable</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">958</context>
+          <context context-type="linenumber">965</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricControversial" datatype="html">
@@ -14898,7 +14978,7 @@
         <target>controversia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">960</context>
+          <context context-type="linenumber">967</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricTop" datatype="html">
@@ -14906,7 +14986,7 @@
         <target>votos positivos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">969</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudTitle" datatype="html">
@@ -14914,7 +14994,7 @@
         <target>Nube de palabras Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">965</context>
+          <context context-type="linenumber">972</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14926,7 +15006,7 @@
         <target>Las palabras y frases grandes vienen de preguntas con mucho apoyo y suficientes votos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">969</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintControversial" datatype="html">
@@ -14934,7 +15014,7 @@
         <target>Las palabras y frases grandes vienen de preguntas con reacciones opuestas. Pasa el cursor para ver las preguntas relacionadas.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintTop" datatype="html">
@@ -14942,7 +15022,7 @@
         <target>Las palabras y frases grandes vienen de preguntas con muchos votos positivos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">973</context>
+          <context context-type="linenumber">980</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudThemeFallbackHint" datatype="html">
@@ -14950,7 +15030,7 @@
         <target>Se muestran palabras sueltas hasta que los grupos de palabras y las frases sean fiables.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1026</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintBest" datatype="html">
@@ -14958,7 +15038,7 @@
         <target>Muestra primero preguntas con mucho apoyo y suficientes votos. Las preguntas fijadas quedan marcadas, pero no se adelantan.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1024</context>
+          <context context-type="linenumber">1031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintControversial" datatype="html">
@@ -14966,7 +15046,7 @@
         <target>Muestra primero preguntas con reacciones mixtas. Las preguntas fijadas quedan marcadas, pero no se adelantan.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1026</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintTop" datatype="html">
@@ -14974,7 +15054,7 @@
         <target>Muestra primero preguntas con más votos positivos. Las preguntas fijadas quedan marcadas, pero no se adelantan.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1028</context>
+          <context context-type="linenumber">1035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudShow" datatype="html">
@@ -14982,7 +15062,7 @@
         <target>Mostrar nube de palabras</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1032</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountOneMetric" datatype="html">
@@ -14990,7 +15070,7 @@
         <target>1 pregunta visible · Tamaño de las palabras y frases: <x id="metric" equiv-text="metric"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1043</context>
+          <context context-type="linenumber">1050</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountManyMetric" datatype="html">
@@ -14998,7 +15078,7 @@
         <target><x id="count" equiv-text="count"/> preguntas visibles · Tamaño de las palabras y frases: <x id="metric" equiv-text="metric"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1045</context>
+          <context context-type="linenumber">1052</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountOne" datatype="html">
@@ -15006,7 +15086,7 @@
         <target>1 respuesta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1552</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
@@ -15014,7 +15094,7 @@
         <target><x id="count" equiv-text="count"/> respuestas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1546</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
@@ -15022,7 +15102,7 @@
         <target>Bajo · <x id="label" equiv-text="q.confidenceLabelLow"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1637</context>
+          <context context-type="linenumber">1644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
@@ -15030,7 +15110,7 @@
         <target>Bajo (1–2)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
@@ -15038,7 +15118,7 @@
         <target>Medio (3)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1642</context>
+          <context context-type="linenumber">1649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
@@ -15046,7 +15126,7 @@
         <target>Alto · <x id="label" equiv-text="q.confidenceLabelHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1674</context>
+          <context context-type="linenumber">1681</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
@@ -15054,7 +15134,7 @@
         <target>Alto (4–5)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
@@ -15062,7 +15142,7 @@
         <target>Correcto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1696</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
@@ -15070,7 +15150,7 @@
         <target>Incorrecto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1696</context>
+          <context context-type="linenumber">1703</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
@@ -15078,7 +15158,7 @@
         <target><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
@@ -15086,7 +15166,7 @@
         <target>1 respuesta incorrecta y segura: posible error</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1793</context>
+          <context context-type="linenumber">1800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
@@ -15094,7 +15174,7 @@
         <target><x id="count" equiv-text="count"/> respuestas incorrectas seguras: posibles conceptos erróneos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1794</context>
+          <context context-type="linenumber">1801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
@@ -15102,7 +15182,7 @@
         <target>Correcto+alto <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · Incorrecto+alto <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1805</context>
+          <context context-type="linenumber">1812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
@@ -15110,7 +15190,7 @@
         <target>2 (Instrucción entre pares)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1825</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
@@ -15118,7 +15198,7 @@
         <target>Ronda 1: <x id="r1" equiv-text="round1Count"/> votos · Agregado: Ronda 2 con <x id="r2" equiv-text="round2Count"/> votos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1843</context>
+          <context context-type="linenumber">1850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
@@ -15126,7 +15206,7 @@
         <target>Ronda de agregación 2 (instrucción entre pares)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1845</context>
+          <context context-type="linenumber">1852</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
@@ -15134,7 +15214,7 @@
         <target>Ronda de agregación 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1848</context>
+          <context context-type="linenumber">1855</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
@@ -15142,7 +15222,7 @@
         <target>Esta vez no ha llegado del todo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2452</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
@@ -15150,7 +15230,7 @@
         <target>Sin dramas, pasa (un tirón o un Wi‑Fi caprichoso). Espera unos segundos y pulsa « Probar otra vez » — casi siempre basta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2453</context>
+          <context context-type="linenumber">2460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
@@ -15158,7 +15238,7 @@
         <target>Con las preguntas va un poco a trompicones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2460</context>
+          <context context-type="linenumber">2467</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
@@ -15166,7 +15246,7 @@
         <target>No está roto; solo no ha cuadrado esta vez. Espera unos segundos y pulsa « Probar otra vez » — a veces enseguida vuelve.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2461</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
@@ -15174,7 +15254,7 @@
         <target>Exportación aún no lista</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2468</context>
+          <context context-type="linenumber">2475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
@@ -15182,7 +15262,7 @@
         <target>La exportación a PDF o Excel no ha salido redonda esta vez. Espera unos segundos y pulsa « Probar otra vez » — el segundo intento suele ir bien.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2469</context>
+          <context context-type="linenumber">2476</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
@@ -15190,7 +15270,7 @@
         <target>Los participantes y la vista de presentación son redirigidos a la página de inicio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2610</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
@@ -15198,7 +15278,7 @@
         <target>La sesión termina para todos; No es posible continuar con el mismo código.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
@@ -15206,7 +15286,7 @@
         <target><x id="participantCount" equiv-text="participants"/> Los participantes todavía están en la sesión.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2608</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
@@ -15214,7 +15294,7 @@
         <target>Ya tienes resultados. Después de finalizar, puedes exportarlos o revisar el feedback en la vista final.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2613</context>
+          <context context-type="linenumber">2620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
@@ -15222,7 +15302,7 @@
         <target>Todavía no hay resultados aprovechables. Después de finalizar, irás directamente a la página de inicio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2617</context>
+          <context context-type="linenumber">2624</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
@@ -15230,7 +15310,7 @@
         <target>Para códigos de bonificación: recomiende a los participantes que copien su código personal ahora (portapapeles) antes de abandonar la página; de lo contrario, pueden perderlo fácilmente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2622</context>
+          <context context-type="linenumber">2629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
@@ -15238,7 +15318,7 @@
         <target>¿Salir de la sesión?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
@@ -15246,7 +15326,7 @@
         <target>Tu sesión aún está activa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2629</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
@@ -15254,7 +15334,7 @@
         <target>Todavía queda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2631</context>
+          <context context-type="linenumber">2638</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
@@ -15262,7 +15342,7 @@
         <target>Volver a la sesión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2632</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
@@ -15270,7 +15350,7 @@
         <target>Detener vista previa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2823</context>
+          <context context-type="linenumber">2830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
@@ -15278,7 +15358,7 @@
         <target>Escucha la pista un momento (máx. 12 s)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2824</context>
+          <context context-type="linenumber">2831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
@@ -15286,7 +15366,7 @@
         <target>Sonido encendido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2836</context>
+          <context context-type="linenumber">2843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
@@ -15294,7 +15374,7 @@
         <target>Sonido apagado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2837</context>
+          <context context-type="linenumber">2844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
@@ -15302,7 +15382,7 @@
         <target>Partícipe</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
@@ -15310,7 +15390,7 @@
         <target>participantes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2898</context>
+          <context context-type="linenumber">2905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
@@ -15318,7 +15398,7 @@
         <target>1 conectado en vivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
@@ -15326,7 +15406,7 @@
         <target><x id="connectedCount" equiv-text="connectedCount"/> conectado en vivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2917</context>
+          <context context-type="linenumber">2924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
@@ -15334,7 +15414,7 @@
         <target>Todavía no hay nadie en este equipo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2943</context>
+          <context context-type="linenumber">2950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
@@ -15342,7 +15422,7 @@
         <target>Evaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3759</context>
+          <context context-type="linenumber">3766</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
@@ -15350,7 +15430,7 @@
         <target>Reseñas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3763</context>
+          <context context-type="linenumber">3770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
@@ -15358,11 +15438,11 @@
         <target>Los resultados están disponibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3768</context>
+          <context context-type="linenumber">3775</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3775</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
@@ -15370,11 +15450,11 @@
         <target>El tiempo expiró.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3769</context>
+          <context context-type="linenumber">3776</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3776</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
@@ -15382,7 +15462,7 @@
         <target>Esperando reseñas…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3770</context>
+          <context context-type="linenumber">3777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
@@ -15390,7 +15470,7 @@
         <target>Esperando respuestas...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
@@ -15398,7 +15478,7 @@
         <target><x id="PH" equiv-text="votes"/> por <x id="PH_1" equiv-text="participants"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3781</context>
+          <context context-type="linenumber">3788</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
@@ -15406,7 +15486,7 @@
         <target>Una persona todavía usa su tiempo ×10. «Publicar de todos modos» cierra su ventana personal.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3788</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
@@ -15414,7 +15494,7 @@
         <target>Una persona todavía usa su tiempo ×10. Espera la cuenta atrás de la sala o hasta que termine el tiempo ×10.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3789</context>
+          <context context-type="linenumber">3796</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
@@ -15422,7 +15502,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> personas todavía usan su tiempo ×10. «Publicar de todos modos» cierra sus ventanas personales.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3793</context>
+          <context context-type="linenumber">3800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
@@ -15430,7 +15510,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> personas todavía usan su tiempo ×10. Espera la cuenta atrás de la sala o hasta que termine el tiempo ×10.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3794</context>
+          <context context-type="linenumber">3801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
@@ -15438,7 +15518,7 @@
         <target>Una persona responde sin plazo personal. «Mostrar resultado» cierra su respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3797</context>
+          <context context-type="linenumber">3804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
@@ -15446,7 +15526,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> personas responden sin plazo personal. «Mostrar resultado» cierra su respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3799</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
@@ -15454,7 +15534,7 @@
         <target><x id="votes" equiv-text="votes"/> de <x id="participants" equiv-text="participants"/> participantes votaron. Se alcanzó el <x id="percentage" equiv-text="percentage"/> por ciento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3805</context>
+          <context context-type="linenumber">3812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
@@ -15462,7 +15542,7 @@
         <target><x id="votes" equiv-text="votes"/> de <x id="participants" equiv-text="participants"/> participantes han votado. Se alcanzó el <x id="percentage" equiv-text="percentage"/> por ciento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3807</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
@@ -15470,7 +15550,7 @@
         <target><x id="voteCount"/> de <x id="participantTotal"/> ha votado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3818</context>
+          <context context-type="linenumber">3825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
@@ -15478,7 +15558,7 @@
         <target><x id="voteCount"/> de <x id="participantTotal"/> han votado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3827</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
@@ -15486,7 +15566,7 @@
         <target><x id="voteCount"/> de <x id="participantTotal"/> ha valorado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3831</context>
+          <context context-type="linenumber">3838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
@@ -15494,7 +15574,7 @@
         <target><x id="voteCount"/> de <x id="participantTotal"/> han valorado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3833</context>
+          <context context-type="linenumber">3840</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
@@ -15502,7 +15582,7 @@
         <target><x id="correctCount"/> de <x id="voteTotal"/> completamente correctos (<x id="percentage"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3839</context>
+          <context context-type="linenumber">3846</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
@@ -15510,7 +15590,7 @@
         <target><x id="changed"/> de <x id="both"/> (<x id="pct"/>%) cambiaron de opinión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3843</context>
+          <context context-type="linenumber">3850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
@@ -15518,7 +15598,7 @@
         <target>↑ <x id="count"/> incorrecto → correcto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3847</context>
+          <context context-type="linenumber">3854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
@@ -15526,7 +15606,7 @@
         <target>↓ <x id="count"/> correcto → incorrecto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3851</context>
+          <context context-type="linenumber">3858</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
@@ -15534,7 +15614,7 @@
         <target>Media <x id="avg"/> de 5 estrellas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3857</context>
+          <context context-type="linenumber">3864</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
@@ -15542,7 +15622,7 @@
         <target><x id="PH" equiv-text="total"/> reacción</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
@@ -15550,7 +15630,7 @@
         <target><x id="PH" equiv-text="total"/> reacciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
@@ -15558,7 +15638,7 @@
         <target>Lobby: las personas participantes pueden entrar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3917</context>
+          <context context-type="linenumber">3924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
@@ -15566,7 +15646,7 @@
         <target>Se está preparando la ronda de preguntas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3918</context>
+          <context context-type="linenumber">3925</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
@@ -15574,15 +15654,15 @@
         <target>La ronda de preguntas está en marcha</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3919</context>
+          <context context-type="linenumber">3926</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3921</context>
+          <context context-type="linenumber">3928</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3922</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
@@ -15590,7 +15670,7 @@
         <target>En pausa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3920</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
@@ -15598,7 +15678,7 @@
         <target>Ronda de preguntas finalizada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3923</context>
+          <context context-type="linenumber">3930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
@@ -15606,7 +15686,7 @@
         <target>Votación finalizada – esperando evaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3928</context>
+          <context context-type="linenumber">3935</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
@@ -15614,7 +15694,7 @@
         <target>Vestíbulo: los participantes pueden unirse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3931</context>
+          <context context-type="linenumber">3938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
@@ -15622,7 +15702,7 @@
         <target>Fase de lectura: respuestas aún bloqueadas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3932</context>
+          <context context-type="linenumber">3939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
@@ -15630,7 +15710,7 @@
         <target>La votación está en curso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3933</context>
+          <context context-type="linenumber">3940</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
@@ -15638,7 +15718,7 @@
         <target>En pausa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3934</context>
+          <context context-type="linenumber">3941</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
@@ -15646,7 +15726,7 @@
         <target>Se muestran los resultados</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3935</context>
+          <context context-type="linenumber">3942</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
@@ -15654,7 +15734,7 @@
         <target>Fase de discusión – intercambio antes de la segunda ronda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3936</context>
+          <context context-type="linenumber">3943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
@@ -15662,7 +15742,7 @@
         <target>Sesión finalizada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3937</context>
+          <context context-type="linenumber">3944</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
@@ -15670,7 +15750,7 @@
         <target><x id="readyCount" equiv-text="readyCount"/> de <x id="connectedCount" equiv-text="connectedCount"/> listos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3948</context>
+          <context context-type="linenumber">3955</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
@@ -15678,7 +15758,7 @@
         <target><x id="PH" equiv-text="readyCount"/> de <x id="PH_1" equiv-text="connectedCount"/> conectado listo · <x id="PH_2" equiv-text="totalParticipantCount"/> total</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3950</context>
+          <context context-type="linenumber">3957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
@@ -15686,7 +15766,7 @@
         <target>Todas las personas participantes están listas; se pueden revelar las opciones de respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3955</context>
+          <context context-type="linenumber">3962</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
@@ -15694,7 +15774,7 @@
         <target>Todas las personas participantes conectadas están listas; se pueden revelar las opciones de respuesta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3957</context>
+          <context context-type="linenumber">3964</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
@@ -15702,7 +15782,7 @@
         <target>1 segundo restante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3988</context>
+          <context context-type="linenumber">3995</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
@@ -15710,7 +15790,7 @@
         <target>Quedan <x id="seconds" equiv-text="seconds"/> segundos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3989</context>
+          <context context-type="linenumber">3996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -15724,7 +15804,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4113,4116</context>
+          <context context-type="linenumber">4120,4123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -15738,7 +15818,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4158,4161</context>
+          <context context-type="linenumber">4165,4168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -15752,7 +15832,7 @@
       )"/> a <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4163,4166</context>
+          <context context-type="linenumber">4170,4173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -15767,7 +15847,7 @@
     )"/> a <x id="right" equiv-text="formatNumber(band.right, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4168,4171</context>
+          <context context-type="linenumber">4175,4178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
@@ -15775,7 +15855,7 @@
         <target>Mediana <x id="median" equiv-text="formatNumber(stats.median, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4286</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
@@ -15783,7 +15863,7 @@
         <target>Estimaciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4319</context>
+          <context context-type="linenumber">4326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
@@ -15791,7 +15871,7 @@
         <target>respuestas válidas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
@@ -15799,7 +15879,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4327</context>
+          <context context-type="linenumber">4334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
@@ -15807,7 +15887,7 @@
         <target>Promedio de todas las estimaciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4329</context>
+          <context context-type="linenumber">4336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
@@ -15815,7 +15895,7 @@
         <target>Mediana</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4335</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
@@ -15823,7 +15903,7 @@
         <target>Valor central ordenado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4337</context>
+          <context context-type="linenumber">4344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
@@ -15831,7 +15911,7 @@
         <target>Dispersión</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4343</context>
+          <context context-type="linenumber">4350</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
@@ -15839,7 +15919,7 @@
         <target>Desviación estándar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4345</context>
+          <context context-type="linenumber">4352</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
@@ -15847,7 +15927,7 @@
         <target>50 % centrales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4351</context>
+          <context context-type="linenumber">4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -15862,7 +15942,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4356,4359</context>
+          <context context-type="linenumber">4363,4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
@@ -15870,7 +15950,7 @@
         <target>Rango</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4365</context>
+          <context context-type="linenumber">4372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
@@ -15878,7 +15958,7 @@
         <target>estimación menor a mayor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4370</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
@@ -15886,7 +15966,7 @@
         <target>En el intervalo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4376</context>
+          <context context-type="linenumber">4383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -15902,7 +15982,7 @@
         )"/>% aceptado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4382,4386</context>
+          <context context-type="linenumber">4389,4393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
@@ -15910,7 +15990,7 @@
         <target>Distancia media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4392</context>
+          <context context-type="linenumber">4399</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
@@ -15918,7 +15998,7 @@
         <target>a la referencia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394</context>
+          <context context-type="linenumber">4401</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
@@ -15926,7 +16006,7 @@
         <target>Mediana</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4402</context>
+          <context context-type="linenumber">4409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
@@ -15934,7 +16014,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4405</context>
+          <context context-type="linenumber">4412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
@@ -15942,7 +16022,7 @@
         <target>Estimaciones</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4407</context>
+          <context context-type="linenumber">4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -15958,7 +16038,7 @@
     )"/> % en el rango aceptado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4438,4442</context>
+          <context context-type="linenumber">4445,4449</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
@@ -15966,7 +16046,7 @@
         <target>Distancia media a la referencia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4456</context>
+          <context context-type="linenumber">4463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
@@ -15974,7 +16054,7 @@
         <target>más cerca del valor de referencia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4470</context>
+          <context context-type="linenumber">4477</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
@@ -15982,7 +16062,7 @@
         <target>Cambio medio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4487</context>
+          <context context-type="linenumber">4494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
@@ -15990,7 +16070,7 @@
         <target>cambio medio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4488</context>
+          <context context-type="linenumber">4495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -16005,7 +16085,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4499,4502</context>
+          <context context-type="linenumber">4506,4509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -16020,7 +16100,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4511</context>
+          <context context-type="linenumber">4515,4518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -16036,7 +16116,7 @@
         )"/> puntos porcentuales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520,4524</context>
+          <context context-type="linenumber">4527,4531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -16060,7 +16140,7 @@
           )"/> estimaciones comparables han mejorado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4540,4548</context>
+          <context context-type="linenumber">4547,4555</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -16084,7 +16164,7 @@
           )"/> estimaciones comparables están más lejos.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4552,4560</context>
+          <context context-type="linenumber">4559,4567</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
@@ -16092,7 +16172,7 @@
         <target>La segunda ronda es mixta: las estimaciones más cercanas y más distantes se equilibran en la comparación de pares.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4564</context>
+          <context context-type="linenumber">4571</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -16106,7 +16186,7 @@
           )"/> en la ronda 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4576,4579</context>
+          <context context-type="linenumber">4583,4586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -16120,7 +16200,7 @@
           )"/> mayor en la ronda 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4583,4586</context>
+          <context context-type="linenumber">4590,4593</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -16136,7 +16216,7 @@
         )"/> puntos porcentuales.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4598,4602</context>
+          <context context-type="linenumber">4605,4609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -16160,7 +16240,7 @@
         )"/> estimaciones están dentro de la banda de tolerancia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4617,4625</context>
+          <context context-type="linenumber">4624,4632</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -16174,7 +16254,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4630,4633</context>
+          <context context-type="linenumber">4637,4640</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -16188,7 +16268,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4637,4640</context>
+          <context context-type="linenumber">4644,4647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
@@ -16196,7 +16276,7 @@
         <target>Quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4686</context>
+          <context context-type="linenumber">4693</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16208,7 +16288,7 @@
         <target>Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4688</context>
+          <context context-type="linenumber">4695</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16220,11 +16300,11 @@
         <target><x id="count" equiv-text="this.qaUnseenCount()"/> nueva(s)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4696</context>
+          <context context-type="linenumber">4703</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4713</context>
+          <context context-type="linenumber">4720</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelInactive" datatype="html">
@@ -16232,7 +16312,7 @@
         <target>Desactivado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4813</context>
+          <context context-type="linenumber">4820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelClosed" datatype="html">
@@ -16240,7 +16320,7 @@
         <target>Cerrado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4816</context>
+          <context context-type="linenumber">4823</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16252,7 +16332,7 @@
         <target>Pregunta de <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16264,7 +16344,7 @@
         <target>Pregunta del público</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16276,7 +16356,7 @@
         <target>Deseleccionar <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4879</context>
+          <context context-type="linenumber">4886</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16292,7 +16372,7 @@
         <target>Resalte todas las preguntas de <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4880</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16308,7 +16388,7 @@
         <target>Se está respondiendo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4909</context>
+          <context context-type="linenumber">4916</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16320,7 +16400,7 @@
         <target>Abierta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4911</context>
+          <context context-type="linenumber">4918</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16332,7 +16412,7 @@
         <target>Esperando aprobación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4913</context>
+          <context context-type="linenumber">4920</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16344,7 +16424,7 @@
         <target>Respondida</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4915</context>
+          <context context-type="linenumber">4922</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16356,7 +16436,7 @@
         <target>Eliminada</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4917</context>
+          <context context-type="linenumber">4924</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16368,7 +16448,7 @@
         <target>Aprobar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5018</context>
+          <context context-type="linenumber">5025</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
@@ -16376,7 +16456,7 @@
         <target>Destacar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5020</context>
+          <context context-type="linenumber">5027</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
@@ -16384,7 +16464,7 @@
         <target>Quitar resaltado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5022</context>
+          <context context-type="linenumber">5029</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
@@ -16392,7 +16472,7 @@
         <target>Archivar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5024</context>
+          <context context-type="linenumber">5031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
@@ -16400,7 +16480,7 @@
         <target>Eliminar definitivamente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5027</context>
+          <context context-type="linenumber">5034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
@@ -16408,7 +16488,7 @@
         <target>Eliminar</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5028</context>
+          <context context-type="linenumber">5035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
@@ -16416,7 +16496,7 @@
         <target>Cerrar canal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5372</context>
+          <context context-type="linenumber">5379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
@@ -16424,7 +16504,7 @@
         <target>Reabrir canal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5373</context>
+          <context context-type="linenumber">5380</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
@@ -16432,7 +16512,7 @@
         <target>Pre-moderación activada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5787</context>
+          <context context-type="linenumber">5794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
@@ -16440,7 +16520,7 @@
         <target>Pre-moderación desactivada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5788</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
@@ -16448,7 +16528,7 @@
         <target>Pregunta aprobada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5821</context>
+          <context context-type="linenumber">5828</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
@@ -16456,7 +16536,7 @@
         <target>Pregunta destacada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5823</context>
+          <context context-type="linenumber">5830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
@@ -16464,7 +16544,7 @@
         <target>Pregunta archivada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5825</context>
+          <context context-type="linenumber">5832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
@@ -16472,7 +16552,7 @@
         <target>Pregunta eliminada.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5826</context>
+          <context context-type="linenumber">5833</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
@@ -16480,7 +16560,7 @@
         <target>El plazo personal ×10 abierto de esta persona termina de inmediato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5927</context>
+          <context context-type="linenumber">5934</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
@@ -16488,11 +16568,11 @@
         <target>Después ya no será posible responder.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5928</context>
+          <context context-type="linenumber">5935</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5932</context>
+          <context context-type="linenumber">5939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
@@ -16500,7 +16580,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> plazos personales ×10 abiertos terminan de inmediato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5931</context>
+          <context context-type="linenumber">5938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
@@ -16508,7 +16588,7 @@
         <target>¿Terminar los plazos personales?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5936</context>
+          <context context-type="linenumber">5943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
@@ -16516,7 +16596,7 @@
         <target>Inicias la fase de discusión aunque aún hay temporizadores personales en curso.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5939</context>
+          <context context-type="linenumber">5946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
@@ -16524,7 +16604,7 @@
         <target>Muestras el resultado aunque aún hay temporizadores personales en curso.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5940</context>
+          <context context-type="linenumber">5947</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
@@ -16532,7 +16612,7 @@
         <target>Publicar de todos modos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5942</context>
+          <context context-type="linenumber">5949</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
@@ -16540,7 +16620,7 @@
         <target>Seguir esperando</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5943</context>
+          <context context-type="linenumber">5950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
@@ -16548,7 +16628,7 @@
         <target>N.º pregunta;Texto;Tipo;Participantes;Ronda de agregación;Ø Puntos;Autoevaluación n;Consolidado;Riesgo de concepto erróneo;Frágil;Brecha reconocida;Indeciso;Respuesta incorrecta más frecuente con alta autoevaluación;Detalles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6089</context>
+          <context context-type="linenumber">6096</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
@@ -16556,7 +16636,7 @@
         <target>Nivel de aprendizaje y autoevaluación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6143</context>
+          <context context-type="linenumber">6150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
@@ -16564,7 +16644,7 @@
         <target>Respuestas válidas;Preguntas evaluadas;No agregadas (&lt;5 respuestas con autoevaluación);Sólido;Riesgo de conceptos erróneos;Frágil;Brecha de conocimientos identificada;Indeciso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
@@ -16572,7 +16652,7 @@
         <target>Clasificación por equipos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6167</context>
+          <context context-type="linenumber">6174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
@@ -16580,7 +16660,7 @@
         <target>Posición;Equipo;Color;Miembros;Puntos del equipo;Puntos medios por miembro</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6169</context>
+          <context context-type="linenumber">6176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
@@ -16588,7 +16668,7 @@
         <target>Códigos de bonificación</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6187</context>
+          <context context-type="linenumber">6194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
@@ -16596,7 +16676,7 @@
         <target>Posición;Alias;Código;Puntos;Generado el</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6189</context>
+          <context context-type="linenumber">6196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
@@ -16604,7 +16684,7 @@
         <target>Resultado CSV exportado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6197</context>
+          <context context-type="linenumber">6204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
@@ -16612,7 +16692,7 @@
         <target>Ver el plan de debriefing en PDF – 1 pregunta para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6209</context>
+          <context context-type="linenumber">6216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
@@ -16620,7 +16700,7 @@
         <target>Ver el plan de debriefing en PDF – <x id="count" equiv-text="count"/> preguntas para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6212</context>
+          <context context-type="linenumber">6219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
@@ -16628,7 +16708,7 @@
         <target>Ver el plan de debriefing en PDF</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6214</context>
+          <context context-type="linenumber">6221</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
@@ -16636,7 +16716,7 @@
         <target>1 pregunta recomendada para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6219</context>
+          <context context-type="linenumber">6226</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
@@ -16644,7 +16724,7 @@
         <target><x id="count" equiv-text="count"/> preguntas recomendadas para el debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6221</context>
+          <context context-type="linenumber">6228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
@@ -16652,7 +16732,7 @@
         <target>Se crea el PDF (<x id="PH" equiv-text="exportData.questions.length"/> preguntas)…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6233</context>
+          <context context-type="linenumber">6240</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
@@ -16660,7 +16740,7 @@
         <target>Resultados PDF descargados.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6239</context>
+          <context context-type="linenumber">6246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
@@ -16668,7 +16748,7 @@
         <target>Resultado PDF abierto para guardar.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6240</context>
+          <context context-type="linenumber">6247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
@@ -16676,7 +16756,7 @@
         <target>N.º;ID de pregunta;Estado;Pregunta;Puntuación;Votos positivos;Votos negativos;Votos totales;Puntuación de Wilson;Puntuación de controversia;Polémica;Creada el</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6267</context>
+          <context context-type="linenumber">6274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
@@ -16684,7 +16764,7 @@
         <target>CSV de Q&amp;A exportado.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6290</context>
+          <context context-type="linenumber">6297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
@@ -16692,11 +16772,11 @@
         <target>Pregunta <x id="questionNumber" equiv-text="data.questionOrder + 1"/>: <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6453</context>
+          <context context-type="linenumber">6460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6461</context>
+          <context context-type="linenumber">6468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16712,7 +16792,7 @@
         <target>Se actualiza el texto libre en vivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6456</context>
+          <context context-type="linenumber">6463</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16724,7 +16804,7 @@
         <target>La pregunta actual no es una pregunta de texto libre.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6464</context>
+          <context context-type="linenumber">6471</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16736,7 +16816,7 @@
         <target>Aún no es una pregunta activa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6467</context>
+          <context context-type="linenumber">6474</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16748,7 +16828,7 @@
         <target>No se pudieron cargar datos de texto libre en vivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6471</context>
+          <context context-type="linenumber">6478</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -20289,6 +20369,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/countdown-fingers/countdown-fingers.component.ts</context>
           <context context-type="linenumber">126</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="infoLanding.openInNewTab" datatype="html">
+        <source>öffnet in neuem Tab</source>
+        <target>se abre en una pestaña nueva</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/info-landing-link/info-landing-link.component.ts</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="markdown.copyCode" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -110,12 +110,28 @@
           <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.infoLandingAria" datatype="html">
+        <source>Was arsnova.eu kann (öffnet in neuem Tab)</source>
+        <target>Ce que permet arsnova.eu (s’ouvre dans un nouvel onglet)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">188</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.infoLanding" datatype="html">
+        <source>Was arsnova.eu kann</source>
+        <target>Ce que permet arsnova.eu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">192</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <target>Mentions légales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
@@ -123,7 +139,7 @@
         <target>Confidentialité</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">188</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">
@@ -131,7 +147,7 @@
         <target>Accessibilité</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibility" datatype="html">
@@ -139,7 +155,7 @@
         <target>Accessibilité</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7981911571029514989" datatype="html">
@@ -147,7 +163,7 @@
         <target>Encore plus rapide et plus fluide !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1136696335453039978" datatype="html">
@@ -155,7 +171,7 @@
         <target>Préréglage : Professionnel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6151253518820826531" datatype="html">
@@ -163,7 +179,7 @@
         <target>Préréglage : Ludique</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2911090466936872230" datatype="html">
@@ -171,7 +187,7 @@
         <target>Connexion…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/feedback/feedback-host.component.html</context>
@@ -187,7 +203,7 @@
         <target>Essayer à nouveau</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAria" datatype="html">
@@ -195,7 +211,7 @@
         <target>Ouvrir les archives d&apos;actualités</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
@@ -203,7 +219,7 @@
         <target>Ouvrir les archives d&apos;actualités, un message non lu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
@@ -211,7 +227,7 @@
         <target>Ouvrir les archives d&apos;actualités, <x id="INTERPOLATION" equiv-text="{{ n }}"/> messages non lus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">227</context>
+          <context context-type="linenumber">230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.notFound" datatype="html">
@@ -1899,7 +1915,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">402</context>
+          <context context-type="linenumber">410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -1939,7 +1955,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">397</context>
+          <context context-type="linenumber">405</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -4876,7 +4892,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4690</context>
+          <context context-type="linenumber">4697</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -4928,7 +4944,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3633</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -5370,7 +5386,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1899</context>
+          <context context-type="linenumber">1906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -5382,7 +5398,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1904</context>
+          <context context-type="linenumber">1911</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -5406,7 +5422,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -5418,7 +5434,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -6225,12 +6241,28 @@
           <context context-type="linenumber">56,61</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.infoLandingTitle" datatype="html">
+        <source> Mehr zu Nutzen und Hintergründen</source>
+        <target>En savoir plus sur les usages et le contexte</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">63,65</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingBody" datatype="html">
+        <source> Auf der Informationsseite findest du Einsatzmöglichkeiten, Hinweise zu Datenschutz und Barrierefreiheit sowie die Abgrenzung zu anderen Audience-Response-Systemen.</source>
+        <target>Sur la page d’information, tu trouveras des usages, des précisions sur la protection des données et l’accessibilité, ainsi que la distinction par rapport à d’autres systèmes de réponse du public.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66,69</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.formatsTitle" datatype="html">
         <source> Frageformate: passend zum didaktischen Ziel</source>
         <target>Formats de questions : à chaque objectif pédagogique son format</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">78,80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsLead" datatype="html">
@@ -6238,7 +6270,7 @@
         <target>Choisissez le format selon ce qui se passe dans la salle : voulez-vous vérifier des connaissances, rendre visibles des positions, collecter des notions ou discuter des estimations ? Les formats sont volontairement distincts pour que l’affichage, l’évaluation et la modération correspondent à l’usage.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">81,85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsGridAria" datatype="html">
@@ -6246,7 +6278,7 @@
         <target>Formats de questions de quiz disponibles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
@@ -6254,7 +6286,7 @@
         <target>Single Choice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTag" datatype="html">
@@ -6262,7 +6294,7 @@
         <target>une seule bonne réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
+          <context context-type="linenumber">97,99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceBody" datatype="html">
@@ -6270,7 +6302,7 @@
         <target>Pour des checks de compréhension ciblés : une réponse est correcte, le résultat et les points sont immédiatement lisibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
+          <context context-type="linenumber">100,103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
@@ -6278,7 +6310,7 @@
         <target>Multiple Choice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
@@ -6286,7 +6318,7 @@
         <target>plusieurs bonnes réponses</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
@@ -6294,7 +6326,7 @@
         <target>Pour les notions plus complexes, les idées reçues ou les questions du type « Quelles affirmations sont vraies ? » — plusieurs réponses peuvent compter.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
+          <context context-type="linenumber">113,116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTitle" datatype="html">
@@ -6302,7 +6334,7 @@
         <target>Réponse courte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTag" datatype="html">
@@ -6310,7 +6342,7 @@
         <target>réponse modèle plutôt que choix</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
+          <context context-type="linenumber">123,125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextBody" datatype="html">
@@ -6318,7 +6350,7 @@
         <target>Les participant·es répondent en quelques mots. Vous indiquez des réponses modèles ; arsnova.eu peut évaluer les variantes d’écriture, les tolérances et, si nécessaire, les nombres ou les unités.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
+          <context context-type="linenumber">126,129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTitle" datatype="html">
@@ -6326,7 +6358,7 @@
         <target>Texte libre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">135</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTag" datatype="html">
@@ -6334,7 +6366,7 @@
         <target>réponses ouvertes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
+          <context context-type="linenumber">136,138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextBody" datatype="html">
@@ -6342,7 +6374,7 @@
         <target>Pour les idées, les réflexions et les attentes. Pas de correction automatique ; les réponses peuvent être collectées et affichées sous forme de nuage de mots.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
+          <context context-type="linenumber">139,142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTitle" datatype="html">
@@ -6350,7 +6382,7 @@
         <target>Sondage</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTag" datatype="html">
@@ -6358,7 +6390,7 @@
         <target>opinion sans vrai/faux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
+          <context context-type="linenumber">149,151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyBody" datatype="html">
@@ -6366,7 +6398,7 @@
         <target>Pour les priorités, les connaissances de départ ou les décisions dans la salle. Les options sont comptées sans logique de score.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
+          <context context-type="linenumber">152,155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTitle" datatype="html">
@@ -6374,7 +6406,7 @@
         <target>Échelle d’évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTag" datatype="html">
@@ -6382,7 +6414,7 @@
         <target>échelle avec pôles personnalisés</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
+          <context context-type="linenumber">162,164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingBody" datatype="html">
@@ -6390,7 +6422,7 @@
         <target>Pour mesurer l’accord, la confiance, le rythme ou un feedback de faible à élevé, avec des extrémités nommées si besoin.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
+          <context context-type="linenumber">165,168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
@@ -6398,7 +6430,7 @@
         <target>Question d’estimation numérique</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTag" datatype="html">
@@ -6406,7 +6438,7 @@
         <target>estimer des nombres, voir la dispersion</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
+          <context context-type="linenumber">175,177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateBody" datatype="html">
@@ -6414,7 +6446,7 @@
         <target>Pour les années, les ordres de grandeur, les mesures et les probabilités. Avec valeur de référence, bande de tolérance, histogramme, statistiques et deuxième tour en option.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
+          <context context-type="linenumber">178,181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsBlitzNote" datatype="html">
@@ -6422,7 +6454,7 @@
         <target>Le feedback express est séparé de ces formats : il sert aux retours live spontanés quand vous ne voulez pas créer une question de quiz complète.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
+          <context context-type="linenumber">185,188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceTitle" datatype="html">
@@ -6430,7 +6462,7 @@
         <target>Auto-évaluation pour les questions évaluables</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
+          <context context-type="linenumber">192,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceLead" datatype="html">
@@ -6438,7 +6470,7 @@
         <target>L&apos;auto-évaluation n&apos;est pas un type de question distinct, mais une question supplémentaire facultative selon une question à choix unique, à choix multiple, à réponse courte et d&apos;estimation numérique : les participants indiquent dans quelle mesure ils sont confiants dans leur réponse (échelle 1 à 5). Cela n&apos;affecte aucun point, mais cela vous aide à reconnaître votre niveau d&apos;apprentissage et vos idées fausses.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
+          <context context-type="linenumber">195,200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceListAria" datatype="html">
@@ -6446,7 +6478,7 @@
         <target>Fonctions didactiques d&apos;auto-évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
@@ -6454,7 +6486,7 @@
         <target>Après la réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
@@ -6462,7 +6494,7 @@
         <target>Divulgation progressive : sélectionnez ou saisissez d&apos;abord la réponse, puis l&apos;auto-évaluation. Lors du vote, personne ne voit les valeurs globales des autres.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
+          <context context-type="linenumber">210,214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorTitle" datatype="html">
@@ -6470,7 +6502,7 @@
         <target>Configurer dans l&apos;éditeur</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorBody" datatype="html">
@@ -6478,7 +6510,7 @@
         <target>Basculez par question, étiquettes facultatives pour une confiance de réponse faible et élevée et un aperçu en direct de l&apos;échelle. L&apos;auto-évaluation est active par défaut pour les nouvelles questions évaluables.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
+          <context context-type="linenumber">221,225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostTitle" datatype="html">
@@ -6486,7 +6518,7 @@
         <target>Évaluation hôte après publication des résultats</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostBody" datatype="html">
@@ -6494,7 +6526,7 @@
         <target>Matrice croisant exactitude et confiance en la réponse, avec mise en évidence des réponses <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>fausses et très sûres<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Pour les questions à choix, tu vois quelles mauvaises options ont été choisies avec une haute confiance en la réponse.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">232,236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportTitle" datatype="html">
@@ -6502,7 +6534,7 @@
         <target>Finalisation et export</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportBody" datatype="html">
@@ -6510,7 +6542,7 @@
         <target> À la fin de la session, l’évaluation résume les connaissances consolidées, le risque d’idées fausses et les connaissances fragiles. Les questions avec moins de 5 réponses avec autoévaluation ne sont pas agrégées. Le plan de débriefing (PDF) est le format recommandé ; le CSV est disponible sous « Plus » pour Excel. Dans la collection de quiz, tu trouveras le plan de débriefing sur la carte du quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">243,249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTitle" datatype="html">
@@ -6518,7 +6550,7 @@
         <target>Quiz de démonstration</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">256</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoCardHint" datatype="html">
@@ -6526,7 +6558,7 @@
         <target>Un quiz d’exemple préinstallé montre les formats de questions dans des moments pédagogiques concrets : check de connaissances, nuage de mots, réponse courte, estimation, échelle d’évaluation, auto-évaluation, formules et Markdown. Vous le trouverez dans votre bibliothèque de quiz et pourrez l’ouvrir en aperçu.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTip" datatype="html">
@@ -6534,7 +6566,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Conseil :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> ouvrez l’aperçu une fois sur un deuxième appareil avant votre première session live. Vous verrez tout de suite comment la vue hôte et l’écran des participant·es fonctionnent ensemble.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">264,267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstartTitle" datatype="html">
@@ -6542,7 +6574,7 @@
         <target>Démarrage rapide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart1" datatype="html">
@@ -6550,7 +6582,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Créer un quiz :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> choisissez « Ouvrir la collection de quiz », créez un nouveau quiz et choisissez le bon format pour chaque question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
+          <context context-type="linenumber">274,276</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart2" datatype="html">
@@ -6558,7 +6590,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lancer l’événement :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> définissez le style, les minuteurs, les équipes et le classement. Un code à 6 caractères est ensuite créé ; vous le partagez sous forme de texte ou de QR code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
+          <context context-type="linenumber">278,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart3" datatype="html">
@@ -6566,7 +6598,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Modérer en live :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> affichez la question, lancez la phase de réponse, publiez ou gardez les résultats en réserve et ajoutez un deuxième tour si cela aide.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
+          <context context-type="linenumber">282,284</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostTitle" datatype="html">
@@ -6574,7 +6606,7 @@
         <target>Diriger l&apos;événement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
+          <context context-type="linenumber">289</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLead" datatype="html">
@@ -6582,7 +6614,7 @@
         <target>Dans la vue hôte, vous pilotez la session comme une petite régie : faire entrer les participant·es, afficher les contenus, ouvrir la discussion et rendre les résultats visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
+          <context context-type="linenumber">290,294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostStartStep" datatype="html">
@@ -6590,7 +6622,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lancer la session :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> depuis votre bibliothèque de quiz, démarrez un événement et choisissez s’il commence par un quiz ou par le Q&amp;A. Le code d’accès est alors créé.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
+          <context context-type="linenumber">297,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLobby" datatype="html">
@@ -6598,7 +6630,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lobby :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Vous voyez qui a rejoint ; un code QR pour rejoindre s&apos;affichera.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
+          <context context-type="linenumber">301,303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostBeamer" datatype="html">
@@ -6606,7 +6638,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vue projecteur et vue présentateur :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> question, réponses, compte à rebours et résultats sont assez grands pour une projection, une diffusion ou un deuxième écran.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSteuerung" datatype="html">
@@ -6614,7 +6646,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Pilotage :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> utilisez « Question suivante » pour afficher le contenu. Vous pouvez commencer par une phase de lecture, ouvrir ensuite la phase de réponse et décider du moment où le résultat arrive à l’écran.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
+          <context context-type="linenumber">309,312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPeer" datatype="html">
@@ -6622,7 +6654,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (doubles tours) :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> pour les questions de quiz adaptées, les estimations et les retours express : vote, discussion, puis nouveau vote. La comparaison avant/après rend les progrès visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
+          <context context-type="linenumber">314,317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSettings" datatype="html">
@@ -6630,7 +6662,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Paramètres :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> au lancement, vous choisissez le style et les options : sobre ou ludique, avec ou sans classement, son, phase de lecture, mode équipe, pseudonymes et minuteur.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
+          <context context-type="linenumber">319,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallTitle" datatype="html">
@@ -6638,7 +6670,7 @@
         <target> Mur de questions dans le canal live Q&amp;A </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
+          <context context-type="linenumber">327,329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLead" datatype="html">
@@ -6646,7 +6678,7 @@
         <target> Le Q&amp;A ne doit pas disparaître dans un chat parallèle. Le mur de questions rend les questions visibles, priorisables et modérables : vous gardez le fil, tandis que le groupe indique collectivement les points qui demandent vraiment clarification. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
+          <context context-type="linenumber">330,334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallListAria" datatype="html">
@@ -6654,7 +6686,7 @@
         <target>Fonctions pédagogiques du mur de questions Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
+          <context context-type="linenumber">338</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationTitle" datatype="html">
@@ -6662,7 +6694,7 @@
         <target> Modération au bon tempo pédagogique </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">343</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationBody" datatype="html">
@@ -6670,7 +6702,7 @@
         <target> Si besoin, les nouvelles questions attendent d’abord votre validation. Vous pouvez valider, épingler, archiver ou retirer des contributions et piloter cadre de confiance, pertinence et timing : répondre tout de suite, garder pour plus tard ou ouvrir une piste de discussion. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
+          <context context-type="linenumber">344,349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingTitle" datatype="html">
@@ -6678,7 +6710,7 @@
         <target> Vote collectif pour ou contre </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingBody" datatype="html">
@@ -6686,7 +6718,7 @@
         <target> Les participant·es pondèrent ensemble les questions. Les votes positifs et négatifs montrent plus que la popularité : ils font apparaître incertitudes, désaccords et besoins de clarification. Les tris « les plus soutenues », « meilleures questions » et « controversées » aident à placer le temps live là où il a le plus de valeur pédagogique. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
+          <context context-type="linenumber">356,361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
@@ -6694,7 +6726,7 @@
         <target> Nuage de mots Q&amp;A au niveau des thèmes </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
+          <context context-type="linenumber">367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudBody" datatype="html">
@@ -6702,7 +6734,7 @@
         <target> Le nuage de mots condense les questions visibles en mots et expressions, pondérés par le soutien, l’accord robuste ou la controverse. Il peut être figé, lu selon la logique de tri et affiché dans la vue présentateur : une lecture rapide des clusters thématiques, pas une liste décorative. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
+          <context context-type="linenumber">368,373</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmTitle" datatype="html">
@@ -6710,7 +6742,7 @@
         <target>Prochaine étape : boussole de modération</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
+          <context context-type="linenumber">379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmBody" datatype="html">
@@ -6718,7 +6750,7 @@
         <target> La première étape prévue est une boussole de modération déterministe. Plus tard, des signaux Q&amp;A NLP asynchrones et des résumés liés aux sources pourront être ajoutés en option, comme aide à la modération respectueuse des données plutôt qu’une notation boîte noire. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
+          <context context-type="linenumber">380,384</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.blitzTitle" datatype="html">
@@ -6726,7 +6758,7 @@
         <target>Feedback express</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
+          <context context-type="linenumber">391</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackIntro" datatype="html">
@@ -6734,7 +6766,7 @@
         <target>Sondages rapides sur l’humeur ou la compréhension, avant une pause, en ouverture ou pour prendre la température à chaud. Disponibles dans la vue hôte de votre session live ou directement depuis la page d’accueil.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
+          <context context-type="linenumber">392,396</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfMood" datatype="html">
@@ -6742,7 +6774,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Baromètre d’ambiance<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟) : comment va le groupe ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
+          <context context-type="linenumber">399,400</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfYesNoMaybe" datatype="html">
@@ -6750,7 +6782,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Oui / Non / Peut-être<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷) : prise de position rapide.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
+          <context context-type="linenumber">402,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackYesNo" datatype="html">
@@ -6758,7 +6790,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Oui / Non<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎) : question binaire claire, sans réponse intermédiaire.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">405,406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
@@ -6766,7 +6798,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vrai / Faux / Je ne sais pas<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?) : pour des estimations rapides ou de petits tests de connaissances.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
+          <context context-type="linenumber">408,410</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
@@ -6774,7 +6806,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Options rapides en plusieurs niveaux<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D) : trois ou quatre options fixes pour voter spontanément, sans créer une vraie question de quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
+          <context context-type="linenumber">412,414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTempo" datatype="html">
@@ -6782,7 +6814,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Feedback sur le rythme<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈) : avec quatre icônes, votre groupe indique en continu s’il suit. Les participant·es peuvent modifier leur retour ; vous ne voyez que la tendance agrégée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">416,419</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
@@ -6790,7 +6822,7 @@
         <target>Vous lancez le tour depuis la vue hôte de votre session live ou via la carte « Feedback express » (« Feedback instantané en un clic ») sur la page d’accueil. Les participant·es votent d’un geste ; les résultats s’affichent en live sous forme de graphique en barres.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">421,425</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfPeer" datatype="html">
@@ -6798,7 +6830,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Instruction par les pairs (deux tours) :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Premier vote, résultat masqué, phase de discussion, puis deuxième vote. La comparaison avant/après montre comment l’avis du groupe évolue après l’échange.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">428,432</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfStop" datatype="html">
@@ -6806,7 +6838,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Arrêter :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Fige le vote : les participant·es voient « Le vote est en pause » et ne peuvent plus voter jusqu’à ce que vous choisissiez « Reprendre ».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">434,436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfReset" datatype="html">
@@ -6814,7 +6846,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Réinitialiser :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Supprimez tous les votes et laissez-les voter à nouveau.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">438,439</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfNewRound" datatype="html">
@@ -6822,7 +6854,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Nouveau tour :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Générez un nouveau code et démarrez un nouveau tour.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">441,442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfCopyLink" datatype="html">
@@ -6830,7 +6862,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Copier le lien :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Copiez le lien de participation dans le presse-papiers, par exemple pour le partager dans un chat.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">444,446</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsTitle" datatype="html">
@@ -6838,7 +6870,7 @@
         <target>Pour vos participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsLead" datatype="html">
@@ -6846,7 +6878,7 @@
         <target>En bref : ce que vous pouvez transmettre pendant votre événement :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">452,454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsJoin" datatype="html">
@@ -6854,7 +6886,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Rejoindre :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Saisissez le code à 6 chiffres sur arsnova.eu et « C’est parti » — valable pour quiz, Q&amp;A et feedback express. Aucune inscription.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">457,459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsNick" datatype="html">
@@ -6862,7 +6894,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Pseudos :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Selon vos paramètres, noms prédéfinis, votre nom propre ou anonyme.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">461,463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsVote" datatype="html">
@@ -6870,7 +6902,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Votez :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> La question apparaît sur l'appareil ; choisis la réponse et envoie-la. Si l'auto-évaluation est activée, l'échelle 1–5 suit. Avec limite de temps, un compte à rebours démarre.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">465,468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTitle" datatype="html">
@@ -6878,7 +6910,7 @@
         <target>Votre bibliothèque de quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionLead" datatype="html">
@@ -6886,7 +6918,7 @@
         <target>Ici, vous créez et préparez vos quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionEditor" datatype="html">
@@ -6894,7 +6926,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Éditeur :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Triez les questions par glisser-déposer, développez et réduisez, vérifiez l'aperçu.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">477,479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTypes" datatype="html">
@@ -6902,7 +6934,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Types de questions :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single choice, multiple choice, réponse courte, texte libre, sondage, échelle d’évaluation et question d’estimation numérique — chaque question peut aussi avoir un minuteur, une difficulté et une auto-évaluation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">481,484</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionImport" datatype="html">
@@ -6910,7 +6942,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Import / export :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Importez ou exportez des quiz en JSON. Utilisez les modèles de génération et de vérification pour créer des quiz exigeants avec votre outil d’IA préféré, les vérifier et les importer directement. Vos contenus et présentations ne sont pas envoyés à arsnova.eu ; vous utilisez votre propre outil d’IA.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">486,490</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionSync" datatype="html">
@@ -6918,7 +6950,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sync :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Utilisez le lien de sync pour partager votre bibliothèque de quiz avec des collègues ou continuer sur d&apos;autres appareils. Toute personne qui a le lien peut ouvrir la bibliothèque. Les infos sur l&apos;appareil servent seulement à vous aider à vous repérer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">492,495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoQuizHint" datatype="html">
@@ -6926,7 +6958,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Quiz de démonstration :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> un quiz préinstallé montre tous les formats avec des exemples, y compris des formules KaTeX et du Markdown. Ouvrez-le depuis la bibliothèque de quiz en aperçu.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">497,500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesTitle" datatype="html">
@@ -6934,7 +6966,7 @@
         <target>Sérieux et ludique</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesLead" datatype="html">
@@ -6942,7 +6974,7 @@
         <target>Deux styles pour différentes situations – sélectionnables sur la page d&apos;accueil et au début de la session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">506,509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.styleSerious" datatype="html">
@@ -6950,7 +6982,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sérieux :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonyme, sans classement — idéal pour les évaluations formatives, la préparation aux examens et les sujets sensibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">512,514</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylePlayful" datatype="html">
@@ -6958,7 +6990,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Ludique :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Avec classement, sons et encouragements - idéal pour se détendre, participer à des compétitions et des quiz motivants.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">516,518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesOptions" datatype="html">
@@ -6966,7 +6998,7 @@
         <target>Toutes les options (classements, son, phase de lecture, équipe, bonus) peuvent être activées et désactivées individuellement.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">520,523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTitle" datatype="html">
@@ -6974,7 +7006,7 @@
         <target>Plus de fonctionnalités</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreBonus" datatype="html">
@@ -6982,7 +7014,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Codes bonus :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Les premiers finalistes reçoivent un code échangeable (par exemple, contre des points bonus). Vous voyez la liste des codes ; Les données personnelles ne sont pas stockées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">530,533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTeams" datatype="html">
@@ -6990,7 +7022,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Mode équipe :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Vos participants jouent en équipes avec leur propre classement d'équipe - p. ex. pour les compétitions de groupe en séminaires.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">535,537</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreGamification" datatype="html">
@@ -6998,7 +7030,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamification :<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Effets sonores, effets de récompense pour les meilleures places, messages de motivation - en mode ludique.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">539,541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyTitle" datatype="html">
@@ -7006,7 +7038,7 @@
         <target>Protection des données et technologie</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyBody" datatype="html">
@@ -7014,7 +7046,15 @@
         <target>arsnova.eu est gratuit, open source et conçu pour les écoles, l’enseignement supérieur et la formation continue — avec un vrai focus sur la protection des données (RGPD). Les contenus de quiz restent stockés localement dans le navigateur. Aucune inscription nécessaire, ni pour vous ni pour vos participant·es. Installable comme application (PWA), par exemple pour démarrer plus vite sur smartphone. Interface disponible en allemand, anglais, français, espagnol et italien.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">547,553</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingLink" datatype="html">
+        <source>Hintergründe und Einsatzmöglichkeiten</source>
+        <target>Contexte et usages</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.ts</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">
@@ -7098,11 +7138,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">408</context>
+          <context context-type="linenumber">416</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">864</context>
+          <context context-type="linenumber">872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -7138,11 +7178,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">409</context>
+          <context context-type="linenumber">417</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">865</context>
+          <context context-type="linenumber">873</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -7410,7 +7450,7 @@
         <target>À partager avec d&apos;autres ou sur un second appareil :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">447,449</context>
+          <context context-type="linenumber">453,455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareAria" datatype="html">
@@ -7418,7 +7458,7 @@
         <target>Afficher le lien de sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">456</context>
+          <context context-type="linenumber">462</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareLink" datatype="html">
@@ -7426,7 +7466,7 @@
         <target>Afficher le lien de sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">459</context>
+          <context context-type="linenumber">465</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncOpenHint" datatype="html">
@@ -7434,7 +7474,7 @@
         <target>Coller ici le lien de sync reçu :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">465,467</context>
+          <context context-type="linenumber">471,473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkLabel" datatype="html">
@@ -7442,7 +7482,7 @@
         <target>Lien de sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkPlaceholder" datatype="html">
@@ -7450,7 +7490,7 @@
         <target>sync-room-12345678</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">483</context>
+          <context context-type="linenumber">489</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkInputAria" datatype="html">
@@ -7458,7 +7498,7 @@
         <target>Saisir le lien de sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">489</context>
+          <context context-type="linenumber">495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkSubmit" datatype="html">
@@ -7466,7 +7506,7 @@
         <target>Ouvrir</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">497,499</context>
+          <context context-type="linenumber">503,505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkedHintWithOrigin" datatype="html">
@@ -7474,7 +7514,7 @@
         <target>Les quiz sont partagés avec <x id="INTERPOLATION" equiv-text="{{ originSummary }}"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">513,515</context>
+          <context context-type="linenumber">519,521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkCta" datatype="html">
@@ -7482,7 +7522,7 @@
         <target>Supprimer le lien</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayTitle" datatype="html">
@@ -7490,7 +7530,7 @@
         <target>Actualités actuelles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">567,569</context>
+          <context context-type="linenumber">573,575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayCloseAria" datatype="html">
@@ -7498,7 +7538,7 @@
         <target>Fermer le message</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">585</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.ack" datatype="html">
@@ -7506,7 +7546,7 @@
         <target>Compris !</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">593,595</context>
+          <context context-type="linenumber">599,601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbGroupAria" datatype="html">
@@ -7514,7 +7554,7 @@
         <target>Évaluation du message</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">599</context>
+          <context context-type="linenumber">605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpTooltip" datatype="html">
@@ -7522,7 +7562,7 @@
         <target>Utile — appuyer à nouveau pour annuler le vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">609</context>
+          <context context-type="linenumber">615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpAria" datatype="html">
@@ -7530,7 +7570,7 @@
         <target>Utile, appuyer à nouveau pour annuler le vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">611</context>
+          <context context-type="linenumber">617</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownTooltip" datatype="html">
@@ -7538,7 +7578,7 @@
         <target>Pas utile — appuyer à nouveau pour annuler le vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">623</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownAria" datatype="html">
@@ -7546,7 +7586,15 @@
         <target>Pas utile, appuyer à nouveau pour annuler le vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">625</context>
+          <context context-type="linenumber">631</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="homeHostCard.infoLanding" datatype="html">
+        <source>Einsatzmöglichkeiten entdecken</source>
+        <target>Découvrir les usages</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.syncOrigin" datatype="html">
@@ -7554,11 +7602,11 @@
         <target><x id="browser" equiv-text="peer.browserLabel"/> sur <x id="device" equiv-text="peer.deviceLabel"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2862374619655540985" datatype="html">
@@ -7566,11 +7614,11 @@
         <target>tout à l&apos; heure</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">470</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5002</context>
+          <context context-type="linenumber">5009</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7582,11 +7630,11 @@
         <target>Il y a <x id="PH" equiv-text="minutes"/> minutes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">467</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5004</context>
+          <context context-type="linenumber">5011</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7598,11 +7646,11 @@
         <target>il y a 1 heure</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7614,11 +7662,11 @@
         <target>Il y a <x id="PH" equiv-text="hours"/> heures</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7630,11 +7678,11 @@
         <target>il y a 1 jour</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7646,11 +7694,11 @@
         <target>Il y a <x id="PH" equiv-text="days"/> jours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7662,7 +7710,7 @@
         <target>Supprimer la session <x id="PH" equiv-text="code"/> de la liste</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">477</context>
+          <context context-type="linenumber">482</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.heroChipStartError" datatype="html">
@@ -7670,7 +7718,7 @@
         <target>Impossible de démarrer le canal. Réessayez.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">586</context>
+          <context context-type="linenumber">591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkError" datatype="html">
@@ -7678,7 +7726,7 @@
         <target>Merci de saisir un lien de sync valide.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">645</context>
+          <context context-type="linenumber">650</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkConfirmPrompt" datatype="html">
@@ -7686,7 +7734,7 @@
         <target>Supprimer vraiment le lien ? La bibliothèque de quiz actuelle restera sur cet appareil.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">666</context>
+          <context context-type="linenumber">671</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkSuccess" datatype="html">
@@ -7694,7 +7742,7 @@
         <target>Lien supprimé. La bibliothèque de quiz est maintenant active uniquement sur cet appareil.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">674</context>
+          <context context-type="linenumber">679</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeFeedbackCard.startError" datatype="html">
@@ -7702,7 +7750,7 @@
         <target>Impossible de lancer le feedback express. Réessayez.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">700</context>
+          <context context-type="linenumber">705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6627607898679527757" datatype="html">
@@ -7710,7 +7758,7 @@
         <target>Saisissez le code à 6 caractères.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">730</context>
+          <context context-type="linenumber">735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2422920312042178920" datatype="html">
@@ -7718,7 +7766,7 @@
         <target>Cette séance est déjà terminée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">787</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/join/join.component.ts</context>
@@ -7906,7 +7954,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7926,7 +7974,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -8022,7 +8070,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2939</context>
+          <context context-type="linenumber">2946</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -8666,7 +8714,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1882</context>
+          <context context-type="linenumber">1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.previewSaveAndOpen" datatype="html">
@@ -8678,7 +8726,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1886</context>
+          <context context-type="linenumber">1900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1736772795054152455" datatype="html">
@@ -8874,7 +8922,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">595</context>
+          <context context-type="linenumber">603</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -9386,7 +9434,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1599,1602</context>
+          <context context-type="linenumber">1613,1616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionEditSaveHint" datatype="html">
@@ -9458,7 +9506,7 @@
         <target>Il est temps pour cette question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">568,570</context>
+          <context context-type="linenumber">576,578</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9470,7 +9518,7 @@
         <target>La valeur par défaut est la limite de temps définie dans les paramètres du quiz. Vous pouvez définir votre propre limite par question.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">571,574</context>
+          <context context-type="linenumber">579,582</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9482,7 +9530,7 @@
         <target>Utiliser la limite de temps du quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">587</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9494,7 +9542,7 @@
         <target>Secondes pour cette question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">585</context>
+          <context context-type="linenumber">593</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9506,7 +9554,7 @@
         <target>Secondes pour cette question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">590</context>
+          <context context-type="linenumber">598</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9518,7 +9566,7 @@
         <target>Pas de phase de lecture pour cette question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">602,604</context>
+          <context context-type="linenumber">610,612</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9530,7 +9578,7 @@
         <target>Autoévaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">609,611</context>
+          <context context-type="linenumber">617,619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceConfigHint" datatype="html">
@@ -9538,7 +9586,7 @@
         <target>Après leur réponse, les participants indiquent leur degré de confiance. N&apos;affecte pas le score.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">612,615</context>
+          <context context-type="linenumber">620,623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceEnabledToggle" datatype="html">
@@ -9546,7 +9594,7 @@
         <target>Autoévaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">620,622</context>
+          <context context-type="linenumber">634,636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelLowField" datatype="html">
@@ -9554,7 +9602,7 @@
         <target>Faible certitude de réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">632</context>
+          <context context-type="linenumber">646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelHighField" datatype="html">
@@ -9562,7 +9610,7 @@
         <target>Forte certitude de réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">652</context>
+          <context context-type="linenumber">666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewLabel" datatype="html">
@@ -9570,7 +9618,7 @@
         <target>Aperçu pour les participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">676,678</context>
+          <context context-type="linenumber">690,692</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8205020163645016790" datatype="html">
@@ -9578,7 +9626,7 @@
         <target>Formatage rapide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">715</context>
+          <context context-type="linenumber">729</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.quickFormatAria" datatype="html">
@@ -9586,7 +9634,7 @@
         <target>Choisissez le format rapide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">720</context>
+          <context context-type="linenumber">734</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7287117104463920417" datatype="html">
@@ -9594,7 +9642,7 @@
         <target>Écrase les réponses existantes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">726</context>
+          <context context-type="linenumber">740</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetSection" datatype="html">
@@ -9602,7 +9650,7 @@
         <target>Démarrage rapide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">731,733</context>
+          <context context-type="linenumber">745,747</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetGroupAria" datatype="html">
@@ -9610,7 +9658,7 @@
         <target>Sélectionnez un modèle de question d&apos;estimation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">738</context>
+          <context context-type="linenumber">752</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8648957206736539595" datatype="html">
@@ -9618,7 +9666,7 @@
         <target>Type d&apos;entrée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">756</context>
+          <context context-type="linenumber">770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateInputTypeLabel" datatype="html">
@@ -9626,7 +9674,7 @@
         <target>Type de numéro</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">759</context>
+          <context context-type="linenumber">773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntegerOption" datatype="html">
@@ -9634,7 +9682,7 @@
         <target>Nombre entier</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">762</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalOption" datatype="html">
@@ -9642,7 +9690,7 @@
         <target>Nombre décimal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">765</context>
+          <context context-type="linenumber">779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalPlacesLabel" datatype="html">
@@ -9650,7 +9698,7 @@
         <target>Max. décimales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">772</context>
+          <context context-type="linenumber">786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceSection" datatype="html">
@@ -9658,7 +9706,7 @@
         <target>Mode tolérance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">788,790</context>
+          <context context-type="linenumber">802,804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceModeLabel" datatype="html">
@@ -9666,7 +9714,7 @@
         <target>mode</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">792</context>
+          <context context-type="linenumber">806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteIntervalOption" datatype="html">
@@ -9674,7 +9722,7 @@
         <target>Intervalle absolu [L, R]</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">797</context>
+          <context context-type="linenumber">811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateRelativePercentOption" datatype="html">
@@ -9682,7 +9730,7 @@
         <target>Bande de tolérance relative (V ± p%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">802</context>
+          <context context-type="linenumber">816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalLeftLabel" datatype="html">
@@ -9690,7 +9738,7 @@
         <target>Bordure gauche L</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">811</context>
+          <context context-type="linenumber">825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalRightLabel" datatype="html">
@@ -9698,7 +9746,7 @@
         <target>Bordure droite R</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">817</context>
+          <context context-type="linenumber">831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueLabel" datatype="html">
@@ -9706,7 +9754,7 @@
         <target>Valeur de référence pour l’analyse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">824</context>
+          <context context-type="linenumber">838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueHint" datatype="html">
@@ -9714,7 +9762,7 @@
         <target>Facultatif pour la ligne de référence, l’erreur et la comparaison des tours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">828</context>
+          <context context-type="linenumber">842</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueLabel" datatype="html">
@@ -9722,7 +9770,7 @@
         <target>Valeur de référence V</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueHint" datatype="html">
@@ -9730,7 +9778,7 @@
         <target>Doit être ≠ 0</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">840</context>
+          <context context-type="linenumber">854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTolerancePercentLabel" datatype="html">
@@ -9738,7 +9786,7 @@
         <target>Tolérance p (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">845</context>
+          <context context-type="linenumber">859</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateBoundsSection" datatype="html">
@@ -9746,7 +9794,7 @@
         <target>Limites de plausibilité (facultatif)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">858,860</context>
+          <context context-type="linenumber">872,874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMinLabel" datatype="html">
@@ -9754,7 +9802,7 @@
         <target>Entrée minimale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">863</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMaxLabel" datatype="html">
@@ -9762,7 +9810,7 @@
         <target>Entrée maximale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">867</context>
+          <context context-type="linenumber">881</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewAria" datatype="html">
@@ -9770,7 +9818,7 @@
         <target>Aperçu de la question d&apos;estimation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">876</context>
+          <context context-type="linenumber">890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewTitle" datatype="html">
@@ -9778,7 +9826,7 @@
         <target>Aperçu du groupe</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">881</context>
+          <context context-type="linenumber">895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTwoRoundsToggle" datatype="html">
@@ -9786,7 +9834,7 @@
         <target>Deux tours de vote (instruction par les pairs)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">937,939</context>
+          <context context-type="linenumber">951,953</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8259238864102475814" datatype="html">
@@ -9794,7 +9842,7 @@
         <target>échelle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">945</context>
+          <context context-type="linenumber">959</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.ratingScaleAria" datatype="html">
@@ -9802,7 +9850,7 @@
         <target>Sélectionnez l&apos;échelle de notation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">949</context>
+          <context context-type="linenumber">963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4298652859209119138" datatype="html">
@@ -9810,7 +9858,7 @@
         <target>Bordure gauche (facultatif)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3739377380076895717" datatype="html">
@@ -9818,7 +9866,7 @@
         <target>Bordure droite (facultatif)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">985</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigLegend" datatype="html">
@@ -9826,7 +9874,7 @@
         <target>Fautes de frappe et variantes d&apos;orthographe</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">983,985</context>
+          <context context-type="linenumber">997,999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigHint" datatype="html">
@@ -9834,7 +9882,7 @@
         <target>Choisissez quelles fautes de frappe comptent encore. L&apos;aperçu ci-dessous montre si elles donnent tous les points, des points partiels ou aucun point.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">989,992</context>
+          <context context-type="linenumber">1003,1006</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindFieldLabel" datatype="html">
@@ -9842,7 +9890,7 @@
         <target>Type de réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">996</context>
+          <context context-type="linenumber">1010</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthFieldLabel" datatype="html">
@@ -9850,7 +9898,7 @@
         <target>Longueur maximale de la réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1010</context>
+          <context context-type="linenumber">1024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthHint" datatype="html">
@@ -9858,7 +9906,7 @@
         <target>1 à 500 caractères</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationModeFieldLabel" datatype="html">
@@ -9866,7 +9914,7 @@
         <target>Évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1025</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceFieldLabel" datatype="html">
@@ -9874,7 +9922,7 @@
         <target>Tolérance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceHint" datatype="html">
@@ -9882,7 +9930,7 @@
         <target>Les pourcentages décrivent l&apos;écart autorisé par rapport à la réponse modèle, pas le score. Faible ≈ 10 %, moyenne ≈ 20 %, généreuse ≈ 30 %. Pour les termes courts, le même niveau paraît plus strict.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1042,1044</context>
+          <context context-type="linenumber">1056,1058</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextAllowPartialCreditToggle" datatype="html">
@@ -9890,7 +9938,7 @@
         <target>Attribuer des points partiels</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1066,1068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextCaseSensitiveToggle" datatype="html">
@@ -9898,7 +9946,7 @@
         <target>Tenir compte des majuscules/minuscules</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1058,1060</context>
+          <context context-type="linenumber">1072,1074</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindFieldLabel" datatype="html">
@@ -9906,7 +9954,7 @@
         <target>Format numérique</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1064</context>
+          <context context-type="linenumber">1078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeFieldLabel" datatype="html">
@@ -9914,7 +9962,7 @@
         <target>Tolérance numérique</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1074</context>
+          <context context-type="linenumber">1088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeHint" datatype="html">
@@ -9922,7 +9970,7 @@
         <target>Le mode exact exige la même valeur numérique. La tolérance absolue utilise une plage fixe ±, la tolérance relative utilise un pourcentage autour de la réponse modèle.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1082,1083</context>
+          <context context-type="linenumber">1096,1097</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceFieldLabel" datatype="html">
@@ -9930,7 +9978,7 @@
         <target>Tolérance absolue (±)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1090</context>
+          <context context-type="linenumber">1104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceHint" datatype="html">
@@ -9938,7 +9986,7 @@
         <target>Exemple : avec 10 et ±0,5, les réponses de 9,5 à 10,5 sont acceptées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1100</context>
+          <context context-type="linenumber">1114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceFieldLabel" datatype="html">
@@ -9946,7 +9994,7 @@
         <target>Tolérance relative (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1108</context>
+          <context context-type="linenumber">1122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceHint" datatype="html">
@@ -9954,7 +10002,7 @@
         <target>Exemple : avec 200 et 5 %, les réponses de 190 à 210 sont acceptées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1118</context>
+          <context context-type="linenumber">1132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyFieldLabel" datatype="html">
@@ -9962,7 +10010,7 @@
         <target>Famille d&apos;unités</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1126</context>
+          <context context-type="linenumber">1140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitToggle" datatype="html">
@@ -9970,7 +10018,7 @@
         <target> Rendre l&apos;unité obligatoire </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1139,1141</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAcceptEquivalentUnitsToggle" datatype="html">
@@ -9978,7 +10026,7 @@
         <target> Accepter les unités équivalentes </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1159,1161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLegend" datatype="html">
@@ -9986,7 +10034,7 @@
         <target>Effet de l&apos;évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1154,1156</context>
+          <context context-type="linenumber">1168,1170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningLabel" datatype="html">
@@ -9994,7 +10042,7 @@
         <target>Note pédagogique :</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1200</context>
+          <context context-type="linenumber">1214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsToggle" datatype="html">
@@ -10002,7 +10050,7 @@
         <target>Afficher les détails techniques</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1208,1210</context>
+          <context context-type="linenumber">1222,1224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsIntro" datatype="html">
@@ -10010,7 +10058,7 @@
         <target>Le mode auto combine correspondance exacte, Hamming, Damerau-Levenshtein et Levenshtein. Hamming fonctionne pour un seul caractère erroné dans des réponses de même longueur, Damerau-Levenshtein gère aussi les lettres voisines inversées, et Levenshtein couvre les caractères manquants ou supplémentaires.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1215,1220</context>
+          <context context-type="linenumber">1229,1234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTrimWhitespaceToggle" datatype="html">
@@ -10018,7 +10066,7 @@
         <target>Ignorer les espaces au début et à la fin</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1225,1227</context>
+          <context context-type="linenumber">1239,1241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextNormalizeWhitespaceToggle" datatype="html">
@@ -10026,7 +10074,7 @@
         <target>Fusionner les espaces répétés</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1231,1233</context>
+          <context context-type="linenumber">1245,1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextValidSolutionHint" datatype="html">
@@ -10034,7 +10082,7 @@
         <target>Valide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1272,1274</context>
+          <context context-type="linenumber">1286,1288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8021687558521014030" datatype="html">
@@ -10042,7 +10090,7 @@
         <target>option</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1276</context>
+          <context context-type="linenumber">1290</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6278157135662238363" datatype="html">
@@ -10050,7 +10098,7 @@
         <target>Saisissez un texte de réponse.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2650319028885568688" datatype="html">
@@ -10058,7 +10106,7 @@
         <target>500 caractères maximum.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2525684207823121577" datatype="html">
@@ -10066,7 +10114,7 @@
         <target>Ici, les participants répondent librement – ​​aucune réponse prédéterminée n&apos;est nécessaire.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1332,1334</context>
+          <context context-type="linenumber">1346,1348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.livePreviewCardTitle" datatype="html">
@@ -10074,7 +10122,7 @@
         <target>Aperçu complet</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1357,1359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7492260970005034710" datatype="html">
@@ -10082,7 +10130,7 @@
         <target>Erreur de formule : <x id="INTERPOLATION" equiv-text="{{ previewKatexError() }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1350,1352</context>
+          <context context-type="linenumber">1364,1366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2863483573986908286" datatype="html">
@@ -10090,7 +10138,7 @@
         <target>Demander</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1355</context>
+          <context context-type="linenumber">1369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10102,7 +10150,7 @@
         <target>Liste des questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1429</context>
+          <context context-type="linenumber">1443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionsListTitle" datatype="html">
@@ -10110,7 +10158,7 @@
         <target>Questions du quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1437,1439</context>
+          <context context-type="linenumber">1451,1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8122550761270535954" datatype="html">
@@ -10118,7 +10166,7 @@
         <target>Ajouté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1441</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3827964072457808965" datatype="html">
@@ -10126,7 +10174,7 @@
         <target>Aucune question pour l&apos;instant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1451</context>
+          <context context-type="linenumber">1465</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -10138,7 +10186,7 @@
         <target>Ajoutez votre première question ci-dessus pour commencer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1452,1454</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionListPosition" datatype="html">
@@ -10146,7 +10194,7 @@
         <target>Question <x id="INTERPOLATION" equiv-text="{{ question.order + 1 }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1514,1515</context>
+          <context context-type="linenumber">1528,1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionDisabledBadge" datatype="html">
@@ -10154,7 +10202,7 @@
         <target>Désactivé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1539</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineDisabledHint" datatype="html">
@@ -10162,7 +10210,7 @@
         <target>Cette question est désactivée et n&apos;apparaît pas dans l&apos;aperçu et le quiz en direct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1565,1568</context>
+          <context context-type="linenumber">1579,1582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.activateQuestion" datatype="html">
@@ -10170,15 +10218,15 @@
         <target>Activer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1575</context>
+          <context context-type="linenumber">1589</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1772</context>
+          <context context-type="linenumber">1786</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineEditEyebrow" datatype="html">
@@ -10186,7 +10234,7 @@
         <target>Mode édition</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1587,1589</context>
+          <context context-type="linenumber">1601,1603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.editQuestionTitle" datatype="html">
@@ -10194,7 +10242,7 @@
         <target>Modifier cette question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1593,1595</context>
+          <context context-type="linenumber">1607,1609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.freeTextWordCloudHint" datatype="html">
@@ -10202,7 +10250,7 @@
         <target>Réponse en texte libre sous forme de nuage de mots</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1617,1619</context>
+          <context context-type="linenumber">1631,1633</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10214,7 +10262,7 @@
         <target>Réponse courte avec comparaison automatique aux réponses modèles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1624,1626</context>
+          <context context-type="linenumber">1638,1640</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10226,7 +10274,7 @@
         <target>L’autoévaluation est demandée après la réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1715,1717</context>
+          <context context-type="linenumber">1729,1731</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6920196637619975735" datatype="html">
@@ -10234,11 +10282,11 @@
         <target>Modifier</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1754</context>
+          <context context-type="linenumber">1768</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1802</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10250,11 +10298,11 @@
         <target>Désactiver</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1763</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1797</context>
+          <context context-type="linenumber">1811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4580399730639224598" datatype="html">
@@ -10262,11 +10310,11 @@
         <target>Supprimer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1791</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1811</context>
+          <context context-type="linenumber">1825</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -10278,11 +10326,11 @@
         <target>Retour à la liste des quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1843</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1900</context>
+          <context context-type="linenumber">1914</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -10298,7 +10346,7 @@
         <target>Dos</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1832</context>
+          <context context-type="linenumber">1846</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -10310,11 +10358,11 @@
         <target>Annuler</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1842</context>
+          <context context-type="linenumber">1856</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1846</context>
+          <context context-type="linenumber">1860</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButtonAria" datatype="html">
@@ -10322,7 +10370,7 @@
         <target>Ajouter une autre question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1869</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButton" datatype="html">
@@ -10330,7 +10378,7 @@
         <target>Une autre question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1859</context>
+          <context context-type="linenumber">1873</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.saveAllButton" datatype="html">
@@ -10338,11 +10386,11 @@
         <target>Enregistrer les modifications</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1869</context>
+          <context context-type="linenumber">1883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1873</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7620597678842046410" datatype="html">
@@ -10350,7 +10398,7 @@
         <target>Quiz introuvable.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1895</context>
+          <context context-type="linenumber">1909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6672916435220201136" datatype="html">
@@ -10358,7 +10406,23 @@
         <target>Retour à la liste</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1903</context>
+          <context context-type="linenumber">1917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingEstimate" datatype="html">
+        <source>Schätzfragen didaktisch einsetzen</source>
+        <target>Exploiter les questions d’estimation à des fins pédagogiques</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <target>Comprendre l’autoévaluation et le débriefing</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="924826286502636331" datatype="html">
@@ -10366,7 +10430,7 @@
         <target>Choix unique</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">399</context>
+          <context context-type="linenumber">407</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4737017620429217247" datatype="html">
@@ -10374,7 +10438,7 @@
         <target>Choix multiples</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">400</context>
+          <context context-type="linenumber">408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="493996564238682027" datatype="html">
@@ -10382,7 +10446,7 @@
         <target>Texte libre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">401</context>
+          <context context-type="linenumber">409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8680267345873464947" datatype="html">
@@ -10390,7 +10454,7 @@
         <target>Sondage</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">403</context>
+          <context context-type="linenumber">411</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5472460529727499985" datatype="html">
@@ -10398,7 +10462,7 @@
         <target>Évaluation (1-5 / 1-10)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">404</context>
+          <context context-type="linenumber">412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearLabel" datatype="html">
@@ -10406,7 +10470,7 @@
         <target>année</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">427</context>
+          <context context-type="linenumber">435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearHint" datatype="html">
@@ -10414,7 +10478,7 @@
         <target>Nombre entier, 1 500-2 000 plausible, 1 700-1 900 accepté, deux tours.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">428</context>
+          <context context-type="linenumber">436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementLabel" datatype="html">
@@ -10422,7 +10486,7 @@
         <target>Valeur mesurée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">433</context>
+          <context context-type="linenumber">441</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementHint" datatype="html">
@@ -10430,7 +10494,7 @@
         <target>Valeur décimale avec une décimale et une bande de tolérance absolue étroite.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">434</context>
+          <context context-type="linenumber">442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentLabel" datatype="html">
@@ -10438,7 +10502,7 @@
         <target>Pourcentage</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">439</context>
+          <context context-type="linenumber">447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentHint" datatype="html">
@@ -10446,7 +10510,7 @@
         <target>Entier de 0 à 100 avec une tolérance de dix points de pourcentage.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">440</context>
+          <context context-type="linenumber">448</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeLabel" datatype="html">
@@ -10454,7 +10518,7 @@
         <target>Ampleur</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">445</context>
+          <context context-type="linenumber">453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeHint" datatype="html">
@@ -10462,7 +10526,7 @@
         <target>Grand nombre entier avec bande de tolérance relative pour les estimations d&apos;ordre de grandeur.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">446</context>
+          <context context-type="linenumber">454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.easy" datatype="html">
@@ -10470,7 +10534,7 @@
         <target>Facile</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">452</context>
+          <context context-type="linenumber">460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10478,7 +10542,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4673</context>
+          <context context-type="linenumber">4680</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10490,7 +10554,7 @@
         <target>Moyen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">453</context>
+          <context context-type="linenumber">461</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10498,7 +10562,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4675</context>
+          <context context-type="linenumber">4682</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10510,7 +10574,7 @@
         <target>Difficile</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">454</context>
+          <context context-type="linenumber">462</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10518,7 +10582,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4677</context>
+          <context context-type="linenumber">4684</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10530,7 +10594,7 @@
         <target>Correspondance exacte uniquement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">464</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10542,7 +10606,7 @@
         <target>N&apos;accepte qu&apos;une écriture identique.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeAutoLabel" datatype="html">
@@ -10550,7 +10614,7 @@
         <target>Autoriser les petites fautes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">469</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10562,7 +10626,7 @@
         <target>Pour la plupart des termes techniques : prend en compte les correspondances exactes, les petites fautes de frappe, les inversions de lettres et les caractères manquants.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeHammingLabel" datatype="html">
@@ -10570,7 +10634,7 @@
         <target>Même longueur, petites inversions de lettres</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">474</context>
+          <context context-type="linenumber">482</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10582,7 +10646,7 @@
         <target>Pour des termes de même longueur avec une lettre erronée ou inversée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">475</context>
+          <context context-type="linenumber">483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeLevenshteinLabel" datatype="html">
@@ -10590,7 +10654,7 @@
         <target>Autoriser aussi les caractères manquants ou supplémentaires</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">479</context>
+          <context context-type="linenumber">487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10602,7 +10666,7 @@
         <target>Pour des termes avec un caractère manquant ou supplémentaire.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">480</context>
+          <context context-type="linenumber">488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindText" datatype="html">
@@ -10610,7 +10674,7 @@
         <target>Évaluer par similarité de texte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">491</context>
+          <context context-type="linenumber">499</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindTextHint" datatype="html">
@@ -10618,7 +10682,7 @@
         <target>Adapté aux termes techniques et aux orthographes fixes avec de petites fautes de frappe.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumeric" datatype="html">
@@ -10626,7 +10690,7 @@
         <target>Évaluer des nombres</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">496</context>
+          <context context-type="linenumber">504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericHint" datatype="html">
@@ -10634,7 +10698,7 @@
         <target>Évalue des valeurs numériques au lieu de la similarité de texte et prend en charge des tolérances exactes, absolues ou relatives.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">497</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnit" datatype="html">
@@ -10642,7 +10706,7 @@
         <target>Évaluer des nombres et des unités</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">501</context>
+          <context context-type="linenumber">509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnitHint" datatype="html">
@@ -10650,7 +10714,7 @@
         <target>Vérifiez les valeurs numériques avec une famille d&apos;unités sélectionnée et expliquez les unités manquantes ou différentes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">502</context>
+          <context context-type="linenumber">510</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindInteger" datatype="html">
@@ -10658,7 +10722,7 @@
         <target>Nombre entier</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">507</context>
+          <context context-type="linenumber">515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindDecimal" datatype="html">
@@ -10666,7 +10730,7 @@
         <target>Nombre décimal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">508</context>
+          <context context-type="linenumber">516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceExact" datatype="html">
@@ -10674,7 +10738,7 @@
         <target>Valeur exacte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">512</context>
+          <context context-type="linenumber">520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceAbsolute" datatype="html">
@@ -10682,7 +10746,7 @@
         <target>Tolérance absolue</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">515</context>
+          <context context-type="linenumber">523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelative" datatype="html">
@@ -10690,7 +10754,7 @@
         <target>Tolérance relative (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">519</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyLength" datatype="html">
@@ -10698,7 +10762,7 @@
         <target>Longueur</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">524</context>
+          <context context-type="linenumber">532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyMass" datatype="html">
@@ -10706,7 +10770,7 @@
         <target>Masse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">525</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyTime" datatype="html">
@@ -10714,7 +10778,7 @@
         <target>Temps</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">526</context>
+          <context context-type="linenumber">534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyVolume" datatype="html">
@@ -10722,7 +10786,7 @@
         <target>Volume</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceNone" datatype="html">
@@ -10730,7 +10794,7 @@
         <target>Aucune tolérance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">531</context>
+          <context context-type="linenumber">539</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10742,7 +10806,7 @@
         <target>Faible</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">532</context>
+          <context context-type="linenumber">540</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10754,7 +10818,7 @@
         <target>Moyenne</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">541</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10766,7 +10830,7 @@
         <target>Généreuse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">534</context>
+          <context context-type="linenumber">542</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10778,7 +10842,7 @@
         <target>Prix Nobel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">538</context>
+          <context context-type="linenumber">546</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10794,7 +10858,7 @@
         <target>Maternelle (émoticônes d&apos;animaux)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">541</context>
+          <context context-type="linenumber">549</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10810,7 +10874,7 @@
         <target>École primaire</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">551</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10826,7 +10890,7 @@
         <target>Collège</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">552</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10842,7 +10906,7 @@
         <target>Lycée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">545</context>
+          <context context-type="linenumber">553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10858,7 +10922,7 @@
         <target>Norme de quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">768</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4668229613641280742" datatype="html">
@@ -10866,7 +10930,7 @@
         <target>Personnalisé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">866</context>
+          <context context-type="linenumber">874</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10878,7 +10942,7 @@
         <target>Échelle à cinq niveaux de 1 à 5, faible : <x id="low" equiv-text="low"/>, élevé : <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">980</context>
+          <context context-type="linenumber">988</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithLow" datatype="html">
@@ -10886,7 +10950,7 @@
         <target>Échelle à cinq niveaux de 1 à 5, bas : <x id="low" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">983</context>
+          <context context-type="linenumber">991</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithHigh" datatype="html">
@@ -10894,7 +10958,7 @@
         <target>Échelle à cinq niveaux de 1 à 5, élevé : <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">986</context>
+          <context context-type="linenumber">994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAria" datatype="html">
@@ -10902,7 +10966,7 @@
         <target>Échelle à cinq niveaux de 1 à 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">988</context>
+          <context context-type="linenumber">996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceLabel" datatype="html">
@@ -10914,7 +10978,7 @@
           )"/> à <x id="right" equiv-text="this.formatNumericEstimateEditorValue(band.right)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReferenceLabel" datatype="html">
@@ -10926,7 +10990,7 @@
             )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1152,1154</context>
+          <context context-type="linenumber">1160,1162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewIncomplete" datatype="html">
@@ -10934,7 +10998,7 @@
         <target>La bande de tolérance s&apos;affiche une fois que les limites ou la référence et le pourcentage sont atteints.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1168</context>
+          <context context-type="linenumber">1176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceOutside" datatype="html">
@@ -10942,7 +11006,7 @@
         <target>Les limites de plausibilité et les plages de tolérance ne correspondent pas encore. Les valeurs de la bande doivent également pouvoir être saisies.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1177</context>
+          <context context-type="linenumber">1185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReady" datatype="html">
@@ -10950,7 +11014,7 @@
         <target>La plausibilité limite les entrées autorisées ; la bande de tolérance décide des points.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1179</context>
+          <context context-type="linenumber">1187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityRange" datatype="html">
@@ -10962,7 +11026,7 @@
       )"/> à <x id="max" equiv-text="this.formatNumericEstimateEditorValue(max)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1186,1188</context>
+          <context context-type="linenumber">1194,1196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMin" datatype="html">
@@ -10974,7 +11038,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1191,1193</context>
+          <context context-type="linenumber">1199,1201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMax" datatype="html">
@@ -10986,7 +11050,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1196,1198</context>
+          <context context-type="linenumber">1204,1206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionLabel" datatype="html">
@@ -10994,7 +11058,7 @@
         <target>Réponse modèle <x id="solutionNumber" equiv-text="index + 1"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1286</context>
+          <context context-type="linenumber">1294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.answerLabel" datatype="html">
@@ -11002,7 +11066,7 @@
         <target>Réponse <x id="answerNumber" equiv-text="index + 1"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1289</context>
+          <context context-type="linenumber">1297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.markAnswerCorrectAria" datatype="html">
@@ -11010,7 +11074,7 @@
         <target>Marquer la réponse <x id="answerNumber" equiv-text="answerNumber"/> comme correcte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1293</context>
+          <context context-type="linenumber">1301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.toggleAnswerCorrectAria" datatype="html">
@@ -11018,7 +11082,7 @@
         <target>Réponse <x id="answerNumber" equiv-text="answerNumber"/> correcte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1297</context>
+          <context context-type="linenumber">1305</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.removeAnswerAria" datatype="html">
@@ -11026,7 +11090,7 @@
         <target>Supprimer la réponse <x id="answerNumber" equiv-text="answerNumber"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.collapseQuestionAria" datatype="html">
@@ -11034,7 +11098,7 @@
         <target>Réduire la question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1306</context>
+          <context context-type="linenumber">1314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.expandQuestionAria" datatype="html">
@@ -11042,7 +11106,7 @@
         <target>Développer la question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsPreviewLabel" datatype="html">
@@ -11050,7 +11114,7 @@
         <target>Réponses modèles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.livePreviewAnswersLabel" datatype="html">
@@ -11058,7 +11122,7 @@
         <target>Réponses</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1313</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.addShortTextSolution" datatype="html">
@@ -11066,7 +11130,7 @@
         <target>Ajouter une réponse modèle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1318</context>
+          <context context-type="linenumber">1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8266267788371304686" datatype="html">
@@ -11074,7 +11138,7 @@
         <target>Une autre réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1319</context>
+          <context context-type="linenumber">1327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthSummary" datatype="html">
@@ -11082,11 +11146,11 @@
         <target>Max. <x id="maxLength" equiv-text="resolveShortTextMaxLength(question.shortTextMaxLength)"/> caractères</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1436</context>
+          <context context-type="linenumber">1444</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1479</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11098,7 +11162,7 @@
         <target>±{$tolerance} absolue</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelativeSummary" datatype="html">
@@ -11106,7 +11170,7 @@
         <target>±{$tolerance} % relative</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1455</context>
+          <context context-type="linenumber">1463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilySummary" datatype="html">
@@ -11114,7 +11178,7 @@
         <target>Unités : {$unitFamily}</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1469</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitSummary" datatype="html">
@@ -11122,7 +11186,7 @@
         <target>Unité obligatoire</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitOptionalSummary" datatype="html">
@@ -11130,7 +11194,7 @@
         <target>Unité facultative</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1466</context>
+          <context context-type="linenumber">1474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEquivalentUnitsSummary" datatype="html">
@@ -11138,7 +11202,7 @@
         <target>Unités équivalentes autorisées</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1470</context>
+          <context context-type="linenumber">1478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericExactUnitsSummary" datatype="html">
@@ -11146,7 +11210,7 @@
         <target>Uniquement l&apos;unité exacte configurée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1471</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceSummary" datatype="html">
@@ -11154,7 +11218,7 @@
         <target>Tolérance : <x id="tolerance" equiv-text="this.shortTextToleranceLabel(question.shortTextToleranceLevel)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1484</context>
+          <context context-type="linenumber">1492</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11166,7 +11230,7 @@
         <target>Respect de la casse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1488</context>
+          <context context-type="linenumber">1496</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11178,7 +11242,7 @@
         <target>Points entiers uniquement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1491</context>
+          <context context-type="linenumber">1499</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11190,7 +11254,7 @@
         <target>Les espaces sont vérifiés strictement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1498</context>
+          <context context-type="linenumber">1506</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11202,7 +11266,7 @@
         <target>Définissez au moins une réponse de référence avec unité, gardez un petit jeu d&apos;unités et n&apos;activez l&apos;obligation d&apos;unité que si l&apos;unité doit vraiment être évaluée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1507</context>
+          <context context-type="linenumber">1515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningNumeric" datatype="html">
@@ -11210,7 +11274,7 @@
         <target>Définissez au moins une valeur de référence claire et choisissez une tolérance qui autorise les imprécisions de calcul tout en excluant clairement les valeurs scientifiquement fausses.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1508</context>
+          <context context-type="linenumber">1516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarning" datatype="html">
@@ -11218,7 +11282,7 @@
         <target>Réservez l&apos;évaluation tolérante aux termes techniques clairement définis. Pour des formulations ouvertes, plusieurs réponses modèles sont souvent plus justes qu&apos;une forte tolérance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11230,7 +11294,7 @@
         <target>Ajoutez entre une et dix réponses de référence avec une unité prise en charge, par exemple « 2 m ».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1521</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHintNumeric" datatype="html">
@@ -11238,7 +11302,7 @@
         <target>Ajoutez entre une et dix réponses de référence sous forme de nombre, par exemple « 3,5 ».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1530</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHint" datatype="html">
@@ -11246,7 +11310,7 @@
         <target>Ajoutez entre une et dix réponses modèles. Toutes les variantes sont considérées comme des réponses courtes correctes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewExactLabel" datatype="html">
@@ -11254,11 +11318,11 @@
         <target>Saisie exacte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1621</context>
+          <context context-type="linenumber">1629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLengthLabel" datatype="html">
@@ -11266,7 +11330,7 @@
         <target>Caractère manquant ou supplémentaire</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1553</context>
+          <context context-type="linenumber">1561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewWrongLabel" datatype="html">
@@ -11274,11 +11338,11 @@
         <target>Terme différent</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1557</context>
+          <context context-type="linenumber">1565</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1658</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeFull" datatype="html">
@@ -11286,11 +11350,11 @@
         <target>Tous les points</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1592</context>
+          <context context-type="linenumber">1600</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeAccepted" datatype="html">
@@ -11298,11 +11362,11 @@
         <target>Accepté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1593</context>
+          <context context-type="linenumber">1601</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1669</context>
+          <context context-type="linenumber">1677</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomePartial" datatype="html">
@@ -11310,11 +11374,11 @@
         <target>Points partiels (<x id="points" equiv-text="result.points"/> %)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1596</context>
+          <context context-type="linenumber">1604</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1672</context>
+          <context context-type="linenumber">1680</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeRejected" datatype="html">
@@ -11322,11 +11386,11 @@
         <target>Non accepté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1599</context>
+          <context context-type="linenumber">1607</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1683</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewNumericToleranceLabel" datatype="html">
@@ -11334,7 +11398,7 @@
         <target>Dans la tolérance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1629</context>
+          <context context-type="linenumber">1637</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewEquivalentUnitLabel" datatype="html">
@@ -11342,7 +11406,7 @@
         <target>Unité équivalente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewMissingUnitLabel" datatype="html">
@@ -11350,7 +11414,7 @@
         <target>Unité manquante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1644</context>
+          <context context-type="linenumber">1652</context>
         </context-group>
       </trans-unit>
       <trans-unit id="705009069021941649" datatype="html">
@@ -11358,7 +11422,7 @@
         <target>Sélectionne exactement une bonne réponse.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2025</context>
+          <context context-type="linenumber">2033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5903298630443190027" datatype="html">
@@ -11366,7 +11430,7 @@
         <target>Choisissez au moins une bonne réponse.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2037</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2211937330568533798" datatype="html">
@@ -11374,7 +11438,7 @@
         <target>L&apos;enregistrement a échoué.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2148</context>
+          <context context-type="linenumber">2156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5746363347338638819" datatype="html">
@@ -11382,7 +11446,7 @@
         <target>Les paramètres n&apos;ont pas pu être enregistrés.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2165</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3347548161086861397" datatype="html">
@@ -11390,7 +11454,7 @@
         <target>La question n&apos;a pas pu être mise à jour.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.saveConfirmation" datatype="html">
@@ -11398,7 +11462,7 @@
         <target>Modifications enregistrées. La question, les données du quiz et les paramètres sont maintenant repris dans l’aperçu et le quiz en direct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2284</context>
+          <context context-type="linenumber">2292</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogTitle" datatype="html">
@@ -11406,7 +11470,7 @@
         <target>Supprimer la question ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2312</context>
+          <context context-type="linenumber">2320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogMessage" datatype="html">
@@ -11414,7 +11478,7 @@
         <target>La question <x id="PH" equiv-text="position"/> sera définitivement supprimée du quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2313</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.deleteIrreversible" datatype="html">
@@ -11422,7 +11486,7 @@
         <target>Cela ne peut pas être annulé.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2315</context>
+          <context context-type="linenumber">2323</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -11434,7 +11498,7 @@
         <target>Supprimer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionCancel" datatype="html">
@@ -11442,7 +11506,7 @@
         <target>Annuler</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2318</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4357290152640831712" datatype="html">
@@ -11450,7 +11514,7 @@
         <target>Échec de la suppression.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2335</context>
+          <context context-type="linenumber">2343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -11462,11 +11526,11 @@
         <target>Le déplacement a échoué.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2356</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionUp" datatype="html">
@@ -11474,7 +11538,7 @@
         <target>Déplacer la question <x id="position" equiv-text="position"/> vers le haut</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2370</context>
+          <context context-type="linenumber">2378</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionDown" datatype="html">
@@ -11482,7 +11546,7 @@
         <target>Déplacer la question <x id="position" equiv-text="position"/> vers le bas</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2374</context>
+          <context context-type="linenumber">2382</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.dragQuestion" datatype="html">
@@ -11490,7 +11554,7 @@
         <target>Déplacez la question <x id="position" equiv-text="position"/> en la faisant glisser</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2378</context>
+          <context context-type="linenumber">2386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionMovedAnnouncement" datatype="html">
@@ -11498,7 +11562,7 @@
         <target>La question <x id="previousPosition" equiv-text="previousPosition"/> a été déplacée à la position <x id="currentPosition" equiv-text="currentPosition"/> sur <x id="total" equiv-text="total"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2385</context>
+          <context context-type="linenumber">2393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesDialogHeading" datatype="html">
@@ -13290,7 +13354,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3010</context>
+          <context context-type="linenumber">3016</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -13302,7 +13366,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3013</context>
+          <context context-type="linenumber">3019</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -13314,7 +13378,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3018</context>
+          <context context-type="linenumber">3024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -13326,7 +13390,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3208</context>
+          <context context-type="linenumber">3220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -13338,7 +13402,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3212</context>
+          <context context-type="linenumber">3224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -13350,7 +13414,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3215</context>
+          <context context-type="linenumber">3227</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -13362,7 +13426,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3218</context>
+          <context context-type="linenumber">3230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -13518,7 +13582,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2718</context>
+          <context context-type="linenumber">2724</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -13538,7 +13602,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2981</context>
+          <context context-type="linenumber">2987</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -13742,7 +13806,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2951</context>
+          <context context-type="linenumber">2957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -13798,7 +13862,7 @@
         <target>Voir le plan de débriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1212</context>
+          <context context-type="linenumber">1218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuVisual" datatype="html">
@@ -13806,7 +13870,7 @@
         <target>Standard (avec schémas)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1230</context>
+          <context context-type="linenumber">1236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuPdfUa" datatype="html">
@@ -13814,7 +13878,7 @@
         <target>Sans obstacle (PDF/UA-1)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1241</context>
+          <context context-type="linenumber">1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
@@ -13822,7 +13886,7 @@
         <target>Plus d&apos;options d&apos;exportation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1258</context>
+          <context context-type="linenumber">1264</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButton" datatype="html">
@@ -13830,7 +13894,7 @@
         <target>Plus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1261</context>
+          <context context-type="linenumber">1267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7070792224026857010" datatype="html">
@@ -13838,7 +13902,7 @@
         <target>Vers la page d&apos;accueil</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1265</context>
+          <context context-type="linenumber">1271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelTooltip" datatype="html">
@@ -13846,7 +13910,7 @@
         <target>Données brutes tabulaires pour tableur – moins de détails que le plan de débriefing.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1275</context>
+          <context context-type="linenumber">1281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelMenuItem" datatype="html">
@@ -13854,7 +13918,7 @@
         <target>Exporter les données brutes (CSV)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1280</context>
+          <context context-type="linenumber">1286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressAria" datatype="html">
@@ -13862,7 +13926,7 @@
         <target>L&apos;exportation est en cours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1290</context>
+          <context context-type="linenumber">1296</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
@@ -13870,7 +13934,7 @@
         <target>Exportation…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1295,1297</context>
+          <context context-type="linenumber">1301,1303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
@@ -13878,7 +13942,7 @@
         <target>Discutez avec votre voisin·e</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1323,1325</context>
+          <context context-type="linenumber">1329,1331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1952538840507841358" datatype="html">
@@ -13886,7 +13950,7 @@
         <target>Même réponse ? Super. Avis différent ? Convainquez-vous mutuellement.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1326,1328</context>
+          <context context-type="linenumber">1332,1334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5596291527944555255" datatype="html">
@@ -13894,7 +13958,7 @@
         <target>Le 2e tour commence bientôt.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1329,1331</context>
+          <context context-type="linenumber">1335,1337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveLabel" datatype="html">
@@ -13902,7 +13966,7 @@
         <target>Session de questions en cours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1339,1341</context>
+          <context context-type="linenumber">1345,1347</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveHint" datatype="html">
@@ -13910,7 +13974,7 @@
         <target>Les participantes et participants peuvent maintenant rejoindre la session avec le code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1349,1351</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionCounter" datatype="html">
@@ -13918,7 +13982,7 @@
         <target>Question <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/> / <x id="INTERPOLATION_1" equiv-text="{{ q.totalQuestions }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1358,1359</context>
+          <context context-type="linenumber">1364,1365</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionNumber" datatype="html">
@@ -13926,7 +13990,7 @@
         <target>Question <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1361,1362</context>
+          <context context-type="linenumber">1367,1368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1017989655370592681" datatype="html">
@@ -13934,7 +13998,7 @@
         <target>Dernière question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1364</context>
+          <context context-type="linenumber">1370</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7135032209126516357" datatype="html">
@@ -13942,7 +14006,7 @@
         <target>Tout le monde a voté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1403</context>
+          <context context-type="linenumber">1409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
@@ -13950,7 +14014,7 @@
         <target>Les participants peuvent prolonger ou désactiver leur délai personnel si nécessaire.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1424,1427</context>
+          <context context-type="linenumber">1430,1433</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.questionMetadataAria" datatype="html">
@@ -13958,7 +14022,7 @@
         <target>Métadonnées de la question</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1439</context>
+          <context context-type="linenumber">1445</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
@@ -13978,7 +14042,7 @@
         <target>Phase de lecture</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1464</context>
+          <context context-type="linenumber">1470</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
@@ -13986,7 +14050,7 @@
         <target>Les réponses arrivent dans un instant.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1465,1467</context>
+          <context context-type="linenumber">1471,1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
@@ -13994,7 +14058,7 @@
         <target>Échelle d&apos;évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
@@ -14002,7 +14066,7 @@
         <target>Répartition des évaluations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1551</context>
+          <context context-type="linenumber">1557</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
@@ -14010,7 +14074,7 @@
         <target>En attente des estimations…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1590,1592</context>
+          <context context-type="linenumber">1596,1598</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
@@ -14018,7 +14082,7 @@
         <target><x id="INTERPOLATION"/> réponses reçues</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1598,1600</context>
+          <context context-type="linenumber">1604,1606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
@@ -14026,11 +14090,11 @@
         <target>Résumé des statistiques</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1610</context>
+          <context context-type="linenumber">1616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2043</context>
+          <context context-type="linenumber">2049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
@@ -14038,7 +14102,7 @@
         <target>Tour 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615</context>
+          <context context-type="linenumber">1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
@@ -14046,11 +14110,11 @@
         <target>Accepté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1633</context>
+          <context context-type="linenumber">1639</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2063</context>
+          <context context-type="linenumber">2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
@@ -14058,7 +14122,7 @@
         <target>Comparaison ronde</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1653</context>
+          <context context-type="linenumber">1659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
@@ -14066,7 +14130,7 @@
         <target>changement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
@@ -14074,7 +14138,7 @@
         <target>Tour 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1695</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
@@ -14082,7 +14146,7 @@
         <target>Tour 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1694</context>
+          <context context-type="linenumber">1700</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
@@ -14090,11 +14154,11 @@
         <target>Afficher les détails statistiques</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2180</context>
+          <context context-type="linenumber">2186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
@@ -14102,7 +14166,7 @@
         <target>Tour 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1895,1897</context>
+          <context context-type="linenumber">1901,1903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
@@ -14110,7 +14174,7 @@
         <target>Tour 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1923,1925</context>
+          <context context-type="linenumber">1929,1931</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
@@ -14118,7 +14182,7 @@
         <target>Δ par paires : <x id="INTERPOLATION"/> plus proche, <x id="INTERPOLATION_1"/> plus loin, <x id="INTERPOLATION_2"/> inchangé (<x id="INTERPOLATION_3"/> paires)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1954,1962</context>
+          <context context-type="linenumber">1960,1968</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
@@ -14126,7 +14190,7 @@
         <target>Distribution Δx</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1972</context>
+          <context context-type="linenumber">1978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
@@ -14134,7 +14198,7 @@
         <target>plus petit est plus proche</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2086</context>
+          <context context-type="linenumber">2092</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
@@ -14142,7 +14206,7 @@
         <target>Tour de résultats</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2193,2195</context>
+          <context context-type="linenumber">2199,2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
@@ -14150,7 +14214,7 @@
         <target>Aucune estimation reçue.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2220,2222</context>
+          <context context-type="linenumber">2226,2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
@@ -14158,7 +14222,7 @@
         <target>Comparaison avant et après pour la Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2232</context>
+          <context context-type="linenumber">2238</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
@@ -14166,7 +14230,7 @@
         <target>Tour 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> vote)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2240</context>
+          <context context-type="linenumber">2246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
@@ -14174,7 +14238,7 @@
         <target>Tour 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> votes)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2246</context>
+          <context context-type="linenumber">2252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
@@ -14182,7 +14246,7 @@
         <target>Tour 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> vote)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2254</context>
+          <context context-type="linenumber">2260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
@@ -14190,7 +14254,7 @@
         <target>Tour 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> votes)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2260</context>
+          <context context-type="linenumber">2266</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
@@ -14198,7 +14262,7 @@
         <target>Correct&#160;: <x id="INTERPOLATION" equiv-text="{{ q.roundComparison.round1CorrectCount }}"/> au tour&#160;1, puis <x id="INTERPOLATION_1" equiv-text="{{ q.roundComparison.round2CorrectCount }}"/> au tour&#160;2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2272,2276</context>
+          <context context-type="linenumber">2278,2282</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
@@ -14206,7 +14270,7 @@
         <target>Peer Instruction recommandée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2519,2521</context>
+          <context context-type="linenumber">2525,2527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
@@ -14214,7 +14278,7 @@
         <target>35–70 % entièrement corrects — 2e tour adapté.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2526,2528</context>
+          <context context-type="linenumber">2532,2534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
@@ -14222,7 +14286,7 @@
         <target>1er tour encore masqué jusqu’à votre action.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2533,2535</context>
+          <context context-type="linenumber">2539,2541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
@@ -14230,7 +14294,7 @@
         <target>Lancer la discussion ou afficher le résultat.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2540,2542</context>
+          <context context-type="linenumber">2546,2548</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
@@ -14238,7 +14302,7 @@
         <target>Autoévaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2598,2600</context>
+          <context context-type="linenumber">2604,2606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
@@ -14246,7 +14310,7 @@
         <target> Juste ou faux — et avec quelle assurance ? Surtout : faux malgré une forte certitude de réponse. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2604,2607</context>
+          <context context-type="linenumber">2610,2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
@@ -14254,7 +14318,7 @@
         <target>Justesse et autoévaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2634</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
@@ -14262,7 +14326,7 @@
         <target> Souvent faux avec forte certitude de réponse </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2682,2684</context>
+          <context context-type="linenumber">2688,2690</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
@@ -14270,7 +14334,7 @@
         <target>Mise à jour de la question …</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2727,2729</context>
+          <context context-type="linenumber">2733,2735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
@@ -14278,7 +14342,7 @@
         <target>Aucune question active. Commencez par « Question suivante ».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2731,2733</context>
+          <context context-type="linenumber">2737,2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -14286,7 +14350,7 @@
         <target>Réactions des participantes et participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2751</context>
+          <context context-type="linenumber">2757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
@@ -14294,7 +14358,7 @@
         <target>2e manche</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2757</context>
+          <context context-type="linenumber">2763</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
@@ -14302,7 +14366,7 @@
         <target>nouveau</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2765</context>
+          <context context-type="linenumber">2771</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
@@ -14310,7 +14374,7 @@
         <target>Aucune réaction pour l&apos;instant.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2788</context>
+          <context context-type="linenumber">2794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
@@ -14318,7 +14382,7 @@
         <target>Top 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2801</context>
+          <context context-type="linenumber">2807</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
@@ -14326,7 +14390,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ entry.totalScore | number }}"/> pts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2868</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
@@ -14334,7 +14398,7 @@
         <target>Égalité : temps de réponse.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2877</context>
+          <context context-type="linenumber">2883</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
@@ -14342,7 +14406,7 @@
         <target>Score des équipes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2895</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
@@ -14350,7 +14414,7 @@
         <target>pts.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2942</context>
+          <context context-type="linenumber">2948</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
@@ -14358,7 +14422,7 @@
         <target>Changer de quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2971</context>
+          <context context-type="linenumber">2977</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
@@ -14366,7 +14430,7 @@
         <target>Modifier le titre Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3074</context>
+          <context context-type="linenumber">3086</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
@@ -14374,7 +14438,7 @@
         <target>Titre du Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3087</context>
+          <context context-type="linenumber">3099</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
@@ -14382,15 +14446,15 @@
         <target>Questions sur l'événement...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3098</context>
+          <context context-type="linenumber">3110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">886</context>
+          <context context-type="linenumber">893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">898</context>
+          <context context-type="linenumber">905</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14402,7 +14466,7 @@
         <target>Enregistrer le titre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3110</context>
+          <context context-type="linenumber">3122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
@@ -14410,7 +14474,7 @@
         <target>Annuler la modification</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3121</context>
+          <context context-type="linenumber">3133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
@@ -14418,7 +14482,7 @@
         <target>Pré-modération</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3140,3142</context>
+          <context context-type="linenumber">3152,3154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
@@ -14426,7 +14490,7 @@
         <target>La pré-modération est activée. Les nouvelles questions attendent d’abord votre validation.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3144,3146</context>
+          <context context-type="linenumber">3156,3158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
@@ -14434,7 +14498,7 @@
         <target>Pas encore de questions.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3153,3155</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
@@ -14442,7 +14506,7 @@
         <target>Total : <x id="INTERPOLATION" equiv-text="qaQuestions().length"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3165,3166</context>
+          <context context-type="linenumber">3177,3178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
@@ -14450,7 +14514,7 @@
         <target>En attente de validation : <x id="INTERPOLATION" equiv-text="qaPendingCount()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3174,3175</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
@@ -14458,7 +14522,7 @@
         <target>Afficher toutes les questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3227</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
@@ -14466,7 +14530,7 @@
         <target>Tout afficher</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3230</context>
+          <context context-type="linenumber">3242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
@@ -14474,7 +14538,7 @@
         <target>Afficher uniquement les questions épinglées</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3238</context>
+          <context context-type="linenumber">3250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
@@ -14482,7 +14546,7 @@
         <target>Épinglées seulement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3241</context>
+          <context context-type="linenumber">3253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
@@ -14490,7 +14554,7 @@
         <target>Afficher les nouvelles questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3253</context>
+          <context context-type="linenumber">3265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
@@ -14498,7 +14562,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ qaUnseenCount() }}"/> nouvelles questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3259</context>
+          <context context-type="linenumber">3271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
@@ -14506,7 +14570,7 @@
         <target>Exporter les questions en CSV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3291</context>
+          <context context-type="linenumber">3303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
@@ -14514,7 +14578,7 @@
         <target>Exporter les questions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3294</context>
+          <context context-type="linenumber">3306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
@@ -14522,7 +14586,7 @@
         <target>Export en cours…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3302,3304</context>
+          <context context-type="linenumber">3314,3316</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
@@ -14530,7 +14594,7 @@
         <target>Controversée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3371</context>
+          <context context-type="linenumber">3383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
@@ -14538,7 +14602,7 @@
         <target><x id="INTERPOLATION" equiv-text="question.positiveVoteCount"/> positifs · <x id="INTERPOLATION_1" equiv-text="question.negativeVoteCount"/> négatifs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3399,3400</context>
+          <context context-type="linenumber">3411,3412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
@@ -14546,7 +14610,7 @@
         <target>Approbation fiable <x id="INTERPOLATION" equiv-text="formatQaPercent(question.bestScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3407,3408</context>
+          <context context-type="linenumber">3419,3420</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
@@ -14554,7 +14618,7 @@
         <target>Réactions partagées <x id="INTERPOLATION" equiv-text="formatQaPercent(question.controversyScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3417,3419</context>
+          <context context-type="linenumber">3429,3431</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
@@ -14562,7 +14626,7 @@
         <target>Vue épinglée active – aucune question épinglée pour le moment.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3460,3462</context>
+          <context context-type="linenumber">3472,3474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
@@ -14570,7 +14634,7 @@
         <target>Afficher les options de réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3513</context>
+          <context context-type="linenumber">3525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
@@ -14578,7 +14642,7 @@
         <target>Démarrer la phase de discussion – échanger avant le deuxième vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3549</context>
+          <context context-type="linenumber">3561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
@@ -14586,7 +14650,7 @@
         <target>Phase de discussion</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3552</context>
+          <context context-type="linenumber">3564</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
@@ -14594,11 +14658,11 @@
         <target>Publier quand même</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3579</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3589</context>
+          <context context-type="linenumber">3601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
@@ -14606,7 +14670,7 @@
         <target>Afficher quand même le résultat</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3570</context>
+          <context context-type="linenumber">3582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
@@ -14614,7 +14678,7 @@
         <target>Afficher le résultat</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3591</context>
+          <context context-type="linenumber">3603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
@@ -14622,7 +14686,7 @@
         <target>Question suivante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3607,3609</context>
+          <context context-type="linenumber">3619,3621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
@@ -14630,7 +14694,7 @@
         <target>Passons à la question suivante sans deuxième vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3630</context>
+          <context context-type="linenumber">3642</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
@@ -14638,7 +14702,7 @@
         <target>Passons à la question suivante sans deuxième vote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3633</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
@@ -14646,7 +14710,7 @@
         <target>Réaffiche la question précédente avec son résultat et la bonne réponse (sans nouveau vote).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650</context>
+          <context context-type="linenumber">3662</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
@@ -14654,7 +14718,7 @@
         <target>Afficher à nouveau le résultat précédent</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3652,3654</context>
+          <context context-type="linenumber">3664,3666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
@@ -14662,7 +14726,7 @@
         <target>Terminer la session</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3662,3664</context>
+          <context context-type="linenumber">3674,3676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -14670,7 +14734,7 @@
         <target>Vue hôte pour le lobby et le contrôle.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3670</context>
+          <context context-type="linenumber">3682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
@@ -14678,7 +14742,7 @@
         <target>Lobby · Chaleureux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">322</context>
+          <context context-type="linenumber">324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyArrival" datatype="html">
@@ -14686,7 +14750,7 @@
         <target>Lobby · Arrivée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyCalm" datatype="html">
@@ -14694,7 +14758,7 @@
         <target>Lobby · Calme</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyPulse" datatype="html">
@@ -14702,7 +14766,7 @@
         <target>Lobby · Pulsation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">334</context>
+          <context context-type="linenumber">336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackReadingBuild" datatype="html">
@@ -14710,7 +14774,7 @@
         <target>Lecture · Montée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">338</context>
+          <context context-type="linenumber">340</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownFocus" datatype="html">
@@ -14718,7 +14782,7 @@
         <target>Compte à rebours · Focus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownTempo" datatype="html">
@@ -14726,7 +14790,7 @@
         <target>Compte à rebours · Rythme</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownIntense" datatype="html">
@@ -14734,7 +14798,23 @@
         <target>Compte à rebours · Intense</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">350</context>
+          <context context-type="linenumber">352</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingQa" datatype="html">
+        <source>Warum die Fragenwand mehr als ein Chat ist</source>
+        <target>Pourquoi le mur de questions va au-delà d’un chat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">421</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <target>Comprendre l’autoévaluation et le débriefing</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">423</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4017389878545296254" datatype="html">
@@ -14742,7 +14822,7 @@
         <target>En attente des réponses libres en direct...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">500</context>
+          <context context-type="linenumber">507</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14754,7 +14834,7 @@
         <target>Texte libre en direct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">503</context>
+          <context context-type="linenumber">510</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14766,7 +14846,7 @@
         <target>Mots fréquents dans les réponses.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">504</context>
+          <context context-type="linenumber">511</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14778,7 +14858,7 @@
         <target>Analyse Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">505</context>
+          <context context-type="linenumber">512</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14790,7 +14870,7 @@
         <target>Indique quels mots et expressions dominent dans les questions Q&amp;A visibles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">506</context>
+          <context context-type="linenumber">513</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14802,7 +14882,7 @@
         <target>Masquer le nuage de mots</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">647</context>
+          <context context-type="linenumber">654</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudShow" datatype="html">
@@ -14810,7 +14890,7 @@
         <target>Afficher le nuage de mots</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">648</context>
+          <context context-type="linenumber">655</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudResume" datatype="html">
@@ -14818,11 +14898,11 @@
         <target>Reprendre le direct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">653</context>
+          <context context-type="linenumber">660</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1036</context>
+          <context context-type="linenumber">1043</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFreeze" datatype="html">
@@ -14830,11 +14910,11 @@
         <target>Figer le nuage de mots</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">654</context>
+          <context context-type="linenumber">661</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1037</context>
+          <context context-type="linenumber">1044</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFrozenInfo" datatype="html">
@@ -14842,7 +14922,7 @@
         <target>Nuage de mots figé.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">679</context>
+          <context context-type="linenumber">686</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobbyShort" datatype="html">
@@ -14850,7 +14930,7 @@
         <target>Lobby</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseConnectingShort" datatype="html">
@@ -14858,7 +14938,7 @@
         <target>Lecture</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">837</context>
+          <context context-type="linenumber">844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseRunningShort" datatype="html">
@@ -14866,7 +14946,7 @@
         <target>Compte à rebours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">838</context>
+          <context context-type="linenumber">845</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicLabelOff" datatype="html">
@@ -14874,7 +14954,7 @@
         <target>Couper la musique</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">870</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
@@ -14882,7 +14962,7 @@
         <target>Session quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">891</context>
+          <context context-type="linenumber">898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricBest" datatype="html">
@@ -14890,7 +14970,7 @@
         <target>approbation fiable</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">958</context>
+          <context context-type="linenumber">965</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricControversial" datatype="html">
@@ -14898,7 +14978,7 @@
         <target>controverse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">960</context>
+          <context context-type="linenumber">967</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricTop" datatype="html">
@@ -14906,7 +14986,7 @@
         <target>votes positifs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">969</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudTitle" datatype="html">
@@ -14914,7 +14994,7 @@
         <target>Nuage de mots Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">965</context>
+          <context context-type="linenumber">972</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14926,7 +15006,7 @@
         <target>Les grands mots et expressions viennent de questions avec beaucoup d’approbation et assez de votes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">969</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintControversial" datatype="html">
@@ -14934,7 +15014,7 @@
         <target>Les grands mots et expressions viennent de questions aux réactions opposées. Survolez-les pour voir les questions associées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintTop" datatype="html">
@@ -14942,7 +15022,7 @@
         <target>Les grands mots et expressions viennent de questions avec beaucoup de votes positifs.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">973</context>
+          <context context-type="linenumber">980</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudThemeFallbackHint" datatype="html">
@@ -14950,7 +15030,7 @@
         <target>Les mots seuls s’affichent jusqu’à ce que les groupes de mots et les expressions soient suffisamment fiables.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1026</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintBest" datatype="html">
@@ -14958,7 +15038,7 @@
         <target>Affiche d’abord les questions avec beaucoup d’approbation et assez de votes. Les questions épinglées restent signalées, sans être remontées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1024</context>
+          <context context-type="linenumber">1031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintControversial" datatype="html">
@@ -14966,7 +15046,7 @@
         <target>Affiche d’abord les questions aux réactions partagées. Les questions épinglées restent signalées, sans être remontées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1026</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintTop" datatype="html">
@@ -14974,7 +15054,7 @@
         <target>Affiche d’abord les questions avec le plus de votes positifs. Les questions épinglées restent signalées, sans être remontées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1028</context>
+          <context context-type="linenumber">1035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudShow" datatype="html">
@@ -14982,7 +15062,7 @@
         <target>Afficher le nuage de mots</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1032</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountOneMetric" datatype="html">
@@ -14990,7 +15070,7 @@
         <target>1 question visible · Taille des mots et expressions : <x id="metric" equiv-text="metric"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1043</context>
+          <context context-type="linenumber">1050</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountManyMetric" datatype="html">
@@ -14998,7 +15078,7 @@
         <target><x id="count" equiv-text="count"/> questions visibles · Taille des mots et expressions : <x id="metric" equiv-text="metric"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1045</context>
+          <context context-type="linenumber">1052</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountOne" datatype="html">
@@ -15006,7 +15086,7 @@
         <target>1 réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1552</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
@@ -15014,7 +15094,7 @@
         <target><x id="count" equiv-text="count"/> réponses</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1546</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
@@ -15022,7 +15102,7 @@
         <target>Faible · <x id="label" equiv-text="q.confidenceLabelLow"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1637</context>
+          <context context-type="linenumber">1644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
@@ -15030,7 +15110,7 @@
         <target>Faible (1–2)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
@@ -15038,7 +15118,7 @@
         <target>Moyen (3)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1642</context>
+          <context context-type="linenumber">1649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
@@ -15046,7 +15126,7 @@
         <target>Élevé · <x id="label" equiv-text="q.confidenceLabelHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1674</context>
+          <context context-type="linenumber">1681</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
@@ -15054,7 +15134,7 @@
         <target>Élevé (4–5)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
@@ -15062,7 +15142,7 @@
         <target>Correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1696</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
@@ -15070,7 +15150,7 @@
         <target>Faux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1696</context>
+          <context context-type="linenumber">1703</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
@@ -15078,7 +15158,7 @@
         <target><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
@@ -15086,7 +15166,7 @@
         <target>1 mauvaise réponse sûre – possible idée fausse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1793</context>
+          <context context-type="linenumber">1800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
@@ -15094,7 +15174,7 @@
         <target><x id="count" equiv-text="count"/> mauvaises réponses confiantes – idées fausses possibles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1794</context>
+          <context context-type="linenumber">1801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
@@ -15102,7 +15182,7 @@
         <target>Juste+élevé <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · Faux+élevé <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1805</context>
+          <context context-type="linenumber">1812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
@@ -15110,7 +15190,7 @@
         <target>2 (Instruction par les pairs)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1825</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
@@ -15118,7 +15198,7 @@
         <target>Tour 1 : <x id="r1" equiv-text="round1Count"/> voix · Agrégé : Tour 2 avec <x id="r2" equiv-text="round2Count"/> voix</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1843</context>
+          <context context-type="linenumber">1850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
@@ -15126,7 +15206,7 @@
         <target>Agrégation Round 2 (Instruction par les pairs)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1845</context>
+          <context context-type="linenumber">1852</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
@@ -15134,7 +15214,7 @@
         <target>Agrégation tour 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1848</context>
+          <context context-type="linenumber">1855</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
@@ -15142,7 +15222,7 @@
         <target>Ça n’est pas passé tout de suite</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2452</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
@@ -15150,7 +15230,7 @@
         <target>Pas de stress, ça arrive (petit à-coup ou Wi‑Fi capricieux). Compte jusqu’à trois, puis appuie sur « Réessayer » — en général ça suffit.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2453</context>
+          <context context-type="linenumber">2460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
@@ -15158,7 +15238,7 @@
         <target>Avec les questions, ça bloque un instant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2460</context>
+          <context context-type="linenumber">2467</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
@@ -15166,7 +15246,7 @@
         <target>Rien n’est cassé, ça n’a juste pas marché cette fois. Respire un coup, attends 2–3 secondes, puis « Réessayer » — souvent ça repart.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2461</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
@@ -15174,7 +15254,7 @@
         <target>Export pas encore prêt</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2468</context>
+          <context context-type="linenumber">2475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
@@ -15182,7 +15262,7 @@
         <target>L’export PDF ou Excel n’est pas passé cette fois. Attends quelques secondes et appuie sur « Réessayer » — le deuxième essai fait souvent l’affaire.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2469</context>
+          <context context-type="linenumber">2476</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
@@ -15190,7 +15270,7 @@
         <target>Les participants et la vue de la présentation sont redirigés vers la page d&apos;accueil.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2610</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
@@ -15198,7 +15278,7 @@
         <target>La séance se termine pour tout le monde ; il n&apos;est pas possible de continuer avec le même code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
@@ -15206,7 +15286,7 @@
         <target>Il reste <x id="participantCount" equiv-text="participants"/> participant·es dans la session.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2608</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
@@ -15214,7 +15294,7 @@
         <target>Vous avez déjà des résultats. Après avoir terminé, vous pouvez les exporter ou consulter les retours dans la vue finale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2613</context>
+          <context context-type="linenumber">2620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
@@ -15222,7 +15302,7 @@
         <target>Il n&apos;y a pas encore de résultats exploitables. Après avoir terminé, vous serez redirigé·e directement vers l&apos;accueil.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2617</context>
+          <context context-type="linenumber">2624</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
@@ -15230,7 +15310,7 @@
         <target>Codes bonus : demandez aux participant·es de copier maintenant leur code personnel dans le presse-papiers avant de quitter la page, sinon ils risquent de le perdre.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2622</context>
+          <context context-type="linenumber">2629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
@@ -15238,7 +15318,7 @@
         <target>Quitter la séance ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
@@ -15246,7 +15326,7 @@
         <target>Votre session est toujours active.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2629</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
@@ -15254,7 +15334,7 @@
         <target>Il reste toujours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2631</context>
+          <context context-type="linenumber">2638</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
@@ -15262,7 +15342,7 @@
         <target>Retour à la séance</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2632</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
@@ -15270,7 +15350,7 @@
         <target>Arrêter l&apos;aperçu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2823</context>
+          <context context-type="linenumber">2830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
@@ -15278,7 +15358,7 @@
         <target>Écouter brièvement le morceau (12 s max.)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2824</context>
+          <context context-type="linenumber">2831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
@@ -15286,7 +15366,7 @@
         <target>Son activé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2836</context>
+          <context context-type="linenumber">2843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
@@ -15294,7 +15374,7 @@
         <target>Son coupé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2837</context>
+          <context context-type="linenumber">2844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
@@ -15302,7 +15382,7 @@
         <target>Participant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
@@ -15310,7 +15390,7 @@
         <target>participants</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2898</context>
+          <context context-type="linenumber">2905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
@@ -15318,7 +15398,7 @@
         <target>1 participant connecté en live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
@@ -15326,7 +15406,7 @@
         <target><x id="connectedCount" equiv-text="connectedCount"/> participants connectés en live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2917</context>
+          <context context-type="linenumber">2924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
@@ -15334,7 +15414,7 @@
         <target>Personne n’est encore dans cette équipe.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2943</context>
+          <context context-type="linenumber">2950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
@@ -15342,7 +15422,7 @@
         <target>Évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3759</context>
+          <context context-type="linenumber">3766</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
@@ -15350,7 +15430,7 @@
         <target>Avis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3763</context>
+          <context context-type="linenumber">3770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
@@ -15358,11 +15438,11 @@
         <target>Les résultats sont là.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3768</context>
+          <context context-type="linenumber">3775</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3775</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
@@ -15370,11 +15450,11 @@
         <target>Le temps est écoulé.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3769</context>
+          <context context-type="linenumber">3776</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3776</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
@@ -15382,7 +15462,7 @@
         <target>En attente des avis…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3770</context>
+          <context context-type="linenumber">3777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
@@ -15390,7 +15470,7 @@
         <target>En attente de réponses...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
@@ -15398,7 +15478,7 @@
         <target><x id="PH" equiv-text="votes"/> sur <x id="PH_1" equiv-text="participants"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3781</context>
+          <context context-type="linenumber">3788</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
@@ -15406,7 +15486,7 @@
         <target>Une personne utilise encore son temps ×10. « Publier quand même » termine sa fenêtre personnelle.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3788</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
@@ -15414,7 +15494,7 @@
         <target>Une personne utilise encore son temps ×10. Attends le compte à rebours de la salle ou la fin du temps ×10.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3789</context>
+          <context context-type="linenumber">3796</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
@@ -15422,7 +15502,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> personnes utilisent encore leur temps ×10. « Publier quand même » termine leurs fenêtres personnelles.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3793</context>
+          <context context-type="linenumber">3800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
@@ -15430,7 +15510,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> personnes utilisent encore leur temps ×10. Attends le compte à rebours de la salle ou la fin du temps ×10.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3794</context>
+          <context context-type="linenumber">3801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
@@ -15438,7 +15518,7 @@
         <target>Une personne répond sans délai personnel. « Afficher le résultat » ferme sa saisie.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3797</context>
+          <context context-type="linenumber">3804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
@@ -15446,7 +15526,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> personnes répondent sans délai personnel. « Afficher le résultat » ferme leur saisie.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3799</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
@@ -15454,7 +15534,7 @@
         <target><x id="votes" equiv-text="votes"/> sur <x id="participants" equiv-text="participants"/> participants ont voté. <x id="percentage" equiv-text="percentage"/> pour cent atteint.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3805</context>
+          <context context-type="linenumber">3812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
@@ -15462,7 +15542,7 @@
         <target><x id="votes" equiv-text="votes"/> des <x id="participants" equiv-text="participants"/> participants ont voté. <x id="percentage" equiv-text="percentage"/> pour cent atteint.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3807</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
@@ -15470,7 +15550,7 @@
         <target><x id="voteCount"/> sur <x id="participantTotal"/> a voté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3818</context>
+          <context context-type="linenumber">3825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
@@ -15478,7 +15558,7 @@
         <target><x id="voteCount"/> sur <x id="participantTotal"/> ont voté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3827</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
@@ -15486,7 +15566,7 @@
         <target><x id="voteCount"/> sur <x id="participantTotal"/> a noté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3831</context>
+          <context context-type="linenumber">3838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
@@ -15494,7 +15574,7 @@
         <target><x id="voteCount"/> sur <x id="participantTotal"/> ont noté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3833</context>
+          <context context-type="linenumber">3840</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
@@ -15502,7 +15582,7 @@
         <target><x id="correctCount"/> réponses entièrement correctes sur <x id="voteTotal"/> (<x id="percentage"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3839</context>
+          <context context-type="linenumber">3846</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
@@ -15510,7 +15590,7 @@
         <target><x id="changed"/> sur <x id="both"/> (<x id="pct"/>%) ont changé d&apos;avis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3843</context>
+          <context context-type="linenumber">3850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
@@ -15518,7 +15598,7 @@
         <target>↑ <x id="count"/> faux → correct</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3847</context>
+          <context context-type="linenumber">3854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
@@ -15526,7 +15606,7 @@
         <target>↓ <x id="count"/> correct → faux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3851</context>
+          <context context-type="linenumber">3858</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
@@ -15534,7 +15614,7 @@
         <target>Moyenne <x id="avg"/> sur 5 étoiles</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3857</context>
+          <context context-type="linenumber">3864</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
@@ -15542,7 +15622,7 @@
         <target>réaction <x id="PH" equiv-text="total"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
@@ -15550,7 +15630,7 @@
         <target><x id="PH" equiv-text="total"/> réactions</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
@@ -15558,7 +15638,7 @@
         <target>Lobby – les participantes et participants peuvent rejoindre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3917</context>
+          <context context-type="linenumber">3924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
@@ -15566,7 +15646,7 @@
         <target>La session de questions se prépare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3918</context>
+          <context context-type="linenumber">3925</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
@@ -15574,15 +15654,15 @@
         <target>Session de questions en cours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3919</context>
+          <context context-type="linenumber">3926</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3921</context>
+          <context context-type="linenumber">3928</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3922</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
@@ -15590,7 +15670,7 @@
         <target>En pause</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3920</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
@@ -15598,7 +15678,7 @@
         <target>Session de questions terminée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3923</context>
+          <context context-type="linenumber">3930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
@@ -15606,7 +15686,7 @@
         <target>Vote terminé – en attente d’évaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3928</context>
+          <context context-type="linenumber">3935</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
@@ -15614,7 +15694,7 @@
         <target>Lobby – les participants peuvent se joindre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3931</context>
+          <context context-type="linenumber">3938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
@@ -15622,7 +15702,7 @@
         <target>Phase de lecture – réponses toujours bloquées</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3932</context>
+          <context context-type="linenumber">3939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
@@ -15630,7 +15710,7 @@
         <target>Le vote est en cours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3933</context>
+          <context context-type="linenumber">3940</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
@@ -15638,7 +15718,7 @@
         <target>En pause</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3934</context>
+          <context context-type="linenumber">3941</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
@@ -15646,7 +15726,7 @@
         <target>Les résultats sont affichés</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3935</context>
+          <context context-type="linenumber">3942</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
@@ -15654,7 +15734,7 @@
         <target>Phase de discussion – échange avant le second tour</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3936</context>
+          <context context-type="linenumber">3943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
@@ -15662,7 +15742,7 @@
         <target>Séance terminée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3937</context>
+          <context context-type="linenumber">3944</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
@@ -15670,7 +15750,7 @@
         <target><x id="readyCount" equiv-text="readyCount"/> sur <x id="connectedCount" equiv-text="connectedCount"/> prêts</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3948</context>
+          <context context-type="linenumber">3955</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
@@ -15678,7 +15758,7 @@
         <target><x id="PH" equiv-text="readyCount"/> participant·es connecté·es prêt·es sur <x id="PH_1" equiv-text="connectedCount"/> · <x id="PH_2" equiv-text="totalParticipantCount"/> au total</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3950</context>
+          <context context-type="linenumber">3957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
@@ -15686,7 +15766,7 @@
         <target>Toutes les personnes participantes sont prêtes ; les options de réponse peuvent être affichées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3955</context>
+          <context context-type="linenumber">3962</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
@@ -15694,7 +15774,7 @@
         <target>Toutes les personnes participantes connectées sont prêtes ; les options de réponse peuvent être affichées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3957</context>
+          <context context-type="linenumber">3964</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
@@ -15702,7 +15782,7 @@
         <target>1 seconde restante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3988</context>
+          <context context-type="linenumber">3995</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
@@ -15710,7 +15790,7 @@
         <target><x id="seconds" equiv-text="seconds"/> secondes restantes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3989</context>
+          <context context-type="linenumber">3996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -15724,7 +15804,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4113,4116</context>
+          <context context-type="linenumber">4120,4123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -15738,7 +15818,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4158,4161</context>
+          <context context-type="linenumber">4165,4168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -15752,7 +15832,7 @@
       )"/> à <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4163,4166</context>
+          <context context-type="linenumber">4170,4173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -15767,7 +15847,7 @@
     )"/> à <x id="right" equiv-text="formatNumber(band.right, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4168,4171</context>
+          <context context-type="linenumber">4175,4178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
@@ -15775,7 +15855,7 @@
         <target>Médiane <x id="median" equiv-text="formatNumber(stats.median, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4286</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
@@ -15783,7 +15863,7 @@
         <target>Estimations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4319</context>
+          <context context-type="linenumber">4326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
@@ -15791,7 +15871,7 @@
         <target>réponses valides</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
@@ -15799,7 +15879,7 @@
         <target>Moyenne</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4327</context>
+          <context context-type="linenumber">4334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
@@ -15807,7 +15887,7 @@
         <target>Moyenne de toutes les estimations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4329</context>
+          <context context-type="linenumber">4336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
@@ -15815,7 +15895,7 @@
         <target>Médiane</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4335</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
@@ -15823,7 +15903,7 @@
         <target>Valeur centrale triée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4337</context>
+          <context context-type="linenumber">4344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
@@ -15831,7 +15911,7 @@
         <target>Dispersion</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4343</context>
+          <context context-type="linenumber">4350</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
@@ -15839,7 +15919,7 @@
         <target>Écart type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4345</context>
+          <context context-type="linenumber">4352</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
@@ -15847,7 +15927,7 @@
         <target>50 % centraux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4351</context>
+          <context context-type="linenumber">4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -15862,7 +15942,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4356,4359</context>
+          <context context-type="linenumber">4363,4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
@@ -15870,7 +15950,7 @@
         <target>Étendue</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4365</context>
+          <context context-type="linenumber">4372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
@@ -15878,7 +15958,7 @@
         <target>de la plus petite à la plus grande estimation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4370</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
@@ -15886,7 +15966,7 @@
         <target>Dans l’intervalle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4376</context>
+          <context context-type="linenumber">4383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -15902,7 +15982,7 @@
         )"/>% accepté</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4382,4386</context>
+          <context context-type="linenumber">4389,4393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
@@ -15910,7 +15990,7 @@
         <target>Distance moy.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4392</context>
+          <context context-type="linenumber">4399</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
@@ -15918,7 +15998,7 @@
         <target>à la référence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394</context>
+          <context context-type="linenumber">4401</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
@@ -15926,7 +16006,7 @@
         <target>Médian</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4402</context>
+          <context context-type="linenumber">4409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
@@ -15934,7 +16014,7 @@
         <target>Moyenne</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4405</context>
+          <context context-type="linenumber">4412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
@@ -15942,7 +16022,7 @@
         <target>Estimations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4407</context>
+          <context context-type="linenumber">4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -15958,7 +16038,7 @@
     )"/> % dans la plage acceptée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4438,4442</context>
+          <context context-type="linenumber">4445,4449</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
@@ -15966,7 +16046,7 @@
         <target>Distance moyenne à la référence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4456</context>
+          <context context-type="linenumber">4463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
@@ -15974,7 +16054,7 @@
         <target>plus proche de la valeur de référence</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4470</context>
+          <context context-type="linenumber">4477</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
@@ -15982,7 +16062,7 @@
         <target>Changement médian</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4487</context>
+          <context context-type="linenumber">4494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
@@ -15990,7 +16070,7 @@
         <target>Changement moyen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4488</context>
+          <context context-type="linenumber">4495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -16005,7 +16085,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4499,4502</context>
+          <context context-type="linenumber">4506,4509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -16020,7 +16100,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4511</context>
+          <context context-type="linenumber">4515,4518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -16036,7 +16116,7 @@
         )"/> points de pourcentage</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520,4524</context>
+          <context context-type="linenumber">4527,4531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -16060,7 +16140,7 @@
           )"/> estimations comparables se sont améliorées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4540,4548</context>
+          <context context-type="linenumber">4547,4555</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -16084,7 +16164,7 @@
           )"/> estimations comparables sont plus éloignées.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4552,4560</context>
+          <context context-type="linenumber">4559,4567</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
@@ -16092,7 +16172,7 @@
         <target>Le tour 2 est mitigé : les estimations plus proches et plus lointaines sont équilibrées dans la comparaison des paires.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4564</context>
+          <context context-type="linenumber">4571</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -16106,7 +16186,7 @@
           )"/> au tour 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4576,4579</context>
+          <context context-type="linenumber">4583,4586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -16120,7 +16200,7 @@
           )"/> plus grande au tour 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4583,4586</context>
+          <context context-type="linenumber">4590,4593</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -16136,7 +16216,7 @@
         )"/> points de pourcentage.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4598,4602</context>
+          <context context-type="linenumber">4605,4609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -16160,7 +16240,7 @@
         )"/> estimations se situent dans la bande de tolérance.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4617,4625</context>
+          <context context-type="linenumber">4624,4632</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -16174,7 +16254,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4630,4633</context>
+          <context context-type="linenumber">4637,4640</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -16188,7 +16268,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4637,4640</context>
+          <context context-type="linenumber">4644,4647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
@@ -16196,7 +16276,7 @@
         <target>Quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4686</context>
+          <context context-type="linenumber">4693</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16208,7 +16288,7 @@
         <target>Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4688</context>
+          <context context-type="linenumber">4695</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16220,11 +16300,11 @@
         <target><x id="count" equiv-text="this.qaUnseenCount()"/> nouvelle(s)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4696</context>
+          <context context-type="linenumber">4703</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4713</context>
+          <context context-type="linenumber">4720</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelInactive" datatype="html">
@@ -16232,7 +16312,7 @@
         <target>Désactivé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4813</context>
+          <context context-type="linenumber">4820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelClosed" datatype="html">
@@ -16240,7 +16320,7 @@
         <target>Fermé</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4816</context>
+          <context context-type="linenumber">4823</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16252,7 +16332,7 @@
         <target>Question de <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16264,7 +16344,7 @@
         <target>Question du public</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16276,7 +16356,7 @@
         <target>Désélectionner <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4879</context>
+          <context context-type="linenumber">4886</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16292,7 +16372,7 @@
         <target>Mettez en surbrillance toutes les questions de <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4880</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16308,7 +16388,7 @@
         <target>En cours de réponse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4909</context>
+          <context context-type="linenumber">4916</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16320,7 +16400,7 @@
         <target>Ouverte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4911</context>
+          <context context-type="linenumber">4918</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16332,7 +16412,7 @@
         <target>En attente de validation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4913</context>
+          <context context-type="linenumber">4920</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16344,7 +16424,7 @@
         <target>Répondue</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4915</context>
+          <context context-type="linenumber">4922</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16356,7 +16436,7 @@
         <target>Supprimée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4917</context>
+          <context context-type="linenumber">4924</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16368,7 +16448,7 @@
         <target>Valider</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5018</context>
+          <context context-type="linenumber">5025</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
@@ -16376,7 +16456,7 @@
         <target>Mettre en avant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5020</context>
+          <context context-type="linenumber">5027</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
@@ -16384,7 +16464,7 @@
         <target>Retirer la mise en avant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5022</context>
+          <context context-type="linenumber">5029</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
@@ -16392,7 +16472,7 @@
         <target>Archiver</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5024</context>
+          <context context-type="linenumber">5031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
@@ -16400,7 +16480,7 @@
         <target>Supprimer définitivement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5027</context>
+          <context context-type="linenumber">5034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
@@ -16408,7 +16488,7 @@
         <target>Supprimer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5028</context>
+          <context context-type="linenumber">5035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
@@ -16416,7 +16496,7 @@
         <target>Fermer le canal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5372</context>
+          <context context-type="linenumber">5379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
@@ -16424,7 +16504,7 @@
         <target>Rouvrir le canal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5373</context>
+          <context context-type="linenumber">5380</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
@@ -16432,7 +16512,7 @@
         <target>Pré-modération activée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5787</context>
+          <context context-type="linenumber">5794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
@@ -16440,7 +16520,7 @@
         <target>Pré-modération désactivée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5788</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
@@ -16448,7 +16528,7 @@
         <target>Question validée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5821</context>
+          <context context-type="linenumber">5828</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
@@ -16456,7 +16536,7 @@
         <target>Question mise en avant.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5823</context>
+          <context context-type="linenumber">5830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
@@ -16464,7 +16544,7 @@
         <target>Question archivée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5825</context>
+          <context context-type="linenumber">5832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
@@ -16472,7 +16552,7 @@
         <target>Question supprimée.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5826</context>
+          <context context-type="linenumber">5833</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
@@ -16480,7 +16560,7 @@
         <target>Le délai personnel ×10 ouvert de cette personne se termine immédiatement.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5927</context>
+          <context context-type="linenumber">5934</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
@@ -16488,11 +16568,11 @@
         <target>Ensuite, aucune autre réponse n’est possible.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5928</context>
+          <context context-type="linenumber">5935</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5932</context>
+          <context context-type="linenumber">5939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
@@ -16500,7 +16580,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> délais personnels ×10 ouverts se terminent immédiatement.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5931</context>
+          <context context-type="linenumber">5938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
@@ -16508,7 +16588,7 @@
         <target>Terminer les délais personnels ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5936</context>
+          <context context-type="linenumber">5943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
@@ -16516,7 +16596,7 @@
         <target>Tu lances la phase de discussion alors que des minuteurs personnels sont encore en cours.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5939</context>
+          <context context-type="linenumber">5946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
@@ -16524,7 +16604,7 @@
         <target>Tu affiches le résultat alors que des minuteurs personnels sont encore en cours.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5940</context>
+          <context context-type="linenumber">5947</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
@@ -16532,7 +16612,7 @@
         <target>Publier quand même</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5942</context>
+          <context context-type="linenumber">5949</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
@@ -16540,7 +16620,7 @@
         <target>Continuer d’attendre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5943</context>
+          <context context-type="linenumber">5950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
@@ -16548,7 +16628,7 @@
         <target>N° question;Texte;Type;Participants;Cycle d’agrégation;Ø Points;Autoévaluation n;Solidifié;Risque d’idée fausse;Fragile;Lacune reconnue;Indécis;Réponse fausse la plus fréquente avec forte certitude;Détails</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6089</context>
+          <context context-type="linenumber">6096</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
@@ -16556,7 +16636,7 @@
         <target>Niveau d&apos;apprentissage et autoévaluation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6143</context>
+          <context context-type="linenumber">6150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
@@ -16564,7 +16644,7 @@
         <target>Réponses valides;Questions évaluées;Non agrégées (&lt;5 réponses avec autoévaluation);Consolidé;Risque de fausse conception;Fragile;Lacune détectée;Indécis</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
@@ -16572,7 +16652,7 @@
         <target>Classement des équipes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6167</context>
+          <context context-type="linenumber">6174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
@@ -16580,7 +16660,7 @@
         <target>Rang;Équipe;Couleur;Membres;Points de l&apos;équipe;Points moyens par membre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6169</context>
+          <context context-type="linenumber">6176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
@@ -16588,7 +16668,7 @@
         <target>Codes bonus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6187</context>
+          <context context-type="linenumber">6194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
@@ -16596,7 +16676,7 @@
         <target>Rang;Pseudonyme;Code;Points;Généré le</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6189</context>
+          <context context-type="linenumber">6196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
@@ -16604,7 +16684,7 @@
         <target>Résultat CSV exporté.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6197</context>
+          <context context-type="linenumber">6204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
@@ -16612,7 +16692,7 @@
         <target>Voir le plan de débriefing en PDF – 1 question à débriefer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6209</context>
+          <context context-type="linenumber">6216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
@@ -16620,7 +16700,7 @@
         <target>Voir le plan de débriefing en PDF – <x id="count" equiv-text="count"/> questions à débriefer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6212</context>
+          <context context-type="linenumber">6219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
@@ -16628,7 +16708,7 @@
         <target>Voir le plan de débriefing en PDF</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6214</context>
+          <context context-type="linenumber">6221</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
@@ -16636,7 +16716,7 @@
         <target>1 question recommandée pour le débriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6219</context>
+          <context context-type="linenumber">6226</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
@@ -16644,7 +16724,7 @@
         <target><x id="count" equiv-text="count"/> questions recommandées pour le débriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6221</context>
+          <context context-type="linenumber">6228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
@@ -16652,7 +16732,7 @@
         <target>Le PDF est créé (<x id="PH" equiv-text="exportData.questions.length"/> questions)…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6233</context>
+          <context context-type="linenumber">6240</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
@@ -16660,7 +16740,7 @@
         <target>Résultats PDF téléchargés.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6239</context>
+          <context context-type="linenumber">6246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
@@ -16668,7 +16748,7 @@
         <target>Résultat PDF ouvert pour enregistrement.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6240</context>
+          <context context-type="linenumber">6247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
@@ -16676,7 +16756,7 @@
         <target>N°;ID de question;Statut;Question;Score;Votes positifs;Votes négatifs;Votes au total;Score de Wilson;Score de controverse;Controversée;Créée le</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6267</context>
+          <context context-type="linenumber">6274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
@@ -16684,7 +16764,7 @@
         <target>CSV Q&amp;A exporté.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6290</context>
+          <context context-type="linenumber">6297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
@@ -16692,11 +16772,11 @@
         <target>Question <x id="questionNumber" equiv-text="data.questionOrder + 1"/> : <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6453</context>
+          <context context-type="linenumber">6460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6461</context>
+          <context context-type="linenumber">6468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16712,7 +16792,7 @@
         <target>Le texte gratuit en direct est mis à jour.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6456</context>
+          <context context-type="linenumber">6463</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16724,7 +16804,7 @@
         <target>La question actuelle n&apos;est pas une question à texte libre.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6464</context>
+          <context context-type="linenumber">6471</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16736,7 +16816,7 @@
         <target>Pas encore de question active.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6467</context>
+          <context context-type="linenumber">6474</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16748,7 +16828,7 @@
         <target>Impossible de charger les réponses libres en direct.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6471</context>
+          <context context-type="linenumber">6478</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -20289,6 +20369,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/countdown-fingers/countdown-fingers.component.ts</context>
           <context context-type="linenumber">126</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="infoLanding.openInNewTab" datatype="html">
+        <source>öffnet in neuem Tab</source>
+        <target>s’ouvre dans un nouvel onglet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/info-landing-link/info-landing-link.component.ts</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="markdown.copyCode" datatype="html">

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -110,12 +110,28 @@
           <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.infoLandingAria" datatype="html">
+        <source>Was arsnova.eu kann (öffnet in neuem Tab)</source>
+        <target>Cosa offre arsnova.eu (si apre in una nuova scheda)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">188</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.infoLanding" datatype="html">
+        <source>Was arsnova.eu kann</source>
+        <target>Cosa offre arsnova.eu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">192</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <target>Note legali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
@@ -123,7 +139,7 @@
         <target>Privacy</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">188</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">
@@ -131,7 +147,7 @@
         <target>Accessibilità</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibility" datatype="html">
@@ -139,7 +155,7 @@
         <target>Accessibilità</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7981911571029514989" datatype="html">
@@ -147,7 +163,7 @@
         <target>Ora ancora più veloce e fluido!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1136696335453039978" datatype="html">
@@ -155,7 +171,7 @@
         <target>Preset: Professionale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6151253518820826531" datatype="html">
@@ -163,7 +179,7 @@
         <target>Preset: Ludico</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2911090466936872230" datatype="html">
@@ -171,7 +187,7 @@
         <target>Collegare…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/feedback/feedback-host.component.html</context>
@@ -187,7 +203,7 @@
         <target>Riprova</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAria" datatype="html">
@@ -195,7 +211,7 @@
         <target>Apri l&apos;archivio delle notizie</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
@@ -203,7 +219,7 @@
         <target>Apri archivio notizie, un messaggio non letto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
@@ -211,7 +227,7 @@
         <target>Apri archivio notizie, <x id="INTERPOLATION" equiv-text="{{ n }}"/> messaggi non letti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">227</context>
+          <context context-type="linenumber">230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.notFound" datatype="html">
@@ -1899,7 +1915,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">402</context>
+          <context context-type="linenumber">410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -1939,7 +1955,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">397</context>
+          <context context-type="linenumber">405</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -4876,7 +4892,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4690</context>
+          <context context-type="linenumber">4697</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -4928,7 +4944,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3633</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -5370,7 +5386,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1899</context>
+          <context context-type="linenumber">1906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -5382,7 +5398,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1904</context>
+          <context context-type="linenumber">1911</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -5406,7 +5422,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -5418,7 +5434,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -6225,12 +6241,28 @@
           <context context-type="linenumber">56,61</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.infoLandingTitle" datatype="html">
+        <source> Mehr zu Nutzen und Hintergründen</source>
+        <target>Di più su vantaggi e contesto</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">63,65</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingBody" datatype="html">
+        <source> Auf der Informationsseite findest du Einsatzmöglichkeiten, Hinweise zu Datenschutz und Barrierefreiheit sowie die Abgrenzung zu anderen Audience-Response-Systemen.</source>
+        <target>Nella pagina informativa trovi ambiti di utilizzo, indicazioni su privacy e accessibilità e il confronto con altri sistemi di audience response.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66,69</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.formatsTitle" datatype="html">
         <source> Frageformate: passend zum didaktischen Ziel</source>
         <target>Formati di domanda: quello giusto per il tuo obiettivo didattico</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">78,80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsLead" datatype="html">
@@ -6238,7 +6270,7 @@
         <target>Scegli il formato in base alla situazione in aula: vuoi verificare conoscenze, rendere visibili opinioni, raccogliere concetti o discutere stime? I formati sono volutamente separati, così visualizzazione, valutazione e moderazione restano coerenti con lo scopo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">81,85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsGridAria" datatype="html">
@@ -6246,7 +6278,7 @@
         <target>Formati di domande quiz disponibili</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
@@ -6254,7 +6286,7 @@
         <target>Single Choice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTag" datatype="html">
@@ -6262,7 +6294,7 @@
         <target>una sola opzione corretta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
+          <context context-type="linenumber">97,99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceBody" datatype="html">
@@ -6270,7 +6302,7 @@
         <target>Per controlli di comprensione puntuali: una risposta è corretta, risultato e punti sono subito chiari.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
+          <context context-type="linenumber">100,103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
@@ -6278,7 +6310,7 @@
         <target>Multiple Choice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
@@ -6286,7 +6318,7 @@
         <target>più opzioni corrette</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
@@ -6294,7 +6326,7 @@
         <target>Per concetti più complessi, false credenze tipiche o domande come “Quali affermazioni sono corrette?” — possono contare più risposte.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
+          <context context-type="linenumber">113,116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTitle" datatype="html">
@@ -6302,7 +6334,7 @@
         <target>Risposta breve</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTag" datatype="html">
@@ -6310,7 +6342,7 @@
         <target>soluzione modello, non scelta guidata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
+          <context context-type="linenumber">123,125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextBody" datatype="html">
@@ -6318,7 +6350,7 @@
         <target>Le persone partecipanti rispondono brevemente con parole proprie. Tu inserisci soluzioni modello; arsnova.eu può valutare varianti di scrittura, tolleranze e, se serve, numeri o unità.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
+          <context context-type="linenumber">126,129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTitle" datatype="html">
@@ -6326,7 +6358,7 @@
         <target>Testo libero</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">135</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTag" datatype="html">
@@ -6334,7 +6366,7 @@
         <target>risposte aperte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
+          <context context-type="linenumber">136,138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextBody" datatype="html">
@@ -6342,7 +6374,7 @@
         <target>Per idee, riflessioni e aspettative. Nessuna valutazione automatica; le risposte possono essere raccolte e mostrate come nuvola di parole.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
+          <context context-type="linenumber">139,142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTitle" datatype="html">
@@ -6350,7 +6382,7 @@
         <target>Sondaggio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTag" datatype="html">
@@ -6358,7 +6390,7 @@
         <target>quadro d’opinione senza giusto/sbagliato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
+          <context context-type="linenumber">149,151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyBody" datatype="html">
@@ -6366,7 +6398,7 @@
         <target>Per priorità, conoscenze pregresse o decisioni in aula. Le opzioni vengono conteggiate senza logica di punteggio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
+          <context context-type="linenumber">152,155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTitle" datatype="html">
@@ -6374,7 +6406,7 @@
         <target>Scala di valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTag" datatype="html">
@@ -6382,7 +6414,7 @@
         <target>scala con estremi personalizzati</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
+          <context context-type="linenumber">162,164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingBody" datatype="html">
@@ -6390,7 +6422,7 @@
         <target>Per accordo, sicurezza, ritmo o feedback da basso ad alto, anche con estremi nominati.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
+          <context context-type="linenumber">165,168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
@@ -6398,7 +6430,7 @@
         <target>Domanda di stima numerica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTag" datatype="html">
@@ -6406,7 +6438,7 @@
         <target>stimare numeri, vedere la dispersione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
+          <context context-type="linenumber">175,177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateBody" datatype="html">
@@ -6414,7 +6446,7 @@
         <target>Per anni, ordini di grandezza, misure e probabilità. Con valore di riferimento, banda di tolleranza, istogramma, statistiche e secondo turno opzionale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
+          <context context-type="linenumber">178,181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsBlitzNote" datatype="html">
@@ -6422,7 +6454,7 @@
         <target>Il sondaggio rapido è separato da questi formati: serve per feedback live spontanei quando non vuoi costruire una domanda quiz completa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
+          <context context-type="linenumber">185,188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceTitle" datatype="html">
@@ -6430,7 +6462,7 @@
         <target>Autovalutazione per domande valutabili</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
+          <context context-type="linenumber">192,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceLead" datatype="html">
@@ -6438,7 +6470,7 @@
         <target>L&apos;autovalutazione non è un tipo di domanda separato, ma una domanda aggiuntiva facoltativa in base alla domanda a scelta singola, a scelta multipla, a risposta breve e con stima numerica: i partecipanti indicano quanto sono sicuri della loro risposta (scala 1–5). Ciò non influisce su nessun punto, ma ti aiuta a riconoscere il tuo livello di apprendimento e le tue idee sbagliate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
+          <context context-type="linenumber">195,200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceListAria" datatype="html">
@@ -6446,7 +6478,7 @@
         <target>Funzioni didattiche di autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
@@ -6454,7 +6486,7 @@
         <target>Dopo la risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
@@ -6462,7 +6494,7 @@
         <target>Divulgazione progressiva: prima seleziona o inserisci la risposta, poi l&apos;autovalutazione. Durante la votazione nessuno vede i valori aggregati degli altri.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
+          <context context-type="linenumber">210,214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorTitle" datatype="html">
@@ -6470,7 +6502,7 @@
         <target>Configura nell&apos;editor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorBody" datatype="html">
@@ -6478,7 +6510,7 @@
         <target>Attiva/disattiva per domanda, etichette opzionali per confidenza della risposta bassa e alta e un&apos;anteprima in tempo reale della scala. L&apos;autovalutazione è attiva di default per le nuove domande valutabili.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
+          <context context-type="linenumber">221,225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostTitle" datatype="html">
@@ -6486,7 +6518,7 @@
         <target>Valutazione host dopo la pubblicazione dei risultati</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostBody" datatype="html">
@@ -6494,7 +6526,7 @@
         <target>Matrice di correttezza e sicurezza nella risposta con evidenziazione delle risposte <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>sicure ma sbagliate<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Nelle domande a scelta vedi quali opzioni errate sono state scelte con alta sicurezza nella risposta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">232,236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportTitle" datatype="html">
@@ -6502,7 +6534,7 @@
         <target>Completamento ed esportazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportBody" datatype="html">
@@ -6510,7 +6542,7 @@
         <target> Alla fine della sessione, la valutazione riassume le conoscenze consolidate, il rischio di concetti errati e le conoscenze fragili. Le domande con meno di 5 risposte con autovalutazione non vengono mostrate in forma aggregata. Il piano di debriefing (PDF) è il formato consigliato; il CSV è disponibile sotto «Altro» per Excel. Nella raccolta quiz trovi il piano di debriefing sulla scheda del quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">243,249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTitle" datatype="html">
@@ -6518,7 +6550,7 @@
         <target>Quiz dimostrativo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">256</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoCardHint" datatype="html">
@@ -6526,7 +6558,7 @@
         <target>Un quiz di esempio preinstallato mostra i formati di domanda in momenti didattici concreti: verifica rapida, nuvola di parole, risposta breve, stima, scala di valutazione, autovalutazione, formule e Markdown. Lo trovi nella tua raccolta quiz e puoi aprirlo in anteprima.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTip" datatype="html">
@@ -6534,7 +6566,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Suggerimento:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> apri una volta l’anteprima su un secondo dispositivo prima della prima sessione live. Vedrai subito come lavorano insieme vista host e schermo dei partecipanti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">264,267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstartTitle" datatype="html">
@@ -6542,7 +6574,7 @@
         <target>Avvio rapido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart1" datatype="html">
@@ -6550,7 +6582,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Crea quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> scegli “Apri raccolta quiz”, crea un nuovo quiz e scegli il formato giusto per ogni domanda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
+          <context context-type="linenumber">274,276</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart2" datatype="html">
@@ -6558,7 +6590,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Avvia evento:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> imposta stile, timer, team e classifica. Poi viene creato un codice a 6 caratteri, da condividere come testo o QR code.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
+          <context context-type="linenumber">278,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart3" datatype="html">
@@ -6566,7 +6598,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Modera live:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> mostra la domanda, avvia la fase di risposta, pubblica o trattieni i risultati e aggiungi un secondo turno quando è utile.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
+          <context context-type="linenumber">282,284</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostTitle" datatype="html">
@@ -6574,7 +6606,7 @@
         <target>Guida l&apos;evento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
+          <context context-type="linenumber">289</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLead" datatype="html">
@@ -6582,7 +6614,7 @@
         <target>Nella vista host guidi la sessione come una piccola regia: fai entrare i partecipanti, pubblichi i contenuti, apri la discussione e rendi visibili i risultati.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
+          <context context-type="linenumber">290,294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostStartStep" datatype="html">
@@ -6590,7 +6622,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Avvia sessione:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> dalla tua raccolta quiz avvia un evento e scegli se iniziare con quiz o Q&amp;A. A quel punto viene creato il codice di accesso.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
+          <context context-type="linenumber">297,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLobby" datatype="html">
@@ -6598,7 +6630,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Vedi chi si è iscritto; verrà visualizzato un codice QR per partecipare.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
+          <context context-type="linenumber">301,303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostBeamer" datatype="html">
@@ -6606,7 +6638,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vista proiettore e presentatore:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> domanda, risposte, conto alla rovescia e risultati sono abbastanza grandi per proiezione, streaming o secondo schermo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSteuerung" datatype="html">
@@ -6614,7 +6646,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Controlli:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> usa “Domanda successiva” per portare il contenuto sullo schermo. Puoi iniziare con una fase di lettura, poi aprire la fase di risposta e decidere quando mostrare il risultato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
+          <context context-type="linenumber">309,312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPeer" datatype="html">
@@ -6622,7 +6654,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (doppi turni):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> per domande quiz adatte, domande di stima e sondaggi rapidi: prima si vota, poi si discute, quindi si vota di nuovo. Il confronto prima/dopo rende visibile il progresso di apprendimento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
+          <context context-type="linenumber">314,317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSettings" datatype="html">
@@ -6630,7 +6662,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Impostazioni:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> all’avvio scegli stile e opzioni: serio o giocoso, con o senza classifica, audio, fase di lettura, modalità team, nickname e timer.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
+          <context context-type="linenumber">319,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallTitle" datatype="html">
@@ -6638,7 +6670,7 @@
         <target> Bacheca delle domande nel canale live Q&amp;A </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
+          <context context-type="linenumber">327,329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLead" datatype="html">
@@ -6646,7 +6678,7 @@
         <target> Il Q&amp;A non deve perdersi in una chat laterale. La bacheca delle domande rende gli interventi visibili, prioritizzabili e moderabili: mantieni il filo della sessione mentre il gruppo segnala insieme quali punti hanno davvero bisogno di chiarimento. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
+          <context context-type="linenumber">330,334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallListAria" datatype="html">
@@ -6654,7 +6686,7 @@
         <target>Funzioni didattiche della bacheca Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
+          <context context-type="linenumber">338</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationTitle" datatype="html">
@@ -6662,7 +6694,7 @@
         <target> Moderazione con ritmo didattico </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">343</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationBody" datatype="html">
@@ -6670,7 +6702,7 @@
         <target> Se serve, le nuove domande attendono prima la tua approvazione. Puoi approvare, mettere in evidenza, archiviare o rimuovere i contributi e governare clima, rilevanza e tempi: rispondere subito, raccogliere per dopo o aprire una traccia di discussione. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
+          <context context-type="linenumber">344,349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingTitle" datatype="html">
@@ -6678,7 +6710,7 @@
         <target> Upvote e downvote collettivi </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingBody" datatype="html">
@@ -6686,7 +6718,7 @@
         <target> Partecipanti pesano insieme le domande. Voti positivi e negativi mostrano non solo popolarità, ma anche incertezza, dissenso e bisogno di chiarimento; ordinamenti come “più supportate”, “migliori domande” e “controverse” ti aiutano a usare il tempo live dove ha più senso didattico. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
+          <context context-type="linenumber">356,361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
@@ -6694,7 +6726,7 @@
         <target> Word cloud Q&amp;A a livello di temi </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
+          <context context-type="linenumber">367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudBody" datatype="html">
@@ -6702,7 +6734,7 @@
         <target> La word cloud condensa le domande visibili in parole e frasi, pesate per supporto, consenso robusto o controversia. Può essere congelata, letta secondo la logica di ordinamento e mostrata nella vista presentatore: una lettura rapida dei cluster tematici, non una lista decorativa di parole. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
+          <context context-type="linenumber">368,373</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmTitle" datatype="html">
@@ -6710,7 +6742,7 @@
         <target>Prossimo passo: bussola di moderazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
+          <context context-type="linenumber">379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmBody" datatype="html">
@@ -6718,7 +6750,7 @@
         <target> Prima è prevista una bussola di moderazione deterministica. In seguito si potranno aggiungere in modo opzionale segnali Q&amp;A NLP asincroni e riepiloghi collegati alle fonti, come supporto alla moderazione attento ai dati invece di una valutazione black box. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
+          <context context-type="linenumber">380,384</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.blitzTitle" datatype="html">
@@ -6726,7 +6758,7 @@
         <target>Sondaggio rapido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
+          <context context-type="linenumber">391</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackIntro" datatype="html">
@@ -6734,7 +6766,7 @@
         <target>Sondaggi rapidi su clima e comprensione, prima della pausa, in apertura o per una verifica al volo. Disponibili nell’area host della sessione live o direttamente dalla pagina iniziale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
+          <context context-type="linenumber">392,396</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfMood" datatype="html">
@@ -6742,7 +6774,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Immagine dell&apos;atmosfera<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): Come stanno i partecipanti?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
+          <context context-type="linenumber">399,400</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfYesNoMaybe" datatype="html">
@@ -6750,7 +6782,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sì/No/Forse<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): richiesta rapida di consenso.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
+          <context context-type="linenumber">402,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackYesNo" datatype="html">
@@ -6758,7 +6790,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sì / No<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): domanda binaria chiara, senza via di mezzo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">405,406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
@@ -6766,7 +6798,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vero / Falso / Non lo so<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): per valutazioni rapide o brevi verifiche di conoscenza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
+          <context context-type="linenumber">408,410</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
@@ -6774,7 +6806,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sondaggi rapidi in più fasi<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A-D): tre o quattro opzioni fisse per la votazione spontanea, senza creare una domanda del quiz completa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
+          <context context-type="linenumber">412,414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTempo" datatype="html">
@@ -6782,7 +6814,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Feedback sul ritmo<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): con quattro icone il gruppo indica continuamente se riesce a seguire. Le persone partecipanti possono cambiare risposta; tu vedi solo la tendenza aggregata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">416,419</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
@@ -6790,7 +6822,7 @@
         <target>Avvii il turno dalla vista host della tua sessione live oppure direttamente dalla scheda «Sondaggio rapido» («In diretta con un clic») nella pagina iniziale. Le persone partecipanti votano con un tocco e tu vedi i risultati in tempo reale come grafico a barre.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">421,425</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfPeer" datatype="html">
@@ -6798,7 +6830,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Peer Instruction (doppi turni):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Primo turno - Non risolvere il risultato - Inizia la "fase di discussione" ("Discuti con il tuo vicino") - "Secondo voto". Il confronto prima/dopo mostra come cambia l’immagine dell’atmosfera grazie allo scambio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">428,432</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfStop" datatype="html">
@@ -6806,7 +6838,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Interrompi:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Blocca la votazione: i partecipanti vedono &quot;La votazione è in pausa&quot; e non possono più votare finché non scegli &quot;Riprendi&quot;.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">434,436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfReset" datatype="html">
@@ -6814,7 +6846,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Reimposta:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Elimina tutti i voti e lascia che votino di nuovo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">438,439</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfNewRound" datatype="html">
@@ -6822,7 +6854,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Nuovo round:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Genera un nuovo codice e inizia un nuovo round.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">441,442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfCopyLink" datatype="html">
@@ -6830,7 +6862,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Copia link:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Copia il link di unione negli appunti, ad es. per la condivisione tramite chat.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">444,446</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsTitle" datatype="html">
@@ -6838,7 +6870,7 @@
         <target>Per i tuoi partecipanti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsLead" datatype="html">
@@ -6846,7 +6878,7 @@
         <target>In breve: cosa puoi condividere durante il tuo evento:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">452,454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsJoin" datatype="html">
@@ -6854,7 +6886,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Entrare:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Inserisci il codice a 6 cifre su arsnova.eu e «Si parte» — vale per quiz, Q&amp;A e sondaggio rapido. Nessuna registrazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">457,459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsNick" datatype="html">
@@ -6862,7 +6894,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Soprannomi:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> A seconda delle tue impostazioni, nomi predefiniti, il tuo nome o anonimo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">461,463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsVote" datatype="html">
@@ -6870,7 +6902,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Vota:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> La domanda appare sul dispositivo; scegli la risposta e invia. Se l'autovalutazione è attiva, segue la scala 1–5. Con limite di tempo, parte un conto alla rovescia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">465,468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTitle" datatype="html">
@@ -6878,7 +6910,7 @@
         <target>La tua raccolta quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionLead" datatype="html">
@@ -6886,7 +6918,7 @@
         <target>Qui crei e prepari i tuoi quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionEditor" datatype="html">
@@ -6894,7 +6926,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ordina le domande utilizzando il trascinamento della selezione, espandi e comprimi, controlla l'anteprima.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">477,479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTypes" datatype="html">
@@ -6902,7 +6934,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Tipi di domanda:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single choice, multiple choice, risposta breve, testo libero, sondaggio, scala di valutazione e domanda di stima numerica — ogni domanda può includere timer, difficoltà e autovalutazione opzionali.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">481,484</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionImport" datatype="html">
@@ -6910,7 +6942,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Import / esportazione:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Importa o esporta quiz come JSON. Con i modelli di generazione e verifica puoi creare quiz di qualità con il tuo strumento IA preferito, verificarli e importarli direttamente. Contenuti e presentazioni non vengono inviati ad arsnova.eu; usi il tuo strumento IA.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">486,490</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionSync" datatype="html">
@@ -6918,7 +6950,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Sincronizzazione:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Usa il link sync per condividere la tua raccolta quiz o per continuare su altri dispositivi. Chiunque abbia il link può aprire la raccolta. I dati del dispositivo servono solo per orientarti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">492,495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoQuizHint" datatype="html">
@@ -6926,7 +6958,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Quiz dimostrativo:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> un quiz preinstallato mostra tutti i formati con esempi, incluse formule KaTeX e Markdown. Aprilo in anteprima dalla raccolta quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">497,500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesTitle" datatype="html">
@@ -6934,7 +6966,7 @@
         <target>Serio e giocoso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesLead" datatype="html">
@@ -6942,7 +6974,7 @@
         <target>Due stili per situazioni diverse: selezionabili sulla home page e all&apos;inizio della sessione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">506,509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.styleSerious" datatype="html">
@@ -6950,7 +6982,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Serio:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonimo, senza classifiche - ideale per valutazioni formative, preparazione agli esami e argomenti delicati.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">512,514</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylePlayful" datatype="html">
@@ -6958,7 +6990,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Giocoso:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Con classifica, suoni e messaggi di incoraggiamento – ideale per alleggerire l’atmosfera, competizioni e quiz motivanti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">516,518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesOptions" datatype="html">
@@ -6966,7 +6998,7 @@
         <target>Tutte le opzioni (classifica, suono, fase di lettura, squadra, bonus) possono essere attivate e disattivate individualmente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">520,523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTitle" datatype="html">
@@ -6974,7 +7006,7 @@
         <target>Più funzionalità</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreBonus" datatype="html">
@@ -6982,7 +7014,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Codici bonus:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> I primi classificati ricevono un codice riscattabile (ad esempio per punti bonus). Vedi l'elenco dei codici; I dati personali non vengono memorizzati.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">530,533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTeams" datatype="html">
@@ -6990,7 +7022,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Modalità squadra:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> I tuoi partecipanti giocano in squadre con la propria classifica di squadra, ad es. per le gare collettive nei seminari.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">535,537</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreGamification" datatype="html">
@@ -6998,7 +7030,7 @@
         <target><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Effetti sonori, effetti di ricompensa per i primi posti, messaggi motivazionali - in modalità giocosa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">539,541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyTitle" datatype="html">
@@ -7006,7 +7038,7 @@
         <target>Protezione dei dati e tecnologia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyBody" datatype="html">
@@ -7014,7 +7046,15 @@
         <target>arsnova.eu è gratuito, open source e destinato all&apos;uso nelle scuole, nelle università e nell&apos;istruzione superiore, con particolare attenzione alla protezione dei dati (GDPR). Il contenuto del quiz viene salvato localmente nel browser. Non è necessaria alcuna registrazione, né per te né per i tuoi partecipanti. Può essere installato come app (PWA) – ad es. B. per un avvio più rapido sullo smartphone. Interfaccia in tedesco, inglese, francese, spagnolo e italiano.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">547,553</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingLink" datatype="html">
+        <source>Hintergründe und Einsatzmöglichkeiten</source>
+        <target>Contesto e ambiti di utilizzo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.ts</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">
@@ -7098,11 +7138,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">408</context>
+          <context context-type="linenumber">416</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">864</context>
+          <context context-type="linenumber">872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -7138,11 +7178,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">409</context>
+          <context context-type="linenumber">417</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">865</context>
+          <context context-type="linenumber">873</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -7410,7 +7450,7 @@
         <target>Condividi con altri o usa la stessa raccolta su un secondo dispositivo:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">447,449</context>
+          <context context-type="linenumber">453,455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareAria" datatype="html">
@@ -7418,7 +7458,7 @@
         <target>Mostra link di sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">456</context>
+          <context context-type="linenumber">462</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareLink" datatype="html">
@@ -7426,7 +7466,7 @@
         <target>Mostra link di sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">459</context>
+          <context context-type="linenumber">465</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncOpenHint" datatype="html">
@@ -7434,7 +7474,7 @@
         <target>Incolla qui il link di sync ricevuto:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">465,467</context>
+          <context context-type="linenumber">471,473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkLabel" datatype="html">
@@ -7442,7 +7482,7 @@
         <target>Link di sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkPlaceholder" datatype="html">
@@ -7450,7 +7490,7 @@
         <target>sync-room-12345678</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">483</context>
+          <context context-type="linenumber">489</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkInputAria" datatype="html">
@@ -7458,7 +7498,7 @@
         <target>Inserisci link di sync</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">489</context>
+          <context context-type="linenumber">495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkSubmit" datatype="html">
@@ -7466,7 +7506,7 @@
         <target>Apri</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">497,499</context>
+          <context context-type="linenumber">503,505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkedHintWithOrigin" datatype="html">
@@ -7474,7 +7514,7 @@
         <target>I quiz sono condivisi con <x id="INTERPOLATION" equiv-text="{{ originSummary }}"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">513,515</context>
+          <context context-type="linenumber">519,521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkCta" datatype="html">
@@ -7482,7 +7522,7 @@
         <target>Scollega</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayTitle" datatype="html">
@@ -7490,7 +7530,7 @@
         <target>Notizie attuali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">567,569</context>
+          <context context-type="linenumber">573,575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayCloseAria" datatype="html">
@@ -7498,7 +7538,7 @@
         <target>Chiudi il messaggio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">585</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.ack" datatype="html">
@@ -7506,7 +7546,7 @@
         <target>Va bene!</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">593,595</context>
+          <context context-type="linenumber">599,601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbGroupAria" datatype="html">
@@ -7514,7 +7554,7 @@
         <target>Valuta il messaggio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">599</context>
+          <context context-type="linenumber">605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpTooltip" datatype="html">
@@ -7522,7 +7562,7 @@
         <target>Utile — tocca di nuovo per annullare il voto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">609</context>
+          <context context-type="linenumber">615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpAria" datatype="html">
@@ -7530,7 +7570,7 @@
         <target>Utile, tocca di nuovo per annullare il voto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">611</context>
+          <context context-type="linenumber">617</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownTooltip" datatype="html">
@@ -7538,7 +7578,7 @@
         <target>Non utile — tocca di nuovo per annullare il voto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">623</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownAria" datatype="html">
@@ -7546,7 +7586,15 @@
         <target>Non utile, tocca di nuovo per annullare il voto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">625</context>
+          <context context-type="linenumber">631</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="homeHostCard.infoLanding" datatype="html">
+        <source>Einsatzmöglichkeiten entdecken</source>
+        <target>Scopri gli ambiti di utilizzo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.syncOrigin" datatype="html">
@@ -7554,11 +7602,11 @@
         <target><x id="browser" equiv-text="peer.browserLabel"/> su <x id="device" equiv-text="peer.deviceLabel"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2862374619655540985" datatype="html">
@@ -7566,11 +7614,11 @@
         <target>proprio adesso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">470</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5002</context>
+          <context context-type="linenumber">5009</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7582,11 +7630,11 @@
         <target><x id="PH" equiv-text="minutes"/> minuti fa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">467</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5004</context>
+          <context context-type="linenumber">5011</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7598,11 +7646,11 @@
         <target>1 ora fa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7614,11 +7662,11 @@
         <target><x id="PH" equiv-text="hours"/> ore fa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7630,11 +7678,11 @@
         <target>1 giorno fa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7646,11 +7694,11 @@
         <target><x id="PH" equiv-text="days"/> giorni fa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7662,7 +7710,7 @@
         <target>Rimuovi la sessione <x id="PH" equiv-text="code"/> dall&apos;elenco</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">477</context>
+          <context context-type="linenumber">482</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.heroChipStartError" datatype="html">
@@ -7670,7 +7718,7 @@
         <target>Impossibile avviare il canale. Riprova.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">586</context>
+          <context context-type="linenumber">591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkError" datatype="html">
@@ -7678,7 +7726,7 @@
         <target>Inserisci un link di sync valido.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">645</context>
+          <context context-type="linenumber">650</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkConfirmPrompt" datatype="html">
@@ -7686,7 +7734,7 @@
         <target>Scollegare davvero? La libreria quiz attuale resterà su questo dispositivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">666</context>
+          <context context-type="linenumber">671</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkSuccess" datatype="html">
@@ -7694,7 +7742,7 @@
         <target>Collegamento rimosso. La libreria quiz ora è attiva solo su questo dispositivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">674</context>
+          <context context-type="linenumber">679</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeFeedbackCard.startError" datatype="html">
@@ -7702,7 +7750,7 @@
         <target>Impossibile avviare il sondaggio rapido. Riprova.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">700</context>
+          <context context-type="linenumber">705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6627607898679527757" datatype="html">
@@ -7710,7 +7758,7 @@
         <target>Inserisci il codice a 6 cifre.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">730</context>
+          <context context-type="linenumber">735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2422920312042178920" datatype="html">
@@ -7718,7 +7766,7 @@
         <target>Questa sessione è già terminata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">787</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/join/join.component.ts</context>
@@ -7906,7 +7954,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7926,7 +7974,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -8022,7 +8070,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2939</context>
+          <context context-type="linenumber">2946</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -8666,7 +8714,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1882</context>
+          <context context-type="linenumber">1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.previewSaveAndOpen" datatype="html">
@@ -8678,7 +8726,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1886</context>
+          <context context-type="linenumber">1900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1736772795054152455" datatype="html">
@@ -8874,7 +8922,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">595</context>
+          <context context-type="linenumber">603</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -9386,7 +9434,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1599,1602</context>
+          <context context-type="linenumber">1613,1616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionEditSaveHint" datatype="html">
@@ -9458,7 +9506,7 @@
         <target>È tempo per questa domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">568,570</context>
+          <context context-type="linenumber">576,578</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9470,7 +9518,7 @@
         <target>L&apos;impostazione predefinita è il limite di tempo indicato nelle impostazioni del quiz. Puoi impostare il tuo limite per domanda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">571,574</context>
+          <context context-type="linenumber">579,582</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9482,7 +9530,7 @@
         <target>Usa il limite di tempo del quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">587</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9494,7 +9542,7 @@
         <target>Secondi per questa domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">585</context>
+          <context context-type="linenumber">593</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9506,7 +9554,7 @@
         <target>Secondi per questa domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">590</context>
+          <context context-type="linenumber">598</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9518,7 +9566,7 @@
         <target>Nessuna fase di lettura per questa domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">602,604</context>
+          <context context-type="linenumber">610,612</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9530,7 +9578,7 @@
         <target>Autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">609,611</context>
+          <context context-type="linenumber">617,619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceConfigHint" datatype="html">
@@ -9538,7 +9586,7 @@
         <target>Dopo la risposta, i partecipanti indicano quanto sono sicuri. Non influisce sul punteggio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">612,615</context>
+          <context context-type="linenumber">620,623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceEnabledToggle" datatype="html">
@@ -9546,7 +9594,7 @@
         <target>Autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">620,622</context>
+          <context context-type="linenumber">634,636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelLowField" datatype="html">
@@ -9554,7 +9602,7 @@
         <target>Bassa sicurezza di risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">632</context>
+          <context context-type="linenumber">646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelHighField" datatype="html">
@@ -9562,7 +9610,7 @@
         <target>Alta sicurezza di risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">652</context>
+          <context context-type="linenumber">666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewLabel" datatype="html">
@@ -9570,7 +9618,7 @@
         <target>Anteprima per i partecipanti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">676,678</context>
+          <context context-type="linenumber">690,692</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8205020163645016790" datatype="html">
@@ -9578,7 +9626,7 @@
         <target>Formato rapido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">715</context>
+          <context context-type="linenumber">729</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.quickFormatAria" datatype="html">
@@ -9586,7 +9634,7 @@
         <target>Scegli il formato veloce</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">720</context>
+          <context context-type="linenumber">734</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7287117104463920417" datatype="html">
@@ -9594,7 +9642,7 @@
         <target>Sovrascrive le risposte esistenti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">726</context>
+          <context context-type="linenumber">740</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetSection" datatype="html">
@@ -9602,7 +9650,7 @@
         <target>Avvio rapido</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">731,733</context>
+          <context context-type="linenumber">745,747</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetGroupAria" datatype="html">
@@ -9610,7 +9658,7 @@
         <target>Seleziona il modello di domanda di stima</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">738</context>
+          <context context-type="linenumber">752</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8648957206736539595" datatype="html">
@@ -9618,7 +9666,7 @@
         <target>Tipo di ingresso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">756</context>
+          <context context-type="linenumber">770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateInputTypeLabel" datatype="html">
@@ -9626,7 +9674,7 @@
         <target>Tipo di numero</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">759</context>
+          <context context-type="linenumber">773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntegerOption" datatype="html">
@@ -9634,7 +9682,7 @@
         <target>Numero intero</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">762</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalOption" datatype="html">
@@ -9642,7 +9690,7 @@
         <target>Numero decimale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">765</context>
+          <context context-type="linenumber">779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalPlacesLabel" datatype="html">
@@ -9650,7 +9698,7 @@
         <target>Massimo. cifre decimali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">772</context>
+          <context context-type="linenumber">786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceSection" datatype="html">
@@ -9658,7 +9706,7 @@
         <target>Modalità tolleranza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">788,790</context>
+          <context context-type="linenumber">802,804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceModeLabel" datatype="html">
@@ -9666,7 +9714,7 @@
         <target>modalità</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">792</context>
+          <context context-type="linenumber">806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteIntervalOption" datatype="html">
@@ -9674,7 +9722,7 @@
         <target>Intervallo assoluto [L, R]</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">797</context>
+          <context context-type="linenumber">811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateRelativePercentOption" datatype="html">
@@ -9682,7 +9730,7 @@
         <target>Banda di tolleranza relativa (V ± p%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">802</context>
+          <context context-type="linenumber">816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalLeftLabel" datatype="html">
@@ -9690,7 +9738,7 @@
         <target>Bordo sinistro L</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">811</context>
+          <context context-type="linenumber">825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalRightLabel" datatype="html">
@@ -9698,7 +9746,7 @@
         <target>Bordo destro R</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">817</context>
+          <context context-type="linenumber">831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueLabel" datatype="html">
@@ -9706,7 +9754,7 @@
         <target>Valore di riferimento per l’analisi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">824</context>
+          <context context-type="linenumber">838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueHint" datatype="html">
@@ -9714,7 +9762,7 @@
         <target>Opzionale per linea di riferimento, metrica di errore e confronto tra round</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">828</context>
+          <context context-type="linenumber">842</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueLabel" datatype="html">
@@ -9722,7 +9770,7 @@
         <target>Valore di riferimento V</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueHint" datatype="html">
@@ -9730,7 +9778,7 @@
         <target>Deve essere ≠ 0</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">840</context>
+          <context context-type="linenumber">854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTolerancePercentLabel" datatype="html">
@@ -9738,7 +9786,7 @@
         <target>Tolleranza p (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">845</context>
+          <context context-type="linenumber">859</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateBoundsSection" datatype="html">
@@ -9746,7 +9794,7 @@
         <target>Limiti di plausibilità (facoltativo)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">858,860</context>
+          <context context-type="linenumber">872,874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMinLabel" datatype="html">
@@ -9754,7 +9802,7 @@
         <target>Ingresso minimo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">863</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMaxLabel" datatype="html">
@@ -9762,7 +9810,7 @@
         <target>Ingresso massimo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">867</context>
+          <context context-type="linenumber">881</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewAria" datatype="html">
@@ -9770,7 +9818,7 @@
         <target>Anteprima della domanda di stima</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">876</context>
+          <context context-type="linenumber">890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewTitle" datatype="html">
@@ -9778,7 +9826,7 @@
         <target>Anteprima della banda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">881</context>
+          <context context-type="linenumber">895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTwoRoundsToggle" datatype="html">
@@ -9786,7 +9834,7 @@
         <target>Due turni di votazione (peer instructions)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">937,939</context>
+          <context context-type="linenumber">951,953</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8259238864102475814" datatype="html">
@@ -9794,7 +9842,7 @@
         <target>scala</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">945</context>
+          <context context-type="linenumber">959</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.ratingScaleAria" datatype="html">
@@ -9802,7 +9850,7 @@
         <target>Seleziona la scala di valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">949</context>
+          <context context-type="linenumber">963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4298652859209119138" datatype="html">
@@ -9810,7 +9858,7 @@
         <target>Bordo sinistro (facoltativo)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3739377380076895717" datatype="html">
@@ -9818,7 +9866,7 @@
         <target>Bordo destro (facoltativo)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">985</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigLegend" datatype="html">
@@ -9826,7 +9874,7 @@
         <target>Errori di digitazione e varianti di scrittura</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">983,985</context>
+          <context context-type="linenumber">997,999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigHint" datatype="html">
@@ -9834,7 +9882,7 @@
         <target>Decidi quali errori di battitura contano ancora. L&apos;anteprima qui sotto mostra se portano al punteggio pieno, a punti parziali o a nessun punto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">989,992</context>
+          <context context-type="linenumber">1003,1006</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindFieldLabel" datatype="html">
@@ -9842,7 +9890,7 @@
         <target>Tipo di risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">996</context>
+          <context context-type="linenumber">1010</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthFieldLabel" datatype="html">
@@ -9850,7 +9898,7 @@
         <target>Lunghezza massima della risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1010</context>
+          <context context-type="linenumber">1024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthHint" datatype="html">
@@ -9858,7 +9906,7 @@
         <target>Da 1 a 500 caratteri</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationModeFieldLabel" datatype="html">
@@ -9866,7 +9914,7 @@
         <target>Valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1025</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceFieldLabel" datatype="html">
@@ -9874,7 +9922,7 @@
         <target>Tolleranza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceHint" datatype="html">
@@ -9882,7 +9930,7 @@
         <target>Le percentuali descrivono lo scostamento consentito dalla soluzione modello, non il punteggio. Bassa ≈ 10 %, media ≈ 20 %, ampia ≈ 30 %. Con termini brevi, lo stesso livello risulta più severo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1042,1044</context>
+          <context context-type="linenumber">1056,1058</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextAllowPartialCreditToggle" datatype="html">
@@ -9890,7 +9938,7 @@
         <target>Assegna punti parziali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1066,1068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextCaseSensitiveToggle" datatype="html">
@@ -9898,7 +9946,7 @@
         <target>Distingui maiuscole e minuscole</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1058,1060</context>
+          <context context-type="linenumber">1072,1074</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindFieldLabel" datatype="html">
@@ -9906,7 +9954,7 @@
         <target>Formato numerico</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1064</context>
+          <context context-type="linenumber">1078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeFieldLabel" datatype="html">
@@ -9914,7 +9962,7 @@
         <target>Tolleranza numerica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1074</context>
+          <context context-type="linenumber">1088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeHint" datatype="html">
@@ -9922,7 +9970,7 @@
         <target>La modalità esatta richiede lo stesso valore numerico. La tolleranza assoluta usa un intervallo fisso ±, quella relativa una percentuale attorno alla soluzione modello.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1082,1083</context>
+          <context context-type="linenumber">1096,1097</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceFieldLabel" datatype="html">
@@ -9930,7 +9978,7 @@
         <target>Tolleranza assoluta (±)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1090</context>
+          <context context-type="linenumber">1104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceHint" datatype="html">
@@ -9938,7 +9986,7 @@
         <target>Esempio: con 10 e ±0,5 sono accettate risposte da 9,5 a 10,5.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1100</context>
+          <context context-type="linenumber">1114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceFieldLabel" datatype="html">
@@ -9946,7 +9994,7 @@
         <target>Tolleranza relativa (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1108</context>
+          <context context-type="linenumber">1122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceHint" datatype="html">
@@ -9954,7 +10002,7 @@
         <target>Esempio: con 200 e 5% sono accettate risposte da 190 a 210.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1118</context>
+          <context context-type="linenumber">1132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyFieldLabel" datatype="html">
@@ -9962,7 +10010,7 @@
         <target>Famiglia di unità</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1126</context>
+          <context context-type="linenumber">1140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitToggle" datatype="html">
@@ -9970,7 +10018,7 @@
         <target> Rendere obbligatoria l&apos;unità </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1139,1141</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAcceptEquivalentUnitsToggle" datatype="html">
@@ -9978,7 +10026,7 @@
         <target> Accettare unità equivalenti </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1159,1161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLegend" datatype="html">
@@ -9986,7 +10034,7 @@
         <target>Così funziona la valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1154,1156</context>
+          <context context-type="linenumber">1168,1170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningLabel" datatype="html">
@@ -9994,7 +10042,7 @@
         <target>Nota didattica:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1200</context>
+          <context context-type="linenumber">1214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsToggle" datatype="html">
@@ -10002,7 +10050,7 @@
         <target>Mostra dettagli tecnici</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1208,1210</context>
+          <context context-type="linenumber">1222,1224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsIntro" datatype="html">
@@ -10010,7 +10058,7 @@
         <target>La modalità automatica combina corrispondenza esatta, Hamming, Damerau-Levenshtein e Levenshtein. Hamming va bene per un solo carattere errato con la stessa lunghezza, Damerau-Levenshtein gestisce anche lettere vicine invertite e Levenshtein copre inoltre caratteri mancanti o extra.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1215,1220</context>
+          <context context-type="linenumber">1229,1234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTrimWhitespaceToggle" datatype="html">
@@ -10018,7 +10066,7 @@
         <target>Ignora gli spazi all&apos;inizio e alla fine</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1225,1227</context>
+          <context context-type="linenumber">1239,1241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextNormalizeWhitespaceToggle" datatype="html">
@@ -10026,7 +10074,7 @@
         <target>Unisci gli spazi ripetuti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1231,1233</context>
+          <context context-type="linenumber">1245,1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextValidSolutionHint" datatype="html">
@@ -10034,7 +10082,7 @@
         <target>Valida</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1272,1274</context>
+          <context context-type="linenumber">1286,1288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8021687558521014030" datatype="html">
@@ -10042,7 +10090,7 @@
         <target>opzione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1276</context>
+          <context context-type="linenumber">1290</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6278157135662238363" datatype="html">
@@ -10050,7 +10098,7 @@
         <target>Inserisci un testo di risposta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2650319028885568688" datatype="html">
@@ -10058,7 +10106,7 @@
         <target>Massimo 500 caratteri.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2525684207823121577" datatype="html">
@@ -10066,7 +10114,7 @@
         <target>Qui i partecipanti rispondono liberamente: non sono necessarie risposte predeterminate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1332,1334</context>
+          <context context-type="linenumber">1346,1348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.livePreviewCardTitle" datatype="html">
@@ -10074,7 +10122,7 @@
         <target>Anteprima completa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1357,1359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7492260970005034710" datatype="html">
@@ -10082,7 +10130,7 @@
         <target>Errore formula: <x id="INTERPOLATION" equiv-text="{{ previewKatexError() }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1350,1352</context>
+          <context context-type="linenumber">1364,1366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2863483573986908286" datatype="html">
@@ -10090,7 +10138,7 @@
         <target>Chiedere</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1355</context>
+          <context context-type="linenumber">1369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10102,7 +10150,7 @@
         <target>Elenco delle domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1429</context>
+          <context context-type="linenumber">1443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionsListTitle" datatype="html">
@@ -10110,7 +10158,7 @@
         <target>Domande nel quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1437,1439</context>
+          <context context-type="linenumber">1451,1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8122550761270535954" datatype="html">
@@ -10118,7 +10166,7 @@
         <target>Aggiunto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1441</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3827964072457808965" datatype="html">
@@ -10126,7 +10174,7 @@
         <target>Nessuna domanda ancora</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1451</context>
+          <context context-type="linenumber">1465</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -10138,7 +10186,7 @@
         <target>Aggiungi la tua prima domanda qui sopra per iniziare.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1452,1454</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionListPosition" datatype="html">
@@ -10146,7 +10194,7 @@
         <target>Domanda <x id="INTERPOLATION" equiv-text="{{ question.order + 1 }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1514,1515</context>
+          <context context-type="linenumber">1528,1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionDisabledBadge" datatype="html">
@@ -10154,7 +10202,7 @@
         <target>Disabilitato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1539</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineDisabledHint" datatype="html">
@@ -10162,7 +10210,7 @@
         <target>Questa domanda è disabilitata e non viene visualizzata nell&apos;anteprima e nel quiz live.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1565,1568</context>
+          <context context-type="linenumber">1579,1582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.activateQuestion" datatype="html">
@@ -10170,15 +10218,15 @@
         <target>Attivare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1575</context>
+          <context context-type="linenumber">1589</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1772</context>
+          <context context-type="linenumber">1786</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineEditEyebrow" datatype="html">
@@ -10186,7 +10234,7 @@
         <target>Modalità modifica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1587,1589</context>
+          <context context-type="linenumber">1601,1603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.editQuestionTitle" datatype="html">
@@ -10194,7 +10242,7 @@
         <target>Modifica questa domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1593,1595</context>
+          <context context-type="linenumber">1607,1609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.freeTextWordCloudHint" datatype="html">
@@ -10202,7 +10250,7 @@
         <target>Risposta a testo libero come nuvola di parole</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1617,1619</context>
+          <context context-type="linenumber">1631,1633</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10214,7 +10262,7 @@
         <target>Risposta breve con confronto automatico con le soluzioni modello</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1624,1626</context>
+          <context context-type="linenumber">1638,1640</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10226,7 +10274,7 @@
         <target>L’autovalutazione viene richiesta dopo la risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1715,1717</context>
+          <context context-type="linenumber">1729,1731</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6920196637619975735" datatype="html">
@@ -10234,11 +10282,11 @@
         <target>Modificare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1754</context>
+          <context context-type="linenumber">1768</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1802</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -10250,11 +10298,11 @@
         <target>Disabilita</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1763</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1797</context>
+          <context context-type="linenumber">1811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4580399730639224598" datatype="html">
@@ -10262,11 +10310,11 @@
         <target>Eliminare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1791</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1811</context>
+          <context context-type="linenumber">1825</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -10278,11 +10326,11 @@
         <target>Torna all&apos;elenco dei quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1843</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1900</context>
+          <context context-type="linenumber">1914</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -10298,7 +10346,7 @@
         <target>Indietro</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1832</context>
+          <context context-type="linenumber">1846</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -10310,11 +10358,11 @@
         <target>Annulla</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1842</context>
+          <context context-type="linenumber">1856</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1846</context>
+          <context context-type="linenumber">1860</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButtonAria" datatype="html">
@@ -10322,7 +10370,7 @@
         <target>Aggiungi un&apos;altra domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1869</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButton" datatype="html">
@@ -10330,7 +10378,7 @@
         <target>Un&apos;altra domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1859</context>
+          <context context-type="linenumber">1873</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.saveAllButton" datatype="html">
@@ -10338,11 +10386,11 @@
         <target>Salva modifiche</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1869</context>
+          <context context-type="linenumber">1883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1873</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7620597678842046410" datatype="html">
@@ -10350,7 +10398,7 @@
         <target>Quiz non trovato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1895</context>
+          <context context-type="linenumber">1909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6672916435220201136" datatype="html">
@@ -10358,7 +10406,23 @@
         <target>Torna alla lista</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1903</context>
+          <context context-type="linenumber">1917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingEstimate" datatype="html">
+        <source>Schätzfragen didaktisch einsetzen</source>
+        <target>Usare le domande di stima nella didattica</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <target>Comprendere l’autovalutazione e l’analisi successiva</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="924826286502636331" datatype="html">
@@ -10366,7 +10430,7 @@
         <target>Scelta unica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">399</context>
+          <context context-type="linenumber">407</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4737017620429217247" datatype="html">
@@ -10374,7 +10438,7 @@
         <target>scelta multipla</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">400</context>
+          <context context-type="linenumber">408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="493996564238682027" datatype="html">
@@ -10382,7 +10446,7 @@
         <target>Testo libero</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">401</context>
+          <context context-type="linenumber">409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8680267345873464947" datatype="html">
@@ -10390,7 +10454,7 @@
         <target>Sondaggio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">403</context>
+          <context context-type="linenumber">411</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5472460529727499985" datatype="html">
@@ -10398,7 +10462,7 @@
         <target>Voto (1-5 / 1-10)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">404</context>
+          <context context-type="linenumber">412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearLabel" datatype="html">
@@ -10406,7 +10470,7 @@
         <target>anno</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">427</context>
+          <context context-type="linenumber">435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearHint" datatype="html">
@@ -10414,7 +10478,7 @@
         <target>Intero, 1500-2000 plausibile, 1700-1900 accettato, due turni.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">428</context>
+          <context context-type="linenumber">436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementLabel" datatype="html">
@@ -10422,7 +10486,7 @@
         <target>Valore misurato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">433</context>
+          <context context-type="linenumber">441</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementHint" datatype="html">
@@ -10430,7 +10494,7 @@
         <target>Valore decimale con una cifra decimale e una fascia di tolleranza assoluta ristretta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">434</context>
+          <context context-type="linenumber">442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentLabel" datatype="html">
@@ -10438,7 +10502,7 @@
         <target>Percentuale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">439</context>
+          <context context-type="linenumber">447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentHint" datatype="html">
@@ -10446,7 +10510,7 @@
         <target>Intero da 0 a 100 con tolleranza di dieci punti percentuali.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">440</context>
+          <context context-type="linenumber">448</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeLabel" datatype="html">
@@ -10454,7 +10518,7 @@
         <target>Grandezza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">445</context>
+          <context context-type="linenumber">453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeHint" datatype="html">
@@ -10462,7 +10526,7 @@
         <target>Intero grande con banda di tolleranza relativa per le stime dell&apos;ordine di grandezza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">446</context>
+          <context context-type="linenumber">454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.easy" datatype="html">
@@ -10470,7 +10534,7 @@
         <target>Facile</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">452</context>
+          <context context-type="linenumber">460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10478,7 +10542,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4673</context>
+          <context context-type="linenumber">4680</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10490,7 +10554,7 @@
         <target>Medio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">453</context>
+          <context context-type="linenumber">461</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10498,7 +10562,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4675</context>
+          <context context-type="linenumber">4682</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10510,7 +10574,7 @@
         <target>Difficile</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">454</context>
+          <context context-type="linenumber">462</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10518,7 +10582,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4677</context>
+          <context context-type="linenumber">4684</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -10530,7 +10594,7 @@
         <target>Solo corrispondenza esatta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">464</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10542,7 +10606,7 @@
         <target>Accetta solo grafie identiche.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeAutoLabel" datatype="html">
@@ -10550,7 +10614,7 @@
         <target>Consenti piccoli errori di battitura</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">469</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10562,7 +10626,7 @@
         <target>Per la maggior parte dei termini tecnici: considera corrispondenze esatte, piccoli errori di battitura, lettere invertite e caratteri mancanti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeHammingLabel" datatype="html">
@@ -10570,7 +10634,7 @@
         <target>Stessa lunghezza, piccoli scambi di lettere</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">474</context>
+          <context context-type="linenumber">482</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10582,7 +10646,7 @@
         <target>Per termini della stessa lunghezza con una lettera errata o invertita.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">475</context>
+          <context context-type="linenumber">483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeLevenshteinLabel" datatype="html">
@@ -10590,7 +10654,7 @@
         <target>Consenti anche caratteri mancanti o aggiuntivi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">479</context>
+          <context context-type="linenumber">487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10602,7 +10666,7 @@
         <target>Per termini con un carattere mancante o aggiuntivo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">480</context>
+          <context context-type="linenumber">488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindText" datatype="html">
@@ -10610,7 +10674,7 @@
         <target>Valuta con similarità testuale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">491</context>
+          <context context-type="linenumber">499</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindTextHint" datatype="html">
@@ -10618,7 +10682,7 @@
         <target>Adatto a termini tecnici e grafie fisse con piccoli errori di battitura.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumeric" datatype="html">
@@ -10626,7 +10690,7 @@
         <target>Valuta numeri</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">496</context>
+          <context context-type="linenumber">504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericHint" datatype="html">
@@ -10634,7 +10698,7 @@
         <target>Valuta i valori numerici invece della similarità testuale e supporta tolleranze esatte, assolute o relative.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">497</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnit" datatype="html">
@@ -10642,7 +10706,7 @@
         <target>Valuta numeri e unità</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">501</context>
+          <context context-type="linenumber">509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnitHint" datatype="html">
@@ -10650,7 +10714,7 @@
         <target>Verifica i valori numerici insieme a una famiglia di unità selezionata e spiega unità mancanti o diverse.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">502</context>
+          <context context-type="linenumber">510</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindInteger" datatype="html">
@@ -10658,7 +10722,7 @@
         <target>Numero intero</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">507</context>
+          <context context-type="linenumber">515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindDecimal" datatype="html">
@@ -10666,7 +10730,7 @@
         <target>Numero decimale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">508</context>
+          <context context-type="linenumber">516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceExact" datatype="html">
@@ -10674,7 +10738,7 @@
         <target>Valore esatto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">512</context>
+          <context context-type="linenumber">520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceAbsolute" datatype="html">
@@ -10682,7 +10746,7 @@
         <target>Tolleranza assoluta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">515</context>
+          <context context-type="linenumber">523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelative" datatype="html">
@@ -10690,7 +10754,7 @@
         <target>Tolleranza relativa (%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">519</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyLength" datatype="html">
@@ -10698,7 +10762,7 @@
         <target>Lunghezza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">524</context>
+          <context context-type="linenumber">532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyMass" datatype="html">
@@ -10706,7 +10770,7 @@
         <target>Massa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">525</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyTime" datatype="html">
@@ -10714,7 +10778,7 @@
         <target>Tempo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">526</context>
+          <context context-type="linenumber">534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyVolume" datatype="html">
@@ -10722,7 +10786,7 @@
         <target>Volume</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceNone" datatype="html">
@@ -10730,7 +10794,7 @@
         <target>Nessuna tolleranza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">531</context>
+          <context context-type="linenumber">539</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10742,7 +10806,7 @@
         <target>Bassa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">532</context>
+          <context context-type="linenumber">540</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10754,7 +10818,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">541</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10766,7 +10830,7 @@
         <target>Ampia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">534</context>
+          <context context-type="linenumber">542</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -10778,7 +10842,7 @@
         <target>Premio Nobel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">538</context>
+          <context context-type="linenumber">546</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10794,7 +10858,7 @@
         <target>Asilo (emoji animali)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">541</context>
+          <context context-type="linenumber">549</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10810,7 +10874,7 @@
         <target>Scuola primaria</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">551</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10826,7 +10890,7 @@
         <target>Scuole medie</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">552</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10842,7 +10906,7 @@
         <target>Scuola superiore</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">545</context>
+          <context context-type="linenumber">553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10858,7 +10922,7 @@
         <target>Quiz standard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">768</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4668229613641280742" datatype="html">
@@ -10866,7 +10930,7 @@
         <target>Personalizzato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">866</context>
+          <context context-type="linenumber">874</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -10878,7 +10942,7 @@
         <target>Scala a cinque livelli da 1 a 5, basso: <x id="low" equiv-text="low"/>, alto: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">980</context>
+          <context context-type="linenumber">988</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithLow" datatype="html">
@@ -10886,7 +10950,7 @@
         <target>Scala a cinque livelli da 1 a 5, bassa: <x id="low" equiv-text="low"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">983</context>
+          <context context-type="linenumber">991</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithHigh" datatype="html">
@@ -10894,7 +10958,7 @@
         <target>Scala a cinque livelli da 1 a 5, alto: <x id="high" equiv-text="high"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">986</context>
+          <context context-type="linenumber">994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAria" datatype="html">
@@ -10902,7 +10966,7 @@
         <target>Scala a cinque livelli da 1 a 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">988</context>
+          <context context-type="linenumber">996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceLabel" datatype="html">
@@ -10914,7 +10978,7 @@
           )"/> a <x id="right" equiv-text="this.formatNumericEstimateEditorValue(band.right)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReferenceLabel" datatype="html">
@@ -10926,7 +10990,7 @@
             )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1152,1154</context>
+          <context context-type="linenumber">1160,1162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewIncomplete" datatype="html">
@@ -10934,7 +10998,7 @@
         <target>La banda di tolleranza viene visualizzata una volta completati i limiti o il riferimento e la percentuale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1168</context>
+          <context context-type="linenumber">1176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceOutside" datatype="html">
@@ -10942,7 +11006,7 @@
         <target>I limiti di plausibilità e gli intervalli di tolleranza non corrispondono ancora. Dovrebbero essere entrabili anche i valori nella fascia.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1177</context>
+          <context context-type="linenumber">1185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReady" datatype="html">
@@ -10950,7 +11014,7 @@
         <target>Limiti di plausibilità delle voci consentite; la fascia di tolleranza decide i punti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1179</context>
+          <context context-type="linenumber">1187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityRange" datatype="html">
@@ -10962,7 +11026,7 @@
       )"/> a <x id="max" equiv-text="this.formatNumericEstimateEditorValue(max)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1186,1188</context>
+          <context context-type="linenumber">1194,1196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMin" datatype="html">
@@ -10974,7 +11038,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1191,1193</context>
+          <context context-type="linenumber">1199,1201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMax" datatype="html">
@@ -10986,7 +11050,7 @@
       )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1196,1198</context>
+          <context context-type="linenumber">1204,1206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionLabel" datatype="html">
@@ -10994,7 +11058,7 @@
         <target>Soluzione modello <x id="solutionNumber" equiv-text="index + 1"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1286</context>
+          <context context-type="linenumber">1294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.answerLabel" datatype="html">
@@ -11002,7 +11066,7 @@
         <target>Risposta <x id="answerNumber" equiv-text="index + 1"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1289</context>
+          <context context-type="linenumber">1297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.markAnswerCorrectAria" datatype="html">
@@ -11010,7 +11074,7 @@
         <target>Contrassegna la risposta <x id="answerNumber" equiv-text="answerNumber"/> come corretta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1293</context>
+          <context context-type="linenumber">1301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.toggleAnswerCorrectAria" datatype="html">
@@ -11018,7 +11082,7 @@
         <target>Risposta <x id="answerNumber" equiv-text="answerNumber"/> corretta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1297</context>
+          <context context-type="linenumber">1305</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.removeAnswerAria" datatype="html">
@@ -11026,7 +11090,7 @@
         <target>Rimuovi la risposta <x id="answerNumber" equiv-text="answerNumber"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.collapseQuestionAria" datatype="html">
@@ -11034,7 +11098,7 @@
         <target>Comprimi la domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1306</context>
+          <context context-type="linenumber">1314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.expandQuestionAria" datatype="html">
@@ -11042,7 +11106,7 @@
         <target>Espandi la domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsPreviewLabel" datatype="html">
@@ -11050,7 +11114,7 @@
         <target>Soluzioni modello</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.livePreviewAnswersLabel" datatype="html">
@@ -11058,7 +11122,7 @@
         <target>Risposte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1313</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.addShortTextSolution" datatype="html">
@@ -11066,7 +11130,7 @@
         <target>Aggiungi un'altra soluzione modello</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1318</context>
+          <context context-type="linenumber">1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8266267788371304686" datatype="html">
@@ -11074,7 +11138,7 @@
         <target>Un&apos;altra risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1319</context>
+          <context context-type="linenumber">1327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthSummary" datatype="html">
@@ -11082,11 +11146,11 @@
         <target>Max. <x id="maxLength" equiv-text="resolveShortTextMaxLength(question.shortTextMaxLength)"/> caratteri</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1436</context>
+          <context context-type="linenumber">1444</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1479</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11098,7 +11162,7 @@
         <target>±{$tolerance} assoluta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelativeSummary" datatype="html">
@@ -11106,7 +11170,7 @@
         <target>±{$tolerance} % relativa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1455</context>
+          <context context-type="linenumber">1463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilySummary" datatype="html">
@@ -11114,7 +11178,7 @@
         <target>Unità: {$unitFamily}</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1469</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitSummary" datatype="html">
@@ -11122,7 +11186,7 @@
         <target>Unità obbligatoria</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitOptionalSummary" datatype="html">
@@ -11130,7 +11194,7 @@
         <target>Unità opzionale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1466</context>
+          <context context-type="linenumber">1474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEquivalentUnitsSummary" datatype="html">
@@ -11138,7 +11202,7 @@
         <target>Unità equivalenti consentite</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1470</context>
+          <context context-type="linenumber">1478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericExactUnitsSummary" datatype="html">
@@ -11146,7 +11210,7 @@
         <target>Solo unità esattamente configurata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1471</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceSummary" datatype="html">
@@ -11154,7 +11218,7 @@
         <target>Tolleranza: <x id="tolerance" equiv-text="this.shortTextToleranceLabel(question.shortTextToleranceLevel)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1484</context>
+          <context context-type="linenumber">1492</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11166,7 +11230,7 @@
         <target>Con distinzione tra maiuscole e minuscole</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1488</context>
+          <context context-type="linenumber">1496</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11178,7 +11242,7 @@
         <target>Solo punteggio pieno</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1491</context>
+          <context context-type="linenumber">1499</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11190,7 +11254,7 @@
         <target>Gli spazi vengono controllati rigorosamente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1498</context>
+          <context context-type="linenumber">1506</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11202,7 +11266,7 @@
         <target>Definisci almeno una risposta di riferimento con unità, mantieni piccolo il set di unità e rendi obbligatoria l&apos;unità solo quando deve essere davvero valutata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1507</context>
+          <context context-type="linenumber">1515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningNumeric" datatype="html">
@@ -11210,7 +11274,7 @@
         <target>Definisci almeno un valore di riferimento chiaro e scegli una tolleranza che consenta imprecisioni di calcolo ma escluda chiaramente valori scientificamente errati.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1508</context>
+          <context context-type="linenumber">1516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarning" datatype="html">
@@ -11218,7 +11282,7 @@
         <target>Usa una valutazione tollerante solo con termini tecnici chiaramente definiti. Per formulazioni aperte, più soluzioni modello sono spesso più eque di una tolleranza alta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -11230,7 +11294,7 @@
         <target>Inserisci da una a dieci risposte di riferimento con un&apos;unità supportata, ad esempio «2 m».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1521</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHintNumeric" datatype="html">
@@ -11238,7 +11302,7 @@
         <target>Inserisci da una a dieci risposte di riferimento come numero, ad esempio «3,5».</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1530</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHint" datatype="html">
@@ -11246,7 +11310,7 @@
         <target>Inserisci da una a dieci soluzioni modello. Tutte le varianti valgono come risposta breve corretta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewExactLabel" datatype="html">
@@ -11254,11 +11318,11 @@
         <target>Inserimento esatto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1621</context>
+          <context context-type="linenumber">1629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLengthLabel" datatype="html">
@@ -11266,7 +11330,7 @@
         <target>Carattere mancante o aggiuntivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1553</context>
+          <context context-type="linenumber">1561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewWrongLabel" datatype="html">
@@ -11274,11 +11338,11 @@
         <target>Termine diverso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1557</context>
+          <context context-type="linenumber">1565</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1658</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeFull" datatype="html">
@@ -11286,11 +11350,11 @@
         <target>Punti pieni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1592</context>
+          <context context-type="linenumber">1600</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeAccepted" datatype="html">
@@ -11298,11 +11362,11 @@
         <target>Accettata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1593</context>
+          <context context-type="linenumber">1601</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1669</context>
+          <context context-type="linenumber">1677</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomePartial" datatype="html">
@@ -11310,11 +11374,11 @@
         <target>Punti parziali (<x id="points" equiv-text="result.points"/> %)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1596</context>
+          <context context-type="linenumber">1604</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1672</context>
+          <context context-type="linenumber">1680</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeRejected" datatype="html">
@@ -11322,11 +11386,11 @@
         <target>Non accettata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1599</context>
+          <context context-type="linenumber">1607</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1683</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewNumericToleranceLabel" datatype="html">
@@ -11334,7 +11398,7 @@
         <target>Entro la tolleranza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1629</context>
+          <context context-type="linenumber">1637</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewEquivalentUnitLabel" datatype="html">
@@ -11342,7 +11406,7 @@
         <target>Unità equivalente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewMissingUnitLabel" datatype="html">
@@ -11350,7 +11414,7 @@
         <target>Unità mancante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1644</context>
+          <context context-type="linenumber">1652</context>
         </context-group>
       </trans-unit>
       <trans-unit id="705009069021941649" datatype="html">
@@ -11358,7 +11422,7 @@
         <target>Scegli esattamente una risposta corretta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2025</context>
+          <context context-type="linenumber">2033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5903298630443190027" datatype="html">
@@ -11366,7 +11430,7 @@
         <target>Scegli almeno una risposta corretta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2037</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2211937330568533798" datatype="html">
@@ -11374,7 +11438,7 @@
         <target>Salvataggio non riuscito.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2148</context>
+          <context context-type="linenumber">2156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5746363347338638819" datatype="html">
@@ -11382,7 +11446,7 @@
         <target>Impossibile salvare le impostazioni.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2165</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3347548161086861397" datatype="html">
@@ -11390,7 +11454,7 @@
         <target>Impossibile aggiornare la domanda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.saveConfirmation" datatype="html">
@@ -11398,7 +11462,7 @@
         <target>Modifiche salvate. La domanda, i dati del quiz e le impostazioni sono ora inclusi nell’anteprima e nel quiz live.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2284</context>
+          <context context-type="linenumber">2292</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogTitle" datatype="html">
@@ -11406,7 +11470,7 @@
         <target>Eliminare la domanda?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2312</context>
+          <context context-type="linenumber">2320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogMessage" datatype="html">
@@ -11414,7 +11478,7 @@
         <target>La domanda <x id="PH" equiv-text="position"/> verrà rimossa definitivamente dal quiz.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2313</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.deleteIrreversible" datatype="html">
@@ -11422,7 +11486,7 @@
         <target>Questa operazione non può essere annullata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2315</context>
+          <context context-type="linenumber">2323</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -11434,7 +11498,7 @@
         <target>Eliminare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionCancel" datatype="html">
@@ -11442,7 +11506,7 @@
         <target>Annulla</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2318</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4357290152640831712" datatype="html">
@@ -11450,7 +11514,7 @@
         <target>Eliminazione non riuscita.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2335</context>
+          <context context-type="linenumber">2343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -11462,11 +11526,11 @@
         <target>Spostamento fallito.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2356</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionUp" datatype="html">
@@ -11474,7 +11538,7 @@
         <target>Sposta la domanda <x id="position" equiv-text="position"/> in alto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2370</context>
+          <context context-type="linenumber">2378</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionDown" datatype="html">
@@ -11482,7 +11546,7 @@
         <target>Sposta la domanda <x id="position" equiv-text="position"/> in basso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2374</context>
+          <context context-type="linenumber">2382</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.dragQuestion" datatype="html">
@@ -11490,7 +11554,7 @@
         <target>Sposta la domanda <x id="position" equiv-text="position"/> trascinandola</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2378</context>
+          <context context-type="linenumber">2386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionMovedAnnouncement" datatype="html">
@@ -11498,7 +11562,7 @@
         <target>La domanda <x id="previousPosition" equiv-text="previousPosition"/> è stata spostata alla posizione <x id="currentPosition" equiv-text="currentPosition"/> di <x id="total" equiv-text="total"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2385</context>
+          <context context-type="linenumber">2393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesDialogHeading" datatype="html">
@@ -13290,7 +13354,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3010</context>
+          <context context-type="linenumber">3016</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -13302,7 +13366,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3013</context>
+          <context context-type="linenumber">3019</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -13314,7 +13378,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3018</context>
+          <context context-type="linenumber">3024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -13326,7 +13390,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3208</context>
+          <context context-type="linenumber">3220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -13338,7 +13402,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3212</context>
+          <context context-type="linenumber">3224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -13350,7 +13414,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3215</context>
+          <context context-type="linenumber">3227</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -13362,7 +13426,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3218</context>
+          <context context-type="linenumber">3230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -13518,7 +13582,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2718</context>
+          <context context-type="linenumber">2724</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -13538,7 +13602,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2981</context>
+          <context context-type="linenumber">2987</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -13742,7 +13806,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2951</context>
+          <context context-type="linenumber">2957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -13798,7 +13862,7 @@
         <target>Vedi il piano di debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1212</context>
+          <context context-type="linenumber">1218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuVisual" datatype="html">
@@ -13806,7 +13870,7 @@
         <target>Standard (con diagrammi)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1230</context>
+          <context context-type="linenumber">1236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuPdfUa" datatype="html">
@@ -13814,7 +13878,7 @@
         <target>Senza barriere (PDF/UA-1)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1241</context>
+          <context context-type="linenumber">1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
@@ -13822,7 +13886,7 @@
         <target>Altre opzioni di esportazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1258</context>
+          <context context-type="linenumber">1264</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButton" datatype="html">
@@ -13830,7 +13894,7 @@
         <target>Di più</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1261</context>
+          <context context-type="linenumber">1267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7070792224026857010" datatype="html">
@@ -13838,7 +13902,7 @@
         <target>Alla home page</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1265</context>
+          <context context-type="linenumber">1271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelTooltip" datatype="html">
@@ -13846,7 +13910,7 @@
         <target>Dati grezzi tabulari per fogli di calcolo – meno dettagli rispetto al piano di debriefing.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1275</context>
+          <context context-type="linenumber">1281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelMenuItem" datatype="html">
@@ -13854,7 +13918,7 @@
         <target>Esporta dati grezzi (CSV)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1280</context>
+          <context context-type="linenumber">1286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressAria" datatype="html">
@@ -13862,7 +13926,7 @@
         <target>L&apos;esportazione è in corso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1290</context>
+          <context context-type="linenumber">1296</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
@@ -13870,7 +13934,7 @@
         <target>Verrà esportato...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1295,1297</context>
+          <context context-type="linenumber">1301,1303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
@@ -13878,7 +13942,7 @@
         <target>Fai una breve chiacchierata con il tuo vicino</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1323,1325</context>
+          <context context-type="linenumber">1329,1331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1952538840507841358" datatype="html">
@@ -13886,7 +13950,7 @@
         <target>Stessa risposta? Grande. Opinione diversa? Convincetevi a vicenda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1326,1328</context>
+          <context context-type="linenumber">1332,1334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5596291527944555255" datatype="html">
@@ -13894,7 +13958,7 @@
         <target>La seconda votazione seguirà presto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1329,1331</context>
+          <context context-type="linenumber">1335,1337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveLabel" datatype="html">
@@ -13902,7 +13966,7 @@
         <target>Il giro di domande è in corso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1339,1341</context>
+          <context context-type="linenumber">1345,1347</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveHint" datatype="html">
@@ -13910,7 +13974,7 @@
         <target>Le persone partecipanti possono ora entrare con il codice della sessione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1349,1351</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionCounter" datatype="html">
@@ -13918,7 +13982,7 @@
         <target>Domanda <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/> / <x id="INTERPOLATION_1" equiv-text="{{ q.totalQuestions }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1358,1359</context>
+          <context context-type="linenumber">1364,1365</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionNumber" datatype="html">
@@ -13926,7 +13990,7 @@
         <target>Domanda <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1361,1362</context>
+          <context context-type="linenumber">1367,1368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1017989655370592681" datatype="html">
@@ -13934,7 +13998,7 @@
         <target>Ultima domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1364</context>
+          <context context-type="linenumber">1370</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7135032209126516357" datatype="html">
@@ -13942,7 +14006,7 @@
         <target>Tutti hanno votato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1403</context>
+          <context context-type="linenumber">1409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
@@ -13950,7 +14014,7 @@
         <target>I partecipanti possono prolungare o disattivare la loro scadenza personale, se necessario.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1424,1427</context>
+          <context context-type="linenumber">1430,1433</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.questionMetadataAria" datatype="html">
@@ -13958,7 +14022,7 @@
         <target>Metadati delle domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1439</context>
+          <context context-type="linenumber">1445</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
@@ -13978,7 +14042,7 @@
         <target>Fase di lettura</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1464</context>
+          <context context-type="linenumber">1470</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
@@ -13986,7 +14050,7 @@
         <target>Le risposte arrivano tra un attimo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1465,1467</context>
+          <context context-type="linenumber">1471,1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
@@ -13994,7 +14058,7 @@
         <target>Scala di valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
@@ -14002,7 +14066,7 @@
         <target>Distribuzione delle valutazioni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1551</context>
+          <context context-type="linenumber">1557</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
@@ -14010,7 +14074,7 @@
         <target>In attesa delle stime…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1590,1592</context>
+          <context context-type="linenumber">1596,1598</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
@@ -14018,7 +14082,7 @@
         <target><x id="INTERPOLATION"/> risposte ricevute</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1598,1600</context>
+          <context context-type="linenumber">1604,1606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
@@ -14026,11 +14090,11 @@
         <target>Riepilogo delle statistiche</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1610</context>
+          <context context-type="linenumber">1616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2043</context>
+          <context context-type="linenumber">2049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
@@ -14038,7 +14102,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615</context>
+          <context context-type="linenumber">1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
@@ -14046,11 +14110,11 @@
         <target>Accettata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1633</context>
+          <context context-type="linenumber">1639</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2063</context>
+          <context context-type="linenumber">2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
@@ -14058,7 +14122,7 @@
         <target>Confronto circolare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1653</context>
+          <context context-type="linenumber">1659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
@@ -14066,7 +14130,7 @@
         <target>spostare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
@@ -14074,7 +14138,7 @@
         <target>Round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1695</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
@@ -14082,7 +14146,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1694</context>
+          <context context-type="linenumber">1700</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
@@ -14090,11 +14154,11 @@
         <target>Mostra dettagli statistici</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2180</context>
+          <context context-type="linenumber">2186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
@@ -14102,7 +14166,7 @@
         <target>Round 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1895,1897</context>
+          <context context-type="linenumber">1901,1903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
@@ -14110,7 +14174,7 @@
         <target>Round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1923,1925</context>
+          <context context-type="linenumber">1929,1931</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
@@ -14118,7 +14182,7 @@
         <target>Δ a coppie: <x id="INTERPOLATION"/> più vicino, <x id="INTERPOLATION_1"/> più lontano, <x id="INTERPOLATION_2"/> invariato (<x id="INTERPOLATION_3"/> coppie)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1954,1962</context>
+          <context context-type="linenumber">1960,1968</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
@@ -14126,7 +14190,7 @@
         <target>Distribuzione Δx</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1972</context>
+          <context context-type="linenumber">1978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
@@ -14134,7 +14198,7 @@
         <target>più piccolo è più vicino</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2086</context>
+          <context context-type="linenumber">2092</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
@@ -14142,7 +14206,7 @@
         <target>Giro di risultati</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2193,2195</context>
+          <context context-type="linenumber">2199,2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
@@ -14150,7 +14214,7 @@
         <target>Nessuna stima ricevuta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2220,2222</context>
+          <context context-type="linenumber">2226,2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
@@ -14158,7 +14222,7 @@
         <target>Confronto prima e dopo per la Peer Instruction</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2232</context>
+          <context context-type="linenumber">2238</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
@@ -14166,7 +14230,7 @@
         <target>Round 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> voto)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2240</context>
+          <context context-type="linenumber">2246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
@@ -14174,7 +14238,7 @@
         <target>Round 1 (<x id="INTERPOLATION" equiv-text="{{ round1Votes }}"/> voti)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2246</context>
+          <context context-type="linenumber">2252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
@@ -14182,7 +14246,7 @@
         <target>Round 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> voto)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2254</context>
+          <context context-type="linenumber">2260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
@@ -14190,7 +14254,7 @@
         <target>Round 2 (<x id="INTERPOLATION" equiv-text="{{ round2Votes }}"/> voti)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2260</context>
+          <context context-type="linenumber">2266</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
@@ -14198,7 +14262,7 @@
         <target>Corrette: <x id="INTERPOLATION" equiv-text="{{ q.roundComparison.round1CorrectCount }}"/> nel round 1, poi <x id="INTERPOLATION_1" equiv-text="{{ q.roundComparison.round2CorrectCount }}"/> nel round 2</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2272,2276</context>
+          <context context-type="linenumber">2278,2282</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
@@ -14206,7 +14270,7 @@
         <target>Peer Instruction consigliata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2519,2521</context>
+          <context context-type="linenumber">2525,2527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
@@ -14214,7 +14278,7 @@
         <target>35–70 % completamente corretti: secondo turno adatto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2526,2528</context>
+          <context context-type="linenumber">2532,2534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
@@ -14222,7 +14286,7 @@
         <target>Primo turno ancora nascosto finché non procedi.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2533,2535</context>
+          <context context-type="linenumber">2539,2541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
@@ -14230,7 +14294,7 @@
         <target>Avvia discussione o mostra risultato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2540,2542</context>
+          <context context-type="linenumber">2546,2548</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
@@ -14238,7 +14302,7 @@
         <target>Autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2598,2600</context>
+          <context context-type="linenumber">2604,2606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
@@ -14246,7 +14310,7 @@
         <target> Giusto o sbagliato — e quanto sei sicuro? Soprattutto: sbagliato nonostante alta sicurezza di risposta. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2604,2607</context>
+          <context context-type="linenumber">2610,2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
@@ -14254,7 +14318,7 @@
         <target>Correttezza e autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2634</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
@@ -14262,7 +14326,7 @@
         <target> Spesso sbagliato con alta sicurezza di risposta </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2682,2684</context>
+          <context context-type="linenumber">2688,2690</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
@@ -14270,7 +14334,7 @@
         <target>Aggiornamento della domanda …</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2727,2729</context>
+          <context context-type="linenumber">2733,2735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
@@ -14278,7 +14342,7 @@
         <target>Nessuna domanda attiva. Inizia con “Domanda successiva”.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2731,2733</context>
+          <context context-type="linenumber">2737,2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -14286,7 +14350,7 @@
         <target>Reazioni delle persone partecipanti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2751</context>
+          <context context-type="linenumber">2757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
@@ -14294,7 +14358,7 @@
         <target>2ª tornata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2757</context>
+          <context context-type="linenumber">2763</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
@@ -14302,7 +14366,7 @@
         <target>nuovo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2765</context>
+          <context context-type="linenumber">2771</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
@@ -14310,7 +14374,7 @@
         <target>Nessuna reazione ancora.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2788</context>
+          <context context-type="linenumber">2794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
@@ -14318,7 +14382,7 @@
         <target>Primi 5</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2801</context>
+          <context context-type="linenumber">2807</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
@@ -14326,7 +14390,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ entry.totalScore | number }}"/> punti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2868</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
@@ -14334,7 +14398,7 @@
         <target>Parità: conta il tempo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2877</context>
+          <context context-type="linenumber">2883</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
@@ -14342,7 +14406,7 @@
         <target>Punteggio delle squadre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2895</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
@@ -14350,7 +14414,7 @@
         <target>punti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2942</context>
+          <context context-type="linenumber">2948</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
@@ -14358,7 +14422,7 @@
         <target>Cambia quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2971</context>
+          <context context-type="linenumber">2977</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
@@ -14366,7 +14430,7 @@
         <target>Modifica titolo Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3074</context>
+          <context context-type="linenumber">3086</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
@@ -14374,7 +14438,7 @@
         <target>Titolo Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3087</context>
+          <context context-type="linenumber">3099</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
@@ -14382,15 +14446,15 @@
         <target>Domande sull'evento...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3098</context>
+          <context context-type="linenumber">3110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">886</context>
+          <context context-type="linenumber">893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">898</context>
+          <context context-type="linenumber">905</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14402,7 +14466,7 @@
         <target>Salva titolo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3110</context>
+          <context context-type="linenumber">3122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
@@ -14410,7 +14474,7 @@
         <target>Annulla modifica</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3121</context>
+          <context context-type="linenumber">3133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
@@ -14418,7 +14482,7 @@
         <target>Pre-moderazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3140,3142</context>
+          <context context-type="linenumber">3152,3154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
@@ -14426,7 +14490,7 @@
         <target>La pre-moderazione è attiva. Le nuove domande aspettano prima la tua approvazione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3144,3146</context>
+          <context context-type="linenumber">3156,3158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
@@ -14434,7 +14498,7 @@
         <target>Ancora nessuna domanda.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3153,3155</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
@@ -14442,7 +14506,7 @@
         <target>Totale: <x id="INTERPOLATION" equiv-text="qaQuestions().length"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3165,3166</context>
+          <context context-type="linenumber">3177,3178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
@@ -14450,7 +14514,7 @@
         <target>In attesa di approvazione: <x id="INTERPOLATION" equiv-text="qaPendingCount()"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3174,3175</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
@@ -14458,7 +14522,7 @@
         <target>Mostra tutte le domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3227</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
@@ -14466,7 +14530,7 @@
         <target>Mostra tutte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3230</context>
+          <context context-type="linenumber">3242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
@@ -14474,7 +14538,7 @@
         <target>Mostra solo le domande fissate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3238</context>
+          <context context-type="linenumber">3250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
@@ -14482,7 +14546,7 @@
         <target>Solo fissate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3241</context>
+          <context context-type="linenumber">3253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
@@ -14490,7 +14554,7 @@
         <target>Mostra nuove domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3253</context>
+          <context context-type="linenumber">3265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
@@ -14498,7 +14562,7 @@
         <target><x id="INTERPOLATION" equiv-text="{{ qaUnseenCount() }}"/> nuove domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3259</context>
+          <context context-type="linenumber">3271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
@@ -14506,7 +14570,7 @@
         <target>Esporta le domande come CSV</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3291</context>
+          <context context-type="linenumber">3303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
@@ -14514,7 +14578,7 @@
         <target>Esporta domande</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3294</context>
+          <context context-type="linenumber">3306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
@@ -14522,7 +14586,7 @@
         <target>Esportazione in corso…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3302,3304</context>
+          <context context-type="linenumber">3314,3316</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
@@ -14530,7 +14594,7 @@
         <target>Controversa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3371</context>
+          <context context-type="linenumber">3383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
@@ -14538,7 +14602,7 @@
         <target><x id="INTERPOLATION" equiv-text="question.positiveVoteCount"/> positivi · <x id="INTERPOLATION_1" equiv-text="question.negativeVoteCount"/> negativi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3399,3400</context>
+          <context context-type="linenumber">3411,3412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
@@ -14546,7 +14610,7 @@
         <target>Approvazione affidabile <x id="INTERPOLATION" equiv-text="formatQaPercent(question.bestScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3407,3408</context>
+          <context context-type="linenumber">3419,3420</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
@@ -14554,7 +14618,7 @@
         <target>Reazioni divise <x id="INTERPOLATION" equiv-text="formatQaPercent(question.controversyScore)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3417,3419</context>
+          <context context-type="linenumber">3429,3431</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
@@ -14562,7 +14626,7 @@
         <target>Vista fissate attiva – non ci sono ancora domande fissate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3460,3462</context>
+          <context context-type="linenumber">3472,3474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
@@ -14570,7 +14634,7 @@
         <target>Mostra opzioni di risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3513</context>
+          <context context-type="linenumber">3525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
@@ -14578,7 +14642,7 @@
         <target>Avvia la fase di discussione – confronto prima della seconda votazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3549</context>
+          <context context-type="linenumber">3561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
@@ -14586,7 +14650,7 @@
         <target>Fase di discussione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3552</context>
+          <context context-type="linenumber">3564</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
@@ -14594,11 +14658,11 @@
         <target>Pubblica comunque</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3579</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3589</context>
+          <context context-type="linenumber">3601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
@@ -14606,7 +14670,7 @@
         <target>Mostra comunque il risultato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3570</context>
+          <context context-type="linenumber">3582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
@@ -14614,7 +14678,7 @@
         <target>Mostra risultato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3591</context>
+          <context context-type="linenumber">3603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
@@ -14622,7 +14686,7 @@
         <target>Prossima domanda</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3607,3609</context>
+          <context context-type="linenumber">3619,3621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
@@ -14630,7 +14694,7 @@
         <target>Alla prossima domanda senza seconda votazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3630</context>
+          <context context-type="linenumber">3642</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
@@ -14638,7 +14702,7 @@
         <target>Alla prossima domanda senza seconda votazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3633</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
@@ -14646,7 +14710,7 @@
         <target>Mostra di nuovo la domanda precedente con il risultato e la risposta corretta (senza una nuova votazione).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650</context>
+          <context context-type="linenumber">3662</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
@@ -14654,7 +14718,7 @@
         <target>Mostra di nuovo il risultato precedente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3652,3654</context>
+          <context context-type="linenumber">3664,3666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
@@ -14662,7 +14726,7 @@
         <target>Termina sessione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3662,3664</context>
+          <context context-type="linenumber">3674,3676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -14670,7 +14734,7 @@
         <target>Vista host per lobby e controllo.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3670</context>
+          <context context-type="linenumber">3682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
@@ -14678,7 +14742,7 @@
         <target>Lobby · Caldo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">322</context>
+          <context context-type="linenumber">324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyArrival" datatype="html">
@@ -14686,7 +14750,7 @@
         <target>Lobby · Arrivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyCalm" datatype="html">
@@ -14694,7 +14758,7 @@
         <target>Lobby · Calma</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyPulse" datatype="html">
@@ -14702,7 +14766,7 @@
         <target>Lobby · Pulsazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">334</context>
+          <context context-type="linenumber">336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackReadingBuild" datatype="html">
@@ -14710,7 +14774,7 @@
         <target>Lettura · Preparazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">338</context>
+          <context context-type="linenumber">340</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownFocus" datatype="html">
@@ -14718,7 +14782,7 @@
         <target>Conto alla rovescia · Focus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownTempo" datatype="html">
@@ -14726,7 +14790,7 @@
         <target>Conto alla rovescia · Ritmo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownIntense" datatype="html">
@@ -14734,7 +14798,23 @@
         <target>Conto alla rovescia · Intenso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">350</context>
+          <context context-type="linenumber">352</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingQa" datatype="html">
+        <source>Warum die Fragenwand mehr als ein Chat ist</source>
+        <target>Perché la bacheca delle domande è più di una chat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">421</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <target>Comprendere l’autovalutazione e l’analisi successiva</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">423</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4017389878545296254" datatype="html">
@@ -14742,7 +14822,7 @@
         <target>In attesa dei dati di testo libero in tempo reale...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">500</context>
+          <context context-type="linenumber">507</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14754,7 +14834,7 @@
         <target>Testo libero dal vivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">503</context>
+          <context context-type="linenumber">510</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14766,7 +14846,7 @@
         <target>Parole frequenti nelle risposte.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">504</context>
+          <context context-type="linenumber">511</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14778,7 +14858,7 @@
         <target>Analisi Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">505</context>
+          <context context-type="linenumber">512</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14790,7 +14870,7 @@
         <target>Mostra quali parole e frasi dominano nelle domande Q&amp;A visibili.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">506</context>
+          <context context-type="linenumber">513</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14802,7 +14882,7 @@
         <target>Nascondi nuvola di parole</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">647</context>
+          <context context-type="linenumber">654</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudShow" datatype="html">
@@ -14810,7 +14890,7 @@
         <target>Mostra nuvola di parole</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">648</context>
+          <context context-type="linenumber">655</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudResume" datatype="html">
@@ -14818,11 +14898,11 @@
         <target>Riprendi live</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">653</context>
+          <context context-type="linenumber">660</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1036</context>
+          <context context-type="linenumber">1043</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFreeze" datatype="html">
@@ -14830,11 +14910,11 @@
         <target>Blocca la nuvola di parole</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">654</context>
+          <context context-type="linenumber">661</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1037</context>
+          <context context-type="linenumber">1044</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFrozenInfo" datatype="html">
@@ -14842,7 +14922,7 @@
         <target>Nuvola di parole bloccata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">679</context>
+          <context context-type="linenumber">686</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobbyShort" datatype="html">
@@ -14850,7 +14930,7 @@
         <target>Lobby</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseConnectingShort" datatype="html">
@@ -14858,7 +14938,7 @@
         <target>Lettura</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">837</context>
+          <context context-type="linenumber">844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseRunningShort" datatype="html">
@@ -14866,7 +14946,7 @@
         <target>Conto alla rovescia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">838</context>
+          <context context-type="linenumber">845</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicLabelOff" datatype="html">
@@ -14874,7 +14954,7 @@
         <target>Musica off</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">870</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
@@ -14882,7 +14962,7 @@
         <target>Sessione quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">891</context>
+          <context context-type="linenumber">898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricBest" datatype="html">
@@ -14890,7 +14970,7 @@
         <target>approvazione affidabile</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">958</context>
+          <context context-type="linenumber">965</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricControversial" datatype="html">
@@ -14898,7 +14978,7 @@
         <target>controversia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">960</context>
+          <context context-type="linenumber">967</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricTop" datatype="html">
@@ -14906,7 +14986,7 @@
         <target>voti positivi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">969</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudTitle" datatype="html">
@@ -14914,7 +14994,7 @@
         <target>Nuvola di parole Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">965</context>
+          <context context-type="linenumber">972</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14926,7 +15006,7 @@
         <target>Le parole e le frasi più grandi provengono da domande con molto consenso e abbastanza voti.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">969</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintControversial" datatype="html">
@@ -14934,7 +15014,7 @@
         <target>Le parole e le frasi più grandi provengono da domande con reazioni opposte. Passa sopra per vedere le domande collegate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintTop" datatype="html">
@@ -14942,7 +15022,7 @@
         <target>Le parole e le frasi più grandi provengono da domande con molti voti positivi.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">973</context>
+          <context context-type="linenumber">980</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudThemeFallbackHint" datatype="html">
@@ -14950,7 +15030,7 @@
         <target>Vengono mostrate parole singole finché gruppi di parole e frasi non sono affidabili.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1026</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintBest" datatype="html">
@@ -14958,7 +15038,7 @@
         <target>Mostra prima le domande con molto consenso e abbastanza voti. Le domande fissate restano evidenziate, ma non vengono anticipate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1024</context>
+          <context context-type="linenumber">1031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintControversial" datatype="html">
@@ -14966,7 +15046,7 @@
         <target>Mostra prima le domande con reazioni miste. Le domande fissate restano evidenziate, ma non vengono anticipate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1026</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintTop" datatype="html">
@@ -14974,7 +15054,7 @@
         <target>Mostra prima le domande con più voti positivi. Le domande fissate restano evidenziate, ma non vengono anticipate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1028</context>
+          <context context-type="linenumber">1035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudShow" datatype="html">
@@ -14982,7 +15062,7 @@
         <target>Mostra nuvola di parole</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1032</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountOneMetric" datatype="html">
@@ -14990,7 +15070,7 @@
         <target>1 domanda visibile · Dimensione di parole e frasi: <x id="metric" equiv-text="metric"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1043</context>
+          <context context-type="linenumber">1050</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountManyMetric" datatype="html">
@@ -14998,7 +15078,7 @@
         <target><x id="count" equiv-text="count"/> domande visibili · Dimensione di parole e frasi: <x id="metric" equiv-text="metric"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1045</context>
+          <context context-type="linenumber">1052</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountOne" datatype="html">
@@ -15006,7 +15086,7 @@
         <target>1 risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1552</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
@@ -15014,7 +15094,7 @@
         <target><x id="count" equiv-text="count"/> risposte</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1546</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
@@ -15022,7 +15102,7 @@
         <target>Basso · <x id="label" equiv-text="q.confidenceLabelLow"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1637</context>
+          <context context-type="linenumber">1644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
@@ -15030,7 +15110,7 @@
         <target>Basso (1–2)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
@@ -15038,7 +15118,7 @@
         <target>Medio (3)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1642</context>
+          <context context-type="linenumber">1649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
@@ -15046,7 +15126,7 @@
         <target>Alto · <x id="label" equiv-text="q.confidenceLabelHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1674</context>
+          <context context-type="linenumber">1681</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
@@ -15054,7 +15134,7 @@
         <target>Alto (4–5)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
@@ -15062,7 +15142,7 @@
         <target>Corretto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1696</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
@@ -15070,7 +15150,7 @@
         <target>Sbagliato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1696</context>
+          <context context-type="linenumber">1703</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
@@ -15078,7 +15158,7 @@
         <target><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
@@ -15086,7 +15166,7 @@
         <target>1 risposta sbagliata sicura – possibile malinteso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1793</context>
+          <context context-type="linenumber">1800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
@@ -15094,7 +15174,7 @@
         <target><x id="count" equiv-text="count"/> risposte sbagliate sicure – possibili malintesi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1794</context>
+          <context context-type="linenumber">1801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
@@ -15102,7 +15182,7 @@
         <target>Corretto+alto <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · Sbagliato+alto <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1805</context>
+          <context context-type="linenumber">1812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
@@ -15110,7 +15190,7 @@
         <target>2 (Istruzione tra pari)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1825</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
@@ -15118,7 +15198,7 @@
         <target>Round 1: <x id="r1" equiv-text="round1Count"/> voti · Complessivo: round 2 con <x id="r2" equiv-text="round2Count"/> voti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1843</context>
+          <context context-type="linenumber">1850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
@@ -15126,7 +15206,7 @@
         <target>Turno di aggregazione 2 (Istruzione tra pari)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1845</context>
+          <context context-type="linenumber">1852</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
@@ -15134,7 +15214,7 @@
         <target>Turno di aggregazione 1</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1848</context>
+          <context context-type="linenumber">1855</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
@@ -15142,7 +15222,7 @@
         <target>Questa volta non è passata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2452</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
@@ -15150,7 +15230,7 @@
         <target>Tranquillo, succede (un attimo di linea o Wi‑Fi ballerino). Aspetta qualche secondo e tocca « Riprova » — di solito basta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2453</context>
+          <context context-type="linenumber">2460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
@@ -15158,7 +15238,7 @@
         <target>Con le domande si incolla un attimo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2460</context>
+          <context context-type="linenumber">2467</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
@@ -15166,7 +15246,7 @@
         <target>Non è rotto, è solo che non ha funzionato quel colpo. Aspetta 2–3 secondi e tocca « Riprova » — spesso si sistema subito.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2461</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
@@ -15174,7 +15254,7 @@
         <target>Export non ancora pronto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2468</context>
+          <context context-type="linenumber">2475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
@@ -15182,7 +15262,7 @@
         <target>L’export PDF o Excel non è arrivato questa volta. Aspetta qualche secondo e tocca « Riprova » — al secondo tentativo di solito va.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2469</context>
+          <context context-type="linenumber">2476</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
@@ -15190,7 +15270,7 @@
         <target>I partecipanti e la visualizzazione della presentazione vengono reindirizzati alla home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2610</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
@@ -15198,7 +15278,7 @@
         <target>La sessione termina per tutti; non è possibile proseguire con lo stesso codice.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
@@ -15206,7 +15286,7 @@
         <target><x id="participantCount" equiv-text="participants"/> I partecipanti sono ancora nella sessione.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2608</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
@@ -15214,7 +15294,7 @@
         <target>Hai già dei risultati. Dopo la chiusura puoi esportarli o vedere il feedback nella vista finale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2613</context>
+          <context context-type="linenumber">2620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
@@ -15222,7 +15302,7 @@
         <target>Non ci sono ancora risultati utilizzabili. Dopo la chiusura verrai portato direttamente alla home page.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2617</context>
+          <context context-type="linenumber">2624</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
@@ -15230,7 +15310,7 @@
         <target>Per i codici bonus: consigliare ai partecipanti di copiare ora il proprio codice personale (appunti) prima di lasciare la pagina, altrimenti potrebbero perderlo facilmente.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2622</context>
+          <context context-type="linenumber">2629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
@@ -15238,7 +15318,7 @@
         <target>Lasciare la sessione?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
@@ -15246,7 +15326,7 @@
         <target>La tua sessione è ancora attiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2629</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
@@ -15254,7 +15334,7 @@
         <target>Esci comunque</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2631</context>
+          <context context-type="linenumber">2638</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
@@ -15262,7 +15342,7 @@
         <target>Torna alla sessione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2632</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
@@ -15270,7 +15350,7 @@
         <target>Interrompi l&apos;anteprima</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2823</context>
+          <context context-type="linenumber">2830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
@@ -15278,7 +15358,7 @@
         <target>Ascolta brevemente il brano (max. 12 secondi)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2824</context>
+          <context context-type="linenumber">2831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
@@ -15286,7 +15366,7 @@
         <target>Audio on</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2836</context>
+          <context context-type="linenumber">2843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
@@ -15294,7 +15374,7 @@
         <target>Audio off</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2837</context>
+          <context context-type="linenumber">2844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
@@ -15302,7 +15382,7 @@
         <target>Partecipante</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
@@ -15310,7 +15390,7 @@
         <target>partecipanti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2898</context>
+          <context context-type="linenumber">2905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
@@ -15318,7 +15398,7 @@
         <target>1 connesso in diretta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
@@ -15326,7 +15406,7 @@
         <target><x id="connectedCount" equiv-text="connectedCount"/> connesso dal vivo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2917</context>
+          <context context-type="linenumber">2924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
@@ -15334,7 +15414,7 @@
         <target>Non c’è ancora nessuno in questa squadra.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2943</context>
+          <context context-type="linenumber">2950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
@@ -15342,7 +15422,7 @@
         <target>Valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3759</context>
+          <context context-type="linenumber">3766</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
@@ -15350,7 +15430,7 @@
         <target>Recensioni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3763</context>
+          <context context-type="linenumber">3770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
@@ -15358,11 +15438,11 @@
         <target>I risultati sono arrivati.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3768</context>
+          <context context-type="linenumber">3775</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3775</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
@@ -15370,11 +15450,11 @@
         <target>Il tempo è scaduto.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3769</context>
+          <context context-type="linenumber">3776</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3776</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
@@ -15382,7 +15462,7 @@
         <target>In attesa di recensioni…</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3770</context>
+          <context context-type="linenumber">3777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
@@ -15390,7 +15470,7 @@
         <target>In attesa di risposte...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
@@ -15398,7 +15478,7 @@
         <target><x id="PH" equiv-text="votes"/> di <x id="PH_1" equiv-text="participants"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3781</context>
+          <context context-type="linenumber">3788</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
@@ -15406,7 +15486,7 @@
         <target>Una persona sta ancora usando il tempo ×10. «Pubblica comunque» chiude la sua finestra personale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3788</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
@@ -15414,7 +15494,7 @@
         <target>Una persona sta ancora usando il tempo ×10. Attendi il conto alla rovescia della stanza o la fine del tempo ×10.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3789</context>
+          <context context-type="linenumber">3796</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
@@ -15422,7 +15502,7 @@
         <target>Le persone <x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> stanno ancora usando il tempo ×10. «Pubblica comunque» chiude le loro finestre personali.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3793</context>
+          <context context-type="linenumber">3800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
@@ -15430,7 +15510,7 @@
         <target>Le persone <x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> stanno ancora usando il tempo ×10. Attendi il conto alla rovescia della stanza o la fine del tempo ×10.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3794</context>
+          <context context-type="linenumber">3801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
@@ -15438,7 +15518,7 @@
         <target>Una persona risponde senza scadenza personale. «Mostra risultato» chiude la sua risposta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3797</context>
+          <context context-type="linenumber">3804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
@@ -15446,7 +15526,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> persone rispondono senza scadenza personale. «Mostra risultato» chiude la loro risposta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3799</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
@@ -15454,7 +15534,7 @@
         <target>Hanno votato <x id="votes" equiv-text="votes"/> partecipanti su <x id="participants" equiv-text="participants"/>. Raggiunto il <x id="percentage" equiv-text="percentage"/> percento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3805</context>
+          <context context-type="linenumber">3812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
@@ -15462,7 +15542,7 @@
         <target><x id="votes" equiv-text="votes"/> partecipanti su <x id="participants" equiv-text="participants"/> hanno votato. Raggiunto il <x id="percentage" equiv-text="percentage"/> percento.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3807</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
@@ -15470,7 +15550,7 @@
         <target><x id="voteCount"/> su <x id="participantTotal"/> ha votato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3818</context>
+          <context context-type="linenumber">3825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
@@ -15478,7 +15558,7 @@
         <target><x id="voteCount"/> su <x id="participantTotal"/> hanno votato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3827</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
@@ -15486,7 +15566,7 @@
         <target><x id="voteCount"/> su <x id="participantTotal"/> ha valutato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3831</context>
+          <context context-type="linenumber">3838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
@@ -15494,7 +15574,7 @@
         <target><x id="voteCount"/> su <x id="participantTotal"/> hanno valutato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3833</context>
+          <context context-type="linenumber">3840</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
@@ -15502,7 +15582,7 @@
         <target><x id="correctCount"/> su <x id="voteTotal"/> completamente corretti (<x id="percentage"/>%)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3839</context>
+          <context context-type="linenumber">3846</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
@@ -15510,7 +15590,7 @@
         <target><x id="changed"/> su <x id="both"/> (<x id="pct"/>%) hanno cambiato idea</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3843</context>
+          <context context-type="linenumber">3850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
@@ -15518,7 +15598,7 @@
         <target>↑ <x id="count"/> sbagliato → corretto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3847</context>
+          <context context-type="linenumber">3854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
@@ -15526,7 +15606,7 @@
         <target>↓ <x id="count"/> corretto → sbagliato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3851</context>
+          <context context-type="linenumber">3858</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
@@ -15534,7 +15614,7 @@
         <target>Media <x id="avg"/> su 5 stelle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3857</context>
+          <context context-type="linenumber">3864</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
@@ -15542,7 +15622,7 @@
         <target><x id="PH" equiv-text="total"/> reazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
@@ -15550,7 +15630,7 @@
         <target><x id="PH" equiv-text="total"/> reazioni</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
@@ -15558,7 +15638,7 @@
         <target>Lobby: le persone partecipanti possono entrare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3917</context>
+          <context context-type="linenumber">3924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
@@ -15566,7 +15646,7 @@
         <target>Il giro di domande si sta preparando</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3918</context>
+          <context context-type="linenumber">3925</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
@@ -15574,15 +15654,15 @@
         <target>Il giro di domande è in corso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3919</context>
+          <context context-type="linenumber">3926</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3921</context>
+          <context context-type="linenumber">3928</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3922</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
@@ -15590,7 +15670,7 @@
         <target>In pausa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3920</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
@@ -15598,7 +15678,7 @@
         <target>Giro di domande terminato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3923</context>
+          <context context-type="linenumber">3930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
@@ -15606,7 +15686,7 @@
         <target>Votazione terminata – in attesa di valutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3928</context>
+          <context context-type="linenumber">3935</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
@@ -15614,7 +15694,7 @@
         <target>Lobby: i partecipanti possono unirsi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3931</context>
+          <context context-type="linenumber">3938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
@@ -15622,7 +15702,7 @@
         <target>Fase di lettura – risposte ancora bloccate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3932</context>
+          <context context-type="linenumber">3939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
@@ -15630,7 +15710,7 @@
         <target>La votazione è in corso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3933</context>
+          <context context-type="linenumber">3940</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
@@ -15638,7 +15718,7 @@
         <target>In pausa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3934</context>
+          <context context-type="linenumber">3941</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
@@ -15646,7 +15726,7 @@
         <target>Vengono visualizzati i risultati</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3935</context>
+          <context context-type="linenumber">3942</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
@@ -15654,7 +15734,7 @@
         <target>Fase di discussione — confronto prima del secondo turno</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3936</context>
+          <context context-type="linenumber">3943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
@@ -15662,7 +15742,7 @@
         <target>La sessione è terminata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3937</context>
+          <context context-type="linenumber">3944</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
@@ -15670,7 +15750,7 @@
         <target><x id="readyCount" equiv-text="readyCount"/> su <x id="connectedCount" equiv-text="connectedCount"/> pronti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3948</context>
+          <context context-type="linenumber">3955</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
@@ -15678,7 +15758,7 @@
         <target><x id="PH" equiv-text="readyCount"/> di <x id="PH_1" equiv-text="connectedCount"/> connesso pronto · <x id="PH_2" equiv-text="totalParticipantCount"/> totale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3950</context>
+          <context context-type="linenumber">3957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
@@ -15686,7 +15766,7 @@
         <target>Tutte le persone partecipanti sono pronte: le opzioni di risposta possono essere mostrate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3955</context>
+          <context context-type="linenumber">3962</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
@@ -15694,7 +15774,7 @@
         <target>Tutte le persone partecipanti collegate sono pronte: le opzioni di risposta possono essere mostrate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3957</context>
+          <context context-type="linenumber">3964</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
@@ -15702,7 +15782,7 @@
         <target>1 secondo rimanente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3988</context>
+          <context context-type="linenumber">3995</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
@@ -15710,7 +15790,7 @@
         <target><x id="seconds" equiv-text="seconds"/> secondi rimanenti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3989</context>
+          <context context-type="linenumber">3996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -15724,7 +15804,7 @@
     )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4113,4116</context>
+          <context context-type="linenumber">4120,4123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -15738,7 +15818,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4158,4161</context>
+          <context context-type="linenumber">4165,4168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -15752,7 +15832,7 @@
       )"/> a <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4163,4166</context>
+          <context context-type="linenumber">4170,4173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -15767,7 +15847,7 @@
     )"/> a <x id="right" equiv-text="formatNumber(band.right, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4168,4171</context>
+          <context context-type="linenumber">4175,4178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
@@ -15775,7 +15855,7 @@
         <target>Mediana <x id="median" equiv-text="formatNumber(stats.median, this.localeId, '1.0-2')"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4286</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
@@ -15783,7 +15863,7 @@
         <target>Stime</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4319</context>
+          <context context-type="linenumber">4326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
@@ -15791,7 +15871,7 @@
         <target>risposte valide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
@@ -15799,7 +15879,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4327</context>
+          <context context-type="linenumber">4334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
@@ -15807,7 +15887,7 @@
         <target>Media di tutte le stime</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4329</context>
+          <context context-type="linenumber">4336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
@@ -15815,7 +15895,7 @@
         <target>Mediana</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4335</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
@@ -15823,7 +15903,7 @@
         <target>Valore centrale ordinato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4337</context>
+          <context context-type="linenumber">4344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
@@ -15831,7 +15911,7 @@
         <target>Dispersione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4343</context>
+          <context context-type="linenumber">4350</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
@@ -15839,7 +15919,7 @@
         <target>Deviazione standard</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4345</context>
+          <context context-type="linenumber">4352</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
@@ -15847,7 +15927,7 @@
         <target>50% centrali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4351</context>
+          <context context-type="linenumber">4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -15862,7 +15942,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4356,4359</context>
+          <context context-type="linenumber">4363,4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
@@ -15870,7 +15950,7 @@
         <target>Intervallo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4365</context>
+          <context context-type="linenumber">4372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
@@ -15878,7 +15958,7 @@
         <target>stima minima e massima</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4370</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
@@ -15886,7 +15966,7 @@
         <target>Nell'intervallo</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4376</context>
+          <context context-type="linenumber">4383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -15902,7 +15982,7 @@
         )"/>% accettato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4382,4386</context>
+          <context context-type="linenumber">4389,4393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
@@ -15910,7 +15990,7 @@
         <target>Distanza media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4392</context>
+          <context context-type="linenumber">4399</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
@@ -15918,7 +15998,7 @@
         <target>dal riferimento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394</context>
+          <context context-type="linenumber">4401</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
@@ -15926,7 +16006,7 @@
         <target>Mediano</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4402</context>
+          <context context-type="linenumber">4409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
@@ -15934,7 +16014,7 @@
         <target>Media</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4405</context>
+          <context context-type="linenumber">4412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
@@ -15942,7 +16022,7 @@
         <target>Stime</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4407</context>
+          <context context-type="linenumber">4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -15958,7 +16038,7 @@
     )"/> % nell&apos;intervallo accettato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4438,4442</context>
+          <context context-type="linenumber">4445,4449</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
@@ -15966,7 +16046,7 @@
         <target>Distanza media dal riferimento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4456</context>
+          <context context-type="linenumber">4463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
@@ -15974,7 +16054,7 @@
         <target>più vicino al valore di riferimento</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4470</context>
+          <context context-type="linenumber">4477</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
@@ -15982,7 +16062,7 @@
         <target>Variazione mediana</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4487</context>
+          <context context-type="linenumber">4494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
@@ -15990,7 +16070,7 @@
         <target>Cambiamento medio</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4488</context>
+          <context context-type="linenumber">4495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -16005,7 +16085,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4499,4502</context>
+          <context context-type="linenumber">4506,4509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -16020,7 +16100,7 @@
         )"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4511</context>
+          <context context-type="linenumber">4515,4518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -16036,7 +16116,7 @@
         )"/> punti percentuali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520,4524</context>
+          <context context-type="linenumber">4527,4531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -16060,7 +16140,7 @@
           )"/> stime comparabili sono migliorate.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4540,4548</context>
+          <context context-type="linenumber">4547,4555</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -16084,7 +16164,7 @@
           )"/> stime comparabili sono più lontane.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4552,4560</context>
+          <context context-type="linenumber">4559,4567</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
@@ -16092,7 +16172,7 @@
         <target>Il secondo round è misto: le stime più vicine e quelle più distanti sono bilanciate nel confronto a coppie.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4564</context>
+          <context context-type="linenumber">4571</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -16106,7 +16186,7 @@
           )"/> nel round 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4576,4579</context>
+          <context context-type="linenumber">4583,4586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -16120,7 +16200,7 @@
           )"/> maggiore nel round 2.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4583,4586</context>
+          <context context-type="linenumber">4590,4593</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -16136,7 +16216,7 @@
         )"/> punti percentuali.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4598,4602</context>
+          <context context-type="linenumber">4605,4609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -16160,7 +16240,7 @@
         )"/> stime rientrano nella fascia di tolleranza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4617,4625</context>
+          <context context-type="linenumber">4624,4632</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -16174,7 +16254,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4630,4633</context>
+          <context context-type="linenumber">4637,4640</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -16188,7 +16268,7 @@
         )"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4637,4640</context>
+          <context context-type="linenumber">4644,4647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
@@ -16196,7 +16276,7 @@
         <target>Quiz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4686</context>
+          <context context-type="linenumber">4693</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16208,7 +16288,7 @@
         <target>Q&amp;A</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4688</context>
+          <context context-type="linenumber">4695</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16220,11 +16300,11 @@
         <target><x id="count" equiv-text="this.qaUnseenCount()"/> nuova/e</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4696</context>
+          <context context-type="linenumber">4703</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4713</context>
+          <context context-type="linenumber">4720</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelInactive" datatype="html">
@@ -16232,7 +16312,7 @@
         <target>Disattivato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4813</context>
+          <context context-type="linenumber">4820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelClosed" datatype="html">
@@ -16240,7 +16320,7 @@
         <target>Chiuso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4816</context>
+          <context context-type="linenumber">4823</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16252,7 +16332,7 @@
         <target>Domanda da <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16264,7 +16344,7 @@
         <target>Domanda dal pubblico</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16276,7 +16356,7 @@
         <target>Deseleziona <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4879</context>
+          <context context-type="linenumber">4886</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16292,7 +16372,7 @@
         <target>Evidenzia tutte le domande di <x id="PH" equiv-text="nickname"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4880</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16308,7 +16388,7 @@
         <target>In risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4909</context>
+          <context context-type="linenumber">4916</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16320,7 +16400,7 @@
         <target>Aperta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4911</context>
+          <context context-type="linenumber">4918</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16332,7 +16412,7 @@
         <target>In attesa di approvazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4913</context>
+          <context context-type="linenumber">4920</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16344,7 +16424,7 @@
         <target>Risposta</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4915</context>
+          <context context-type="linenumber">4922</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16356,7 +16436,7 @@
         <target>Rimossa</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4917</context>
+          <context context-type="linenumber">4924</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -16368,7 +16448,7 @@
         <target>Approva</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5018</context>
+          <context context-type="linenumber">5025</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
@@ -16376,7 +16456,7 @@
         <target>Metti in evidenza</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5020</context>
+          <context context-type="linenumber">5027</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
@@ -16384,7 +16464,7 @@
         <target>Rimuovi evidenziazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5022</context>
+          <context context-type="linenumber">5029</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
@@ -16392,7 +16472,7 @@
         <target>Archivia</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5024</context>
+          <context context-type="linenumber">5031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
@@ -16400,7 +16480,7 @@
         <target>Rimuovi definitivamente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5027</context>
+          <context context-type="linenumber">5034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
@@ -16408,7 +16488,7 @@
         <target>Elimina</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5028</context>
+          <context context-type="linenumber">5035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
@@ -16416,7 +16496,7 @@
         <target>Chiudi canale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5372</context>
+          <context context-type="linenumber">5379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
@@ -16424,7 +16504,7 @@
         <target>Riapri canale</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5373</context>
+          <context context-type="linenumber">5380</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
@@ -16432,7 +16512,7 @@
         <target>Pre-moderazione attivata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5787</context>
+          <context context-type="linenumber">5794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
@@ -16440,7 +16520,7 @@
         <target>Pre-moderazione disattivata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5788</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
@@ -16448,7 +16528,7 @@
         <target>Domanda approvata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5821</context>
+          <context context-type="linenumber">5828</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
@@ -16456,7 +16536,7 @@
         <target>Domanda messa in evidenza.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5823</context>
+          <context context-type="linenumber">5830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
@@ -16464,7 +16544,7 @@
         <target>Domanda archiviata.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5825</context>
+          <context context-type="linenumber">5832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
@@ -16472,7 +16552,7 @@
         <target>Domanda rimossa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5826</context>
+          <context context-type="linenumber">5833</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
@@ -16480,7 +16560,7 @@
         <target>La scadenza personale ×10 aperta di questa persona termina subito.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5927</context>
+          <context context-type="linenumber">5934</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
@@ -16488,11 +16568,11 @@
         <target>Dopo non sarà più possibile rispondere.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5928</context>
+          <context context-type="linenumber">5935</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5932</context>
+          <context context-type="linenumber">5939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
@@ -16500,7 +16580,7 @@
         <target><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> scadenze personali ×10 aperte terminano subito.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5931</context>
+          <context context-type="linenumber">5938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
@@ -16508,7 +16588,7 @@
         <target>Terminare le scadenze personali?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5936</context>
+          <context context-type="linenumber">5943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
@@ -16516,7 +16596,7 @@
         <target>Avvii la fase di discussione mentre i timer personali sono ancora in corso.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5939</context>
+          <context context-type="linenumber">5946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
@@ -16524,7 +16604,7 @@
         <target>Mostri il risultato mentre i timer personali sono ancora in corso.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5940</context>
+          <context context-type="linenumber">5947</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
@@ -16532,7 +16612,7 @@
         <target>Pubblica comunque</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5942</context>
+          <context context-type="linenumber">5949</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
@@ -16540,7 +16620,7 @@
         <target>Continua ad aspettare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5943</context>
+          <context context-type="linenumber">5950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
@@ -16548,7 +16628,7 @@
         <target>N. domanda;Testo;Tipo;Partecipanti;Round di aggregazione;Ø Punti;Autovalutazione n;Consolidato;Rischio di idea errata;Fragile;Lacuna riconosciuta;Indeciso;Risposta errata più frequente con alta autovalutazione;Dettagli</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6089</context>
+          <context context-type="linenumber">6096</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
@@ -16556,7 +16636,7 @@
         <target>Livello di apprendimento e autovalutazione</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6143</context>
+          <context context-type="linenumber">6150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
@@ -16564,7 +16644,7 @@
         <target>Risposte valide;Domande valutate;Non aggregate (&lt;5 risposte con autovalutazione);Solido;Rischio di idee errate;Fragile;Lacuna di conoscenza identificata;Indeciso</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
@@ -16572,7 +16652,7 @@
         <target>Classifica delle squadre</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6167</context>
+          <context context-type="linenumber">6174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
@@ -16580,7 +16660,7 @@
         <target>Posizione;Squadra;Colore;Membri;Punti squadra;Punti medi per membro</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6169</context>
+          <context context-type="linenumber">6176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
@@ -16588,7 +16668,7 @@
         <target>Codici bonus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6187</context>
+          <context context-type="linenumber">6194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
@@ -16596,7 +16676,7 @@
         <target>Posizione;Nickname;Codice;Punti;Generato il</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6189</context>
+          <context context-type="linenumber">6196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
@@ -16604,7 +16684,7 @@
         <target>Risultato CSV esportato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6197</context>
+          <context context-type="linenumber">6204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
@@ -16612,7 +16692,7 @@
         <target>Vedi il piano di debriefing in PDF – 1 domanda da debriefare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6209</context>
+          <context context-type="linenumber">6216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
@@ -16620,7 +16700,7 @@
         <target>Vedi il piano di debriefing in PDF – <x id="count" equiv-text="count"/> domande da debriefare</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6212</context>
+          <context context-type="linenumber">6219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
@@ -16628,7 +16708,7 @@
         <target>Vedi il piano di debriefing in PDF</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6214</context>
+          <context context-type="linenumber">6221</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
@@ -16636,7 +16716,7 @@
         <target>1 domanda consigliata per il debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6219</context>
+          <context context-type="linenumber">6226</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
@@ -16644,7 +16724,7 @@
         <target><x id="count" equiv-text="count"/> domande consigliate per il debriefing</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6221</context>
+          <context context-type="linenumber">6228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
@@ -16652,7 +16732,7 @@
         <target>Il PDF viene creato (<x id="PH" equiv-text="exportData.questions.length"/> domande)...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6233</context>
+          <context context-type="linenumber">6240</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
@@ -16660,7 +16740,7 @@
         <target>PDF dei risultati scaricato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6239</context>
+          <context context-type="linenumber">6246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
@@ -16668,7 +16748,7 @@
         <target>Risultato PDF aperto per il salvataggio.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6240</context>
+          <context context-type="linenumber">6247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
@@ -16676,7 +16756,7 @@
         <target>N.;ID domanda;Stato;Domanda;Punteggio;Voti positivi;Voti negativi;Voti totali;Punteggio Wilson;Punteggio controversia;Controversa;Creata il</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6267</context>
+          <context context-type="linenumber">6274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
@@ -16684,7 +16764,7 @@
         <target>CSV Q&amp;A esportato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6290</context>
+          <context context-type="linenumber">6297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
@@ -16692,11 +16772,11 @@
         <target>Domanda <x id="questionNumber" equiv-text="data.questionOrder + 1"/>: <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6453</context>
+          <context context-type="linenumber">6460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6461</context>
+          <context context-type="linenumber">6468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16712,7 +16792,7 @@
         <target>Il testo libero in tempo reale viene aggiornato.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6456</context>
+          <context context-type="linenumber">6463</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16724,7 +16804,7 @@
         <target>La domanda attuale non è una domanda a testo libero.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6464</context>
+          <context context-type="linenumber">6471</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16736,7 +16816,7 @@
         <target>Non è ancora una domanda attiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6467</context>
+          <context context-type="linenumber">6474</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -16748,7 +16828,7 @@
         <target>Impossibile caricare i dati di testo libero in tempo reale.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6471</context>
+          <context context-type="linenumber">6478</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -20289,6 +20369,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/countdown-fingers/countdown-fingers.component.ts</context>
           <context context-type="linenumber">126</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="infoLanding.openInNewTab" datatype="html">
+        <source>öffnet in neuem Tab</source>
+        <target>si apre in una nuova scheda</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/info-landing-link/info-landing-link.component.ts</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="markdown.copyCode" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -97,60 +97,74 @@
           <context context-type="linenumber">179</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.infoLandingAria" datatype="html">
+        <source>Was arsnova.eu kann (öffnet in neuem Tab)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">188</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.infoLanding" datatype="html">
+        <source>Was arsnova.eu kann</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">192</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">184</context>
+          <context context-type="linenumber">198</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
         <source>Datenschutz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">188</context>
+          <context context-type="linenumber">202</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">
         <source>Barrierefreiheit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">208</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibility" datatype="html">
         <source>Barrierefreiheit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">212</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7981911571029514989" datatype="html">
         <source>Jetzt noch schneller und flüssiger!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">190</context>
+          <context context-type="linenumber">193</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1136696335453039978" datatype="html">
         <source>Preset: Seriös</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">193</context>
+          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6151253518820826531" datatype="html">
         <source>Preset: Spielerisch</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">194</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2911090466936872230" datatype="html">
         <source>Verbinde…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/feedback/feedback-host.component.html</context>
@@ -165,28 +179,28 @@
         <source>Nochmal versuchen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAria" datatype="html">
         <source>News-Archiv öffnen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">222</context>
+          <context context-type="linenumber">225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
         <source>News-Archiv öffnen, eine ungelesene Meldung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">225</context>
+          <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
         <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId)"/> ungelesene Meldungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">227</context>
+          <context context-type="linenumber">230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.notFound" datatype="html">
@@ -1665,7 +1679,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">402</context>
+          <context context-type="linenumber">410</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -1702,7 +1716,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">397</context>
+          <context context-type="linenumber">405</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/question-type-label.ts</context>
@@ -4282,7 +4296,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4690</context>
+          <context context-type="linenumber">4697</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.html</context>
@@ -4330,7 +4344,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3621</context>
+          <context context-type="linenumber">3633</context>
         </context-group>
       </trans-unit>
       <trans-unit id="feedback.compareRoundStartAria" datatype="html">
@@ -4724,7 +4738,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1899</context>
+          <context context-type="linenumber">1906</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.copyJoinLinkFailed" datatype="html">
@@ -4735,7 +4749,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1904</context>
+          <context context-type="linenumber">1911</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9053966995979025004" datatype="html">
@@ -4757,7 +4771,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4286285949730415684" datatype="html">
@@ -4768,7 +4782,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4772</context>
+          <context context-type="linenumber">4779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6496369252923108566" datatype="html">
@@ -5485,697 +5499,718 @@
           <context context-type="linenumber">56,61</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="help.infoLandingTitle" datatype="html">
+        <source> Mehr zu Nutzen und Hintergründen </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">63,65</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingBody" datatype="html">
+        <source> Auf der Informationsseite findest du Einsatzmöglichkeiten, Hinweise zu Datenschutz und Barrierefreiheit sowie die Abgrenzung zu anderen Audience-Response-Systemen. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">66,69</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="help.formatsTitle" datatype="html">
         <source> Frageformate: passend zum didaktischen Ziel </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">65,67</context>
+          <context context-type="linenumber">78,80</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsLead" datatype="html">
         <source> Wähle das Format nach der Situation im Raum: Willst du Wissen prüfen, Haltungen sichtbar machen, Begriffe einsammeln oder Schätzungen diskutieren? Die Formate sind bewusst getrennt, damit Ergebnisanzeige, Bewertung und Moderation zum Einsatzzweck passen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">68,72</context>
+          <context context-type="linenumber">81,85</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsGridAria" datatype="html">
         <source>Verfügbare Quiz-Frageformate</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">76</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTitle" datatype="html">
         <source>Single Choice</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceTag" datatype="html">
         <source> eine richtige Option </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">84,86</context>
+          <context context-type="linenumber">97,99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSingleChoiceBody" datatype="html">
         <source> Für punktgenaue Verständnischecks: Eine Antwort ist korrekt, Ergebnis und Punkte sind sofort klar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">87,90</context>
+          <context context-type="linenumber">100,103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTitle" datatype="html">
         <source>Multiple Choice</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceTag" datatype="html">
         <source> mehrere richtige Optionen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">97,99</context>
+          <context context-type="linenumber">110,112</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatMultipleChoiceBody" datatype="html">
         <source> Für komplexere Konzepte, typische Fehlannahmen oder Fragen wie „Welche Aussagen stimmen?“ – mehrere Lösungen können zählen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">100,103</context>
+          <context context-type="linenumber">113,116</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTitle" datatype="html">
         <source>Kurzantwort</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">109</context>
+          <context context-type="linenumber">122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextTag" datatype="html">
         <source> Musterlösung statt Auswahl </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">110,112</context>
+          <context context-type="linenumber">123,125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatShortTextBody" datatype="html">
         <source> Teilnehmende formulieren kurz selbst. Du hinterlegst Musterlösungen; arsnova.eu kann Schreibvarianten, Toleranz und bei Bedarf Zahlen oder Einheiten auswerten. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">113,116</context>
+          <context context-type="linenumber">126,129</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTitle" datatype="html">
         <source>Freitext</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">122</context>
+          <context context-type="linenumber">135</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextTag" datatype="html">
         <source> offene Antworten </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">123,125</context>
+          <context context-type="linenumber">136,138</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatFreeTextBody" datatype="html">
         <source> Für Ideen, Reflexionen und Erwartungsabfragen. Keine automatische Bewertung; Antworten lassen sich sammeln und als Wortwolke sichtbar machen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">126,129</context>
+          <context context-type="linenumber">139,142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTitle" datatype="html">
         <source>Umfrage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">148</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyTag" datatype="html">
         <source> Meinungsbild ohne richtig/falsch </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">136,138</context>
+          <context context-type="linenumber">149,151</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatSurveyBody" datatype="html">
         <source> Für Prioritäten, Vorwissen oder Entscheidungen im Raum. Optionen werden gezählt, ohne Scorelogik. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">139,142</context>
+          <context context-type="linenumber">152,155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTitle" datatype="html">
         <source>Bewertungsskala</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">148</context>
+          <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingTag" datatype="html">
         <source> Skala mit eigenen Polen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">149,151</context>
+          <context context-type="linenumber">162,164</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatRatingBody" datatype="html">
         <source> Für Zustimmung, Sicherheit, Tempo oder Feedback von niedrig bis hoch; optional mit benannten Endpunkten. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">152,155</context>
+          <context context-type="linenumber">165,168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTitle" datatype="html">
         <source>Numerische Schätzfrage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">161</context>
+          <context context-type="linenumber">174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateTag" datatype="html">
         <source> Zahlen schätzen, Streuung sehen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">162,164</context>
+          <context context-type="linenumber">175,177</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatNumericEstimateBody" datatype="html">
         <source> Für Jahreszahlen, Größenordnungen, Messwerte und Wahrscheinlichkeiten. Mit Referenzwert, Toleranzband, Histogramm, Statistik und optionaler zweiter Runde. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">165,168</context>
+          <context context-type="linenumber">178,181</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.formatsBlitzNote" datatype="html">
         <source> Blitzlicht ist davon getrennt: Es ist für spontane Live-Rückmeldungen gedacht, wenn du keine vollständige Quizfrage bauen willst. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">172,175</context>
+          <context context-type="linenumber">185,188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceTitle" datatype="html">
         <source> Selbsteinschätzung bei bewertbaren Fragen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">179,181</context>
+          <context context-type="linenumber">192,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceLead" datatype="html">
         <source> Die Selbsteinschätzung ist kein eigener Fragetyp, sondern eine optionale Zusatzabfrage nach Single Choice, Multiple Choice, Kurzantwort und numerischer Schätzfrage: Teilnehmende geben an, wie sicher sie bei ihrer Antwort sind (Skala 1–5). Das beeinflusst keine Punkte – hilft dir aber, Lernstand und Fehlkonzepte zu erkennen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">182,187</context>
+          <context context-type="linenumber">195,200</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceListAria" datatype="html">
         <source>Didaktische Funktionen der Selbsteinschätzung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">191</context>
+          <context context-type="linenumber">204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerTitle" datatype="html">
         <source>Nach der Antwort abfragen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">196</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceAfterAnswerBody" datatype="html">
         <source> Progressive Disclosure: Erst Antwort wählen oder eingeben, dann die Selbsteinschätzung. Während der Abstimmung sieht niemand aggregierte Werte anderer Personen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">197,201</context>
+          <context context-type="linenumber">210,214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorTitle" datatype="html">
         <source>Im Editor konfigurieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">207</context>
+          <context context-type="linenumber">220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceEditorBody" datatype="html">
         <source> Toggle pro Frage, optionale Labels für niedrige und hohe Antwortsicherheit und eine Live-Vorschau der Skala. Für neue bewertbare Fragen ist die Selbsteinschätzung standardmäßig aktiv. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">208,212</context>
+          <context context-type="linenumber">221,225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostTitle" datatype="html">
         <source>Host-Auswertung nach Freigabe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">231</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceHostBody" datatype="html">
         <source> Matrix aus Korrektheit und Antwortsicherheit mit Hervorhebung <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>selbstsicher falsch<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>. Bei Auswahlfragen siehst du, welche falschen Optionen mit hoher Antwortsicherheit gewählt wurden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">219,223</context>
+          <context context-type="linenumber">232,236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportTitle" datatype="html">
         <source>Abschluss und Export</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">229</context>
+          <context context-type="linenumber">242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.confidenceExportBody" datatype="html">
         <source> Nach Session-Ende fasst die Auswertung gefestigtes Wissen, Fehlkonzept-Hinweis und fragiles Wissen zusammen. Fragen mit weniger als 5 Antworten mit Selbsteinschätzung werden nicht aggregiert ausgewiesen. Der Nachbesprechungsplan (PDF) ist das empfohlene Format; CSV steht unter „Mehr“ für Excel zur Verfügung. In der Quiz-Sammlung findest du den Nachbesprechungsplan auf der Quizkarte. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">230,236</context>
+          <context context-type="linenumber">243,249</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTitle" datatype="html">
         <source>Demo-Quiz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">243</context>
+          <context context-type="linenumber">256</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoCardHint" datatype="html">
         <source> Ein vorinstalliertes Beispiel-Quiz zeigt die Frageformate in konkreten Unterrichtsmomenten: Wissenscheck, Wortwolke, Kurzantwort, Schätzfrage, Bewertungsskala, Selbsteinschätzung, Formeln und Markdown. Du findest es in deiner Quiz-Sammlung und kannst es dort in der Vorschau öffnen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">244,249</context>
+          <context context-type="linenumber">257,262</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoTip" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tipp:&lt;/stro"/>Tipp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Öffne die Vorschau vor der ersten Live-Session einmal auf einem zweiten Gerät. So siehst du sofort, wie Host-Ansicht und Teilnehmenden-Screen zusammenspielen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">251,254</context>
+          <context context-type="linenumber">264,267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstartTitle" datatype="html">
         <source>Schnellstart</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">258</context>
+          <context context-type="linenumber">271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart1" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Quiz anlegen:&lt;/"/>Quiz anlegen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> „Quiz-Sammlung öffnen&quot; wählen, neues Quiz erstellen und pro Frage das passende Format wählen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">261,263</context>
+          <context context-type="linenumber">274,276</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart2" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Veranstaltung s"/>Veranstaltung starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Stil, Timer, Teams und Rangliste festlegen. Danach entsteht ein 6-stelliger Code, den du als Text oder QR-Code teilst. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">265,267</context>
+          <context context-type="linenumber">278,280</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickstart3" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Live moderieren"/>Live moderieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage zeigen, Antwortphase starten, Ergebnisse freigeben oder zurückhalten und bei Bedarf eine zweite Runde anschließen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">269,271</context>
+          <context context-type="linenumber">282,284</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostTitle" datatype="html">
         <source>Veranstaltung leiten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">276</context>
+          <context context-type="linenumber">289</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLead" datatype="html">
         <source> In der Host-Ansicht führst du durch die Session wie durch eine kleine Senderegie: Teilnehmende reinholen, Inhalte freigeben, Diskussion öffnen und Ergebnisse sichtbar machen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">277,281</context>
+          <context context-type="linenumber">290,294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostStartStep" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Session starten:&lt;"/>Session starten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> In deiner Quiz-Sammlung eine Veranstaltung starten und festlegen, ob sie mit Quiz oder Q&amp;A beginnt. Dann entsteht der Beitrittscode. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">284,286</context>
+          <context context-type="linenumber">297,299</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostLobby" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Lobby:&lt;/stron"/>Lobby:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Du siehst, wer beigetreten ist; ein QR-Code zum Beitritt wird angezeigt. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">288,290</context>
+          <context context-type="linenumber">301,303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostBeamer" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beamer- und Pr"/>Beamer- und Presenter-Ansicht:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage, Antworten, Countdown und Ergebnisse erscheinen groß genug für Projektion, Stream oder zweiten Bildschirm. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">292,294</context>
+          <context context-type="linenumber">305,307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSteuerung" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Steuerung:&lt;/stron"/>Steuerung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Nutze „Nächste Frage“, um den Inhalt einzublenden. Optional läuft zuerst eine Lesephase, danach startest du die Antwortphase und entscheidest, wann das Ergebnis auf den Screen kommt. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">296,299</context>
+          <context context-type="linenumber">309,312</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostPeer" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instruc"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Bei geeigneten Quizfragen, Schätzfragen und Blitzlicht-Runden: erst abstimmen lassen, Diskussion starten, dann erneut abstimmen. Der Vorher/Nachher-Vergleich macht Lernfortschritt sichtbar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">301,304</context>
+          <context context-type="linenumber">314,317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.hostSettings" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Einstellungen:&lt;/"/>Einstellungen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beim Start legst du Stil und Optionen fest: seriös oder spielerisch, mit oder ohne Rangliste, Sound, Lesephase, Team-Modus, Nicknamen und Timer. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">306,309</context>
+          <context context-type="linenumber">319,322</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallTitle" datatype="html">
         <source> Fragenwand im Live-Kanal Q&amp;A </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">314,316</context>
+          <context context-type="linenumber">327,329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLead" datatype="html">
         <source> Q&amp;A soll nicht als Nebenchat verschwinden. Die Fragenwand macht Rückfragen sichtbar, priorisierbar und moderierbar: Du hältst den roten Faden, während die Gruppe gemeinsam zeigt, welche Punkte wirklich Klärung brauchen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">317,321</context>
+          <context context-type="linenumber">330,334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallListAria" datatype="html">
         <source>Didaktische Funktionen der Q&amp;A-Fragenwand</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">325</context>
+          <context context-type="linenumber">338</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationTitle" datatype="html">
         <source>Moderation mit pädagogischem Takt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">343</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallModerationBody" datatype="html">
         <source> Auf Wunsch warten neue Fragen erst auf deine Freigabe. Du kannst Beiträge freigeben, anheften, archivieren oder entfernen und damit Schutzraum, Relevanz und Timing steuern: sofort beantworten, für später sammeln oder als Diskussionsspur markieren. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">331,336</context>
+          <context context-type="linenumber">344,349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingTitle" datatype="html">
         <source>Kollektives Hoch- und Runtervoting</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">355</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallVotingBody" datatype="html">
         <source> Teilnehmende gewichten Fragen gemeinsam. Positive und negative Stimmen zeigen nicht nur Popularität, sondern auch Unsicherheit, Widerspruch und Klärungsbedarf; Sortierungen wie „meist unterstützt“, „beste Fragen“ und „umstritten“ helfen dir, knappe Live-Zeit didaktisch zu setzen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">343,348</context>
+          <context context-type="linenumber">356,361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudTitle" datatype="html">
         <source>Q&amp;A-Wortwolke auf Themenebene</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">354</context>
+          <context context-type="linenumber">367</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallWordCloudBody" datatype="html">
         <source> Die Word-Cloud verdichtet sichtbare Fragen zu Wörtern und Phrasen, gewichtet nach Unterstützung, belastbarer Zustimmung oder Kontroverse. Sie lässt sich einfrieren, nach Sortierlogik betrachten und in der Presenter-Ansicht zeigen – als schneller Blick auf Themencluster, nicht als dekorative Wortliste. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">355,360</context>
+          <context context-type="linenumber">368,373</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmTitle" datatype="html">
         <source>Nächster Schritt: Moderationskompass</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">366</context>
+          <context context-type="linenumber">379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qaWallLlmBody" datatype="html">
         <source> Geplant ist zuerst ein deterministischer Moderationskompass. Optional können später asynchrone Q&amp;A-NLP-Signale und quellengebundene Zusammenfassungen dazukommen – als datenschutzbewusste Moderationshilfe statt Blackbox-Bewertung. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">367,371</context>
+          <context context-type="linenumber">380,384</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.blitzTitle" datatype="html">
         <source>Blitzlicht</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">378</context>
+          <context context-type="linenumber">391</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackIntro" datatype="html">
         <source> Schnelle Stimmungs- und Wissensabfragen – z. B. vor der Pause, zum Einstieg oder für spontane Checks. Nutzbar im Host-Bereich deiner Live-Session oder direkt von der Startseite. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">379,383</context>
+          <context context-type="linenumber">392,396</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfMood" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stimmungsb"/>Stimmungsbild<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (😊😐😟): Wie geht es den Teilnehmenden? </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">386,387</context>
+          <context context-type="linenumber">399,400</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfYesNoMaybe" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein / Viel"/>Ja / Nein / Vielleicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎🤷): Schnelle Zustimmungsabfrage. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">389,390</context>
+          <context context-type="linenumber">402,403</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackYesNo" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Ja / Nein&lt;/strong&gt; (👍"/>Ja / Nein<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (👍👎): Klare Zwei-Optionen-Abfrage ohne Mittelweg. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">392,393</context>
+          <context context-type="linenumber">405,406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTrueFalseUnknown" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Wahr / Falsch / Weiß nicht&lt;/stron"/>Wahr / Falsch / Weiß nicht<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (✓ / × / ?): Für schnelle Einschätzungen oder Wissenschecks. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">395,397</context>
+          <context context-type="linenumber">408,410</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackLetterOptions" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Mehrstufige Schnellabfragen&lt;/s"/>Mehrstufige Schnellabfragen<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (A–D): Drei oder vier feste Optionen für spontane Abstimmungen – ohne eine vollständige Quizfrage zu bauen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">399,401</context>
+          <context context-type="linenumber">412,414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackTempo" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Tempo-Feedback&lt;/strong"/>Tempo-Feedback<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> (🙂🐇🐢🙈): Mit vier Icons meldet deine Gruppe laufend zurück, ob sie folgen kann. Teilnehmende können ihre Rückmeldung ändern; du siehst nur die aggregierte Tendenz. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">403,406</context>
+          <context context-type="linenumber">416,419</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.quickFeedbackStartFlow" datatype="html">
         <source> Du startest die Runde im Host-Bereich deiner Live-Session oder über die Blitzlicht-Karte „Live mit einem Klick&quot; auf der Startseite. Teilnehmende tippen eine Antwort; du siehst die Ergebnisse live als Balkendiagramm. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">408,412</context>
+          <context context-type="linenumber">421,425</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfPeer" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Peer Instr"/>Peer Instruction (Doppelrunden):<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Erste Runde – Ergebnis nicht auflösen – „Diskussionsphase&quot; starten („Diskutiert mit eurem Nachbarn&quot;) – „Zweite Abstimmung&quot;. Vorher/Nachher-Vergleich zeigt, wie sich das Stimmungsbild durch den Austausch verändert hat. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">415,419</context>
+          <context context-type="linenumber">428,432</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfStop" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Stopp:&lt;/st"/>Stopp:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Abstimmung einfrieren – Teilnehmende sehen „Abstimmung ist pausiert&quot; und können nicht mehr abstimmen, bis du „Fortsetzen&quot; wählst. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">421,423</context>
+          <context context-type="linenumber">434,436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfReset" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Zurücksetze"/>Zurücksetzen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Alle Stimmen löschen und erneut abstimmen lassen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">425,426</context>
+          <context context-type="linenumber">438,439</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfNewRound" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Neue Runde:&lt;/s"/>Neue Runde:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Neuen Code erzeugen und eine frische Runde starten. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">428,429</context>
+          <context context-type="linenumber">441,442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.qfCopyLink" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Link kopieren:"/>Link kopieren:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Beitrittslink in die Zwischenablage kopieren, z. B. zum Teilen per Chat. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">431,433</context>
+          <context context-type="linenumber">444,446</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsTitle" datatype="html">
         <source>Für deine Teilnehmenden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">451</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsLead" datatype="html">
         <source> Kurz erklärt, was du in deiner Veranstaltung weitergeben kannst: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">452,454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsJoin" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Beitreten:&lt;/strong&gt;"/>Beitreten:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> 6-stelligen Code auf arsnova.eu eingeben und „Los geht&apos;s&quot; – funktioniert für Quiz, Q&amp;A und Blitzlicht. Keine Anmeldung nötig. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">444,446</context>
+          <context context-type="linenumber">457,459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsNick" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Nicknamen:&lt;/strong&gt;"/>Nicknamen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Je nach deiner Einstellung vorgegebene Namen, eigener Name oder anonym. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">448,450</context>
+          <context context-type="linenumber">461,463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.participantsVote" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Abstimmung:&lt;/strong&gt;"/>Abstimmung:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Frage erscheint auf dem Gerät, Antwort wählen und absenden. Bei aktivierter Selbsteinschätzung folgt danach die Skala 1–5. Bei Zeitlimit läuft ein Countdown. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">452,455</context>
+          <context context-type="linenumber">465,468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTitle" datatype="html">
         <source>Deine Quiz-Sammlung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">460</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionLead" datatype="html">
         <source>Hier legst du deine Quizze an und bereitest sie vor.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">461</context>
+          <context context-type="linenumber">474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionEditor" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Editor:&lt;/strong&gt; Fra"/>Editor:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Fragen per Drag-and-Drop sortieren, auf- und zuklappen, Vorschau prüfen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">464,466</context>
+          <context context-type="linenumber">477,479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionTypes" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Fragetypen:&lt;/strong"/>Fragetypen:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Single Choice, Multiple Choice, Kurzantwort, Freitext, Umfrage, Bewertungsskala und numerische Schätzfrage – pro Frage optional mit Timer, Schwierigkeitsgrad und Selbsteinschätzung. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">468,471</context>
+          <context context-type="linenumber">481,484</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionImport" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Import / Export:&lt;/st"/>Import / Export:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Quiz als JSON importieren oder exportieren. Mit der Start- und Prüfvorlage kannst du anspruchsvolle Quizze mit deinem bevorzugten KI-Tool generieren, prüfen und direkt importieren – deine Inhalte und Präsentationen werden nicht an arsnova.eu gesendet; du nutzt dein eigenes KI-Tool. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">473,477</context>
+          <context context-type="linenumber">486,490</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.collectionSync" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Sync:&lt;/strong&gt; Mit"/>Sync:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit dem Sync-Link deine Quiz-Sammlung mit Kolleg:innen teilen oder auf anderen Geräten weiterarbeiten. Wer den Link hat, kann die Sammlung öffnen. Die Geräteangaben helfen nur bei der Orientierung. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">479,482</context>
+          <context context-type="linenumber">492,495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.demoQuizHint" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Demo-Quiz:&lt;/stro"/>Demo-Quiz:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Ein vorinstalliertes Quiz zeigt alle Formate mit Beispielen inkl. KaTeX-Formeln und Markdown. In der Quiz-Sammlung in der Vorschau öffnen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">484,487</context>
+          <context context-type="linenumber">497,500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesTitle" datatype="html">
         <source>Seriös und Spielerisch</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesLead" datatype="html">
         <source> Zwei Stile für unterschiedliche Situationen – wählbar auf der Startseite und beim Session-Start. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">493,496</context>
+          <context context-type="linenumber">506,509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.styleSerious" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Seriös:&lt;/strong&gt;"/>Seriös:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Anonym, ohne Rangliste – ideal für formative Assessments, Prüfungsvorbereitung und sensible Themen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">499,501</context>
+          <context context-type="linenumber">512,514</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylePlayful" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Spielerisch:&lt;/st"/>Spielerisch:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Mit Rangliste, Sounds und Anfeuerung – ideal für Auflockerung, Wettbewerbe und motivierende Quizze. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">503,505</context>
+          <context context-type="linenumber">516,518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.stylesOptions" datatype="html">
         <source> Alle Optionen (Rangliste, Sound, Lesephase, Team, Bonus) lassen sich einzeln an- und ausschalten. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">507,510</context>
+          <context context-type="linenumber">520,523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTitle" datatype="html">
         <source>Weitere Funktionen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">514</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreBonus" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Bonus-Codes:&lt;"/>Bonus-Codes:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Top-Platzierte erhalten einen einlösbaren Code (z. B. für Bonuspunkte). Du siehst die Code-Liste; personenbezogene Daten werden nicht gespeichert. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">517,520</context>
+          <context context-type="linenumber">530,533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreTeams" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Team-Modus:&lt;/"/>Team-Modus:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Deine Teilnehmenden spielen in Teams mit eigenem Team-Leaderboard – z. B. für Gruppenwettbewerbe im Seminar. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">522,524</context>
+          <context context-type="linenumber">535,537</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.moreGamification" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Gamification:&lt;/stron"/>Gamification:<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> Sound-Effekte, Belohnungseffekte für Top-Plätze, Motivationsmeldungen – im Spielerisch-Modus. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">526,528</context>
+          <context context-type="linenumber">539,541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyTitle" datatype="html">
         <source>Datenschutz und Technik</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">546</context>
         </context-group>
       </trans-unit>
       <trans-unit id="help.privacyBody" datatype="html">
         <source> arsnova.eu ist kostenlos, Open Source und für den Einsatz an Schulen, Hochschulen und in Weiterbildung gedacht – mit Fokus auf Datenschutz (DSGVO). Quiz-Inhalte werden lokal im Browser gespeichert. Keine Anmeldung nötig, weder für dich noch für deine Teilnehmenden. Als App installierbar (PWA) – z. B. für schnelleren Start auf dem Smartphone. Oberfläche auf Deutsch, Englisch, Französisch, Spanisch und Italienisch. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/help/help.component.html</context>
-          <context context-type="linenumber">534,540</context>
+          <context context-type="linenumber">547,553</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="help.infoLandingLink" datatype="html">
+        <source>Hintergründe und Einsatzmöglichkeiten</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.ts</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHero.channelQuiz" datatype="html">
@@ -6249,11 +6284,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">408</context>
+          <context context-type="linenumber">416</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">864</context>
+          <context context-type="linenumber">872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -6288,11 +6323,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">409</context>
+          <context context-type="linenumber">417</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">865</context>
+          <context context-type="linenumber">873</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -6531,148 +6566,155 @@
         <source> Mit anderen teilen oder auf einem zweiten Gerät dieselbe Sammlung nutzen: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">447,449</context>
+          <context context-type="linenumber">453,455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareAria" datatype="html">
         <source>Sync-Link anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">456</context>
+          <context context-type="linenumber">462</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncShareLink" datatype="html">
         <source>Sync-Link anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">459</context>
+          <context context-type="linenumber">465</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncOpenHint" datatype="html">
         <source> Empfangenen Sync-Link hier einfügen: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">465,467</context>
+          <context context-type="linenumber">471,473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkLabel" datatype="html">
         <source>Sync-Link</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkPlaceholder" datatype="html">
         <source>sync-room-12345678</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">483</context>
+          <context context-type="linenumber">489</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkInputAria" datatype="html">
         <source>Sync-Link einfügen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">489</context>
+          <context context-type="linenumber">495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkSubmit" datatype="html">
         <source> Öffnen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">497,499</context>
+          <context context-type="linenumber">503,505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkedHintWithOrigin" datatype="html">
         <source> Quizze werden mit <x id="INTERPOLATION" equiv-text="{{ originSummary }}"/> geteilt. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">513,515</context>
+          <context context-type="linenumber">519,521</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkCta" datatype="html">
         <source>Verknüpfung lösen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayTitle" datatype="html">
         <source> Aktuelle Meldung </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">567,569</context>
+          <context context-type="linenumber">573,575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.overlayCloseAria" datatype="html">
         <source>Meldung schließen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">585</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.ack" datatype="html">
         <source> Alles klar! </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">593,595</context>
+          <context context-type="linenumber">599,601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbGroupAria" datatype="html">
         <source>Bewertung der Meldung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">599</context>
+          <context context-type="linenumber">605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpTooltip" datatype="html">
         <source>Hilfreich – erneut tippen zum Zurücknehmen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">609</context>
+          <context context-type="linenumber">615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbUpAria" datatype="html">
         <source>Hilfreich, erneut tippen zum Zurücknehmen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">611</context>
+          <context context-type="linenumber">617</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownTooltip" datatype="html">
         <source>Nicht hilfreich – erneut tippen zum Zurücknehmen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">623</context>
+          <context context-type="linenumber">629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.thumbDownAria" datatype="html">
         <source>Nicht hilfreich, erneut tippen zum Zurücknehmen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">625</context>
+          <context context-type="linenumber">631</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="homeHostCard.infoLanding" datatype="html">
+        <source>Einsatzmöglichkeiten entdecken</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.syncOrigin" datatype="html">
         <source><x id="browser" equiv-text="peer.browserLabel"/> auf <x id="device" equiv-text="peer.deviceLabel"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">142</context>
+          <context context-type="linenumber">147</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">153</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2862374619655540985" datatype="html">
         <source>gerade eben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">470</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5002</context>
+          <context context-type="linenumber">5009</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -6683,11 +6725,11 @@
         <source>vor <x id="PH" equiv-text="minutes"/> Min.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">467</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5004</context>
+          <context context-type="linenumber">5011</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -6698,11 +6740,11 @@
         <source>vor 1 Std.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -6713,11 +6755,11 @@
         <source>vor <x id="PH" equiv-text="hours"/> Std.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">475</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5007</context>
+          <context context-type="linenumber">5014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -6728,11 +6770,11 @@
         <source>vor 1 Tag</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -6743,11 +6785,11 @@
         <source>vor <x id="PH" equiv-text="days"/> Tagen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">472</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5009</context>
+          <context context-type="linenumber">5016</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -6758,56 +6800,56 @@
         <source>Session <x id="PH" equiv-text="code"/> aus Liste entfernen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">477</context>
+          <context context-type="linenumber">482</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.heroChipStartError" datatype="html">
         <source>Der Kanal konnte nicht gestartet werden. Bitte versuche es erneut.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">586</context>
+          <context context-type="linenumber">591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncLinkError" datatype="html">
         <source>Bitte einen gültigen Sync-Link einfügen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">645</context>
+          <context context-type="linenumber">650</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkConfirmPrompt" datatype="html">
         <source>Verknüpfung wirklich lösen? Die aktuelle Quiz-Sammlung bleibt auf diesem Gerät erhalten.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">666</context>
+          <context context-type="linenumber">671</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeHostCard.syncUnlinkSuccess" datatype="html">
         <source>Verknüpfung gelöst. Die Quiz-Sammlung ist jetzt nur auf diesem Gerät aktiv.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">674</context>
+          <context context-type="linenumber">679</context>
         </context-group>
       </trans-unit>
       <trans-unit id="homeFeedbackCard.startError" datatype="html">
         <source>Blitzlicht konnte nicht gestartet werden. Bitte erneut versuchen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">700</context>
+          <context context-type="linenumber">705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6627607898679527757" datatype="html">
         <source>Bitte den 6-stelligen Code eingeben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">730</context>
+          <context context-type="linenumber">735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2422920312042178920" datatype="html">
         <source>Diese Session ist bereits beendet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">782</context>
+          <context context-type="linenumber">787</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/join/join.component.ts</context>
@@ -6973,7 +7015,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -6992,7 +7034,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2922</context>
+          <context context-type="linenumber">2929</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -7078,7 +7120,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2939</context>
+          <context context-type="linenumber">2946</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -7657,7 +7699,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1882</context>
+          <context context-type="linenumber">1896</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.previewSaveAndOpen" datatype="html">
@@ -7668,7 +7710,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1886</context>
+          <context context-type="linenumber">1900</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1736772795054152455" datatype="html">
@@ -7849,7 +7891,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">595</context>
+          <context context-type="linenumber">603</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -8320,7 +8362,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1599,1602</context>
+          <context context-type="linenumber">1613,1616</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionEditSaveHint" datatype="html">
@@ -8383,7 +8425,7 @@
         <source> Zeit für diese Frage </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">568,570</context>
+          <context context-type="linenumber">576,578</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -8394,7 +8436,7 @@
         <source> Standard ist das Zeitlimit aus den Quiz-Einstellungen. Du kannst pro Frage ein eigenes Limit setzen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">571,574</context>
+          <context context-type="linenumber">579,582</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -8405,7 +8447,7 @@
         <source>Quiz-Zeitlimit verwenden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">587</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -8416,7 +8458,7 @@
         <source>Sekunden für diese Frage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">585</context>
+          <context context-type="linenumber">593</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -8427,7 +8469,7 @@
         <source>Sekunden für diese Frage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">590</context>
+          <context context-type="linenumber">598</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -8438,7 +8480,7 @@
         <source> Für diese Frage keine Lesephase </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">602,604</context>
+          <context context-type="linenumber">610,612</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -8449,497 +8491,497 @@
         <source> Selbsteinschätzung </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">609,611</context>
+          <context context-type="linenumber">617,619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceConfigHint" datatype="html">
         <source> Teilnehmende geben nach ihrer Antwort an, wie sicher sie sind. Beeinflusst nicht die Punktevergabe. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">612,615</context>
+          <context context-type="linenumber">620,623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceEnabledToggle" datatype="html">
         <source> Selbsteinschätzung </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">620,622</context>
+          <context context-type="linenumber">634,636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelLowField" datatype="html">
         <source>Niedrige Antwortsicherheit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">632</context>
+          <context context-type="linenumber">646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidenceLabelHighField" datatype="html">
         <source>Hohe Antwortsicherheit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">652</context>
+          <context context-type="linenumber">666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewLabel" datatype="html">
         <source> Vorschau für Teilnehmende </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">676,678</context>
+          <context context-type="linenumber">690,692</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8205020163645016790" datatype="html">
         <source>Schnellformat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">715</context>
+          <context context-type="linenumber">729</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.quickFormatAria" datatype="html">
         <source>Schnellformat wählen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">720</context>
+          <context context-type="linenumber">734</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7287117104463920417" datatype="html">
         <source>Überschreibt vorhandene Antworten.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">726</context>
+          <context context-type="linenumber">740</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetSection" datatype="html">
         <source> Schnelleinstieg </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">731,733</context>
+          <context context-type="linenumber">745,747</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimatePresetGroupAria" datatype="html">
         <source>Schätzfragen-Vorlage wählen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">738</context>
+          <context context-type="linenumber">752</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8648957206736539595" datatype="html">
         <source>Eingabetyp</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">756</context>
+          <context context-type="linenumber">770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateInputTypeLabel" datatype="html">
         <source>Zahlentyp</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">759</context>
+          <context context-type="linenumber">773</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntegerOption" datatype="html">
         <source>Ganzzahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">762</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalOption" datatype="html">
         <source>Dezimalzahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">765</context>
+          <context context-type="linenumber">779</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateDecimalPlacesLabel" datatype="html">
         <source>Max. Nachkommastellen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">772</context>
+          <context context-type="linenumber">786</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceSection" datatype="html">
         <source> Toleranzmodus </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">788,790</context>
+          <context context-type="linenumber">802,804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateToleranceModeLabel" datatype="html">
         <source>Modus</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">792</context>
+          <context context-type="linenumber">806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteIntervalOption" datatype="html">
         <source>Absolutes Intervall [L, R]</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">797</context>
+          <context context-type="linenumber">811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateRelativePercentOption" datatype="html">
         <source>Relatives Toleranzband (V ± p%)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">802</context>
+          <context context-type="linenumber">816</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalLeftLabel" datatype="html">
         <source>Linke Grenze L</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">811</context>
+          <context context-type="linenumber">825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateIntervalRightLabel" datatype="html">
         <source>Rechte Grenze R</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">817</context>
+          <context context-type="linenumber">831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueLabel" datatype="html">
         <source>Referenzwert für Auswertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">824</context>
+          <context context-type="linenumber">838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateAbsoluteReferenceValueHint" datatype="html">
         <source>Optional für Referenzlinie, Fehlermaß und Rundenvergleich</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">828</context>
+          <context context-type="linenumber">842</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueLabel" datatype="html">
         <source>Referenzwert V</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateReferenceValueHint" datatype="html">
         <source>Muss ≠ 0 sein</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">840</context>
+          <context context-type="linenumber">854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTolerancePercentLabel" datatype="html">
         <source>Toleranz p (%)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">845</context>
+          <context context-type="linenumber">859</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateBoundsSection" datatype="html">
         <source> Plausibilitätsgrenzen (optional) </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">858,860</context>
+          <context context-type="linenumber">872,874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMinLabel" datatype="html">
         <source>Min-Eingabe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">863</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateMaxLabel" datatype="html">
         <source>Max-Eingabe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">867</context>
+          <context context-type="linenumber">881</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewAria" datatype="html">
         <source>Vorschau der Schätzfrage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">876</context>
+          <context context-type="linenumber">890</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewTitle" datatype="html">
         <source>Band-Vorschau</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">881</context>
+          <context context-type="linenumber">895</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEstimateTwoRoundsToggle" datatype="html">
         <source> Zwei Abstimmungsrunden (Peer Instruction) </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">937,939</context>
+          <context context-type="linenumber">951,953</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8259238864102475814" datatype="html">
         <source>Skala</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">945</context>
+          <context context-type="linenumber">959</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.ratingScaleAria" datatype="html">
         <source>Bewertungsskala wählen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">949</context>
+          <context context-type="linenumber">963</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4298652859209119138" datatype="html">
         <source>Linke Grenze (optional)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3739377380076895717" datatype="html">
         <source>Rechte Grenze (optional)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">985</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigLegend" datatype="html">
         <source> Antwortbewertung </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">983,985</context>
+          <context context-type="linenumber">997,999</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextConfigHint" datatype="html">
         <source> Die Vorschau unten zeigt, ob daraus volle Punkte, Teilpunkte oder keine Wertung werden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">989,992</context>
+          <context context-type="linenumber">1003,1006</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindFieldLabel" datatype="html">
         <source>Antworttyp</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">996</context>
+          <context context-type="linenumber">1010</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthFieldLabel" datatype="html">
         <source>Maximale Antwortlänge</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1010</context>
+          <context context-type="linenumber">1024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthHint" datatype="html">
         <source>1 bis 500 Zeichen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationModeFieldLabel" datatype="html">
         <source>Bewertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1025</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceFieldLabel" datatype="html">
         <source>Toleranz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceHint" datatype="html">
         <source>Die Prozentwerte beschreiben die erlaubte Abweichung zur Musterlösung, nicht die Punktzahl. Niedrig ≈ 10 %, Mittel ≈ 20 %, Großzügig ≈ 30 %. Bei kurzen Begriffen wirkt dieselbe Stufe strenger.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1042,1044</context>
+          <context context-type="linenumber">1056,1058</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextAllowPartialCreditToggle" datatype="html">
         <source> Teilpunkte vergeben </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1052,1054</context>
+          <context context-type="linenumber">1066,1068</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextCaseSensitiveToggle" datatype="html">
         <source> Groß- und Kleinschreibung beachten </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1058,1060</context>
+          <context context-type="linenumber">1072,1074</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindFieldLabel" datatype="html">
         <source>Zahlenformat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1064</context>
+          <context context-type="linenumber">1078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeFieldLabel" datatype="html">
         <source>Zahltoleranz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1074</context>
+          <context context-type="linenumber">1088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceModeHint" datatype="html">
         <source>Exakt verlangt denselben Zahlenwert. Absolute Toleranz arbeitet mit einer festen ±-Spanne, relative Toleranz mit Prozent um die Musterlösung.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1082,1083</context>
+          <context context-type="linenumber">1096,1097</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceFieldLabel" datatype="html">
         <source>Absolute Toleranz (±)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1090</context>
+          <context context-type="linenumber">1104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAbsoluteToleranceHint" datatype="html">
         <source>Beispiel: Bei 10 und ±0,5 gelten Antworten von 9,5 bis 10,5.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1100</context>
+          <context context-type="linenumber">1114</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceFieldLabel" datatype="html">
         <source>Relative Toleranz (%)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1108</context>
+          <context context-type="linenumber">1122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRelativeToleranceHint" datatype="html">
         <source>Beispiel: Bei 200 und 5 % gelten Antworten von 190 bis 210.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1118</context>
+          <context context-type="linenumber">1132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyFieldLabel" datatype="html">
         <source>Einheitenfamilie</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1126</context>
+          <context context-type="linenumber">1140</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitToggle" datatype="html">
         <source> Einheit verpflichtend machen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1139,1141</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericAcceptEquivalentUnitsToggle" datatype="html">
         <source> Äquivalente Einheiten akzeptieren </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1159,1161</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLegend" datatype="html">
         <source> So wirkt die Bewertung </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1154,1156</context>
+          <context context-type="linenumber">1168,1170</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningLabel" datatype="html">
         <source>Didaktischer Hinweis:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1200</context>
+          <context context-type="linenumber">1214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsToggle" datatype="html">
         <source> Technische Details anzeigen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1208,1210</context>
+          <context context-type="linenumber">1222,1224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTechnicalDetailsIntro" datatype="html">
         <source> Auto kombiniert exakte Treffer, Hamming, Damerau-Levenshtein und Levenshtein. Hamming eignet sich für einzelne falsche Zeichen bei gleicher Länge, Damerau-Levenshtein zusätzlich für vertauschte Nachbarbuchstaben, Levenshtein außerdem für fehlende oder extra Zeichen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1215,1220</context>
+          <context context-type="linenumber">1229,1234</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextTrimWhitespaceToggle" datatype="html">
         <source> Leerzeichen am Anfang und Ende ignorieren </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1225,1227</context>
+          <context context-type="linenumber">1239,1241</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextNormalizeWhitespaceToggle" datatype="html">
         <source> Mehrfache Leerzeichen zusammenfassen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1231,1233</context>
+          <context context-type="linenumber">1245,1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextValidSolutionHint" datatype="html">
         <source> Gültig </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1272,1274</context>
+          <context context-type="linenumber">1286,1288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8021687558521014030" datatype="html">
         <source>Option</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1276</context>
+          <context context-type="linenumber">1290</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6278157135662238363" datatype="html">
         <source>Gib einen Antworttext ein.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2650319028885568688" datatype="html">
         <source>Maximal 500 Zeichen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2525684207823121577" datatype="html">
         <source> Hier antworten Teilnehmende frei – keine vorgegebenen Antworten nötig. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1332,1334</context>
+          <context context-type="linenumber">1346,1348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.livePreviewCardTitle" datatype="html">
         <source> Gesamtvorschau </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1357,1359</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7492260970005034710" datatype="html">
         <source> Formelfehler: <x id="INTERPOLATION" equiv-text="{{ previewKatexError() }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1350,1352</context>
+          <context context-type="linenumber">1364,1366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2863483573986908286" datatype="html">
         <source>Frage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1355</context>
+          <context context-type="linenumber">1369</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -8950,28 +8992,28 @@
         <source>Fragenliste</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1429</context>
+          <context context-type="linenumber">1443</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionsListTitle" datatype="html">
         <source> Fragen im Quiz </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1437,1439</context>
+          <context context-type="linenumber">1451,1453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8122550761270535954" datatype="html">
         <source>Hinzugefügt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1441</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3827964072457808965" datatype="html">
         <source>Noch keine Fragen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1451</context>
+          <context context-type="linenumber">1465</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -8982,64 +9024,64 @@
         <source> Füge oben deine erste Frage hinzu, um loszulegen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1452,1454</context>
+          <context context-type="linenumber">1466,1468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionListPosition" datatype="html">
         <source>Frage <x id="INTERPOLATION" equiv-text="{{ question.order + 1 }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1514,1515</context>
+          <context context-type="linenumber">1528,1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionDisabledBadge" datatype="html">
         <source>Deaktiviert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1539</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineDisabledHint" datatype="html">
         <source> Diese Frage ist deaktiviert und erscheint nicht in der Vorschau und im Live-Quiz. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1565,1568</context>
+          <context context-type="linenumber">1579,1582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.activateQuestion" datatype="html">
         <source>Aktivieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1575</context>
+          <context context-type="linenumber">1589</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1772</context>
+          <context context-type="linenumber">1786</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1806</context>
+          <context context-type="linenumber">1820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.inlineEditEyebrow" datatype="html">
         <source> Bearbeitungsmodus </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1587,1589</context>
+          <context context-type="linenumber">1601,1603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.editQuestionTitle" datatype="html">
         <source> Diese Frage bearbeiten </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1593,1595</context>
+          <context context-type="linenumber">1607,1609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.freeTextWordCloudHint" datatype="html">
         <source> Freitext-Antwort als Wortwolke </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1617,1619</context>
+          <context context-type="linenumber">1631,1633</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9050,7 +9092,7 @@
         <source> Kurzantwort mit automatischem Abgleich gegen Musterlösungen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1624,1626</context>
+          <context context-type="linenumber">1638,1640</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9061,18 +9103,18 @@
         <source> Selbsteinschätzung wird nach der Antwort abgefragt </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1715,1717</context>
+          <context context-type="linenumber">1729,1731</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6920196637619975735" datatype="html">
         <source>Bearbeiten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1754</context>
+          <context context-type="linenumber">1768</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1802</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -9083,22 +9125,22 @@
         <source>Deaktivieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1763</context>
+          <context context-type="linenumber">1777</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1797</context>
+          <context context-type="linenumber">1811</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4580399730639224598" datatype="html">
         <source>Löschen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1777</context>
+          <context context-type="linenumber">1791</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1811</context>
+          <context context-type="linenumber">1825</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.html</context>
@@ -9109,11 +9151,11 @@
         <source>Zurück zur Quiz-Liste</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1829</context>
+          <context context-type="linenumber">1843</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1900</context>
+          <context context-type="linenumber">1914</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -9128,7 +9170,7 @@
         <source>Zurück</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1832</context>
+          <context context-type="linenumber">1846</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.html</context>
@@ -9139,148 +9181,162 @@
         <source>Verwerfen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1842</context>
+          <context context-type="linenumber">1856</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1846</context>
+          <context context-type="linenumber">1860</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButtonAria" datatype="html">
         <source>Weitere Frage hinzufügen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1855</context>
+          <context context-type="linenumber">1869</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.addAnotherQuestionButton" datatype="html">
         <source>Weitere Frage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1859</context>
+          <context context-type="linenumber">1873</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.saveAllButton" datatype="html">
         <source>Änderungen speichern</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1869</context>
+          <context context-type="linenumber">1883</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1873</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7620597678842046410" datatype="html">
         <source>Quiz nicht gefunden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1895</context>
+          <context context-type="linenumber">1909</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6672916435220201136" datatype="html">
         <source>Zur Liste</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.html</context>
-          <context context-type="linenumber">1903</context>
+          <context context-type="linenumber">1917</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingEstimate" datatype="html">
+        <source>Schätzfragen didaktisch einsetzen</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quizEdit.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="924826286502636331" datatype="html">
         <source>Single Choice</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">399</context>
+          <context context-type="linenumber">407</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4737017620429217247" datatype="html">
         <source>Multiple Choice</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">400</context>
+          <context context-type="linenumber">408</context>
         </context-group>
       </trans-unit>
       <trans-unit id="493996564238682027" datatype="html">
         <source>Freitext</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">401</context>
+          <context context-type="linenumber">409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8680267345873464947" datatype="html">
         <source>Umfrage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">403</context>
+          <context context-type="linenumber">411</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5472460529727499985" datatype="html">
         <source>Bewertung (1–5 / 1–10)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">404</context>
+          <context context-type="linenumber">412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearLabel" datatype="html">
         <source>Jahreszahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">427</context>
+          <context context-type="linenumber">435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetYearHint" datatype="html">
         <source>Ganzzahl, 1500–2000 plausibel, 1700–1900 akzeptiert, zwei Runden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">428</context>
+          <context context-type="linenumber">436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementLabel" datatype="html">
         <source>Messwert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">433</context>
+          <context context-type="linenumber">441</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMeasurementHint" datatype="html">
         <source>Dezimalwert mit einer Nachkommastelle und engem absoluten Toleranzband.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">434</context>
+          <context context-type="linenumber">442</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentLabel" datatype="html">
         <source>Prozentwert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">439</context>
+          <context context-type="linenumber">447</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetPercentHint" datatype="html">
         <source>Ganzzahl von 0 bis 100 mit zehn Prozentpunkten Toleranz.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">440</context>
+          <context context-type="linenumber">448</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeLabel" datatype="html">
         <source>Größenordnung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">445</context>
+          <context context-type="linenumber">453</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPresetMagnitudeHint" datatype="html">
         <source>Große Ganzzahl mit relativem Toleranzband für Schätzungen in Größenordnungen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">446</context>
+          <context context-type="linenumber">454</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.difficulty.easy" datatype="html">
         <source>Leicht</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">452</context>
+          <context context-type="linenumber">460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9288,7 +9344,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4673</context>
+          <context context-type="linenumber">4680</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -9299,7 +9355,7 @@
         <source>Mittel</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">453</context>
+          <context context-type="linenumber">461</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9307,7 +9363,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4675</context>
+          <context context-type="linenumber">4682</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -9318,7 +9374,7 @@
         <source>Schwer</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">454</context>
+          <context context-type="linenumber">462</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9326,7 +9382,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4677</context>
+          <context context-type="linenumber">4684</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -9337,7 +9393,7 @@
         <source>Nur exakt gleich</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">464</context>
+          <context context-type="linenumber">472</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9348,14 +9404,14 @@
         <source>Akzeptiert nur identische Schreibweisen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">465</context>
+          <context context-type="linenumber">473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeAutoLabel" datatype="html">
         <source>Kleine Tippfehler erlauben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">469</context>
+          <context context-type="linenumber">477</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9366,14 +9422,14 @@
         <source>Für die meisten Fachbegriffe: berücksichtigt exakte Treffer, kleine Tippfehler, Buchstabendreher und fehlende Zeichen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">470</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeHammingLabel" datatype="html">
         <source>Gleiche Länge, kleine Buchstabendreher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">474</context>
+          <context context-type="linenumber">482</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9384,14 +9440,14 @@
         <source>Für gleich lange Begriffe mit einem falschen oder vertauschten Buchstaben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">475</context>
+          <context context-type="linenumber">483</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextModeLevenshteinLabel" datatype="html">
         <source>Auch fehlende oder zusätzliche Zeichen erlauben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">479</context>
+          <context context-type="linenumber">487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9402,119 +9458,119 @@
         <source>Für Begriffe mit einem fehlenden oder zusätzlichen Zeichen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">480</context>
+          <context context-type="linenumber">488</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindText" datatype="html">
         <source>Mit Textähnlichkeit bewerten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">491</context>
+          <context context-type="linenumber">499</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindTextHint" datatype="html">
         <source>Geeignet für Fachbegriffe und feste Schreibweisen mit kleinen Tippfehlern.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">492</context>
+          <context context-type="linenumber">500</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumeric" datatype="html">
         <source>Zahlen bewerten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">496</context>
+          <context context-type="linenumber">504</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericHint" datatype="html">
         <source>Bewertet Zahlenwerte statt Zeichenähnlichkeit und unterstützt exakte, absolute oder relative Toleranzen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">497</context>
+          <context context-type="linenumber">505</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnit" datatype="html">
         <source>Zahlen und Einheiten bewerten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">501</context>
+          <context context-type="linenumber">509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextEvaluationKindNumericUnitHint" datatype="html">
         <source>Prüft Zahlenwerte zusammen mit einer kuratierten Einheitenfamilie und erklärt fehlende oder abweichende Einheiten.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">502</context>
+          <context context-type="linenumber">510</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindInteger" datatype="html">
         <source>Ganzzahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">507</context>
+          <context context-type="linenumber">515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericInputKindDecimal" datatype="html">
         <source>Dezimalzahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">508</context>
+          <context context-type="linenumber">516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceExact" datatype="html">
         <source>Exakte Zahl</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">512</context>
+          <context context-type="linenumber">520</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceAbsolute" datatype="html">
         <source>Absolute Toleranz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">515</context>
+          <context context-type="linenumber">523</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelative" datatype="html">
         <source>Relative Toleranz (%)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">519</context>
+          <context context-type="linenumber">527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyLength" datatype="html">
         <source>Länge</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">524</context>
+          <context context-type="linenumber">532</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyMass" datatype="html">
         <source>Masse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">525</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyTime" datatype="html">
         <source>Zeit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">526</context>
+          <context context-type="linenumber">534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilyVolume" datatype="html">
         <source>Volumen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">527</context>
+          <context context-type="linenumber">535</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceNone" datatype="html">
         <source>Keine Toleranz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">531</context>
+          <context context-type="linenumber">539</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9525,7 +9581,7 @@
         <source>Niedrig</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">532</context>
+          <context context-type="linenumber">540</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9536,7 +9592,7 @@
         <source>Mittel</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">533</context>
+          <context context-type="linenumber">541</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9547,7 +9603,7 @@
         <source>Großzügig</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">534</context>
+          <context context-type="linenumber">542</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9558,7 +9614,7 @@
         <source>Nobelpreis</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">538</context>
+          <context context-type="linenumber">546</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -9573,7 +9629,7 @@
         <source>Kindergarten (Tier-Emojis)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">541</context>
+          <context context-type="linenumber">549</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -9588,7 +9644,7 @@
         <source>Grundschule</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">543</context>
+          <context context-type="linenumber">551</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -9603,7 +9659,7 @@
         <source>Mittelstufe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">552</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -9618,7 +9674,7 @@
         <source>Oberstufe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">545</context>
+          <context context-type="linenumber">553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -9633,14 +9689,14 @@
         <source>Quiz-Standard</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">768</context>
+          <context context-type="linenumber">776</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4668229613641280742" datatype="html">
         <source>Benutzerdefiniert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">866</context>
+          <context context-type="linenumber">874</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-new/quiz-new.component.ts</context>
@@ -9651,28 +9707,28 @@
         <source>Fünfstufige Skala von 1 bis 5, niedrig: <x id="low" equiv-text="low"/>, hoch: <x id="high" equiv-text="high"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">980</context>
+          <context context-type="linenumber">988</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithLow" datatype="html">
         <source>Fünfstufige Skala von 1 bis 5, niedrig: <x id="low" equiv-text="low"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">983</context>
+          <context context-type="linenumber">991</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAriaWithHigh" datatype="html">
         <source>Fünfstufige Skala von 1 bis 5, hoch: <x id="high" equiv-text="high"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">986</context>
+          <context context-type="linenumber">994</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.confidencePreviewAria" datatype="html">
         <source>Fünfstufige Skala von 1 bis 5</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">988</context>
+          <context context-type="linenumber">996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceLabel" datatype="html">
@@ -9681,7 +9737,7 @@
           )"/> bis <x id="right" equiv-text="this.formatNumericEstimateEditorValue(band.right)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1145,1147</context>
+          <context context-type="linenumber">1153,1155</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReferenceLabel" datatype="html">
@@ -9690,28 +9746,28 @@
             )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1152,1154</context>
+          <context context-type="linenumber">1160,1162</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewIncomplete" datatype="html">
         <source>Toleranzband wird angezeigt, sobald Grenzen oder Referenz und Prozentwert vollständig sind.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1168</context>
+          <context context-type="linenumber">1176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewToleranceOutside" datatype="html">
         <source>Plausibilitätsgrenzen und Toleranzband passen noch nicht zusammen. Werte im Band sollten auch eingebbar sein.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1177</context>
+          <context context-type="linenumber">1185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewReady" datatype="html">
         <source>Plausibilität begrenzt erlaubte Eingaben; das Toleranzband entscheidet über Punkte.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1179</context>
+          <context context-type="linenumber">1187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityRange" datatype="html">
@@ -9720,7 +9776,7 @@
       )"/> bis <x id="max" equiv-text="this.formatNumericEstimateEditorValue(max)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1186,1188</context>
+          <context context-type="linenumber">1194,1196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMin" datatype="html">
@@ -9729,7 +9785,7 @@
       )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1191,1193</context>
+          <context context-type="linenumber">1199,1201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericPreviewPlausibilityMax" datatype="html">
@@ -9738,95 +9794,95 @@
       )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1196,1198</context>
+          <context context-type="linenumber">1204,1206</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionLabel" datatype="html">
         <source>Musterlösung <x id="solutionNumber" equiv-text="index + 1"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1286</context>
+          <context context-type="linenumber">1294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.answerLabel" datatype="html">
         <source>Antwort <x id="answerNumber" equiv-text="index + 1"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1289</context>
+          <context context-type="linenumber">1297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.markAnswerCorrectAria" datatype="html">
         <source>Antwort <x id="answerNumber" equiv-text="answerNumber"/> als richtig markieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1293</context>
+          <context context-type="linenumber">1301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.toggleAnswerCorrectAria" datatype="html">
         <source>Antwort <x id="answerNumber" equiv-text="answerNumber"/> richtig</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1297</context>
+          <context context-type="linenumber">1305</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.removeAnswerAria" datatype="html">
         <source>Antwort <x id="answerNumber" equiv-text="answerNumber"/> entfernen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1301</context>
+          <context context-type="linenumber">1309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.collapseQuestionAria" datatype="html">
         <source>Frage zuklappen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1306</context>
+          <context context-type="linenumber">1314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.expandQuestionAria" datatype="html">
         <source>Frage aufklappen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1307</context>
+          <context context-type="linenumber">1315</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsPreviewLabel" datatype="html">
         <source>Musterlösungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1312</context>
+          <context context-type="linenumber">1320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.livePreviewAnswersLabel" datatype="html">
         <source>Antworten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1313</context>
+          <context context-type="linenumber">1321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.addShortTextSolution" datatype="html">
         <source>Weitere Musterlösung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1318</context>
+          <context context-type="linenumber">1326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8266267788371304686" datatype="html">
         <source>Weitere Antwort</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1319</context>
+          <context context-type="linenumber">1327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextMaxLengthSummary" datatype="html">
         <source>Max. <x id="maxLength" equiv-text="resolveShortTextMaxLength(question.shortTextMaxLength)"/> Zeichen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1436</context>
+          <context context-type="linenumber">1444</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1479</context>
+          <context context-type="linenumber">1487</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9837,56 +9893,56 @@
         <source>±<x id="tolerance" equiv-text="numericSettings.absoluteTolerance"/> absolut</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1447</context>
+          <context context-type="linenumber">1455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericToleranceRelativeSummary" datatype="html">
         <source>±<x id="tolerance" equiv-text="numericSettings.relativeTolerancePercent"/> % relativ</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1455</context>
+          <context context-type="linenumber">1463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitFamilySummary" datatype="html">
         <source>Einheiten: <x id="unitFamily" equiv-text="this.numericUnitFamilyLabel(numericSettings.unitFamily)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1461</context>
+          <context context-type="linenumber">1469</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericRequireUnitSummary" datatype="html">
         <source>Einheit erforderlich</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1465</context>
+          <context context-type="linenumber">1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericUnitOptionalSummary" datatype="html">
         <source>Einheit optional</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1466</context>
+          <context context-type="linenumber">1474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericEquivalentUnitsSummary" datatype="html">
         <source>Äquivalente Einheiten erlaubt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1470</context>
+          <context context-type="linenumber">1478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.numericExactUnitsSummary" datatype="html">
         <source>Nur exakt angegebene Einheit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1471</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextToleranceSummary" datatype="html">
         <source>Toleranz: <x id="tolerance" equiv-text="this.shortTextToleranceLabel(question.shortTextToleranceLevel)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1484</context>
+          <context context-type="linenumber">1492</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9897,7 +9953,7 @@
         <source>Groß-/Kleinschreibung zählt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1488</context>
+          <context context-type="linenumber">1496</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9908,7 +9964,7 @@
         <source>Nur volle Punkte</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1491</context>
+          <context context-type="linenumber">1499</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9919,7 +9975,7 @@
         <source>Leerzeichen werden streng geprüft</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1498</context>
+          <context context-type="linenumber">1506</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9930,21 +9986,21 @@
         <source>Lege mindestens eine Referenzlösung mit Einheit fest, halte das Einheitenset klein und aktiviere Pflicht-Einheiten nur, wenn die Einheit fachlich wirklich bewertet werden soll.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1507</context>
+          <context context-type="linenumber">1515</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarningNumeric" datatype="html">
         <source>Lege mindestens eine klare Referenzzahl fest und wähle die Toleranz so, dass sie Rechenungenauigkeit erlaubt, aber fachlich falsche Werte klar ausschließt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1508</context>
+          <context context-type="linenumber">1516</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextDidacticWarning" datatype="html">
         <source>Verwende tolerante Bewertung nur bei eindeutigen Fachbegriffen. Für offene Formulierungen sind mehrere Musterlösungen meist fairer als hohe Toleranz.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1511</context>
+          <context context-type="linenumber">1519</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
@@ -9955,178 +10011,178 @@
         <source>Hinterlege mindestens eine und höchstens zehn Referenzlösungen mit unterstützter Einheit, zum Beispiel „2 m“.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1521</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHintNumeric" datatype="html">
         <source>Hinterlege mindestens eine und höchstens zehn Referenzlösungen als Zahl, zum Beispiel „3,5“.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1522</context>
+          <context context-type="linenumber">1530</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextSolutionsHint" datatype="html">
         <source>Hinterlege mindestens eine und höchstens zehn Musterlösungen. Alle Varianten gelten als richtige Kurzantwort.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewExactLabel" datatype="html">
         <source>Exakte Eingabe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1621</context>
+          <context context-type="linenumber">1629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewLengthLabel" datatype="html">
         <source>Fehlendes oder zusätzliches Zeichen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1553</context>
+          <context context-type="linenumber">1561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewWrongLabel" datatype="html">
         <source>Anderer Begriff</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1557</context>
+          <context context-type="linenumber">1565</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1650</context>
+          <context context-type="linenumber">1658</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeFull" datatype="html">
         <source>Volle Punkte</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1592</context>
+          <context context-type="linenumber">1600</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeAccepted" datatype="html">
         <source>Akzeptiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1593</context>
+          <context context-type="linenumber">1601</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1669</context>
+          <context context-type="linenumber">1677</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomePartial" datatype="html">
         <source>Teilpunkte (<x id="points" equiv-text="result.points"/> %)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1596</context>
+          <context context-type="linenumber">1604</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1672</context>
+          <context context-type="linenumber">1680</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewOutcomeRejected" datatype="html">
         <source>Nicht akzeptiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1599</context>
+          <context context-type="linenumber">1607</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1683</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewNumericToleranceLabel" datatype="html">
         <source>Innerhalb der Toleranz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1629</context>
+          <context context-type="linenumber">1637</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewEquivalentUnitLabel" datatype="html">
         <source>Äquivalente Einheit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1646</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.shortTextPreviewMissingUnitLabel" datatype="html">
         <source>Fehlende Einheit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">1644</context>
+          <context context-type="linenumber">1652</context>
         </context-group>
       </trans-unit>
       <trans-unit id="705009069021941649" datatype="html">
         <source>Wähle genau eine richtige Antwort aus.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2025</context>
+          <context context-type="linenumber">2033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5903298630443190027" datatype="html">
         <source>Wähle mindestens eine richtige Antwort aus.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2029</context>
+          <context context-type="linenumber">2037</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2211937330568533798" datatype="html">
         <source>Speichern fehlgeschlagen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2148</context>
+          <context context-type="linenumber">2156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5746363347338638819" datatype="html">
         <source>Einstellungen konnten nicht gespeichert werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2165</context>
+          <context context-type="linenumber">2173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3347548161086861397" datatype="html">
         <source>Frage konnte nicht aktualisiert werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2277</context>
+          <context context-type="linenumber">2285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizEdit.saveConfirmation" datatype="html">
         <source>Änderungen gespeichert. Frage, Quizdaten und Einstellungen sind jetzt in Vorschau und Live-Quiz übernommen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2284</context>
+          <context context-type="linenumber">2292</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogTitle" datatype="html">
         <source>Frage löschen?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2312</context>
+          <context context-type="linenumber">2320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionDialogMessage" datatype="html">
         <source>Frage <x id="PH" equiv-text="position"/> wird dauerhaft aus dem Quiz entfernt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2313</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.deleteIrreversible" datatype="html">
         <source>Das lässt sich nicht rückgängig machen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2315</context>
+          <context context-type="linenumber">2323</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -10137,21 +10193,21 @@
         <source>Löschen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2317</context>
+          <context context-type="linenumber">2325</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.deleteQuestionCancel" datatype="html">
         <source>Abbrechen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2318</context>
+          <context context-type="linenumber">2326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4357290152640831712" datatype="html">
         <source>Löschen fehlgeschlagen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2335</context>
+          <context context-type="linenumber">2343</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-list/quiz-list.component.ts</context>
@@ -10162,39 +10218,39 @@
         <source>Verschieben fehlgeschlagen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2348</context>
+          <context context-type="linenumber">2356</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2364</context>
+          <context context-type="linenumber">2372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionUp" datatype="html">
         <source>Frage <x id="position" equiv-text="position"/> nach oben verschieben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2370</context>
+          <context context-type="linenumber">2378</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.moveQuestionDown" datatype="html">
         <source>Frage <x id="position" equiv-text="position"/> nach unten verschieben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2374</context>
+          <context context-type="linenumber">2382</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.dragQuestion" datatype="html">
         <source>Frage <x id="position" equiv-text="position"/> durch Ziehen verschieben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2378</context>
+          <context context-type="linenumber">2386</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quiz.edit.questionMovedAnnouncement" datatype="html">
         <source>Frage <x id="previousPosition" equiv-text="previousPosition"/> wurde an Position <x id="currentPosition" equiv-text="currentPosition"/> von <x id="total" equiv-text="total"/> verschoben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-edit/quiz-edit.component.ts</context>
-          <context context-type="linenumber">2385</context>
+          <context context-type="linenumber">2393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quizList.bonusCodesDialogHeading" datatype="html">
@@ -11773,7 +11829,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3010</context>
+          <context context-type="linenumber">3016</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisWords" datatype="html">
@@ -11784,7 +11840,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3013</context>
+          <context context-type="linenumber">3019</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudAnalysisPhrases" datatype="html">
@@ -11795,7 +11851,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3018</context>
+          <context context-type="linenumber">3024</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortAria" datatype="html">
@@ -11806,7 +11862,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3208</context>
+          <context context-type="linenumber">3220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortTop" datatype="html">
@@ -11817,7 +11873,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3212</context>
+          <context context-type="linenumber">3224</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortBest" datatype="html">
@@ -11828,7 +11884,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3215</context>
+          <context context-type="linenumber">3227</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortControversial" datatype="html">
@@ -11839,7 +11895,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3218</context>
+          <context context-type="linenumber">3230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudAnalysisAria" datatype="html">
@@ -11977,7 +12033,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2718</context>
+          <context context-type="linenumber">2724</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startQa" datatype="html">
@@ -11995,7 +12051,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2981</context>
+          <context context-type="linenumber">2987</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.playfulLobbyTeamsLabel" datatype="html">
@@ -12174,7 +12230,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2951</context>
+          <context context-type="linenumber">2957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5866404944747657974" datatype="html">
@@ -12223,147 +12279,147 @@
         <source>Nachbesprechungsplan ansehen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1212</context>
+          <context context-type="linenumber">1218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuVisual" datatype="html">
         <source>Standard (mit Diagrammen)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1230</context>
+          <context context-type="linenumber">1236</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfMenuPdfUa" datatype="html">
         <source>Barrierefrei (PDF/UA-1)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1241</context>
+          <context context-type="linenumber">1247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButtonAria" datatype="html">
         <source>Weitere Exportoptionen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1258</context>
+          <context context-type="linenumber">1264</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportMoreButton" datatype="html">
         <source>Mehr</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1261</context>
+          <context context-type="linenumber">1267</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7070792224026857010" datatype="html">
         <source>Zur Startseite</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1265</context>
+          <context context-type="linenumber">1271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelTooltip" datatype="html">
         <source>Tabellarische Rohdaten für Tabellenkalkulation – weniger Details als der Nachbesprechungsplan.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1275</context>
+          <context context-type="linenumber">1281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvExcelMenuItem" datatype="html">
         <source>Rohdaten als CSV exportieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1280</context>
+          <context context-type="linenumber">1286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressAria" datatype="html">
         <source>Export läuft</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1290</context>
+          <context context-type="linenumber">1296</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportProgressLabel" datatype="html">
         <source> Wird exportiert… </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1295,1297</context>
+          <context context-type="linenumber">1301,1303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4578537259986258154" datatype="html">
         <source> Tauscht euch kurz mit eurem Nachbarn aus </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1323,1325</context>
+          <context context-type="linenumber">1329,1331</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1952538840507841358" datatype="html">
         <source> Gleiche Antwort? Prima. Verschiedene Meinung? Überzeugt euch gegenseitig. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1326,1328</context>
+          <context context-type="linenumber">1332,1334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5596291527944555255" datatype="html">
         <source> Zweite Abstimmung folgt gleich. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1329,1331</context>
+          <context context-type="linenumber">1335,1337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveLabel" datatype="html">
         <source> Fragerunde läuft </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1339,1341</context>
+          <context context-type="linenumber">1345,1347</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaLiveHint" datatype="html">
         <source> Teilnehmende können jetzt mit dem Session-Code beitreten. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1343,1345</context>
+          <context context-type="linenumber">1349,1351</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionCounter" datatype="html">
         <source>Frage <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/> / <x id="INTERPOLATION_1" equiv-text="{{ q.totalQuestions }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1358,1359</context>
+          <context context-type="linenumber">1364,1365</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionNumber" datatype="html">
         <source>Frage <x id="INTERPOLATION" equiv-text="{{ q.order + 1 }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1361,1362</context>
+          <context context-type="linenumber">1367,1368</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1017989655370592681" datatype="html">
         <source>Letzte Frage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1364</context>
+          <context context-type="linenumber">1370</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7135032209126516357" datatype="html">
         <source>Alle haben abgestimmt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1403</context>
+          <context context-type="linenumber">1409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationNote" datatype="html">
         <source> Teilnehmende können ihre persönliche Frist bei Bedarf verlängern oder abschalten. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1424,1427</context>
+          <context context-type="linenumber">1430,1433</context>
         </context-group>
       </trans-unit>
       <trans-unit id="session.questionMetadataAria" datatype="html">
         <source>Frage-Metadaten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1439</context>
+          <context context-type="linenumber">1445</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.html</context>
@@ -12382,370 +12438,370 @@
         <source>Lesephase</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1464</context>
+          <context context-type="linenumber">1470</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6096095357858309629" datatype="html">
         <source> Antworten folgen gleich. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1465,1467</context>
+          <context context-type="linenumber">1471,1473</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingScaleAria" datatype="html">
         <source>Bewertungsskala</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1523</context>
+          <context context-type="linenumber">1529</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingDistributionAria" datatype="html">
         <source>Bewertungsverteilung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1551</context>
+          <context context-type="linenumber">1557</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericWaiting" datatype="html">
         <source> Warte auf Schätzungen… </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1590,1592</context>
+          <context context-type="linenumber">1596,1598</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericVoteCount" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ formatCount(numericVoteCount) }}"/> Antworten eingegangen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1598,1600</context>
+          <context context-type="linenumber">1604,1606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInsightsAria" datatype="html">
         <source>Statistik-Kurzfassung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1610</context>
+          <context context-type="linenumber">1616</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2043</context>
+          <context context-type="linenumber">2049</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRound2InsightLabel" datatype="html">
         <source>Runde 2</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1615</context>
+          <context context-type="linenumber">1621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandInsightKicker" datatype="html">
         <source>Akzeptiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1633</context>
+          <context context-type="linenumber">1639</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2063</context>
+          <context context-type="linenumber">2069</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightKicker" datatype="html">
         <source>Rundenvergleich</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1653</context>
+          <context context-type="linenumber">1659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaInsightKicker" datatype="html">
         <source>Verschiebung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1668</context>
+          <context context-type="linenumber">1674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel1" datatype="html">
         <source>Runde 1</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1695</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundLabel2" datatype="html">
         <source>Runde 2</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1694</context>
+          <context context-type="linenumber">1700</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailsSummary" datatype="html">
         <source>Statistische Details anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1881</context>
+          <context context-type="linenumber">1887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2180</context>
+          <context context-type="linenumber">2186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail1" datatype="html">
         <source> Runde 1 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1895,1897</context>
+          <context context-type="linenumber">1901,1903</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericRoundDetail2" datatype="html">
         <source> Runde 2 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1923,1925</context>
+          <context context-type="linenumber">1929,1931</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedImproved" datatype="html">
         <source> Paarvergleich: <x id="INTERPOLATION" equiv-text="{{ formatCount(rc.pairedAnalysis.closerCount) }}"/> näher, <x id="INTERPOLATION_1" equiv-text="{{ formatCount(rc.pairedAnalysis.fartherCount) }}"/> weiter weg, <x id="INTERPOLATION_2" equiv-text="{{ formatCount(rc.pairedAnalysis.unchangedCount) }}"/> gleich (<x id="INTERPOLATION_3" equiv-text="{{ formatCount(rc.pairedAnalysis.pairedCount) }}"/> Paare) </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1954,1962</context>
+          <context context-type="linenumber">1960,1968</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDeltaHistogramLabel" datatype="html">
         <source>Veränderung pro Person</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">1972</context>
+          <context context-type="linenumber">1978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericErrorInsightCaption" datatype="html">
         <source>kleiner ist näher</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2086</context>
+          <context context-type="linenumber">2092</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericDetailCurrentRound" datatype="html">
         <source> Ergebnisrunde </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2193,2195</context>
+          <context context-type="linenumber">2199,2201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericNoData" datatype="html">
         <source> Keine Schätzungen eingegangen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2220,2222</context>
+          <context context-type="linenumber">2226,2228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonPeerInstructionAria" datatype="html">
         <source>Vorher/Nachher-Vergleich Peer Instruction</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2232</context>
+          <context context-type="linenumber">2238</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelOne" datatype="html">
         <source>Runde 1 (<x id="INTERPOLATION" equiv-text="{{ formatCount(round1Votes) }}"/> Stimme)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2240</context>
+          <context context-type="linenumber">2246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound1VotesLabelMany" datatype="html">
         <source>Runde 1 (<x id="INTERPOLATION" equiv-text="{{ formatCount(round1Votes) }}"/> Stimmen)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2246</context>
+          <context context-type="linenumber">2252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelOne" datatype="html">
         <source>Runde 2 (<x id="INTERPOLATION" equiv-text="{{ formatCount(round2Votes) }}"/> Stimme)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2254</context>
+          <context context-type="linenumber">2260</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonRound2VotesLabelMany" datatype="html">
         <source>Runde 2 (<x id="INTERPOLATION" equiv-text="{{ formatCount(round2Votes) }}"/> Stimmen)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2260</context>
+          <context context-type="linenumber">2266</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.roundComparisonCorrectCounts" datatype="html">
         <source>Richtig: <x id="INTERPOLATION" equiv-text="{{ formatCount(q.roundComparison.round1CorrectCount) }}"/> in Runde 1, danach <x id="INTERPOLATION_1" equiv-text="{{ formatCount(q.roundComparison.round2CorrectCount) }}"/> in Runde 2</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2272,2276</context>
+          <context context-type="linenumber">2278,2282</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionTitle" datatype="html">
         <source> Peer Instruction empfohlen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2519,2521</context>
+          <context context-type="linenumber">2525,2527</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionLead" datatype="html">
         <source> 35–70 % vollständig korrekt — zweite Runde passt. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2526,2528</context>
+          <context context-type="linenumber">2532,2534</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionSub" datatype="html">
         <source> Erste Runde noch verborgen, bis du weiter machst. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2533,2535</context>
+          <context context-type="linenumber">2539,2541</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.peerSuggestionNext" datatype="html">
         <source> Diskussion starten oder Ergebnis zeigen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2540,2542</context>
+          <context context-type="linenumber">2546,2548</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionTitle" datatype="html">
         <source> Selbsteinschätzung </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2598,2600</context>
+          <context context-type="linenumber">2604,2606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceSectionLead" datatype="html">
         <source> Richtig oder falsch — und wie sicher? Besonders wichtig: falsch trotz hoher Antwortsicherheit. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2604,2607</context>
+          <context context-type="linenumber">2610,2613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabAria" datatype="html">
         <source>Korrektheit und Selbsteinschätzung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2634</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceWrongOptionsTitle" datatype="html">
         <source> Häufig falsch mit hoher Antwortsicherheit </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2682,2684</context>
+          <context context-type="linenumber">2688,2690</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.questionDetailsPending" datatype="html">
         <source> Frage wird aktualisiert … </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2727,2729</context>
+          <context context-type="linenumber">2733,2735</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7435414614973406916" datatype="html">
         <source> Keine Frage aktiv. Mit „Nächste Frage“ starten. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2731,2733</context>
+          <context context-type="linenumber">2737,2739</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
         <source>Reaktionen der Teilnehmenden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2751</context>
+          <context context-type="linenumber">2757</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsRound2" datatype="html">
         <source>2. Runde</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2757</context>
+          <context context-type="linenumber">2763</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiBadgeNew" datatype="html">
         <source>neu</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2765</context>
+          <context context-type="linenumber">2771</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4887698567767977129" datatype="html">
         <source>Noch keine Reaktionen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2788</context>
+          <context context-type="linenumber">2794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2528702424956729333" datatype="html">
         <source>Top 5</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2801</context>
+          <context context-type="linenumber">2807</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8436638106328843877" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="entry.totalScore | number }}"/> Pkt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2868</context>
+          <context context-type="linenumber">2874</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.interimLeaderboardTiebreakHint" datatype="html">
         <source>Gleichstand: Antwortzeit zählt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2877</context>
+          <context context-type="linenumber">2883</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6896435895128062952" datatype="html">
         <source>Team-Wertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2895</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.pointsAbbr" datatype="html">
         <source>Pkt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2942</context>
+          <context context-type="linenumber">2948</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.replaceQuizBeforeStart" datatype="html">
         <source>Quiz wechseln</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">2971</context>
+          <context context-type="linenumber">2977</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleEditAria" datatype="html">
         <source>Q&amp;A-Titel bearbeiten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3074</context>
+          <context context-type="linenumber">3086</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleFieldLabel" datatype="html">
         <source>Titel für Q&amp;A</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3087</context>
+          <context context-type="linenumber">3099</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaTitleDefault" datatype="html">
         <source>Fragen zur Veranstaltung...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3098</context>
+          <context context-type="linenumber">3110</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">886</context>
+          <context context-type="linenumber">893</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">898</context>
+          <context context-type="linenumber">905</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -12756,305 +12812,319 @@
         <source>Titel speichern</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3110</context>
+          <context context-type="linenumber">3122</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.qaTitleDiscardAria" datatype="html">
         <source>Bearbeiten abbrechen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3121</context>
+          <context context-type="linenumber">3133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationToggleLabel" datatype="html">
         <source> Vorab-Moderation </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3140,3142</context>
+          <context context-type="linenumber">3152,3154</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationModeHint" datatype="html">
         <source> Neue Fragen warten erst auf deine Freigabe. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3144,3146</context>
+          <context context-type="linenumber">3156,3158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.qaHostPlaceholder" datatype="html">
         <source> Noch keine Fragen. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3153,3155</context>
+          <context context-type="linenumber">3165,3167</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryTotal" datatype="html">
         <source>Gesamt: <x id="INTERPOLATION" equiv-text="{{ formatCount(qaForumQuestionCount()) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3165,3166</context>
+          <context context-type="linenumber">3177,3178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.summaryPending" datatype="html">
         <source>Warten auf Freigabe: <x id="INTERPOLATION" equiv-text="{{ formatCount(qaPendingCount()) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3174,3175</context>
+          <context context-type="linenumber">3186,3187</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllAria" datatype="html">
         <source>Alle Fragen anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3227</context>
+          <context context-type="linenumber">3239</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterShowAllLabel" datatype="html">
         <source>Alle anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3230</context>
+          <context context-type="linenumber">3242</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedAria" datatype="html">
         <source>Nur angeheftete Fragen anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3238</context>
+          <context context-type="linenumber">3250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterPinnedLabel" datatype="html">
         <source>Nur angeheftete</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3241</context>
+          <context context-type="linenumber">3253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsAria" datatype="html">
         <source>Neue Fragen anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3253</context>
+          <context context-type="linenumber">3265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.newQuestionsLabel" datatype="html">
         <source><x id="INTERPOLATION"/> neue Fragen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3259</context>
+          <context context-type="linenumber">3271</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportAria" datatype="html">
         <source>Fragen als CSV exportieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3291</context>
+          <context context-type="linenumber">3303</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLabel" datatype="html">
         <source>Fragen exportieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3294</context>
+          <context context-type="linenumber">3306</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportLoading" datatype="html">
         <source> Wird exportiert… </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3302,3304</context>
+          <context context-type="linenumber">3314,3316</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.badgeControversial" datatype="html">
         <source>Umstritten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3371</context>
+          <context context-type="linenumber">3383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.voteBreakdown" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="veVoteCount) }}"/> positiv · <x id="INTERPOLATION_1" equiv-text="{{ formatCount(question.negativeVoteCount) }}"/> negativ</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3399,3400</context>
+          <context context-type="linenumber">3411,3412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.bestMetric" datatype="html">
         <source>Belastbare Zustimmung <x id="INTERPOLATION" equiv-text="{{ formatQaPercent(question.bestScore) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3407,3408</context>
+          <context context-type="linenumber">3419,3420</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.controversyMetric" datatype="html">
         <source>Geteilte Reaktionen <x id="INTERPOLATION" equiv-text="{{ formatQaPercent(question.controversyScore) }}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3417,3419</context>
+          <context context-type="linenumber">3429,3431</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.filterEmptyHint" datatype="html">
         <source> Nur angeheftete aktiv – noch keine angehefteten Fragen vorhanden. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3460,3462</context>
+          <context context-type="linenumber">3472,3474</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptions" datatype="html">
         <source>Antwortoptionen freigeben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3513</context>
+          <context context-type="linenumber">3525</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
         <source>Diskussionsphase starten – Austausch vor zweiter Abstimmung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3549</context>
+          <context context-type="linenumber">3561</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.discussionPhaseButton" datatype="html">
         <source>Diskussionsphase</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3552</context>
+          <context context-type="linenumber">3564</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsForceClose" datatype="html">
         <source>Trotzdem freigeben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3567</context>
+          <context context-type="linenumber">3579</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3589</context>
+          <context context-type="linenumber">3601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsDespiteSuggestion" datatype="html">
         <source>Ergebnis trotzdem zeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3570</context>
+          <context context-type="linenumber">3582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.revealResultsAnchor" datatype="html">
         <source>Ergebnis zeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3591</context>
+          <context context-type="linenumber">3603</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.nextQuestionAnchor" datatype="html">
         <source> Nächste Frage </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3607,3609</context>
+          <context context-type="linenumber">3619,3621</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
         <source>Zur nächsten Frage ohne zweite Abstimmung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3630</context>
+          <context context-type="linenumber">3642</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestion" datatype="html">
         <source>Zur nächsten Frage ohne zweite Abstimmung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3633</context>
+          <context context-type="linenumber">3645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
         <source>Zeigt die letzte Frage mit Ergebnis und richtiger Lösung erneut an (ohne neue Abstimmung).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3650</context>
+          <context context-type="linenumber">3662</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchor" datatype="html">
         <source> Letztes Ergebnis erneut anzeigen </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3652,3654</context>
+          <context context-type="linenumber">3664,3666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.endSessionAnchor" datatype="html">
         <source> Session beenden </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3662,3664</context>
+          <context context-type="linenumber">3674,3676</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
         <source>Host-Ansicht für Lobby und Steuerung.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3670</context>
+          <context context-type="linenumber">3682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyWarm" datatype="html">
         <source>Lobby · Warm</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">322</context>
+          <context context-type="linenumber">324</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyArrival" datatype="html">
         <source>Lobby · Ankommen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">326</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyCalm" datatype="html">
         <source>Lobby · Ruhig</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">332</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackLobbyPulse" datatype="html">
         <source>Lobby · Puls</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">334</context>
+          <context context-type="linenumber">336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackReadingBuild" datatype="html">
         <source>Lesen · Aufbau</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">338</context>
+          <context context-type="linenumber">340</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownFocus" datatype="html">
         <source>Countdown · Fokus</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">342</context>
+          <context context-type="linenumber">344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownTempo" datatype="html">
         <source>Countdown · Tempo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">346</context>
+          <context context-type="linenumber">348</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicTrackCountdownIntense" datatype="html">
         <source>Countdown · Intensiv</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">350</context>
+          <context context-type="linenumber">352</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingQa" datatype="html">
+        <source>Warum die Fragenwand mehr als ein Chat ist</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">421</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.infoLandingConfidence" datatype="html">
+        <source>Selbsteinschätzung und Nachbesprechung verstehen</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">423</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4017389878545296254" datatype="html">
         <source>Warte auf Live-Freitextdaten …</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">500</context>
+          <context context-type="linenumber">507</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13065,7 +13135,7 @@
         <source>Live-Freitext</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">503</context>
+          <context context-type="linenumber">510</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13076,7 +13146,7 @@
         <source>Häufige Wörter aus den Antworten.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">504</context>
+          <context context-type="linenumber">511</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13087,7 +13157,7 @@
         <source>Q&amp;A-Analyse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">505</context>
+          <context context-type="linenumber">512</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13098,7 +13168,7 @@
         <source>Zeigt, welche Wörter und Phrasen in den sichtbaren Q&amp;A-Fragen dominieren.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">506</context>
+          <context context-type="linenumber">513</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13109,106 +13179,106 @@
         <source>Wortwolke ausblenden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">647</context>
+          <context context-type="linenumber">654</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudShow" datatype="html">
         <source>Wortwolke anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">648</context>
+          <context context-type="linenumber">655</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudResume" datatype="html">
         <source>Live fortsetzen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">653</context>
+          <context context-type="linenumber">660</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1036</context>
+          <context context-type="linenumber">1043</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFreeze" datatype="html">
         <source>Wortwolke einfrieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">654</context>
+          <context context-type="linenumber">661</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1037</context>
+          <context context-type="linenumber">1044</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.wordCloudFrozenInfo" datatype="html">
         <source>Wortwolke eingefroren.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">679</context>
+          <context context-type="linenumber">686</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobbyShort" datatype="html">
         <source>Lobby</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">836</context>
+          <context context-type="linenumber">843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseConnectingShort" datatype="html">
         <source>Lesen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">837</context>
+          <context context-type="linenumber">844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseRunningShort" datatype="html">
         <source>Countdown</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">838</context>
+          <context context-type="linenumber">845</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicLabelOff" datatype="html">
         <source>Musik aus</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">870</context>
+          <context context-type="linenumber">877</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.lobbyQuizHeadingFallback" datatype="html">
         <source>Quiz-Session</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">891</context>
+          <context context-type="linenumber">898</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricBest" datatype="html">
         <source>belastbare Zustimmung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">958</context>
+          <context context-type="linenumber">965</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricControversial" datatype="html">
         <source>Kontroverse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">960</context>
+          <context context-type="linenumber">967</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudMetricTop" datatype="html">
         <source>positive Stimmen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">962</context>
+          <context context-type="linenumber">969</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudTitle" datatype="html">
         <source>Q&amp;A-Wortwolke</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">965</context>
+          <context context-type="linenumber">972</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -13219,695 +13289,695 @@
         <source>Große Wörter und Phrasen kommen aus Fragen mit viel Zustimmung und ausreichend Stimmen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">969</context>
+          <context context-type="linenumber">976</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintControversial" datatype="html">
         <source>Große Wörter und Phrasen kommen aus Fragen mit gegensätzlichen Reaktionen. Darüberfahren zeigt die zugehörigen Fragen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">971</context>
+          <context context-type="linenumber">978</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudHintTop" datatype="html">
         <source>Große Wörter und Phrasen kommen aus Fragen mit vielen positiven Stimmen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">973</context>
+          <context context-type="linenumber">980</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudThemeFallbackHint" datatype="html">
         <source>Es werden Einzelwörter gezeigt, bis Wortgruppen und Phrasen belastbar sind.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1019</context>
+          <context context-type="linenumber">1026</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintBest" datatype="html">
         <source>Zeigt Fragen mit viel Zustimmung und genug Stimmen zuerst. Angeheftete Fragen sind markiert, aber nicht vorgezogen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1024</context>
+          <context context-type="linenumber">1031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintControversial" datatype="html">
         <source>Zeigt Fragen mit gemischter Reaktion zuerst. Angeheftete Fragen sind markiert, aber nicht vorgezogen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1026</context>
+          <context context-type="linenumber">1033</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.sortHintTop" datatype="html">
         <source>Zeigt Fragen mit den meisten positiven Stimmen zuerst. Angeheftete Fragen sind markiert, aber nicht vorgezogen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1028</context>
+          <context context-type="linenumber">1035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudShow" datatype="html">
         <source>Wortwolke anzeigen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1032</context>
+          <context context-type="linenumber">1039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountOneMetric" datatype="html">
         <source>1 sichtbare Frage · Größe von Wörtern und Phrasen: <x id="metric" equiv-text="metric"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1043</context>
+          <context context-type="linenumber">1050</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.wordCloudCountManyMetric" datatype="html">
         <source><x id="count" equiv-text="count"/> sichtbare Fragen · Größe von Wörtern und Phrasen: <x id="metric" equiv-text="metric"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1045</context>
+          <context context-type="linenumber">1052</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountOne" datatype="html">
         <source>1 Antwort</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1545</context>
+          <context context-type="linenumber">1552</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.responseCountMany" datatype="html">
         <source><x id="count" equiv-text="count"/> Antworten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1546</context>
+          <context context-type="linenumber">1553</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLowWithLabel" datatype="html">
         <source>Niedrig · <x id="label" equiv-text="q.confidenceLabelLow"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1637</context>
+          <context context-type="linenumber">1644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierLow" datatype="html">
         <source>Niedrig (1–2)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1638</context>
+          <context context-type="linenumber">1645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierMid" datatype="html">
         <source>Mitte (3)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1642</context>
+          <context context-type="linenumber">1649</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHighWithLabel" datatype="html">
         <source>Hoch · <x id="label" equiv-text="q.confidenceLabelHigh"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1674</context>
+          <context context-type="linenumber">1681</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceTierHigh" datatype="html">
         <source>Hoch (4–5)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1675</context>
+          <context context-type="linenumber">1682</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCorrect" datatype="html">
         <source>Richtig</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1689</context>
+          <context context-type="linenumber">1696</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabIncorrect" datatype="html">
         <source>Falsch</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1696</context>
+          <context context-type="linenumber">1703</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceCrossTabCellAria" datatype="html">
         <source><x id="row" equiv-text="rowLabel"/> · <x id="tier" equiv-text="tierLabel"/> · <x id="count" equiv-text="count"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1788</context>
+          <context context-type="linenumber">1795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionSingular" datatype="html">
         <source>1 selbstsicher falsche Antwort – mögliches Fehlkonzept</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1793</context>
+          <context context-type="linenumber">1800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.confidenceMisconceptionPlural" datatype="html">
         <source><x id="count" equiv-text="count"/> selbstsicher falsche Antworten – mögliche Fehlkonzepte</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1794</context>
+          <context context-type="linenumber">1801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceCrossTab" datatype="html">
         <source>Kreuz richtig/hoch <x id="correctHigh" equiv-text="crossTab.correctHigh"/> · falsch/hoch <x id="incorrectHigh" equiv-text="crossTab.incorrectHigh"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1805</context>
+          <context context-type="linenumber">1812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Label" datatype="html">
         <source>2 (Peer Instruction)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1825</context>
+          <context context-type="linenumber">1832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportRoundParticipationGap" datatype="html">
         <source>Runde 1: <x id="r1" equiv-text="round1Count"/> Stimmen · Aggregiert: Runde 2 mit <x id="r2" equiv-text="round2Count"/> Stimmen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1843</context>
+          <context context-type="linenumber">1850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound2Context" datatype="html">
         <source>Aggregationsrunde 2 (Peer Instruction)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1845</context>
+          <context context-type="linenumber">1852</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportAggregationRound1Context" datatype="html">
         <source>Aggregationsrunde 1</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">1848</context>
+          <context context-type="linenumber">1855</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutTitle" datatype="html">
         <source>Das ist gerade nicht angekommen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2452</context>
+          <context context-type="linenumber">2459</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutBody" datatype="html">
         <source>Kein Stress – so was passiert manchmal (kurzer Ruckler oder instabiles WLAN). Warte zwei, drei Sekunden und tippe auf „Nochmal probieren“ – meist reicht das.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2453</context>
+          <context context-type="linenumber">2460</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaTitle" datatype="html">
         <source>Mit den Fragen klappt es gerade nicht</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2460</context>
+          <context context-type="linenumber">2467</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutQaBody" datatype="html">
         <source>Hier ist nichts kaputt – es hat nur gerade nicht geklappt. Kurz durchatmen, 2–3 Sekunden warten, dann „Nochmal probieren“ – oft läuft es gleich wieder.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2461</context>
+          <context context-type="linenumber">2468</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportTitle" datatype="html">
         <source>Export noch nicht bereit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2468</context>
+          <context context-type="linenumber">2475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.steeringCalloutExportBody" datatype="html">
         <source>PDF- oder Excel-Export ist diesmal nicht durchgekommen. Warte ein paar Sekunden und tippe auf „Nochmal probieren“ – meist klappt’s beim zweiten Anlauf.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2469</context>
+          <context context-type="linenumber">2476</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceParticipantsHome" datatype="html">
         <source>Teilnehmende und die Präsentationsansicht werden zur Startseite weitergeleitet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2603</context>
+          <context context-type="linenumber">2610</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceSessionEnds" datatype="html">
         <source>Die Session endet für alle; ein Fortsetzen mit demselben Code ist nicht möglich.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2604</context>
+          <context context-type="linenumber">2611</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceWaitingCount" datatype="html">
         <source><x id="participantCount" equiv-text="participants"/> Teilnehmende sind noch in der Session.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2608</context>
+          <context context-type="linenumber">2615</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceExportAfterEnd" datatype="html">
         <source>Du hast bereits Ergebnisse. Nach dem Beenden kannst du sie in der Abschlussansicht exportieren oder Feedback ansehen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2613</context>
+          <context context-type="linenumber">2620</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceNoResultsYet" datatype="html">
         <source>Es liegen noch keine verwertbaren Ergebnisse vor. Nach dem Beenden wirst du direkt zur Startseite geführt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2617</context>
+          <context context-type="linenumber">2624</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.leaveConsequenceBonusCodes" datatype="html">
         <source>Für Bonus-Codes: Weise die Teilnehmenden darauf hin, ihren persönlichen Code jetzt zu kopieren (Zwischenablage), bevor sie die Seite verlassen – sonst können sie ihn leicht verlieren.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2622</context>
+          <context context-type="linenumber">2629</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1449856638611469268" datatype="html">
         <source>Session verlassen?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2628</context>
+          <context context-type="linenumber">2635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5874101222082342849" datatype="html">
         <source>Deine Session ist noch aktiv.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2629</context>
+          <context context-type="linenumber">2636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="388074101804534257" datatype="html">
         <source>Trotzdem verlassen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2631</context>
+          <context context-type="linenumber">2638</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7676535372692514896" datatype="html">
         <source>Zurück zur Session</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2632</context>
+          <context context-type="linenumber">2639</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewStopAria" datatype="html">
         <source>Vorschau stoppen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2823</context>
+          <context context-type="linenumber">2830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicPreviewTrackAria" datatype="html">
         <source>Track kurz anhören (max. 12 Sekunden)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2824</context>
+          <context context-type="linenumber">2831</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOn" datatype="html">
         <source>Ton an</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2836</context>
+          <context context-type="linenumber">2843</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.musicToggleOff" datatype="html">
         <source>Ton aus</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2837</context>
+          <context context-type="linenumber">2844</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountOne" datatype="html">
         <source>teilnehmende Person</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2894</context>
+          <context context-type="linenumber">2901</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.participantCountMany" datatype="html">
         <source>Teilnehmende</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2898</context>
+          <context context-type="linenumber">2905</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountOne" datatype="html">
         <source>1 live verbunden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2915</context>
+          <context context-type="linenumber">2922</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.connectedParticipantCountMany" datatype="html">
         <source><x id="connectedCount" equiv-text="formatLocaleCount(connectedCount, this.localeId)"/> live verbunden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2917</context>
+          <context context-type="linenumber">2924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6807726879921681315" datatype="html">
         <source>Noch niemand in diesem Team.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">2943</context>
+          <context context-type="linenumber">2950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="241839647344135361" datatype="html">
         <source>Bewertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3759</context>
+          <context context-type="linenumber">3766</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1477629611819298713" datatype="html">
         <source>Bewertungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3763</context>
+          <context context-type="linenumber">3770</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1459586565397898784" datatype="html">
         <source>Die Ergebnisse liegen vor.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3768</context>
+          <context context-type="linenumber">3775</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3775</context>
+          <context context-type="linenumber">3782</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3158548505527185467" datatype="html">
         <source>Zeit abgelaufen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3769</context>
+          <context context-type="linenumber">3776</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3776</context>
+          <context context-type="linenumber">3783</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1777945885954120583" datatype="html">
         <source>Warte auf Bewertungen…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3770</context>
+          <context context-type="linenumber">3777</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6747188936976845111" datatype="html">
         <source>Warte auf Antworten…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3777</context>
+          <context context-type="linenumber">3784</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8216228250854226494" datatype="html">
         <source><x id="PH" equiv-text="formatLocaleCount(votes, this.localeId)"/> von <x id="PH_1" equiv-text="formatLocaleCount(participants, this.localeId)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3781</context>
+          <context context-type="linenumber">3788</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOneForce" datatype="html">
         <source>Eine Person nutzt noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihr persönliches Fenster.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3788</context>
+          <context context-type="linenumber">3795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingOne" datatype="html">
         <source>Eine Person nutzt noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3789</context>
+          <context context-type="linenumber">3796</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingManyForce" datatype="html">
         <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. „Trotzdem freigeben“ beendet ihre persönlichen Fenster.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3793</context>
+          <context context-type="linenumber">3800</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationBlockingMany" datatype="html">
         <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> Personen nutzen noch ihre 10× Zeit. Warte auf den Raum-Countdown oder bis die 10× Zeit endet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3794</context>
+          <context context-type="linenumber">3801</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingOne" datatype="html">
         <source>Eine Person antwortet ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3797</context>
+          <context context-type="linenumber">3804</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.timerAccommodationPendingMany" datatype="html">
         <source><x id="count" equiv-text="formatLocaleCount(count, this.localeId)"/> Personen antworten ohne persönliche Frist. „Ergebnis zeigen“ beendet ihre Eingabe.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3799</context>
+          <context context-type="linenumber">3806</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaOne" datatype="html">
         <source><x id="votes" equiv-text="formatLocaleCount(votes, this.localeId)"/> von <x id="participants" equiv-text="formatLocaleCount(participants, this.localeId)"/> Teilnehmenden hat abgestimmt. <x id="percentage" equiv-text="formattedPercentage"/> Prozent erreicht.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3805</context>
+          <context context-type="linenumber">3812</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.voteProgressAriaMany" datatype="html">
         <source><x id="votes" equiv-text="formatLocaleCount(votes, this.localeId)"/> von <x id="participants" equiv-text="formatLocaleCount(participants, this.localeId)"/> Teilnehmenden haben abgestimmt. <x id="percentage" equiv-text="formattedPercentage"/> Prozent erreicht.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3807</context>
+          <context context-type="linenumber">3814</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastOne" datatype="html">
         <source><x id="voteCount" equiv-text="voteCount"/> von <x id="participantTotal" equiv-text="totalStr"/> hat abgestimmt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3818</context>
+          <context context-type="linenumber">3825</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.votesCastMany" datatype="html">
         <source><x id="voteCount" equiv-text="voteCount"/> von <x id="participantTotal" equiv-text="totalStr"/> haben abgestimmt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3820</context>
+          <context context-type="linenumber">3827</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedOne" datatype="html">
         <source><x id="voteCount" equiv-text="voteCount"/> von <x id="participantTotal" equiv-text="totalStr"/> hat bewertet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3831</context>
+          <context context-type="linenumber">3838</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.ratingSubmittedMany" datatype="html">
         <source><x id="voteCount" equiv-text="voteCount"/> von <x id="participantTotal" equiv-text="totalStr"/> haben bewertet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3833</context>
+          <context context-type="linenumber">3840</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.correctAllVoters" datatype="html">
         <source><x id="correctCount" equiv-text="formatLocaleCount(correct, this.localeId)"/> von <x id="voteTotal" equiv-text="formatLocaleCount(total, this.localeId)"/> komplett richtig (<x id="percentage" equiv-text="formatLocaleCount(pct, this.localeId)"/> %)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3839</context>
+          <context context-type="linenumber">3846</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftChangedMind" datatype="html">
         <source><x id="changed" equiv-text="formatLocaleCount(changed, this.localeId)"/> von <x id="both" equiv-text="formatLocaleCount(both, this.localeId)"/> (<x id="pct" equiv-text="formatLocaleCount(pct, this.localeId)"/> %) änderten ihre Meinung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3843</context>
+          <context context-type="linenumber">3850</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftWrongToCorrect" datatype="html">
         <source>↑ <x id="count" equiv-text="count"/> falsch → richtig</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3847</context>
+          <context context-type="linenumber">3854</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.opinionShiftCorrectToWrong" datatype="html">
         <source>↓ <x id="count" equiv-text="count"/> richtig → falsch</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3851</context>
+          <context context-type="linenumber">3858</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.feedbackAvgStarsAria" datatype="html">
         <source>Durchschnitt <x id="avg" equiv-text="formatted"/> von 5 Sternen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3857</context>
+          <context context-type="linenumber">3864</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6038081262407463029" datatype="html">
         <source><x id="PH" equiv-text="total"/> Reaktion</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8711778533396778089" datatype="html">
         <source><x id="PH" equiv-text="total"/> Reaktionen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3861</context>
+          <context context-type="linenumber">3868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseLobby" datatype="html">
         <source>Lobby – Teilnehmende können beitreten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3917</context>
+          <context context-type="linenumber">3924</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaPreparing" datatype="html">
         <source>Fragerunde wird vorbereitet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3918</context>
+          <context context-type="linenumber">3925</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaActive" datatype="html">
         <source>Fragerunde läuft</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3919</context>
+          <context context-type="linenumber">3926</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3921</context>
+          <context context-type="linenumber">3928</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3922</context>
+          <context context-type="linenumber">3929</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phasePaused" datatype="html">
         <source>Pausiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3920</context>
+          <context context-type="linenumber">3927</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.phaseQaFinished" datatype="html">
         <source>Fragerunde beendet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3923</context>
+          <context context-type="linenumber">3930</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6183226753731581202" datatype="html">
         <source>Abstimmung beendet – warte auf Auswertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3928</context>
+          <context context-type="linenumber">3935</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7334576405532009332" datatype="html">
         <source>Lobby – Teilnehmende können beitreten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3931</context>
+          <context context-type="linenumber">3938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1220327087999810393" datatype="html">
         <source>Lesephase – Antworten noch gesperrt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3932</context>
+          <context context-type="linenumber">3939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8314358219279011566" datatype="html">
         <source>Abstimmung läuft</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3933</context>
+          <context context-type="linenumber">3940</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3438822305353981453" datatype="html">
         <source>Pausiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3934</context>
+          <context context-type="linenumber">3941</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1693990659982068798" datatype="html">
         <source>Ergebnisse werden angezeigt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3935</context>
+          <context context-type="linenumber">3942</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6318529117726534409" datatype="html">
         <source>Diskussionsphase – Austausch vor zweiter Runde</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3936</context>
+          <context context-type="linenumber">3943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="882376754672492511" datatype="html">
         <source>Session beendet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3937</context>
+          <context context-type="linenumber">3944</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyProgressAll" datatype="html">
         <source><x id="readyCount" equiv-text="readyCount"/> von <x id="connectedCount" equiv-text="connectedCount"/> bereit</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3948</context>
+          <context context-type="linenumber">3955</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3059004459552059204" datatype="html">
         <source><x id="PH" equiv-text="readyCount"/> von <x id="PH_1" equiv-text="connectedCount"/> verbunden bereit · <x id="PH_2" equiv-text="totalParticipantCount"/> insgesamt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3950</context>
+          <context context-type="linenumber">3957</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintAll" datatype="html">
         <source>Alle Teilnehmenden sind bereit – Antwortoptionen können freigegeben werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3955</context>
+          <context context-type="linenumber">3962</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.readingReadyReleaseHintConnected" datatype="html">
         <source>Alle verbundenen Teilnehmenden sind bereit – Antwortoptionen können freigegeben werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3957</context>
+          <context context-type="linenumber">3964</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaOne" datatype="html">
         <source>1 Sekunde verbleibend</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3988</context>
+          <context context-type="linenumber">3995</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.countdownAriaMany" datatype="html">
         <source><x id="seconds" equiv-text="seconds"/> Sekunden verbleibend</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">3989</context>
+          <context context-type="linenumber">3996</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericReferenceAxisLabel" datatype="html">
@@ -13917,7 +13987,7 @@
     )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4113,4116</context>
+          <context context-type="linenumber">4120,4123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedSingleLabel" datatype="html">
@@ -13927,7 +13997,7 @@
         )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4158,4161</context>
+          <context context-type="linenumber">4165,4168</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericAcceptedRangeLabel" datatype="html">
@@ -13937,7 +14007,7 @@
       )"/> bis <x id="right" equiv-text="this.formatNumericHostValue(acceptedRight, question)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4163,4166</context>
+          <context context-type="linenumber">4170,4173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericToleranceBandLabel" datatype="html">
@@ -13947,77 +14017,77 @@
     )"/> bis <x id="right" equiv-text="this.formatNumericHostValue(band.right, question)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4168,4171</context>
+          <context context-type="linenumber">4175,4178</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedian" datatype="html">
         <source>Median <x id="median" equiv-text="this.formatNumericHostStatValue(stats.median, question)"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4286</context>
+          <context context-type="linenumber">4293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountLabel" datatype="html">
         <source>Schätzungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4319</context>
+          <context context-type="linenumber">4326</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatCountCaption" datatype="html">
         <source>gültige Antworten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4321</context>
+          <context context-type="linenumber">4328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanLabel" datatype="html">
         <source>Mittelwert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4327</context>
+          <context context-type="linenumber">4334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanCaption" datatype="html">
         <source>Durchschnitt aller Schätzungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4329</context>
+          <context context-type="linenumber">4336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianLabel" datatype="html">
         <source>Median</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4335</context>
+          <context context-type="linenumber">4342</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMedianCaption" datatype="html">
         <source>Mitte der sortierten Werte</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4337</context>
+          <context context-type="linenumber">4344</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevLabel" datatype="html">
         <source>Streuung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4343</context>
+          <context context-type="linenumber">4350</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatStdDevCaption" datatype="html">
         <source>Standardabweichung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4345</context>
+          <context context-type="linenumber">4352</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Label" datatype="html">
         <source>Mittlere 50 %</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4351</context>
+          <context context-type="linenumber">4358</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMiddle50Caption" datatype="html">
@@ -14027,28 +14097,28 @@
         )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4356,4359</context>
+          <context context-type="linenumber">4363,4366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeLabel" datatype="html">
         <source>Spanne</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4365</context>
+          <context context-type="linenumber">4372</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatRangeCaption" datatype="html">
         <source>kleinste bis größte Schätzung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4370</context>
+          <context context-type="linenumber">4377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandLabel" datatype="html">
         <source>Im Band</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4376</context>
+          <context context-type="linenumber">4383</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatInBandCaption" datatype="html">
@@ -14059,42 +14129,42 @@
         )"/> % akzeptiert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4382,4386</context>
+          <context context-type="linenumber">4389,4393</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorLabel" datatype="html">
         <source>Mittlerer Abstand</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4392</context>
+          <context context-type="linenumber">4399</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericStatMeanAbsoluteErrorCaption" datatype="html">
         <source>zur Referenz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4394</context>
+          <context context-type="linenumber">4401</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMedian" datatype="html">
         <source>Median</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4402</context>
+          <context context-type="linenumber">4409</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryMean" datatype="html">
         <source>Mittelwert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4405</context>
+          <context context-type="linenumber">4412</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPrimaryResponses" datatype="html">
         <source>Schätzungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4407</context>
+          <context context-type="linenumber">4414</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandCaption" datatype="html">
@@ -14105,35 +14175,35 @@
     )"/> % im akzeptierten Bereich</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4438,4442</context>
+          <context context-type="linenumber">4445,4449</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanAbsoluteErrorCaption" datatype="html">
         <source>Mittlerer Abstand zur Referenz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4456</context>
+          <context context-type="linenumber">4463</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericPairedInsightCaption" datatype="html">
         <source>näher am Referenzwert</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4470</context>
+          <context context-type="linenumber">4477</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDeltaCaption" datatype="html">
         <source>Median-Veränderung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4487</context>
+          <context context-type="linenumber">4494</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaCaption" datatype="html">
         <source>Mittelwert-Veränderung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4488</context>
+          <context context-type="linenumber">4495</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMeanDeltaReadable" datatype="html">
@@ -14143,7 +14213,7 @@
         )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4499,4502</context>
+          <context context-type="linenumber">4506,4509</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericMedianDelta" datatype="html">
@@ -14153,7 +14223,7 @@
         )"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4508,4511</context>
+          <context context-type="linenumber">4515,4518</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInBandDeltaReadable" datatype="html">
@@ -14164,7 +14234,7 @@
         )"/> Prozentpunkte</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4520,4524</context>
+          <context context-type="linenumber">4527,4531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundCloser" datatype="html">
@@ -14179,7 +14249,7 @@
           )"/> vergleichbaren Schätzungen haben sich verbessert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4540,4548</context>
+          <context context-type="linenumber">4547,4555</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundFarther" datatype="html">
@@ -14194,14 +14264,14 @@
           )"/> vergleichbaren Schätzungen sind weiter entfernt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4552,4560</context>
+          <context context-type="linenumber">4559,4567</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationRoundMixed" datatype="html">
         <source>Runde 2 ist gemischt: näher und weiter entfernte Schätzungen halten sich im Paarvergleich die Waage.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4564</context>
+          <context context-type="linenumber">4571</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorImproved" datatype="html">
@@ -14211,7 +14281,7 @@
           )"/> kleiner.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4576,4579</context>
+          <context context-type="linenumber">4583,4586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationErrorWorse" datatype="html">
@@ -14221,7 +14291,7 @@
           )"/> größer.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4583,4586</context>
+          <context context-type="linenumber">4590,4593</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationInBandDelta" datatype="html">
@@ -14232,7 +14302,7 @@
         )"/> Prozentpunkte.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4598,4602</context>
+          <context context-type="linenumber">4605,4609</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleInBand" datatype="html">
@@ -14247,7 +14317,7 @@
         )"/> Schätzungen liegen im Toleranzband.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4617,4625</context>
+          <context context-type="linenumber">4624,4632</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleError" datatype="html">
@@ -14257,7 +14327,7 @@
         )"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4630,4633</context>
+          <context context-type="linenumber">4637,4640</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.numericInterpretationSingleMedian" datatype="html">
@@ -14267,14 +14337,14 @@
         )"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4637,4640</context>
+          <context context-type="linenumber">4644,4647</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.quiz" datatype="html">
         <source>Quiz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4686</context>
+          <context context-type="linenumber">4693</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14285,7 +14355,7 @@
         <source>Q&amp;A</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4688</context>
+          <context context-type="linenumber">4695</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14296,25 +14366,25 @@
         <source><x id="count" equiv-text="formatLocaleCount(this.qaUnseenCount(), this.localeId)"/> neu</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4696</context>
+          <context context-type="linenumber">4703</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4713</context>
+          <context context-type="linenumber">4720</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelInactive" datatype="html">
         <source>Aus</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4813</context>
+          <context context-type="linenumber">4820</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.channelClosed" datatype="html">
         <source>Zu</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4816</context>
+          <context context-type="linenumber">4823</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14325,7 +14395,7 @@
         <source>Frage von <x id="PH" equiv-text="nickname"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14336,7 +14406,7 @@
         <source>Frage aus dem Publikum</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4865</context>
+          <context context-type="linenumber">4872</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14347,7 +14417,7 @@
         <source>Auswahl für <x id="PH" equiv-text="nickname"/> aufheben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4879</context>
+          <context context-type="linenumber">4886</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14362,7 +14432,7 @@
         <source>Alle Fragen von <x id="PH" equiv-text="nickname"/> hervorheben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4880</context>
+          <context context-type="linenumber">4887</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14377,7 +14447,7 @@
         <source>Wird beantwortet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4909</context>
+          <context context-type="linenumber">4916</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14388,7 +14458,7 @@
         <source>Offen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4911</context>
+          <context context-type="linenumber">4918</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14399,7 +14469,7 @@
         <source>Wartet auf Freigabe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4913</context>
+          <context context-type="linenumber">4920</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14410,7 +14480,7 @@
         <source>Beantwortet</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4915</context>
+          <context context-type="linenumber">4922</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14421,7 +14491,7 @@
         <source>Entfernt</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">4917</context>
+          <context context-type="linenumber">4924</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-vote/session-vote.component.ts</context>
@@ -14432,295 +14502,295 @@
         <source>Freigeben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5018</context>
+          <context context-type="linenumber">5025</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPin" datatype="html">
         <source>Hervorheben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5020</context>
+          <context context-type="linenumber">5027</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionUnpin" datatype="html">
         <source>Hervorhebung aufheben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5022</context>
+          <context context-type="linenumber">5029</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionArchive" datatype="html">
         <source>Archivieren</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5024</context>
+          <context context-type="linenumber">5031</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionPurge" datatype="html">
         <source>Endgültig entfernen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5027</context>
+          <context context-type="linenumber">5034</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.actionDelete" datatype="html">
         <source>Löschen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5028</context>
+          <context context-type="linenumber">5035</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.closeChannelAction" datatype="html">
         <source>Kanal schließen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5372</context>
+          <context context-type="linenumber">5379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionTabs.reopenChannelAction" datatype="html">
         <source>Kanal wieder öffnen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5373</context>
+          <context context-type="linenumber">5380</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationEnabled" datatype="html">
         <source>Vorab-Moderation aktiviert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5787</context>
+          <context context-type="linenumber">5794</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDisabled" datatype="html">
         <source>Vorab-Moderation deaktiviert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5788</context>
+          <context context-type="linenumber">5795</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationApproved" datatype="html">
         <source>Frage freigegeben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5821</context>
+          <context context-type="linenumber">5828</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationPinned" datatype="html">
         <source>Frage hervorgehoben.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5823</context>
+          <context context-type="linenumber">5830</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationArchived" datatype="html">
         <source>Frage archiviert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5825</context>
+          <context context-type="linenumber">5832</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.moderationDeleted" datatype="html">
         <source>Frage entfernt.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5826</context>
+          <context context-type="linenumber">5833</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceOne" datatype="html">
         <source>Die offene persönliche 10×-Frist dieser Person endet sofort.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5927</context>
+          <context context-type="linenumber">5934</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceNoFurtherInput" datatype="html">
         <source>Danach ist keine weitere Antwort mehr möglich.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5928</context>
+          <context context-type="linenumber">5935</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5932</context>
+          <context context-type="linenumber">5939</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConsequenceMany" datatype="html">
         <source><x id="count" equiv-text="formatLocaleCount(blockingCount, this.localeId)"/> offene persönliche 10×-Fristen enden sofort.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5931</context>
+          <context context-type="linenumber">5938</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersTitle" datatype="html">
         <source>Persönliche Fristen beenden?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5936</context>
+          <context context-type="linenumber">5943</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageDiscussion" datatype="html">
         <source>Du startest die Diskussionsphase, obwohl noch persönliche Timer laufen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5939</context>
+          <context context-type="linenumber">5946</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersMessageReveal" datatype="html">
         <source>Du zeigst das Ergebnis, obwohl noch persönliche Timer laufen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5940</context>
+          <context context-type="linenumber">5947</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersConfirm" datatype="html">
         <source>Trotzdem freigeben</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5942</context>
+          <context context-type="linenumber">5949</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.forceClosePersonalTimersCancel" datatype="html">
         <source>Weiter warten</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">5943</context>
+          <context context-type="linenumber">5950</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportQuestionsHeader" datatype="html">
         <source>Frage Nr.;Fragentext;Typ;Teilnehmende;Aggregationsrunde;Ø Punkte;Selbsteinschätzung n;Gefestigt;Fehlkonzept-Hinweis;Fragil;Erkannte Wissenslücke;Unentschieden;Häufigste selbstsicher falsche Antwort;Details</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6089</context>
+          <context context-type="linenumber">6096</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryTitle" datatype="html">
         <source>Lernstand und Selbsteinschätzung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6143</context>
+          <context context-type="linenumber">6150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportConfidenceSummaryHeader" datatype="html">
         <source>Gültige Antworten;Ausgewertete Fragen;Nicht aggregiert (&lt;5 Antworten mit Selbsteinschätzung);Gefestigt;Fehlkonzept-Hinweis;Fragil;Erkannte Wissenslücke;Unentschieden</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6146</context>
+          <context context-type="linenumber">6153</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardTitle" datatype="html">
         <source>Team-Wertung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6167</context>
+          <context context-type="linenumber">6174</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportTeamLeaderboardHeader" datatype="html">
         <source>Rang;Team;Farbe;Mitglieder;Team-Punkte;Ø Punkte pro Mitglied</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6169</context>
+          <context context-type="linenumber">6176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesTitle" datatype="html">
         <source>Bonus-Codes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6187</context>
+          <context context-type="linenumber">6194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportBonusCodesHeader" datatype="html">
         <source>Rang;Nickname;Code;Punkte;Generiert am</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6189</context>
+          <context context-type="linenumber">6196</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportCsvDone" datatype="html">
         <source>Ergebnis-CSV exportiert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6197</context>
+          <context context-type="linenumber">6204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityOne" datatype="html">
         <source>Nachbesprechungsplan als PDF ansehen – 1 Frage zur Nachbesprechung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6209</context>
+          <context context-type="linenumber">6216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAriaWithPriorityMany" datatype="html">
         <source>Nachbesprechungsplan als PDF ansehen – <x id="count" equiv-text="count"/> Fragen zur Nachbesprechung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6212</context>
+          <context context-type="linenumber">6219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfButtonAria" datatype="html">
         <source>Nachbesprechungsplan als PDF ansehen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6214</context>
+          <context context-type="linenumber">6221</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintSingular" datatype="html">
         <source>1 Frage zur Nachbesprechung empfohlen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6219</context>
+          <context context-type="linenumber">6226</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPriorityHintPlural" datatype="html">
         <source><x id="count" equiv-text="count"/> Fragen zur Nachbesprechung empfohlen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6221</context>
+          <context context-type="linenumber">6228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfGeneratingLarge" datatype="html">
         <source>PDF wird erstellt (<x id="PH" equiv-text="questionCount"/> Fragen)…</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6233</context>
+          <context context-type="linenumber">6240</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfDownloadDone" datatype="html">
         <source>Ergebnis-PDF heruntergeladen.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6239</context>
+          <context context-type="linenumber">6246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.exportPdfPrintDone" datatype="html">
         <source>Ergebnis-PDF zum Speichern geöffnet.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6240</context>
+          <context context-type="linenumber">6247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportHeader" datatype="html">
         <source>Nr.;Frage-ID;Status;Frage;Score;Positive Stimmen;Negative Stimmen;Stimmen gesamt;Wilson-Score;Kontroverse-Score;Umstritten;Erstellt am</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6267</context>
+          <context context-type="linenumber">6274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionQa.exportDone" datatype="html">
         <source>Q&amp;A-CSV exportiert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6290</context>
+          <context context-type="linenumber">6297</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7304749878499794874" datatype="html">
         <source>Frage <x id="questionNumber" equiv-text="data.questionOrder + 1"/>: <x id="questionText" equiv-text="data.questionText ?? &apos;&apos;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6453</context>
+          <context context-type="linenumber">6460</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6461</context>
+          <context context-type="linenumber">6468</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14735,7 +14805,7 @@
         <source>Live-Freitext wird aktualisiert.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6456</context>
+          <context context-type="linenumber">6463</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14746,7 +14816,7 @@
         <source>Aktuelle Frage ist keine Freitext-Frage.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6464</context>
+          <context context-type="linenumber">6471</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14757,7 +14827,7 @@
         <source>Noch keine aktive Frage.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6467</context>
+          <context context-type="linenumber">6474</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -14768,7 +14838,7 @@
         <source>Live-Freitextdaten konnten nicht geladen werden.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
-          <context context-type="linenumber">6471</context>
+          <context context-type="linenumber">6478</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-present/session-present.component.ts</context>
@@ -17860,6 +17930,13 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/countdown-fingers/countdown-fingers.component.ts</context>
           <context context-type="linenumber">126</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="infoLanding.openInNewTab" datatype="html">
+        <source>öffnet in neuem Tab</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/info-landing-link/info-landing-link.component.ts</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="markdown.copyCode" datatype="html">

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -4,9 +4,34 @@
 > Marketing- und Informationsseite wird über GitHub Pages unter
 > **https://info.arsnova.eu/** ausgeliefert.
 
-Marketing- und Informationsseite für arsnova.eu. Astro 6 + Tailwind 3 (PostCSS), SEO-optimiert, für GitHub Pages oder beliebigen Static Host.
+Marketing- und Informationsseite für arsnova.eu. Astro 7 + Tailwind 3 (PostCSS), SEO-optimiert, für GitHub Pages oder beliebigen Static Host.
 
-**Node.js:** Landing-Build und `dev:landing` benötigen **Node ≥ 22.12** (Astro 6). CI und `.nvmrc` nutzen Node 24 LTS.
+**Node.js:** Landing-Build und `dev:landing` benötigen **Node ≥ 22.12** (Astro 7). CI und `.nvmrc` nutzen Node 24 LTS.
+
+## Sprachen (i18n)
+
+Die Landingpage ist fünfsprachig (`de`, `en`, `fr`, `it`, `es`), analog zur App:
+
+| Locale            | URL                         |
+| ----------------- | --------------------------- |
+| Deutsch (Default) | https://info.arsnova.eu/de/ |
+| English           | https://info.arsnova.eu/en/ |
+| Français          | https://info.arsnova.eu/fr/ |
+| Italiano          | https://info.arsnova.eu/it/ |
+| Español           | https://info.arsnova.eu/es/ |
+
+- `/` leitet auf `/de/` weiter (`prefixDefaultLocale` + `redirectToDefaultLocale`).
+- Texte liegen in typisierten Dictionaries unter `src/i18n/` (`de.ts` … `es.ts`); fehlende Keys werfen beim Import einen Build-Fehler.
+- Abschnitte nutzen **kanonische Anker** (`#workflow`, `#numeric-estimate`, `#confidence`, `#qa-wall`, …). Alte deutsche Hashes (`#schaetzfrage`, `#ablauf`, …) bleiben als Alias-IDs gültig.
+- App-CTAs verlinken immer locale-sicher auf `https://arsnova.eu/{locale}/` (`appHomeUrl`).
+- **Impressum** und **Datenschutz** bleiben bewusst deutschsprachig unter `/impressum/` und `/datenschutz/` (rechtliche Pflichttexte); die lokalisierten Homepages verlinken dorthin.
+
+Prüfungen:
+
+```bash
+npm run build -w @arsnova/landing
+npm run test:i18n -w @arsnova/landing
+```
 
 ## Entwicklung
 
@@ -15,7 +40,7 @@ Marketing- und Informationsseite für arsnova.eu. Astro 6 + Tailwind 3 (PostCSS)
 npm run dev:landing
 ```
 
-Öffnen: [http://localhost:4321](http://localhost:4321)
+Öffnen: [http://localhost:4321](http://localhost:4321) (Root leitet nach `/de/`)
 
 ## Build
 
@@ -26,7 +51,7 @@ BASE_PATH=/ \
 npm run build:landing
 ```
 
-Output: `apps/landing/dist/`
+Output: `apps/landing/dist/` mit `/de/`, `/en/`, `/fr/`, `/it/`, `/es/`.
 
 ## GitHub Pages
 
@@ -57,16 +82,18 @@ den Pages-Einstellungen.
 
 ## SEO
 
-- Meta Title/Description, Open Graph, Twitter Cards
-- JSON-LD `WebApplication` für Suchmaschinen
-- generierte Sitemap unter `/sitemap.xml`
-- generierte `robots.txt` unter `/robots.txt`
+- Lokalisiertes `<html lang>`, Title/Description, Open Graph, Twitter Cards
+- `hreflang` für alle fünf Locales plus `x-default` → `/de/`
+- Canonical pro Sprachfassung (nicht alle auf DE)
+- JSON-LD `WebSite` / `WebApplication` mit `inLanguage`
+- Sitemap unter `/sitemap.xml` enthält alle Locale-Homes
+- `robots.txt` unter `/robots.txt`
 
-Für Builds auf GitHub Pages setzt der Workflow `PUBLIC_SITE_URL=https://info.arsnova.eu/` und `BASE_PATH=/`. Dadurch verweisen Canonical, Open Graph, Sitemap und `robots.txt` auf die Landing-Domain. App-CTAs und das JSON-LD-Objekt `WebApplication` verwenden dagegen weiterhin `https://arsnova.eu`.
+Für Builds auf GitHub Pages setzt der Workflow `PUBLIC_SITE_URL=https://info.arsnova.eu/` und `BASE_PATH=/`. Dadurch verweisen Canonical, Open Graph, Sitemap und `robots.txt` auf die Landing-Domain. App-CTAs und das JSON-LD-Objekt `WebApplication` verwenden dagegen weiterhin `https://arsnova.eu/{locale}/`.
 
 ## Impressum & Datenschutz (DSGVO)
 
-Die Seiten `/impressum/` und `/datenschutz/` sind mit DSGVO-tauglichen Inhalten vorstrukturiert. **Vor Go-Live** die Platzhalter in **`src/config/legal.ts`** durch echte Angaben ersetzen (Anbieter, Anschrift, E-Mail, ggf. USt-ID, Verantwortliche Person, Datenschutz-E-Mail). Die Texte (Haftung, Urheberrecht, Betroffenenrechte etc.) sind rechtlich üblich formuliert; bei Bedarf durch einen Anwalt prüfen lassen.
+Die Seiten `/impressum/` und `/datenschutz/` sind mit DSGVO-tauglichen Inhalten vorstrukturiert und bleiben auf Deutsch. **Vor Go-Live** die Platzhalter in **`src/config/legal.ts`** durch echte Angaben ersetzen (Anbieter, Anschrift, E-Mail, ggf. USt-ID, Verantwortliche Person, Datenschutz-E-Mail). Die Texte (Haftung, Urheberrecht, Betroffenenrechte etc.) sind rechtlich üblich formuliert; bei Bedarf durch einen Anwalt prüfen lassen.
 
 ## OG-Bild
 

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -20,7 +20,7 @@ Die Landingpage ist fünfsprachig (`de`, `en`, `fr`, `it`, `es`), analog zur App
 | Italiano          | https://info.arsnova.eu/it/ |
 | Español           | https://info.arsnova.eu/es/ |
 
-- `/` leitet auf `/de/` weiter (`prefixDefaultLocale` + `redirectToDefaultLocale`).
+- `/` leitet auf `/de/` weiter und behält dabei Legacy-Hashes (`/#schaetzfrage` → `/de/#schaetzfrage`).
 - Texte liegen in typisierten Dictionaries unter `src/i18n/` (`de.ts` … `es.ts`); fehlende Keys werfen beim Import einen Build-Fehler.
 - Abschnitte nutzen **kanonische Anker** (`#workflow`, `#numeric-estimate`, `#confidence`, `#qa-wall`, …). Alte deutsche Hashes (`#schaetzfrage`, `#ablauf`, …) bleiben als Alias-IDs gültig.
 - App-CTAs verlinken immer locale-sicher auf `https://arsnova.eu/{locale}/` (`appHomeUrl`).
@@ -83,7 +83,7 @@ den Pages-Einstellungen.
 ## SEO
 
 - Lokalisiertes `<html lang>`, Title/Description, Open Graph, Twitter Cards
-- `hreflang` für alle fünf Locales plus `x-default` → `/de/`
+- `hreflang` auf lokalisierten Homepages für alle fünf Locales plus `x-default` → `/de/` (nicht auf deutschsprachigen Legal-Seiten)
 - Canonical pro Sprachfassung (nicht alle auf DE)
 - JSON-LD `WebSite` / `WebApplication` mit `inLanguage`
 - Sitemap unter `/sitemap.xml` enthält alle Locale-Homes

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -10,4 +10,12 @@ export default defineConfig({
   site,
   base,
   output: 'static',
+  i18n: {
+    locales: ['de', 'en', 'fr', 'it', 'es'],
+    defaultLocale: 'de',
+    routing: {
+      prefixDefaultLocale: true,
+      redirectToDefaultLocale: true,
+    },
+  },
 });

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -15,7 +15,9 @@ export default defineConfig({
     defaultLocale: 'de',
     routing: {
       prefixDefaultLocale: true,
-      redirectToDefaultLocale: true,
+      // Root `/` is owned by `src/pages/index.astro` so legacy hashes survive
+      // the redirect to `/de/` (Astro's static redirect drops fragments).
+      redirectToDefaultLocale: false,
     },
   },
 });

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -11,6 +11,7 @@
     "build": "export PUBLIC_GITHUB_REPO=${PUBLIC_GITHUB_REPO:-$(node scripts/get-github-repo.mjs 2>/dev/null || echo 'kqc-real/arsnova.eu')} && astro build",
     "preview": "astro preview",
     "test:a11y": "A11Y_APP=landing node ../frontend/scripts/check-a11y-static.mjs",
+    "test:i18n": "node scripts/check-i18n.mjs",
     "check": "astro check"
   },
   "dependencies": {

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -12,6 +12,7 @@
     "preview": "astro preview",
     "test:a11y": "A11Y_APP=landing node ../frontend/scripts/check-a11y-static.mjs",
     "test:i18n": "node scripts/check-i18n.mjs",
+    "test:language-switcher": "node scripts/check-language-switcher.mjs",
     "check": "astro check"
   },
   "dependencies": {

--- a/apps/landing/scripts/check-i18n.mjs
+++ b/apps/landing/scripts/check-i18n.mjs
@@ -120,12 +120,47 @@ function checkSitemap() {
   }
 }
 
+function checkRootRedirectPreservesHash() {
+  const indexPath = join(dist, 'index.html');
+  if (!existsSync(indexPath)) {
+    fail('Missing dist/index.html root redirect page');
+    return;
+  }
+  const html = readFileSync(indexPath, 'utf8');
+  if (!html.includes('window.location.hash')) {
+    fail('Root redirect must preserve window.location.hash for legacy bookmarks');
+  }
+  if (!html.includes('de/')) {
+    fail('Root redirect must target the default locale /de/');
+  }
+}
+
+function checkLegalPagesOmitHomeHreflang() {
+  for (const page of ['impressum', 'datenschutz']) {
+    const pagePath = join(dist, page, 'index.html');
+    if (!existsSync(pagePath)) {
+      fail(`Missing built legal page: /${page}/`);
+      continue;
+    }
+    const html = readFileSync(pagePath, 'utf8');
+    // Language-switcher anchors may carry hreflang; only head alternates are SEO clusters.
+    if (
+      html.includes('rel="alternate" hreflang="x-default"') ||
+      html.includes('rel="alternate" hreflang="en"')
+    ) {
+      fail(`/${page}/ must not declare localized-home hreflang alternates`);
+    }
+  }
+}
+
 ensureBuild();
 if (!errors.length) assertDictionaries();
 if (!errors.length) {
   checkLocalePaths();
   checkNoGermanFallback();
   checkSitemap();
+  checkRootRedirectPreservesHash();
+  checkLegalPagesOmitHomeHreflang();
 }
 
 if (errors.length) {

--- a/apps/landing/scripts/check-i18n.mjs
+++ b/apps/landing/scripts/check-i18n.mjs
@@ -154,7 +154,7 @@ function checkLegalPagesOmitHomeHreflang() {
 }
 
 /**
- * Exact demo / WCAG / editorial phrases from the Issue #192 re-reviews.
+ * Exact demo / WCAG / editorial phrases from Issues #192/#194.
  * Only pin strings after the dictionaries have been editorially approved.
  */
 const localeContentSmoke = {
@@ -169,12 +169,16 @@ const localeContentSmoke = {
     ],
     round2: '14 Antworten näher am Referenzwert',
     editorial: [
-      'Falsche Antworten mit hoher Antwortsicherheit weisen auf mögliche Fehlkonzepte hin.',
+      'Bei der Selbsteinschätzung geben Teilnehmende nach ihrer Antwort an, wie sicher sie sind',
+      'falsche Antworten mit hoher Antwortsicherheit',
+      'im jeweiligen didaktischen Kontext relevant sind',
+      'Aussagekräftige Wortwolke',
       'Live-Aktualisierung pausiert',
       'Was arsnova.eu auszeichnet',
       'Auf langjähriger Erfahrung aufgebaut',
       'technischen Grundlagen für Bereitstellung und Betrieb',
     ],
+    banned: ['selbstsicher falsch', 'Elaborierte Word Cloud', 'didaktischen Moment passen'],
   },
   en: {
     matrix: [
@@ -194,7 +198,11 @@ const localeContentSmoke = {
       'Pedagogical analysis',
       'Coming next: moderation compass',
       'Built on an established foundation',
+      'The facilitator and presenter show the quiz, Q&amp;A wall, word cloud',
+      'Until then, only a neutral progress indicator is visible.',
+      'Facilitator’s Q&amp;A view',
     ],
+    banned: ['Until then only neutral progress', 'Facilitator view Q&amp;A'],
   },
   fr: {
     matrix: [
@@ -210,12 +218,24 @@ const localeContentSmoke = {
     term: 'sondage express',
     editorial: [
       'Prêt en quelques secondes',
-      'Vue de l’animateur',
       'Publier les questions uniquement lorsqu’elles sont pertinentes dans le contexte pédagogique.',
       'À venir : boussole de modération',
       'L’animateur et le présentateur affichent le quiz,',
+      'indiquent les priorités, les désaccords et les besoins de clarification',
+      'Vue Q&amp;A de l’animateur',
+      'indicateur neutre de progression',
+      'mode présentateur',
+      'croisement entre l’exactitude des réponses et le degré de confiance',
     ],
-    banned: ['Feedback express', 'Vue hôte', 'En direct immédiatement'],
+    banned: [
+      'Feedback express',
+      'Vue hôte',
+      'En direct immédiatement',
+      'montrent priorité, friction',
+      'Vue de l’animateur Q&amp;A',
+      'flux présentateur',
+      'progression neutre',
+    ],
   },
   it: {
     matrix: [
@@ -234,8 +254,18 @@ const localeContentSmoke = {
       'spazio di moderazione',
       'In arrivo: bussola di moderazione',
       'si adattano a contesti che vanno dalla classe e dal seminario al workshop',
+      'mostrano il quiz, la bacheca delle domande',
+      'i punti di disaccordo e le esigenze di chiarimento',
+      'modalità presentatore',
+      'indicatore neutro di avanzamento',
     ],
-    banned: ['superficie di moderazione', 'Prospettiva della bussola'],
+    banned: [
+      'superficie di moderazione',
+      'Prospettiva della bussola',
+      'priorità, attrito',
+      'flusso presentatore',
+      'progresso neutrale',
+    ],
   },
   es: {
     matrix: [
@@ -256,9 +286,23 @@ const localeContentSmoke = {
       'Próximamente: brújula de moderación',
       'El Q&amp;A permite premoderar',
       'infraestructura de despliegue y operación de la plataforma',
+      'El anfitrión y el presentador muestran el cuestionario',
+      'indican las prioridades, los puntos de desacuerdo',
+      'modo de presentación',
+      'El objetivo no es únicamente votar',
+      'indicador neutro de progreso',
+      'Compatibilidad con lectores de pantalla',
       'en directo',
     ],
-    banned: ['en vivo', 'superficie de moderación', 'palanca fuerte'],
+    banned: [
+      'en vivo',
+      'superficie de moderación',
+      'palanca fuerte',
+      'flujo presentador',
+      'El centro no es solo',
+      'progreso neutro',
+      'Apoyo de lector',
+    ],
   },
 };
 

--- a/apps/landing/scripts/check-i18n.mjs
+++ b/apps/landing/scripts/check-i18n.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Automated i18n checks for the landing page (Issue #192).
+ * Expects a production build in dist/ (runs build when locale pages are missing).
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const dist = join(root, 'dist');
+const locales = ['de', 'en', 'fr', 'it', 'es'];
+const legacyAliases = [
+  'schaetzfrage',
+  'selbsteinschaetzung',
+  'fragenwand',
+  'ablauf',
+  'barrierefreiheit',
+  'vertrauen',
+  'vergleich',
+];
+const canonicalAnchors = [
+  'workflow',
+  'numeric-estimate',
+  'confidence',
+  'qa-wall',
+  'features',
+  'accessibility',
+  'trust',
+  'comparison',
+  'faq',
+];
+const deSmokePhrases = [
+  'Jetzt ausprobieren',
+  'Zum Inhalt springen',
+  'Menü öffnen',
+  'So funktioniert’s',
+  'Jetzt live ausprobieren',
+  'Häufige Fragen vor dem ersten Einsatz',
+  'Bereit für die nächste Live-Session?',
+];
+
+const errors = [];
+const fail = (message) => errors.push(message);
+
+function ensureBuild() {
+  const hasLocales = locales.every((locale) => existsSync(join(dist, locale, 'index.html')));
+  if (hasLocales) return;
+  console.log('dist/ incomplete — running landing build…');
+  const result = spawnSync('npm', ['run', 'build'], {
+    cwd: root,
+    stdio: 'inherit',
+    env: process.env,
+    shell: process.platform === 'win32',
+  });
+  if (result.status !== 0) fail('Landing build failed');
+}
+
+function assertDictionaries() {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', join(root, 'scripts/probe-dicts.ts')],
+    {
+      cwd: root,
+      encoding: 'utf8',
+    },
+  );
+  if (result.status !== 0 || !result.stdout.includes('dictionaries-ok')) {
+    fail(`Dictionary key check failed:\n${result.stderr || result.stdout}`);
+  }
+}
+
+function checkLocalePaths() {
+  for (const locale of locales) {
+    const indexPath = join(dist, locale, 'index.html');
+    if (!existsSync(indexPath)) {
+      fail(`Missing built locale path: /${locale}/`);
+      continue;
+    }
+    const html = readFileSync(indexPath, 'utf8');
+    if (!html.includes(`lang="${locale}"`)) fail(`/${locale}/ missing html lang="${locale}"`);
+    if (!html.includes('hreflang="x-default"')) fail(`/${locale}/ missing hreflang x-default`);
+    for (const other of locales) {
+      if (!html.includes(`hreflang="${other}"`)) fail(`/${locale}/ missing hreflang="${other}"`);
+    }
+    for (const anchor of canonicalAnchors) {
+      if (!html.includes(`id="${anchor}"`)) fail(`/${locale}/ missing canonical anchor #${anchor}`);
+    }
+    for (const alias of legacyAliases) {
+      if (!html.includes(`id="${alias}"`)) fail(`/${locale}/ missing legacy alias #${alias}`);
+    }
+    if (!html.includes(`https://arsnova.eu/${locale}/`)) {
+      fail(`/${locale}/ missing locale-safe app URL https://arsnova.eu/${locale}/`);
+    }
+  }
+}
+
+function checkNoGermanFallback() {
+  for (const locale of locales) {
+    if (locale === 'de') continue;
+    const html = readFileSync(join(dist, locale, 'index.html'), 'utf8');
+    for (const phrase of deSmokePhrases) {
+      if (html.includes(phrase)) {
+        fail(`/${locale}/ contains German UI phrase: ${JSON.stringify(phrase)}`);
+      }
+    }
+  }
+}
+
+function checkSitemap() {
+  const sitemapPath = join(dist, 'sitemap.xml');
+  if (!existsSync(sitemapPath)) {
+    fail('Missing dist/sitemap.xml');
+    return;
+  }
+  const xml = readFileSync(sitemapPath, 'utf8');
+  for (const locale of locales) {
+    if (!xml.includes(`/${locale}/`)) fail(`Sitemap missing locale /${locale}/`);
+  }
+}
+
+ensureBuild();
+if (!errors.length) assertDictionaries();
+if (!errors.length) {
+  checkLocalePaths();
+  checkNoGermanFallback();
+  checkSitemap();
+}
+
+if (errors.length) {
+  console.error('\nLanding i18n checks failed:\n- ' + errors.join('\n- '));
+  process.exit(1);
+}
+
+console.log('Landing i18n checks passed:');
+console.log(`- locales: ${locales.join(', ')}`);
+console.log(`- dictionaries: matching keys`);
+console.log(`- canonical anchors + legacy aliases present`);
+console.log('- sitemap includes all locales');
+console.log('- no German UI smoke phrases in en/fr/it/es');

--- a/apps/landing/scripts/check-i18n.mjs
+++ b/apps/landing/scripts/check-i18n.mjs
@@ -153,6 +153,112 @@ function checkLegalPagesOmitHomeHreflang() {
   }
 }
 
+/** Exact demo / WCAG phrases required by the Issue #192 re-review. */
+const localeContentSmoke = {
+  de: {
+    matrix: [
+      'Richtig · geringe Sicherheit',
+      'Richtig · mittlere Sicherheit',
+      'Richtig · hohe Sicherheit',
+      'Falsch · geringe Sicherheit',
+      'Falsch · mittlere Sicherheit',
+      'Falsch · hohe Sicherheit',
+    ],
+    round2: '14 Antworten näher am Referenzwert',
+  },
+  en: {
+    matrix: [
+      'Correct · low confidence',
+      'Correct · medium confidence',
+      'Correct · high confidence',
+      'Incorrect · low confidence',
+      'Incorrect · medium confidence',
+      'Incorrect · high confidence',
+    ],
+    round2: '14 answers closer to the reference',
+    wcag: 'Conforms to WCAG 2.2 Level AA',
+    term: 'numeric estimation question',
+  },
+  fr: {
+    matrix: [
+      'Réponse correcte · confiance faible',
+      'Réponse correcte · confiance moyenne',
+      'Réponse correcte · confiance élevée',
+      'Réponse incorrecte · confiance faible',
+      'Réponse incorrecte · confiance moyenne',
+      'Réponse incorrecte · confiance élevée',
+    ],
+    round2: '14 réponses plus proches de la référence',
+    wcag: 'Conforme aux WCAG 2.2, niveau AA',
+    term: 'sondage express',
+    banned: ['Feedback express'],
+  },
+  it: {
+    matrix: [
+      'Corretta · sicurezza bassa',
+      'Corretta · sicurezza media',
+      'Corretta · sicurezza alta',
+      'Errata · sicurezza bassa',
+      'Errata · sicurezza media',
+      'Errata · sicurezza alta',
+    ],
+    round2: '14 risposte più vicine al valore di riferimento',
+    wcag: 'Conforme alle WCAG 2.2, livello AA',
+    term: 'domanda di stima numerica',
+  },
+  es: {
+    matrix: [
+      'Correcta · confianza baja',
+      'Correcta · confianza media',
+      'Correcta · confianza alta',
+      'Incorrecta · confianza baja',
+      'Incorrecta · confianza media',
+      'Incorrecta · confianza alta',
+    ],
+    round2: '14 respuestas más próximas al valor de referencia',
+    wcag: 'Cumple las WCAG 2.2, nivel AA',
+    term: 'pregunta de estimación numérica',
+  },
+};
+
+function checkLocaleContentSmoke() {
+  for (const locale of locales) {
+    const html = readFileSync(join(dist, locale, 'index.html'), 'utf8');
+    const smoke = localeContentSmoke[locale];
+    for (const label of smoke.matrix) {
+      if (!html.includes(label)) fail(`/${locale}/ missing matrix label ${JSON.stringify(label)}`);
+    }
+    if (!html.includes(smoke.round2)) {
+      fail(`/${locale}/ missing round-2 phrase ${JSON.stringify(smoke.round2)}`);
+    }
+    if (smoke.wcag && !html.includes(smoke.wcag)) {
+      fail(`/${locale}/ missing WCAG phrase ${JSON.stringify(smoke.wcag)}`);
+    }
+    if (smoke.term && !html.includes(smoke.term)) {
+      fail(`/${locale}/ missing terminology ${JSON.stringify(smoke.term)}`);
+    }
+    for (const banned of smoke.banned || []) {
+      if (html.includes(banned)) fail(`/${locale}/ contains banned phrase ${JSON.stringify(banned)}`);
+    }
+  }
+}
+
+function checkLanguageSwitcherMarkup() {
+  const html = readFileSync(join(dist, 'de', 'index.html'), 'utf8');
+  if (html.includes('aria-haspopup')) {
+    fail('/de/ language switcher must not use aria-haspopup for disclosure links');
+  }
+  if (!html.includes('data-language-switcher') || !html.includes('data-lang-menu')) {
+    fail('/de/ missing language switcher disclosure markup');
+  }
+  if (!html.includes('syncLocaleHrefs') || !html.includes("addEventListener('hashchange'")) {
+    fail('/de/ must sync locale href hashes on load and hashchange');
+  }
+  if (!html.includes('id="lang-desktop-button"') || !html.includes('id="lang-mobile-button"')) {
+    fail('/de/ missing desktop and mobile language switcher instances');
+  }
+}
+
 ensureBuild();
 if (!errors.length) assertDictionaries();
 if (!errors.length) {
@@ -161,6 +267,8 @@ if (!errors.length) {
   checkSitemap();
   checkRootRedirectPreservesHash();
   checkLegalPagesOmitHomeHreflang();
+  checkLocaleContentSmoke();
+  checkLanguageSwitcherMarkup();
 }
 
 if (errors.length) {

--- a/apps/landing/scripts/check-i18n.mjs
+++ b/apps/landing/scripts/check-i18n.mjs
@@ -153,7 +153,10 @@ function checkLegalPagesOmitHomeHreflang() {
   }
 }
 
-/** Exact demo / WCAG phrases required by the Issue #192 re-review. */
+/**
+ * Exact demo / WCAG / editorial phrases from the Issue #192 re-reviews.
+ * Only pin strings after the dictionaries have been editorially approved.
+ */
 const localeContentSmoke = {
   de: {
     matrix: [
@@ -165,6 +168,13 @@ const localeContentSmoke = {
       'Falsch · hohe Sicherheit',
     ],
     round2: '14 Antworten näher am Referenzwert',
+    editorial: [
+      'Falsche Antworten mit hoher Antwortsicherheit weisen auf mögliche Fehlkonzepte hin.',
+      'Live-Aktualisierung pausiert',
+      'Was arsnova.eu auszeichnet',
+      'Auf langjähriger Erfahrung aufgebaut',
+      'technischen Grundlagen für Bereitstellung und Betrieb',
+    ],
   },
   en: {
     matrix: [
@@ -178,6 +188,13 @@ const localeContentSmoke = {
     round2: '14 answers closer to the reference',
     wcag: 'Conforms to WCAG 2.2 Level AA',
     term: 'numeric estimation question',
+    editorial: [
+      'With the confidence rating,',
+      'Confidently wrong answers may indicate misconceptions.',
+      'Pedagogical analysis',
+      'Coming next: moderation compass',
+      'Built on an established foundation',
+    ],
   },
   fr: {
     matrix: [
@@ -191,7 +208,14 @@ const localeContentSmoke = {
     round2: '14 réponses plus proches de la référence',
     wcag: 'Conforme aux WCAG 2.2, niveau AA',
     term: 'sondage express',
-    banned: ['Feedback express'],
+    editorial: [
+      'Prêt en quelques secondes',
+      'Vue de l’animateur',
+      'Publier les questions uniquement lorsqu’elles sont pertinentes dans le contexte pédagogique.',
+      'À venir : boussole de modération',
+      'L’animateur et le présentateur affichent le quiz,',
+    ],
+    banned: ['Feedback express', 'Vue hôte', 'En direct immédiatement'],
   },
   it: {
     matrix: [
@@ -205,6 +229,13 @@ const localeContentSmoke = {
     round2: '14 risposte più vicine al valore di riferimento',
     wcag: 'Conforme alle WCAG 2.2, livello AA',
     term: 'domanda di stima numerica',
+    editorial: [
+      'un valore di riferimento, un intervallo di immissione e una tolleranza',
+      'spazio di moderazione',
+      'In arrivo: bussola di moderazione',
+      'si adattano a contesti che vanno dalla classe e dal seminario al workshop',
+    ],
+    banned: ['superficie di moderazione', 'Prospettiva della bussola'],
   },
   es: {
     matrix: [
@@ -218,6 +249,16 @@ const localeContentSmoke = {
     round2: '14 respuestas más próximas al valor de referencia',
     wcag: 'Cumple las WCAG 2.2, nivel AA',
     term: 'pregunta de estimación numérica',
+    editorial: [
+      'estimaciones aceptables desde el punto de vista de la materia',
+      'espacio de moderación',
+      'un recurso útil',
+      'Próximamente: brújula de moderación',
+      'El Q&amp;A permite premoderar',
+      'infraestructura de despliegue y operación de la plataforma',
+      'en directo',
+    ],
+    banned: ['en vivo', 'superficie de moderación', 'palanca fuerte'],
   },
 };
 
@@ -237,8 +278,14 @@ function checkLocaleContentSmoke() {
     if (smoke.term && !html.includes(smoke.term)) {
       fail(`/${locale}/ missing terminology ${JSON.stringify(smoke.term)}`);
     }
+    for (const phrase of smoke.editorial || []) {
+      if (!html.includes(phrase)) {
+        fail(`/${locale}/ missing editorial phrase ${JSON.stringify(phrase)}`);
+      }
+    }
     for (const banned of smoke.banned || []) {
-      if (html.includes(banned)) fail(`/${locale}/ contains banned phrase ${JSON.stringify(banned)}`);
+      if (html.includes(banned))
+        fail(`/${locale}/ contains banned phrase ${JSON.stringify(banned)}`);
     }
   }
 }

--- a/apps/landing/scripts/check-language-switcher.mjs
+++ b/apps/landing/scripts/check-language-switcher.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Browser checks for landing language switchers (desktop + mobile).
+ * Expects a static server serving apps/landing/dist (BASE_URL).
+ */
+import { chromium } from 'playwright';
+
+const BASE_URL = (process.env.BASE_URL || 'http://localhost:4321').replace(/\/+$/, '');
+
+async function waitForServer() {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      const response = await fetch(`${BASE_URL}/de/`);
+      if (response.ok) return;
+    } catch {
+      // still starting
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Landing unter ${BASE_URL} nicht erreichbar.`);
+}
+
+async function assertSwitcher(page, buttonId, label) {
+  const button = page.locator(`#${buttonId}`);
+  await button.waitFor({ state: 'visible' });
+
+  const hasPopup = await button.getAttribute('aria-haspopup');
+  if (hasPopup != null) {
+    throw new Error(`${label}: aria-haspopup must be absent, got ${JSON.stringify(hasPopup)}`);
+  }
+
+  const root = button.locator('xpath=ancestor::*[@data-language-switcher][1]');
+  const menu = root.locator('[data-lang-menu]');
+  const enLink = menu.locator('a[data-locale-link="en"]');
+
+  const hrefWithHash = await enLink.getAttribute('href');
+  if (!hrefWithHash || !hrefWithHash.includes('/en/') || !hrefWithHash.includes('#qa-wall')) {
+    throw new Error(`${label}: expected /en/#qa-wall in href before activation, got ${hrefWithHash}`);
+  }
+
+  await button.click();
+  if ((await button.getAttribute('aria-expanded')) !== 'true') {
+    throw new Error(`${label}: menu did not open`);
+  }
+  if (await menu.evaluate((el) => el.classList.contains('hidden'))) {
+    throw new Error(`${label}: menu still hidden after open`);
+  }
+
+  await page.keyboard.press('Escape');
+  if ((await button.getAttribute('aria-expanded')) !== 'false') {
+    throw new Error(`${label}: Escape did not close menu`);
+  }
+  if ((await page.evaluate(() => document.activeElement?.id)) !== buttonId) {
+    throw new Error(`${label}: Escape did not restore focus to trigger`);
+  }
+
+  await button.click();
+  await page.locator('main').click({ position: { x: 8, y: 8 } });
+  if ((await button.getAttribute('aria-expanded')) !== 'false') {
+    throw new Error(`${label}: outside click did not close menu`);
+  }
+
+  await page.evaluate(() => {
+    window.location.hash = '#fragenwand';
+  });
+  await page.waitForFunction(() => {
+    const link = document.querySelector('[data-language-switcher] a[data-locale-link="en"]');
+    return link?.getAttribute('href')?.includes('#qa-wall') ?? false;
+  });
+  const afterAlias = await enLink.getAttribute('href');
+  if (!afterAlias?.includes('#qa-wall')) {
+    throw new Error(`${label}: hashchange alias fragenwand not canonicalized to #qa-wall (${afterAlias})`);
+  }
+}
+
+async function runViewport(browser, viewport, buttonId, label) {
+  const context = await browser.newContext({
+    reducedMotion: 'reduce',
+    viewport,
+  });
+  const page = await context.newPage();
+  try {
+    await page.goto(`${BASE_URL}/de/#qa-wall`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 20_000,
+    });
+    await page.waitForLoadState('networkidle', { timeout: 5_000 }).catch(() => undefined);
+    await assertSwitcher(page, buttonId, label);
+  } finally {
+    await context.close();
+  }
+}
+
+async function main() {
+  await waitForServer();
+  const browser = await chromium.launch({ headless: true });
+  try {
+    await runViewport(browser, { width: 1280, height: 900 }, 'lang-desktop-button', 'desktop');
+    await runViewport(browser, { width: 390, height: 844 }, 'lang-mobile-button', 'mobile');
+  } finally {
+    await browser.close();
+  }
+  console.log('Language switcher checks passed (desktop + mobile).');
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/apps/landing/scripts/check-language-switcher.mjs
+++ b/apps/landing/scripts/check-language-switcher.mjs
@@ -35,7 +35,9 @@ async function assertSwitcher(page, buttonId, label) {
 
   const hrefWithHash = await enLink.getAttribute('href');
   if (!hrefWithHash || !hrefWithHash.includes('/en/') || !hrefWithHash.includes('#qa-wall')) {
-    throw new Error(`${label}: expected /en/#qa-wall in href before activation, got ${hrefWithHash}`);
+    throw new Error(
+      `${label}: expected /en/#qa-wall in href before activation, got ${hrefWithHash}`,
+    );
   }
 
   await button.click();
@@ -69,7 +71,9 @@ async function assertSwitcher(page, buttonId, label) {
   });
   const afterAlias = await enLink.getAttribute('href');
   if (!afterAlias?.includes('#qa-wall')) {
-    throw new Error(`${label}: hashchange alias fragenwand not canonicalized to #qa-wall (${afterAlias})`);
+    throw new Error(
+      `${label}: hashchange alias fragenwand not canonicalized to #qa-wall (${afterAlias})`,
+    );
   }
 }
 

--- a/apps/landing/scripts/probe-dicts.ts
+++ b/apps/landing/scripts/probe-dicts.ts
@@ -1,0 +1,47 @@
+/**
+ * Dictionary parity probe for `npm run test:i18n`.
+ * Uses explicit `.ts` extensions for Node `--experimental-strip-types`.
+ */
+import de from '../src/i18n/de.ts';
+import en from '../src/i18n/en.ts';
+import es from '../src/i18n/es.ts';
+import fr from '../src/i18n/fr.ts';
+import it from '../src/i18n/it.ts';
+import type { Messages } from '../src/i18n/types.ts';
+
+const dictionaries: Record<string, Messages> = { de, en, fr, it, es };
+
+function collectPaths(value: unknown, prefix = ''): string[] {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [prefix];
+    return value.flatMap((item, index) => collectPaths(item, `${prefix}[${index}]`));
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) =>
+      collectPaths(child, prefix ? `${prefix}.${key}` : key),
+    );
+  }
+  return [prefix];
+}
+
+const reference = collectPaths(de).sort();
+const errors: string[] = [];
+
+for (const [locale, messages] of Object.entries(dictionaries)) {
+  if (locale === 'de') continue;
+  const paths = collectPaths(messages).sort();
+  const missing = reference.filter((path) => !paths.includes(path));
+  const extra = paths.filter((path) => !reference.includes(path));
+  if (missing.length) errors.push(`[${locale}] missing: ${missing.slice(0, 20).join(', ')}`);
+  if (extra.length) errors.push(`[${locale}] extra: ${extra.slice(0, 20).join(', ')}`);
+  if (!messages.meta?.homeTitle || !messages.nav?.ariaLabel || !messages.faq?.items?.length) {
+    errors.push(`[${locale}] incomplete core sections`);
+  }
+}
+
+if (errors.length) {
+  console.error(errors.join('\n'));
+  process.exit(1);
+}
+
+console.log('dictionaries-ok');

--- a/apps/landing/src/components/Accessibility.astro
+++ b/apps/landing/src/components/Accessibility.astro
@@ -1,64 +1,44 @@
 ---
-import { APP_ACCESSIBILITY_URL } from '@/config/github';
+import { appAccessibilityUrl } from '@/config/github';
+import type { Locale, Messages } from '@/i18n';
 
-const benefits = [
-  {
-    title: 'Bedienung mit Tastatur',
-    description:
-      'Du und deine Teilnehmenden bedienen die zentralen Abläufe ohne Maus. Sichtbare Fokusmarkierungen und ein Sprunglink zum Inhalt erleichtern die Navigation.',
-  },
-  {
-    title: 'Screenreader-Unterstützung im Live-Betrieb',
-    description:
-      'Statusänderungen beim Beitritt zur Session, bei Abstimmungen und Phasenwechseln werden für Screenreader ausgegeben, sodass Nutzer:innen den Ablauf nachvollziehen können.',
-  },
-  {
-    title: 'Individuell anpassbare Bearbeitungszeit',
-    description:
-      'Bei zeitlich begrenzten Fragen wählst du die Standardzeit, die zehnfache Bearbeitungszeit oder eine Teilnahme ohne Zeitlimit. So lässt sich ein Nachteilsausgleich direkt in der Live-Session umsetzen.',
-  },
-  {
-    title: 'Barrierefrei strukturierter Ergebnisbericht',
-    description:
-      'Der druckfertige Bericht ist PDF/UA-1-validiert und enthält Dokumenttitel, Sprache und Tags — für die Nachbereitung und barrierefreie Weitergabe.',
-  },
-];
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { locale, t } = Astro.props;
+const a = t.accessibility;
 ---
 
 <section
-  id="barrierefreiheit"
-  class="border-b border-slate-700 bg-slate-900 px-4 py-16 sm:px-6 sm:py-24"
+  id="accessibility"
+  class="relative border-b border-slate-700 bg-slate-900 px-4 py-16 sm:px-6 sm:py-24"
   aria-labelledby="a11y-heading"
 >
+  <span id="barrierefreiheit" class="absolute -top-20" aria-hidden="true"></span>
   <div class="mx-auto max-w-6xl">
-    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">Barrierefreiheit</p>
+    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">{a.eyebrow}</p>
     <h2 id="a11y-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">
-      WCAG 2.2 AA — damit mehr Lernende selbstständig teilnehmen können
+      {a.title}
     </h2>
-    <p class="mt-4 max-w-3xl text-lg leading-8 text-slate-400">
-      Für Schulen, Hochschulen und Weiterbildung ist Barrierefreiheit oft ein entscheidendes Kriterium.
-      arsnova.eu erfüllt die Web Content Accessibility Guidelines (WCAG) 2.2 auf Konformitätsstufe AA —
-      mit Tastaturbedienung, Screenreader-Unterstützung, individuell anpassbarer Bearbeitungszeit und
-      barrierefrei strukturierten PDF-Ergebnisberichten.
-    </p>
+    <p class="mt-4 max-w-3xl text-lg leading-8 text-slate-400">{a.lead}</p>
 
     <ul class="mt-10 grid gap-6 sm:grid-cols-2" role="list">
-      {
-        benefits.map((item) => (
-          <li class="rounded-3xl border border-slate-700 bg-slate-800/80 p-6">
-            <h3 class="font-display text-xl font-semibold text-white">{item.title}</h3>
-            <p class="mt-3 leading-7 text-slate-400">{item.description}</p>
-          </li>
-        ))
-      }
+      {a.benefits.map((item) => (
+        <li class="rounded-3xl border border-slate-700 bg-slate-800/80 p-6">
+          <h3 class="font-display text-xl font-semibold text-white">{item.title}</h3>
+          <p class="mt-3 leading-7 text-slate-400">{item.description}</p>
+        </li>
+      ))}
     </ul>
 
     <div class="mt-8">
       <a
-        href={APP_ACCESSIBILITY_URL}
+        href={appAccessibilityUrl(locale)}
         class="inline-flex items-center justify-center rounded-xl border border-brand-500/40 bg-brand-500/10 px-5 py-3 text-sm font-semibold text-brand-200 transition hover:border-brand-400 hover:bg-brand-500/20 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900"
       >
-        Erklärung zur Barrierefreiheit öffnen
+        {a.statementLink}
       </a>
     </div>
   </div>

--- a/apps/landing/src/components/Comparison.astro
+++ b/apps/landing/src/components/Comparison.astro
@@ -1,30 +1,29 @@
 ---
 import { GITHUB_DOCS_URL } from '@/config/github';
+import type { Locale, Messages } from '@/i18n';
 
-const points = [
-  {
-    title: 'Weniger Einstiegshürden',
-    description: 'Keine getrennte Produktlogik für „Erstellen“ und „Beitreten“. Hosts starten ohne Account, Teilnehmende kommen per Code oder QR in die Session.',
-  },
-  {
-    title: 'Mehr Interaktionsformate',
-    description: 'Neben Quiz auch numerische Schätzfragen, Lesephase, Peer Instruction, Blitzlicht, Q&A-Fragenwand und gewichtete Word Cloud in derselben Plattform statt nur Folien-Abstimmungen.',
-  },
-  {
-    title: 'Mehr Kontrolle über Daten und Zugang',
-    description: 'Open Source, self-hostbar und local-first konzipiert — plus Barrierefreiheit nach WCAG 2.2 AA. Relevant für Schulen, Hochschulen und Organisationen mit Datenschutz- und Inklusionsanforderungen.',
-  },
-];
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { t } = Astro.props;
+const c = t.comparison;
 ---
 
-<section id="vergleich" class="border-b border-slate-700 bg-slate-900 px-4 py-16 sm:px-6 sm:py-24" aria-labelledby="vergleich-heading">
+<section
+  id="comparison"
+  class="relative border-b border-slate-700 bg-slate-900 px-4 py-16 sm:px-6 sm:py-24"
+  aria-labelledby="comparison-heading"
+>
+  <span id="vergleich" class="absolute -top-20" aria-hidden="true"></span>
   <div class="mx-auto max-w-6xl">
-    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">Abgrenzung</p>
-    <h2 id="vergleich-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">Nicht nur ein Ersatz für Mentimeter oder Kahoot</h2>
-    <p class="mt-4 max-w-3xl text-lg leading-8 text-slate-400">Im Mittelpunkt steht nicht nur Abstimmung, sondern der komplette Live-Flow: vorbereiten, moderieren, Ergebnisse sichtbar machen und dabei die Kontrolle über Inhalte und Betrieb behalten.</p>
+    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">{c.eyebrow}</p>
+    <h2 id="comparison-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">{c.title}</h2>
+    <p class="mt-4 max-w-3xl text-lg leading-8 text-slate-400">{c.lead}</p>
 
     <ul class="mt-10 grid gap-6 lg:grid-cols-3" role="list">
-      {points.map((point) => (
+      {c.points.map((point) => (
         <li class="rounded-3xl border border-slate-700 bg-slate-800/80 p-6">
           <h3 class="font-display text-2xl font-semibold text-white">{point.title}</h3>
           <p class="mt-3 leading-7 text-slate-400">{point.description}</p>
@@ -32,6 +31,9 @@ const points = [
       ))}
     </ul>
 
-    <p class="mt-6 text-sm text-slate-400">Den vollständigen Featurevergleich findest du weiterhin in der Doku: <a href={GITHUB_DOCS_URL} class="text-brand-400 underline underline-offset-2 hover:text-brand-300" target="_blank" rel="noopener noreferrer">Vergleich auf GitHub öffnen</a></p>
+    <p class="mt-6 text-sm text-slate-400">
+      {c.comparePrefix}{' '}
+      <a href={GITHUB_DOCS_URL} class="text-brand-400 underline underline-offset-2 hover:text-brand-300" target="_blank" rel="noopener noreferrer">{c.compareLink}</a>
+    </p>
   </div>
 </section>

--- a/apps/landing/src/components/ConfidenceSpotlight.astro
+++ b/apps/landing/src/components/ConfidenceSpotlight.astro
@@ -1,127 +1,102 @@
 ---
 import { GITHUB_URL } from '@/config/github';
+import type { Locale, Messages } from '@/i18n';
 
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { t } = Astro.props;
+const c = t.confidence;
 const confidenceDocsUrl = `${GITHUB_URL}/blob/main/docs/features/confidence-slider.md`;
 const exportDocsUrl = `${GITHUB_URL}/blob/main/docs/features/session-export-pdf.md`;
-
-const summary = [
-  'Kein eigener Fragetyp — optional an bewertbaren Quizfragen.',
-  'Skala 1–5 nach der Antwort, ohne Einfluss auf Punkte.',
-  'Host sieht nach Freigabe Korrektheit × Antwortsicherheit.',
-  'Selbstsicher falsch markiert mögliche Fehlkonzepte.',
-  'Nach Session-Ende: Ergebnisbericht (PDF) und Nachbesprechung.',
-];
-
-const matrix = [
-  { label: 'Richtig · niedrig', count: 3, tone: 'emerald' },
-  { label: 'Richtig · mitte', count: 8, tone: 'emerald' },
-  { label: 'Richtig · hoch', count: 11, tone: 'emerald' },
-  { label: 'Falsch · niedrig', count: 2, tone: 'slate' },
-  { label: 'Falsch · mitte', count: 4, tone: 'amber' },
-  { label: 'Falsch · hoch', count: 2, tone: 'rose' },
-];
 ---
 
 <section
-  id="selbsteinschaetzung"
-  class="border-b border-slate-700 bg-slate-900 px-4 py-16 sm:px-6 sm:py-24"
+  id="confidence"
+  class="relative border-b border-slate-700 bg-slate-900 px-4 py-16 sm:px-6 sm:py-24"
   aria-labelledby="confidence-heading"
 >
+  <span id="selbsteinschaetzung" class="absolute -top-20" aria-hidden="true"></span>
   <div class="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
     <div
       class="order-2 rounded-3xl border border-slate-700 bg-slate-950/80 p-5 shadow-[0_22px_70px_rgba(244,63,94,0.12)] sm:p-6 lg:order-1"
-      aria-label="Beispielauswertung mit Selbsteinschätzung nach Ergebnisfreigabe"
+      aria-label={c.demoAria}
     >
       <div class="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-brand-300">Host-Ansicht nach Freigabe</p>
-          <h3 class="mt-2 font-display text-2xl font-bold text-white">Welche Struktur ist am stabilsten?</h3>
+          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-brand-300">{c.hostView}</p>
+          <h3 class="mt-2 font-display text-2xl font-bold text-white">{c.demoQuestion}</h3>
         </div>
         <span class="rounded-full border border-brand-300/40 bg-brand-400/10 px-3 py-1 text-sm font-semibold text-brand-100">
-          Selbsteinschätzung
+          {c.badge}
         </span>
       </div>
 
       <div class="mt-5 grid gap-2 text-sm sm:grid-cols-3">
-        {
-          matrix.map((cell) => (
-            <div
-              class:list={[
-                'rounded-xl border p-3',
-                cell.tone === 'emerald' && 'border-emerald-400/30 bg-emerald-400/10',
-                cell.tone === 'amber' && 'border-amber-300/30 bg-amber-300/10',
-                cell.tone === 'rose' && 'border-rose-400/40 bg-rose-400/15 ring-1 ring-rose-300/30',
-                cell.tone === 'slate' && 'border-slate-700 bg-slate-900/80',
-              ]}
-            >
-              <p class="text-xs uppercase tracking-[0.16em] text-slate-400">{cell.label}</p>
-              <p class="mt-1 font-semibold text-white">{cell.count}</p>
-            </div>
-          ))
-        }
+        {c.matrix.map((cell) => (
+          <div
+            class:list={[
+              'rounded-xl border p-3',
+              cell.tone === 'emerald' && 'border-emerald-400/30 bg-emerald-400/10',
+              cell.tone === 'amber' && 'border-amber-300/30 bg-amber-300/10',
+              cell.tone === 'rose' && 'border-rose-400/40 bg-rose-400/15 ring-1 ring-rose-300/30',
+              cell.tone === 'slate' && 'border-slate-700 bg-slate-900/80',
+            ]}
+          >
+            <p class="text-xs uppercase tracking-[0.16em] text-slate-400">{cell.label}</p>
+            <p class="mt-1 font-semibold text-white">{cell.count}</p>
+          </div>
+        ))}
       </div>
 
       <div class="mt-5 rounded-2xl border border-rose-400/35 bg-rose-400/10 p-4">
-        <p class="text-sm font-semibold text-rose-100">2 selbstsicher falsche Antworten</p>
-        <p class="mt-2 text-sm leading-6 text-rose-100/80">
-          Option B wurde 2× mit hoher Antwortsicherheit gewählt — ein Signal für mögliche Fehlkonzepte in der
-          Nachbesprechung.
-        </p>
+        <p class="text-sm font-semibold text-rose-100">{c.falseHighTitle}</p>
+        <p class="mt-2 text-sm leading-6 text-rose-100/80">{c.falseHighText}</p>
       </div>
 
       <div class="mt-5 grid gap-3 text-sm sm:grid-cols-3">
         <div class="rounded-xl border border-slate-700 bg-slate-900/80 p-3">
-          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Gefestigt</p>
+          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">{c.consolidated}</p>
           <p class="mt-1 font-semibold text-white">11</p>
         </div>
         <div class="rounded-xl border border-slate-700 bg-slate-900/80 p-3">
-          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Fehlkonzept-Risiko</p>
+          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">{c.misconceptionRisk}</p>
           <p class="mt-1 font-semibold text-white">2</p>
         </div>
         <div class="rounded-xl border border-slate-700 bg-slate-900/80 p-3">
-          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Fragil</p>
+          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">{c.fragile}</p>
           <p class="mt-1 font-semibold text-white">3</p>
         </div>
       </div>
 
-      <div
-        class="mt-5 rounded-2xl border border-slate-700 bg-slate-900/80 p-4"
-        aria-label="Export nach Session-Ende"
-      >
-        <p class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">Nach Session-Ende</p>
+      <div class="mt-5 rounded-2xl border border-slate-700 bg-slate-900/80 p-4" aria-label={c.afterSessionAria}>
+        <p class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">{c.afterSession}</p>
         <div class="mt-3 flex flex-wrap gap-2">
           <span class="inline-flex rounded-lg border border-slate-600 bg-slate-800 px-3 py-2 text-sm font-semibold text-white">
-            Nachbesprechung
+            {c.debriefing}
           </span>
           <span class="inline-flex rounded-lg border border-brand-500/40 bg-brand-500/15 px-3 py-2 text-sm font-semibold text-brand-100">
-            Ergebnisbericht (PDF)
+            {c.resultsPdf}
           </span>
         </div>
-        <p class="mt-3 text-sm leading-6 text-slate-400">
-          Druckfertiger Bericht mit Lernstand, Heatmap und Fragentexten — in der Host-Ansicht und auf der Quizkarte.
-          CSV für Excel bleibt unter „Mehr“ verfügbar.
-        </p>
+        <p class="mt-3 text-sm leading-6 text-slate-400">{c.exportNote}</p>
       </div>
     </div>
 
     <div class="order-1 lg:order-2">
-      <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">Didaktische Auswertung</p>
+      <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">{c.eyebrow}</p>
       <h2 id="confidence-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">
-        Richtig oder falsch — und wie sicher?
+        {c.title}
       </h2>
-      <p class="mt-5 text-lg leading-8 text-slate-400">
-        Mit der Selbsteinschätzung erfassen Teilnehmende nach ihrer Antwort, wie sicher sie sind (1–5). Du erkennst
-        nicht nur Trefferquote, sondern auch selbstsicher falsche Antworten — ein starker Hebel für formative
-        Auswertung, gezielte Nachbesprechung und den Ergebnisbericht (PDF) nach Session-Ende.
-      </p>
+      <p class="mt-5 text-lg leading-8 text-slate-400">{c.lead}</p>
       <ul class="mt-8 grid gap-3 text-sm leading-6 text-slate-300 sm:grid-cols-2" role="list">
-        {
-          summary.map((item) => (
-            <li class="rounded-xl border border-slate-700 bg-slate-800/80 p-4">
-              <span class="font-semibold text-white">{item}</span>
-            </li>
-          ))
-        }
+        {c.summary.map((item) => (
+          <li class="rounded-xl border border-slate-700 bg-slate-800/80 p-4">
+            <span class="font-semibold text-white">{item}</span>
+          </li>
+        ))}
       </ul>
       <div class="mt-8 flex flex-wrap gap-3">
         <a
@@ -130,7 +105,7 @@ const matrix = [
           target="_blank"
           rel="noopener noreferrer"
         >
-          Doku Selbsteinschätzung
+          {c.docsConfidence}
         </a>
         <a
           href={exportDocsUrl}
@@ -138,7 +113,7 @@ const matrix = [
           target="_blank"
           rel="noopener noreferrer"
         >
-          Doku Ergebnisbericht (PDF)
+          {c.docsExport}
         </a>
       </div>
     </div>

--- a/apps/landing/src/components/Cta.astro
+++ b/apps/landing/src/components/Cta.astro
@@ -1,19 +1,28 @@
 ---
-import { GITHUB_URL, APP_URL_V3 } from '@/config/github';
+import { appHomeUrl, GITHUB_URL } from '@/config/github';
+import type { Locale, Messages } from '@/i18n';
+
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { locale, t } = Astro.props;
 const base = (typeof import.meta.env.BASE_URL === 'string' && import.meta.env.BASE_URL) || '/';
+const c = t.ctaSection;
 ---
 
 <section class="bg-slate-900 px-4 py-16 sm:px-6 sm:py-24" aria-labelledby="cta-heading">
   <div class="mx-auto max-w-3xl text-center">
-    <h2 id="cta-heading" class="font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">Bereit für die nächste Live-Session?</h2>
-    <p class="mt-4 text-lg leading-8 text-slate-300">Teste den Live-Flow direkt in der App oder wirf einen Blick auf den offenen Code, die Q&amp;A-Logik, die Word-Cloud-Pipeline und den Betriebspfad hinter der Plattform.</p>
+    <h2 id="cta-heading" class="font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">{c.title}</h2>
+    <p class="mt-4 text-lg leading-8 text-slate-300">{c.lead}</p>
     <div class="mt-8 flex flex-wrap items-center justify-center gap-4">
-      <a href={APP_URL_V3} class="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-brand-500/30 transition hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900">
+      <a href={appHomeUrl(locale)} class="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-brand-500/30 transition hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900">
         <img src={`${base}favicon.svg`} alt="" class="h-5 w-5 shrink-0" width="20" height="20" />
-        App öffnen
+        {t.cta.appOpen}
       </a>
       <a href={GITHUB_URL} class="inline-flex items-center rounded-xl border border-slate-600 bg-slate-800/50 px-6 py-3.5 text-base font-semibold text-white backdrop-blur transition hover:border-slate-500 hover:bg-slate-800" target="_blank" rel="noopener noreferrer">
-        Open Source ansehen
+        {t.cta.viewOpenSource}
       </a>
     </div>
   </div>

--- a/apps/landing/src/components/EstimateSpotlight.astro
+++ b/apps/landing/src/components/EstimateSpotlight.astro
@@ -1,39 +1,36 @@
 ---
 import { GITHUB_URL } from '@/config/github';
+import type { Locale, Messages } from '@/i18n';
 
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { t } = Astro.props;
+const e = t.estimate;
 const numericEstimateDocsUrl = `${GITHUB_URL}/blob/main/docs/features/numeric-estimate.md`;
-
-const summary = [
-  'Plausibilitätsband begrenzt erlaubte Eingaben.',
-  'Toleranzband bewertet fachlich akzeptierte Schätzungen.',
-  'Vor der Freigabe sieht niemand die Verteilung.',
-  'Runde 1 und Runde 2 werden nach der Diskussion verglichen.',
-];
 ---
 
 <section
-  id="schaetzfrage"
-  class="border-b border-slate-700 bg-slate-950 px-4 py-16 sm:px-6 sm:py-24"
+  id="numeric-estimate"
+  class="relative border-b border-slate-700 bg-slate-950 px-4 py-16 sm:px-6 sm:py-24"
   aria-labelledby="estimate-heading"
 >
+  <span id="schaetzfrage" class="absolute -top-20" aria-hidden="true"></span>
   <div class="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
     <div>
-      <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">Neu im Live-Quiz</p>
+      <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">{e.eyebrow}</p>
       <h2 id="estimate-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">
-        Zahlen schätzen, diskutieren und die zweite Runde sichtbar vergleichen
+        {e.title}
       </h2>
-      <p class="mt-5 text-lg leading-8 text-slate-400">
-        Die numerische Schätzfrage ist für Jahreszahlen, Größenordnungen, Messwerte und Wahrscheinlichkeiten gemacht. Lehrende
-        legen Referenzwert, erlaubten Eingabebereich und Toleranz fest; Teilnehmende geben nur eine Zahl ab.
-      </p>
+      <p class="mt-5 text-lg leading-8 text-slate-400">{e.lead}</p>
       <ul class="mt-8 grid gap-3 text-sm leading-6 text-slate-300 sm:grid-cols-2" role="list">
-        {
-          summary.map((item) => (
-            <li class="rounded-xl border border-slate-700 bg-slate-900/80 p-4">
-              <span class="font-semibold text-white">{item}</span>
-            </li>
-          ))
-        }
+        {e.summary.map((item) => (
+          <li class="rounded-xl border border-slate-700 bg-slate-900/80 p-4">
+            <span class="font-semibold text-white">{item}</span>
+          </li>
+        ))}
       </ul>
       <a
         href={numericEstimateDocsUrl}
@@ -41,32 +38,32 @@ const summary = [
         target="_blank"
         rel="noopener noreferrer"
       >
-        Fachliche Doku zur Schätzfrage öffnen
+        {e.docsLink}
       </a>
     </div>
 
     <div
       class="rounded-3xl border border-slate-700 bg-slate-900/80 p-5 shadow-[0_22px_70px_rgba(2,132,199,0.18)] sm:p-6"
-      aria-label="Beispielauswertung einer Schätzfrage zur Französischen Revolution"
+      aria-label={e.demoAria}
     >
       <div class="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-brand-300">Host-Ansicht nach Freigabe</p>
-          <h3 class="mt-2 font-display text-2xl font-bold text-white">Wann begann die Französische Revolution?</h3>
+          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-brand-300">{e.hostView}</p>
+          <h3 class="mt-2 font-display text-2xl font-bold text-white">{e.demoQuestion}</h3>
         </div>
         <span class="rounded-full border border-amber-300/50 bg-amber-300/15 px-3 py-1 text-sm font-semibold text-amber-100">
-          Referenz 1789
+          {e.reference}
         </span>
       </div>
 
       <div class="mt-5 grid gap-3 text-sm sm:grid-cols-2">
         <div class="rounded-xl border border-slate-700 bg-slate-950/80 p-3">
-          <p class="text-xs uppercase tracking-[0.18em] text-slate-400">Toleranzband</p>
-          <p class="mt-1 font-semibold text-white">1700 bis 1900</p>
+          <p class="text-xs uppercase tracking-[0.18em] text-slate-400">{e.toleranceBand}</p>
+          <p class="mt-1 font-semibold text-white">{e.toleranceValue}</p>
         </div>
         <div class="rounded-xl border border-slate-700 bg-slate-950/80 p-3">
-          <p class="text-xs uppercase tracking-[0.18em] text-slate-400">Plausibilitätsband</p>
-          <p class="mt-1 font-semibold text-white">1500 bis 2000</p>
+          <p class="text-xs uppercase tracking-[0.18em] text-slate-400">{e.plausibilityBand}</p>
+          <p class="mt-1 font-semibold text-white">{e.plausibilityValue}</p>
         </div>
       </div>
 
@@ -88,10 +85,7 @@ const summary = [
           <span class="absolute bottom-2 right-[22%] w-10 text-center text-xs text-slate-400">1900</span>
           <span class="absolute bottom-2 right-3 w-10 text-right text-xs text-slate-400">2000</span>
         </div>
-        <p class="mt-3 text-sm leading-6 text-slate-400">
-          Histogramm, Referenzlinie und Toleranzband erscheinen erst nach Ergebnisfreigabe. Vorher bleibt nur der neutrale
-          Fortschritt sichtbar.
-        </p>
+        <p class="mt-3 text-sm leading-6 text-slate-400">{e.histogramNote}</p>
       </div>
 
       <div class="mt-5 grid gap-3 text-sm sm:grid-cols-4">
@@ -100,16 +94,16 @@ const summary = [
           <p class="mt-1 font-semibold text-white">20</p>
         </div>
         <div class="rounded-xl border border-slate-700 bg-slate-950/80 p-3">
-          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Median</p>
+          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">{e.median}</p>
           <p class="mt-1 font-semibold text-white">1788</p>
         </div>
         <div class="rounded-xl border border-slate-700 bg-slate-950/80 p-3">
-          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">im Band</p>
+          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">{e.inBand}</p>
           <p class="mt-1 font-semibold text-white">95 %</p>
         </div>
         <div class="rounded-xl border border-slate-700 bg-slate-950/80 p-3">
-          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">Runde 2</p>
-          <p class="mt-1 font-semibold text-white">14 näher</p>
+          <p class="text-xs uppercase tracking-[0.16em] text-slate-400">{e.round2}</p>
+          <p class="mt-1 font-semibold text-white">{e.round2Value}</p>
         </div>
       </div>
     </div>

--- a/apps/landing/src/components/Faq.astro
+++ b/apps/landing/src/components/Faq.astro
@@ -1,87 +1,39 @@
 ---
-import { APP_ACCESSIBILITY_URL } from '@/config/github';
+import { appAccessibilityUrl } from '@/config/github';
+import type { Locale, Messages } from '@/i18n';
 
-const items = [
-  {
-    question: 'Brauchen Hosts oder Teilnehmende einen Account?',
-    answer:
-      'Nein. Eine Session kann ohne Konto gestartet werden. Teilnehmende treten per Code oder QR bei.',
-  },
-  {
-    question: 'Wo liegen die Daten?',
-    answer:
-      'Quiz-Inhalte sind local-first konzipiert. Für Live-Sessions werden nur die technisch nötigen Sitzungsdaten verarbeitet; bei Self-Hosting liegt der Betrieb in deiner eigenen Infrastruktur.',
-  },
-  {
-    question: 'Kann ich arsnova.eu selbst hosten?',
-    answer:
-      'Ja. Die Plattform ist Open Source und für den Betrieb mit Docker, PostgreSQL und Redis ausgelegt.',
-  },
-  {
-    question: 'Was ist die Selbsteinschätzung im Quiz?',
-    answer:
-      'Eine optionale Zusatzabfrage nach bewertbaren Fragen: Teilnehmende geben auf einer Skala von 1–5 an, wie sicher sie bei ihrer Antwort sind. Punkte bleiben unverändert; in der Host-Auswertung siehst du Korrektheit × Antwortsicherheit und markierst selbstsicher falsche Antworten als Fehlkonzept-Signal. Nach Session-Ende fließt der Lernstand in Nachbesprechung und Ergebnisbericht (PDF) ein.',
-  },
-  {
-    question: 'Kann ich Session-Ergebnisse exportieren?',
-    answer:
-      'Ja. Nach Session-Ende steht der Ergebnisbericht (PDF) als primäres Format bereit — inklusive Selbsteinschätzung, Prioritäten für die Nachbesprechung und vollständiger Fragentexte. In der Quiz-Sammlung findest du Nachbesprechung und PDF für den letzten Durchlauf. Tabellarische CSV-Daten sind unter „Mehr“ für Excel verfügbar.',
-  },
-  {
-    question: 'Was ist an der numerischen Schätzfrage besonders?',
-    answer:
-      'Sie trennt erlaubte Eingaben vom fachlichen Toleranzband, zeigt während der Abstimmung keine Verteilung und kann nach einer Diskussion eine zweite Runde mit Statistik und Rundenvergleich auswerten.',
-  },
-  {
-    question: 'Was kann die Q&A-Fragenwand?',
-    answer:
-      'Teilnehmende reichen Fragen ein und gewichten sie mit Up- und Downvotes. Hosts können vorab moderieren, Fragen anheften, archivieren oder entfernen und die Liste nach Unterstützung, belastbarer Zustimmung oder Kontroverse sortieren.',
-  },
-  {
-    question: 'Was macht die Q&A-Wortwolke anders?',
-    answer:
-      'Sie verdichtet sichtbare Fragen zu Wörtern und Phrasen und übernimmt die aktive Sortierlogik. Dadurch zeigt sie nicht nur häufige Begriffe, sondern Themencluster aus unterstützten, robust bewerteten oder kontroversen Fragen.',
-  },
-  {
-    question: 'Für wen ist die Plattform gedacht?',
-    answer:
-      'Für Live-Interaktion in Bildung und Organisationen: Schule, Hochschule, Weiterbildung, Training, Workshop, Event oder Meeting.',
-  },
-  {
-    question: 'Ist arsnova.eu barrierefrei?',
-    answer:
-      'arsnova.eu erfüllt WCAG 2.2 AA. Zentrale Abläufe sind per Tastatur bedienbar, Screenreader geben Statusänderungen aus, bei zeitlich begrenzten Fragen ist die Bearbeitungszeit individuell anpassbar (Standardzeit, zehnfache Bearbeitungszeit oder ohne Zeitlimit), und der barrierefrei strukturierte Ergebnisbericht ist PDF/UA-1-validiert.',
-    link: {
-      href: APP_ACCESSIBILITY_URL,
-      label: 'Erklärung zur Barrierefreiheit öffnen',
-    },
-  },
-];
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { locale, t } = Astro.props;
+const f = t.faq;
 ---
 
 <section id="faq" class="border-b border-slate-700 bg-slate-950 px-4 py-16 sm:px-6 sm:py-24" aria-labelledby="faq-heading">
   <div class="mx-auto max-w-5xl">
-    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">FAQ</p>
+    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">{f.eyebrow}</p>
     <h2 id="faq-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">
-      Häufige Fragen vor dem ersten Einsatz
+      {f.title}
     </h2>
     <div class="mt-10 grid gap-4">
-      {items.map((item) => (
+      {f.items.map((item) => (
         <details class="group rounded-3xl border border-slate-700 bg-slate-900/75 p-6 open:border-brand-500/40">
           <summary class="flex cursor-pointer list-none items-center justify-between gap-6 font-display text-xl font-semibold text-white marker:content-none">
             <span>{item.question}</span>
             <span class="rounded-full border border-slate-600 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-300 transition group-open:border-brand-400/50 group-open:text-brand-300">
-              Antwort
+              {f.answerLabel}
             </span>
           </summary>
           <p class="mt-4 max-w-3xl leading-7 text-slate-400">{item.answer}</p>
-          {'link' in item && item.link ? (
+          {item.linkLabel ? (
             <p class="mt-3">
               <a
-                href={item.link.href}
+                href={appAccessibilityUrl(locale)}
                 class="text-sm font-semibold text-brand-400 underline underline-offset-2 hover:text-brand-300"
               >
-                {item.link.label}
+                {item.linkLabel}
               </a>
             </p>
           ) : null}

--- a/apps/landing/src/components/Features.astro
+++ b/apps/landing/src/components/Features.astro
@@ -1,96 +1,48 @@
 ---
-const features = [
-  {
-    title: 'Schnell im Einsatz',
-    description: 'Hosts starten ohne Account. Teilnehmende kommen per 6-stelligem Code oder QR direkt in die Session.',
-    icon: 'single',
-  },
-  {
-    title: 'Selbsteinschätzung im Live-Quiz',
-    description: 'Teilnehmende geben nach der Antwort an, wie sicher sie sind. Du erkennst selbstsicher falsche Antworten, priorisierst die Nachbesprechung und exportierst den Lernstand im Ergebnisbericht (PDF).',
-    icon: 'confidence',
-  },
-  {
-    title: 'Ergebnisbericht für die Nachbereitung',
-    description: 'Nach Session-Ende exportierst du einen druckfertigen PDF-Bericht mit Diagrammen, Fragentexten und Selbsteinschätzung. CSV für Excel bleibt optional unter „Mehr“.',
-    icon: 'export',
-  },
-  {
-    title: 'Didaktische Schätzfragen',
-    description: 'Jahreszahlen, Größenordnungen und Messwerte lassen sich mit Referenzwert, Toleranzband, Statistik und optionaler zweiter Runde schätzen.',
-    icon: 'estimate',
-  },
-  {
-    title: 'Mehr als ein Standard-Quiz',
-    description: 'MC/SC, Kurzantwort, Rating, Lesephase, Peer Instruction und Presenter-Flow unterstützen Lernen, Training und Live-Moderation.',
-    icon: 'toggle',
-  },
-  {
-    title: 'Fragenwand statt Nebenchat',
-    description: 'Q&A bietet Vorab-Moderation, Anheften, Archivieren, Up-/Downvoting sowie Sortierung nach Unterstützung, Qualität und Kontroverse.',
-    icon: 'qa',
-  },
-  {
-    title: 'Elaborierte Word Cloud',
-    description: 'Freitext und Q&A werden als Wörter und Phrasen verdichtet; die Fragenwand gewichtet nach Zustimmung, belastbarem Score oder Kontroverse.',
-    icon: 'cloud',
-  },
-  {
-    title: 'Für unterschiedliche Settings',
-    description: 'Presets, Team-Modus, anonymer Modus, Nicknames und Stilwahl helfen von Klasse und Seminar bis Workshop, Event und Meeting.',
-    icon: 'bolt',
-  },
-  {
-    title: 'Barrierefreiheit nach WCAG 2.2 AA',
-    description: 'Tastaturbedienung, Screenreader-Statusmeldungen, individuell anpassbare Bearbeitungszeit und PDF/UA-1-validierte Ergebnisberichte — damit mehr Lernende selbstständig an Live-Sessions teilnehmen können.',
-    icon: 'a11y',
-  },
-  {
-    title: 'Datenschutz und Kontrolle',
-    description: 'Local-first, Data-Stripping und self-hostbarer Betrieb geben dir mehr Kontrolle über Inhalte und Live-Daten.',
-    icon: 'tools',
-  },
-  {
-    title: 'Open Source mit Betriebspfad',
-    description: 'Docker, Postgres, Redis und Admin-Audit machen die Plattform auch für Hosting, Betrieb und Nachvollziehbarkeit belastbar.',
-    icon: 'server',
-  },
-];
+import type { Locale, Messages } from '@/i18n';
+
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { t } = Astro.props;
+const f = t.features;
 ---
 
 <section id="features" class="border-b border-slate-700 bg-slate-800/50 px-4 py-16 sm:px-6 sm:py-24" aria-labelledby="features-heading">
   <div class="mx-auto max-w-6xl">
-    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">Warum es sich anders anfühlt</p>
-    <h2 id="features-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">Gebaut für Live-Interaktion statt nur für Abstimmungsfolien</h2>
-    <p class="mt-4 max-w-3xl text-lg leading-8 text-slate-400">arsnova.eu verbindet schnellen Einstieg, didaktische Stärke und einen transparenten technischen Unterbau. So bleibt die Plattform im Alltag einfach, ohne in den Möglichkeiten klein zu werden.</p>
+    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">{f.eyebrow}</p>
+    <h2 id="features-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">{f.title}</h2>
+    <p class="mt-4 max-w-3xl text-lg leading-8 text-slate-400">{f.lead}</p>
     <ul class="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3" role="list">
-      {features.map((f) => (
+      {f.items.map((item) => (
         <li class="rounded-3xl border border-slate-700 bg-slate-900/75 p-6 transition hover:border-brand-500/50 hover:bg-slate-900">
           <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-brand-500/20 text-brand-400" aria-hidden="true">
-            {f.icon === 'shield' && '🛡️'}
-            {f.icon === 'bolt' && '⚡'}
-            {f.icon === 'academic' && '🎓'}
-            {f.icon === 'toggle' && '↔️'}
-            {f.icon === 'collab' && '🤝'}
-            {f.icon === 'server' && '📦'}
-            {f.icon === 'ai' && '🤖'}
-            {f.icon === 'single' && '🔗'}
-            {f.icon === 'book' && '📚'}
-            {f.icon === 'tools' && '🧭'}
-            {f.icon === 'a11y' && (
+            {item.icon === 'shield' && '🛡️'}
+            {item.icon === 'bolt' && '⚡'}
+            {item.icon === 'academic' && '🎓'}
+            {item.icon === 'toggle' && '↔️'}
+            {item.icon === 'collab' && '🤝'}
+            {item.icon === 'server' && '📦'}
+            {item.icon === 'ai' && '🤖'}
+            {item.icon === 'single' && '🔗'}
+            {item.icon === 'book' && '📚'}
+            {item.icon === 'tools' && '🧭'}
+            {item.icon === 'a11y' && (
               <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                 <circle cx="12" cy="4.5" r="2" />
                 <path stroke-linecap="round" stroke-linejoin="round" d="M5 8.5c2.2 1 4.5 1.5 7 1.5s4.8-.5 7-1.5M12 10v10M8.5 20 12 15l3.5 5" />
               </svg>
             )}
-            {f.icon === 'estimate' && '≈'}
-            {f.icon === 'confidence' && '🎯'}
-            {f.icon === 'export' && '📄'}
-            {f.icon === 'qa' && '❓'}
-            {f.icon === 'cloud' && '☁️'}
+            {item.icon === 'estimate' && '≈'}
+            {item.icon === 'confidence' && '🎯'}
+            {item.icon === 'export' && '📄'}
+            {item.icon === 'qa' && '❓'}
+            {item.icon === 'cloud' && '☁️'}
           </div>
-          <h3 class="mt-4 font-display text-lg font-semibold text-white">{f.title}</h3>
-          <p class="mt-3 leading-7 text-slate-400">{f.description}</p>
+          <h3 class="mt-4 font-display text-lg font-semibold text-white">{item.title}</h3>
+          <p class="mt-3 leading-7 text-slate-400">{item.description}</p>
         </li>
       ))}
     </ul>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -1,47 +1,53 @@
 ---
-import { APP_URL_V3 } from '@/config/github';
+import { appHomeUrl } from '@/config/github';
+import type { Locale, Messages } from '@/i18n';
+
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { locale, t } = Astro.props;
 const base = (typeof import.meta.env.BASE_URL === 'string' && import.meta.env.BASE_URL) || '/';
+const localeHome = `${base}${locale}/`.replace(/\/{2,}/g, '/');
+const h = t.hero;
 ---
 
 <section class="relative overflow-hidden bg-slate-900 px-4 py-20 sm:px-6 sm:py-28 lg:py-36" aria-labelledby="hero-heading">
   <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_50%_-20%,rgba(14,165,233,0.25),transparent)]" aria-hidden="true" />
   <div class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-brand-400/50 to-transparent" aria-hidden="true" />
   <div class="relative mx-auto max-w-5xl text-center">
-    <p
-      class="mx-auto mb-4 max-w-xs text-xs font-semibold uppercase leading-6 tracking-[0.12em] text-brand-400 sm:max-w-none sm:text-sm sm:tracking-[0.24em]"
-    >
-      Audience Response für Bildung und Organisationen
+    <p class="mx-auto mb-4 max-w-xs text-xs font-semibold uppercase leading-6 tracking-[0.12em] text-brand-400 sm:max-w-none sm:text-sm sm:tracking-[0.24em]">
+      {h.eyebrow}
     </p>
-    <h1
-      id="hero-heading"
-      class="mx-auto max-w-[22rem] font-display text-3xl font-extrabold tracking-tight text-white sm:max-w-4xl sm:text-5xl lg:text-6xl"
-    >
-      <span class="block">Quizzen, schätzen,</span>
-      <span class="block">Fragen moderieren</span>
-      <span class="mt-2 block text-brand-400 sm:inline">live und kostenlos</span>
-      <span class="block text-brand-400 sm:inline"> ohne Account.</span>
+    <h1 id="hero-heading" class="mx-auto max-w-[22rem] font-display text-3xl font-extrabold tracking-tight text-white sm:max-w-4xl sm:text-5xl lg:text-6xl">
+      <span class="block">{h.titleLine1}</span>
+      <span class="block">{h.titleLine2}</span>
+      <span class="mt-2 block text-brand-400 sm:inline">{h.titleAccent1}</span>
+      <span class="block text-brand-400 sm:inline">{h.titleAccent2}</span>
     </h1>
     <p class="mx-auto mt-6 max-w-3xl text-base leading-8 text-slate-300 sm:text-xl">
-      arsnova.eu bündelt Live-Quiz, numerische Schätzfragen, Selbsteinschätzung bei bewertbaren Fragen, Q&amp;A-Fragenwand, Word-Cloud-Analyse und Blitzlicht-Feedback in einer Oberfläche für Schulen, Hochschulen, Weiterbildung, Workshops und Business. Open Source, self-hostbar und für DSGVO-orientierten Betrieb ausgelegt.
+      {h.lead}
     </p>
     <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row sm:flex-wrap" id="start">
-      <a href={APP_URL_V3} class="inline-flex w-full max-w-xs items-center justify-center gap-2 rounded-xl bg-brand-700 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-brand-500/30 transition hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900 sm:w-auto">
+      <a href={appHomeUrl(locale)} class="inline-flex w-full max-w-xs items-center justify-center gap-2 rounded-xl bg-brand-700 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-brand-500/30 transition hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900 sm:w-auto">
         <img src={`${base}favicon.svg`} alt="" class="h-5 w-5 shrink-0" width="20" height="20" />
-        Jetzt live ausprobieren
+        {t.cta.tryLive}
       </a>
-      <a href={`${base}#ablauf`} class="inline-flex w-full max-w-xs items-center justify-center rounded-xl border border-slate-600 bg-slate-800/50 px-6 py-3.5 text-base font-semibold text-white backdrop-blur transition hover:border-slate-500 hover:bg-slate-800 sm:w-auto">
-        So funktioniert’s
+      <a href={`${localeHome}#workflow`} class="inline-flex w-full max-w-xs items-center justify-center rounded-xl border border-slate-600 bg-slate-800/50 px-6 py-3.5 text-base font-semibold text-white backdrop-blur transition hover:border-slate-500 hover:bg-slate-800 sm:w-auto">
+        {t.cta.howItWorks}
       </a>
     </div>
     <p class="mx-auto mt-6 max-w-2xl text-sm leading-7 text-slate-400 sm:text-base">
-      <a href={`${base}#barrierefreiheit`} class="font-semibold text-brand-300 underline-offset-2 hover:text-brand-200 hover:underline focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900 rounded">Barrierefrei nach WCAG 2.2 AA</a>
-      {' '}— Tastatur, Screenreader und individuell anpassbare Bearbeitungszeit.
+      <a href={`${localeHome}#accessibility`} class="font-semibold text-brand-300 underline-offset-2 hover:text-brand-200 hover:underline focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900 rounded">{h.a11yLink}</a>
+      {' '}{h.a11ySuffix}
     </p>
     <ul class="mt-12 grid gap-3 text-left text-sm text-slate-300 sm:grid-cols-2 xl:grid-cols-4" role="list">
-      <li class="rounded-2xl border border-slate-700 bg-slate-800/60 px-4 py-3"><span class="font-semibold text-white">Sofort live</span><br />Session per Code oder QR teilen</li>
-      <li class="rounded-2xl border border-slate-700 bg-slate-800/60 px-4 py-3"><span class="font-semibold text-white">Q&amp;A mit Fragenwand</span><br />Moderation, Voting und Themen-Wortwolke</li>
-      <li class="rounded-2xl border border-slate-700 bg-slate-800/60 px-4 py-3"><span class="font-semibold text-white">Selbsteinschätzung &amp; Nachbereitung</span><br />Fehlkonzepte erkennen, Ergebnisbericht als PDF</li>
-      <li class="rounded-2xl border border-slate-700 bg-slate-800/60 px-4 py-3"><span class="font-semibold text-white">Open Source &amp; self-hostbar</span><br />Docker, Postgres, Redis und Admin-Audit</li>
+      {h.cards.map((card) => (
+        <li class="rounded-2xl border border-slate-700 bg-slate-800/60 px-4 py-3">
+          <span class="font-semibold text-white">{card.title}</span><br />{card.text}
+        </li>
+      ))}
     </ul>
   </div>
 </section>

--- a/apps/landing/src/components/LanguageSwitcher.astro
+++ b/apps/landing/src/components/LanguageSwitcher.astro
@@ -30,7 +30,6 @@ const localeHref = (code: Locale) => `${base}${code}/`.replace(/\/{2,}/g, '/');
     id={buttonId}
     class="inline-flex min-h-11 items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium text-slate-300 hover:bg-slate-800 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900"
     aria-expanded="false"
-    aria-haspopup="true"
     aria-controls={menuId}
     aria-label={t.languageSwitcher.chooseLanguage}
   >

--- a/apps/landing/src/components/LanguageSwitcher.astro
+++ b/apps/landing/src/components/LanguageSwitcher.astro
@@ -15,15 +15,22 @@ export interface Props {
 const { locale, t, idPrefix = 'lang' } = Astro.props;
 const menuId = `${idPrefix}-menu`;
 const buttonId = `${idPrefix}-button`;
+const base = (typeof import.meta.env.BASE_URL === 'string' && import.meta.env.BASE_URL) || '/';
+const localeHref = (code: Locale) => `${base}${code}/`.replace(/\/{2,}/g, '/');
 ---
 
-<div class="relative language-switcher" data-language-switcher data-current-locale={locale}>
+<div
+  class="relative language-switcher"
+  data-language-switcher
+  data-current-locale={locale}
+  data-base-url={base}
+>
   <button
     type="button"
     id={buttonId}
     class="inline-flex min-h-11 items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium text-slate-300 hover:bg-slate-800 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900"
     aria-expanded="false"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-controls={menuId}
     aria-label={t.languageSwitcher.chooseLanguage}
   >
@@ -37,7 +44,6 @@ const buttonId = `${idPrefix}-button`;
   </button>
   <ul
     id={menuId}
-    role="listbox"
     aria-label={t.languageSwitcher.label}
     class="absolute right-0 z-50 mt-2 hidden min-w-[11rem] rounded-xl border border-slate-700 bg-slate-900 py-1 shadow-xl"
     data-lang-menu
@@ -46,9 +52,9 @@ const buttonId = `${idPrefix}-button`;
       LOCALES.map((code) => {
         const active = code === locale;
         return (
-          <li role="option" aria-selected={active}>
+          <li>
             <a
-              href={`/${code}/`}
+              href={localeHref(code)}
               lang={code}
               hreflang={code}
               data-locale-link={code}

--- a/apps/landing/src/components/LanguageSwitcher.astro
+++ b/apps/landing/src/components/LanguageSwitcher.astro
@@ -1,0 +1,68 @@
+---
+import {
+  LOCALES,
+  LOCALE_NATIVE_NAMES,
+  type Locale,
+  type Messages,
+} from '@/i18n';
+
+export interface Props {
+  locale: Locale;
+  t: Messages;
+  idPrefix?: string;
+}
+
+const { locale, t, idPrefix = 'lang' } = Astro.props;
+const menuId = `${idPrefix}-menu`;
+const buttonId = `${idPrefix}-button`;
+---
+
+<div class="relative language-switcher" data-language-switcher data-current-locale={locale}>
+  <button
+    type="button"
+    id={buttonId}
+    class="inline-flex min-h-11 items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium text-slate-300 hover:bg-slate-800 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-slate-900"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-controls={menuId}
+    aria-label={t.languageSwitcher.chooseLanguage}
+  >
+    <svg class="h-5 w-5 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0 0c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m-7.5 9h15" />
+    </svg>
+    <span>{t.languageSwitcher.currentLanguage}</span>
+    <svg class="h-4 w-4 shrink-0 opacity-70" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+    </svg>
+  </button>
+  <ul
+    id={menuId}
+    role="listbox"
+    aria-label={t.languageSwitcher.label}
+    class="absolute right-0 z-50 mt-2 hidden min-w-[11rem] rounded-xl border border-slate-700 bg-slate-900 py-1 shadow-xl"
+    data-lang-menu
+  >
+    {
+      LOCALES.map((code) => {
+        const active = code === locale;
+        return (
+          <li role="option" aria-selected={active}>
+            <a
+              href={`/${code}/`}
+              lang={code}
+              hreflang={code}
+              data-locale-link={code}
+              class:list={[
+                'block min-h-11 px-4 py-2.5 text-sm font-medium focus:outline-none focus:bg-slate-800',
+                active ? 'bg-slate-800 text-white' : 'text-slate-300 hover:bg-slate-800 hover:text-white',
+              ]}
+              aria-current={active ? 'true' : undefined}
+            >
+              {LOCALE_NATIVE_NAMES[code]}
+            </a>
+          </li>
+        );
+      })
+    }
+  </ul>
+</div>

--- a/apps/landing/src/components/QaWallSpotlight.astro
+++ b/apps/landing/src/components/QaWallSpotlight.astro
@@ -1,89 +1,38 @@
 ---
 import { GITHUB_URL } from '@/config/github';
+import type { Locale, Messages } from '@/i18n';
 
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { t } = Astro.props;
+const q = t.qaWall;
 const controversyDocsUrl = `${GITHUB_URL}/blob/main/docs/features/controversy-score.md`;
-
-const signals = [
-  {
-    label: 'Vorab-Moderation',
-    text: 'Fragen erst freigeben, wenn sie in den didaktischen Moment passen.',
-  },
-  {
-    label: 'Kollektives Voting',
-    text: 'Up- und Downvotes zeigen Priorität, Reibung und Klärungsbedarf.',
-  },
-  {
-    label: 'Themen-Wortwolke',
-    text: 'Wörter und Phrasen werden nach Unterstützung, Zustimmung oder Kontroverse gewichtet.',
-  },
-  {
-    label: 'Kompass-Ausblick',
-    text: 'Deterministische Signale kommen zuerst; Q&A-NLP und Zusammenfassung bleiben optionale Ausbaustufen.',
-  },
-];
-
-const questions = [
-  {
-    score: '+18',
-    title: 'Wann ist eine Schätzung fachlich noch plausibel?',
-    meta: '15 positiv · 3 negativ · beste Frage',
-  },
-  {
-    score: '+4',
-    title: 'Sollten wir Ergebnisse vor der Diskussion wirklich ausblenden?',
-    meta: '9 positiv · 5 negativ · umstritten',
-  },
-  {
-    score: '+11',
-    title: 'Wie unterscheidet sich Q&A von Freitext im Quiz?',
-    meta: '11 positiv · 0 negativ · meist unterstützt',
-  },
-];
-
-const terms = [
-  { label: 'Toleranzband', className: 'text-3xl text-brand-200' },
-  { label: 'Diskussion', className: 'text-2xl text-emerald-200' },
-  { label: 'Q&A', className: 'text-4xl text-white' },
-  { label: 'Plausibilität', className: 'text-xl text-amber-200' },
-  { label: 'Kontroverse', className: 'text-2xl text-rose-200' },
-  { label: 'Peer Instruction', className: 'text-lg text-slate-300' },
-  { label: 'Moderation', className: 'text-3xl text-cyan-200' },
-  { label: 'Klärungsbedarf', className: 'text-xl text-violet-200' },
-];
 ---
 
 <section
-  id="fragenwand"
-  class="border-b border-slate-700 bg-slate-900 px-4 py-16 sm:px-6 sm:py-24"
+  id="qa-wall"
+  class="relative border-b border-slate-700 bg-slate-900 px-4 py-16 sm:px-6 sm:py-24"
   aria-labelledby="qa-wall-heading"
 >
+  <span id="fragenwand" class="absolute -top-20" aria-hidden="true"></span>
   <div class="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
     <div>
-      <p class="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-300">
-        Live-Q&amp;A als Moderationsfläche
-      </p>
-      <h2
-        id="qa-wall-heading"
-        class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl"
-      >
-        Fragen sammeln, priorisieren und als Themenbild lesen
+      <p class="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-300">{q.eyebrow}</p>
+      <h2 id="qa-wall-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        {q.title}
       </h2>
-      <p class="mt-5 text-lg leading-8 text-slate-300">
-        Die Fragenwand ist kein Nebenchat. Sie ist ein eigener Live-Kanal für Lehrende und
-        Vortragende: Beiträge moderieren, kollektive Prioritäten erkennen, kontroverse Punkte
-        sichtbar machen und die wichtigsten Themen über eine gewichtete Q&amp;A-Wortwolke in den
-        Raum holen.
-      </p>
+      <p class="mt-5 text-lg leading-8 text-slate-300">{q.lead}</p>
       <ul class="mt-8 grid gap-3 text-sm leading-6 text-slate-300 sm:grid-cols-2" role="list">
-        {
-          signals.map((item) => (
-            <li class="rounded-lg border border-slate-700 bg-slate-950/70 p-4">
-              <span class="font-semibold text-white">{item.label}</span>
-              <br />
-              {item.text}
-            </li>
-          ))
-        }
+        {q.signals.map((item) => (
+          <li class="rounded-lg border border-slate-700 bg-slate-950/70 p-4">
+            <span class="font-semibold text-white">{item.label}</span>
+            <br />
+            {item.text}
+          </li>
+        ))}
       </ul>
       <a
         href={controversyDocsUrl}
@@ -91,75 +40,66 @@ const terms = [
         target="_blank"
         rel="noopener noreferrer"
       >
-        Q&amp;A-Scoring und Kontroversität auf GitHub öffnen
+        {q.docsLink}
       </a>
     </div>
 
     <div
       class="rounded-lg border border-slate-700 bg-slate-950 p-4 shadow-[0_22px_70px_rgba(16,185,129,0.16)] sm:p-5"
-      aria-label="Beispiel einer Q&A-Fragenwand mit Moderation, Voting und Wortwolke"
+      aria-label={q.demoAria}
     >
       <div class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-700 pb-4">
         <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-300">
-            Host-Ansicht Q&amp;A
-          </p>
-          <h3 class="mt-1 font-display text-2xl font-bold text-white">Fragen zur Veranstaltung</h3>
+          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-300">{q.hostView}</p>
+          <h3 class="mt-1 font-display text-2xl font-bold text-white">{q.demoTitle}</h3>
         </div>
         <span class="rounded-lg border border-emerald-300/40 bg-emerald-300/15 px-3 py-1 text-sm font-semibold text-emerald-100">
-          Vorab-Moderation aktiv
+          {q.moderationActive}
         </span>
       </div>
 
       <div class="mt-4 flex flex-wrap gap-2 text-xs font-semibold text-slate-300">
-        <span class="rounded-lg bg-brand-700 px-3 py-1.5 text-white">Meist unterstützt</span>
-        <span class="rounded-lg border border-slate-700 px-3 py-1.5">Beste Fragen</span>
+        <span class="rounded-lg bg-brand-700 px-3 py-1.5 text-white">{q.sortMostSupported}</span>
+        <span class="rounded-lg border border-slate-700 px-3 py-1.5">{q.sortBest}</span>
         <span class="rounded-lg border border-rose-300/40 bg-rose-300/10 px-3 py-1.5 text-rose-100">
-          Umstritten
+          {q.sortControversial}
         </span>
       </div>
 
       <div class="mt-5 grid gap-5 xl:grid-cols-[0.92fr_1.08fr]">
         <div class="grid gap-3">
-          {
-            questions.map((question) => (
-              <article class="rounded-lg border border-slate-700 bg-slate-900/85 p-4">
-                <div class="flex items-start gap-3">
-                  <div class="rounded-lg border border-brand-400/40 bg-brand-400/10 px-2.5 py-2 text-center font-display text-lg font-bold text-brand-100">
-                    {question.score}
-                  </div>
-                  <div>
-                    <h4 class="font-semibold leading-6 text-white">{question.title}</h4>
-                    <p class="mt-1 text-xs leading-5 text-slate-400">{question.meta}</p>
-                  </div>
+          {q.questions.map((question) => (
+            <article class="rounded-lg border border-slate-700 bg-slate-900/85 p-4">
+              <div class="flex items-start gap-3">
+                <div class="rounded-lg border border-brand-400/40 bg-brand-400/10 px-2.5 py-2 text-center font-display text-lg font-bold text-brand-100">
+                  {question.score}
                 </div>
-              </article>
-            ))
-          }
+                <div>
+                  <h4 class="font-semibold leading-6 text-white">{question.title}</h4>
+                  <p class="mt-1 text-xs leading-5 text-slate-400">{question.meta}</p>
+                </div>
+              </div>
+            </article>
+          ))}
         </div>
 
         <div class="rounded-lg border border-slate-700 bg-slate-900/75 p-4">
           <div class="flex items-center justify-between gap-3">
             <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
-                Q&amp;A-Wortwolke
-              </p>
-              <p class="mt-1 text-sm text-slate-300">Gewichtet nach positiver Resonanz und Kontroverse.</p>
+              <p class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">{q.wordCloud}</p>
+              <p class="mt-1 text-sm text-slate-300">{q.wordCloudHint}</p>
             </div>
             <span class="rounded-lg border border-slate-600 px-2.5 py-1 text-xs font-semibold text-slate-300">
-              Live eingefroren
+              {q.frozenLive}
             </span>
           </div>
           <div class="mt-5 flex min-h-52 flex-wrap content-center items-center justify-center gap-x-4 gap-y-3 rounded-lg border border-slate-800 bg-slate-950 p-4 text-center font-display font-bold leading-none">
-            {
-              terms.map((term) => (
-                <span class={term.className}>{term.label}</span>
-              ))
-            }
+            {q.terms.map((term) => (
+              <span class={term.className}>{term.label}</span>
+            ))}
           </div>
           <p class="mt-4 rounded-lg border border-violet-300/30 bg-violet-300/10 p-3 text-sm leading-6 text-violet-100">
-            Nächster Schritt: deterministischer Moderationskompass, optional ergänzt durch
-            asynchrone Q&amp;A-NLP-Signale und quellengebundene Zusammenfassungen.
+            {q.nextStep}
           </p>
         </div>
       </div>

--- a/apps/landing/src/components/Trust.astro
+++ b/apps/landing/src/components/Trust.astro
@@ -1,47 +1,30 @@
 ---
 import { GITHUB_URL } from '@/config/github';
-const researchPdfUrl = `${GITHUB_URL}/blob/main/docs/deep-research-arsnova.click/ARSnova-Recherche.pdf`;
-const proofItems = [
-  { value: 'Seit 2012', label: 'ARSnova-Tradition in Bildung und EdTech' },
-  { value: 'WCAG 2.2 AA', label: 'Geprüfte Barrierefreiheit für Lehre und Institutionen' },
-  { value: '5 UI-Sprachen', label: 'Deutsch, Englisch, Französisch, Spanisch, Italienisch' },
-  { value: 'Open Source', label: 'Transparenter Code statt Black Box' },
-];
+import type { Locale, Messages } from '@/i18n';
 
-const items = [
-  {
-    quote: 'Datenschutzkonformer Weg: keine personenbezogenen Daten dauerhaft auf dem Server.',
-    source: 'DeLFI 2017',
-    tag: 'Wissenschaft',
-  },
-  {
-    quote: 'UX-Evaluation im direkten Vergleich mit Kahoot! als empirischer Prüfpunkt des Designs.',
-    source: 'fnm-austria',
-    tag: 'Studie',
-  },
-  {
-    quote: 'Privacy-by-Design und technische Offenheit sind ein echter Differenzierungsfaktor für europäische EdTech-Kontexte.',
-    source: 'Publikationsanalyse',
-    tag: 'Architektur',
-  },
-  {
-    quote: 'In realen Bildungssettings praktisch erprobt, nicht nur als Konzept beschrieben.',
-    source: 'Nutzung in Lehr- und Trainingskontexten',
-    tag: 'Praxis',
-  },
-];
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { t } = Astro.props;
+const tr = t.trust;
+const researchPdfUrl = `${GITHUB_URL}/blob/main/docs/deep-research-arsnova.click/ARSnova-Recherche.pdf`;
 ---
 
-<section id="vertrauen" class="border-b border-slate-700 bg-slate-800/50 px-4 py-16 sm:px-6 sm:py-24" aria-labelledby="trust-heading">
+<section
+  id="trust"
+  class="relative border-b border-slate-700 bg-slate-800/50 px-4 py-16 sm:px-6 sm:py-24"
+  aria-labelledby="trust-heading"
+>
+  <span id="vertrauen" class="absolute -top-20" aria-hidden="true"></span>
   <div class="mx-auto max-w-6xl">
-    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">Vertrauen</p>
-    <h2 id="trust-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">Glaubwürdig, weil das Produkt nicht bei null anfängt</h2>
-    <p class="mt-4 max-w-3xl text-lg leading-8 text-slate-400">
-      arsnova.eu steht in der Tradition des ARSnova-Ökosystems und knüpft an wissenschaftliche, didaktische und praktische Erfahrungen aus vielen Jahren Bildungstechnologie an.
-    </p>
+    <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">{tr.eyebrow}</p>
+    <h2 id="trust-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">{tr.title}</h2>
+    <p class="mt-4 max-w-3xl text-lg leading-8 text-slate-400">{tr.lead}</p>
 
     <ul class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4" role="list">
-      {proofItems.map((item) => (
+      {tr.proofItems.map((item) => (
         <li class="rounded-3xl border border-slate-700 bg-slate-900/70 p-5">
           <p class="font-display text-3xl font-bold text-white">{item.value}</p>
           <p class="mt-2 text-sm leading-6 text-slate-400">{item.label}</p>
@@ -50,7 +33,7 @@ const items = [
     </ul>
 
     <ul class="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-4" role="list">
-      {items.map((item) => (
+      {tr.items.map((item) => (
         <li class="flex flex-col rounded-3xl border border-slate-700 bg-slate-900/70 p-5 transition hover:border-brand-500/40">
           <span class="mb-2 inline-flex w-fit rounded-full bg-brand-500/20 px-2.5 py-0.5 text-xs font-medium text-brand-400">{item.tag}</span>
           <blockquote class="flex-1 text-sm leading-relaxed text-slate-300">
@@ -64,7 +47,9 @@ const items = [
     </ul>
 
     <p class="mt-6 text-sm text-slate-400">
-      Vollständige Referenzen und die zugrundeliegende Publikationssammlung liegen in <a href={researchPdfUrl} class="text-brand-400 underline underline-offset-2 hover:text-brand-300" target="_blank" rel="noopener noreferrer">ARSnova-Recherche.pdf</a> auf GitHub.
+      {tr.referencesPrefix}{' '}
+      <a href={researchPdfUrl} class="text-brand-400 underline underline-offset-2 hover:text-brand-300" target="_blank" rel="noopener noreferrer">{tr.referencesLink}</a>
+      {' '}{tr.referencesSuffix}
     </p>
   </div>
 </section>

--- a/apps/landing/src/components/Workflow.astro
+++ b/apps/landing/src/components/Workflow.astro
@@ -1,51 +1,37 @@
 ---
-const steps = [
-  {
-    number: '01',
-    title: 'Quiz vorbereiten',
-    description:
-      'Fragen direkt erstellen oder vorhandene Inhalte importieren. Markdown, KaTeX, Kurzantwort und numerische Schätzfragen sind direkt eingebaut.',
-  },
-  {
-    number: '02',
-    title: 'Session starten',
-    description:
-      'Ohne Konto loslegen: Session öffnen, Stil wählen, Code oder QR teilen und bei Bedarf Presenter-Ansicht nutzen.',
-  },
-  {
-    number: '03',
-    title: 'Live moderieren',
-    description:
-      'Teilnehmende stimmen ab, stellen Fragen und priorisieren gemeinsam. Host und Presenter zeigen Quiz, Q&A-Fragenwand, Wortwolke, Lesephase, Countdown, zweite Runde und Ergebnisansicht in einem Flow.',
-  },
-  {
-    number: '04',
-    title: 'Nachbereiten und exportieren',
-    description:
-      'Nach Session-Ende steht der Ergebnisbericht (PDF) bereit — mit Lernstand, Selbsteinschätzung und vollständigen Fragentexten. In der Quiz-Sammlung findest du Nachbesprechung und PDF für den letzten Durchlauf; CSV für Excel unter „Mehr“.',
-  },
-];
+import type { Locale, Messages } from '@/i18n';
+
+export interface Props {
+  locale: Locale;
+  t: Messages;
+}
+
+const { t } = Astro.props;
+const w = t.workflow;
 ---
 
-<section id="ablauf" class="border-b border-slate-700 bg-slate-950 px-4 py-16 sm:px-6 sm:py-24" aria-labelledby="workflow-heading">
+<section
+  id="workflow"
+  class="relative border-b border-slate-700 bg-slate-950 px-4 py-16 sm:px-6 sm:py-24"
+  aria-labelledby="workflow-heading"
+>
+  <span id="ablauf" class="absolute -top-20" aria-hidden="true"></span>
   <div class="mx-auto max-w-6xl">
     <div class="max-w-3xl">
-      <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">Für Unterricht, Training und Workshops</p>
+      <p class="text-sm font-semibold uppercase tracking-[0.24em] text-brand-400">{w.eyebrow}</p>
       <h2 id="workflow-heading" class="mt-3 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">
-        In wenigen Minuten von der Idee zur Live-Session
+        {w.title}
       </h2>
-      <p class="mt-4 text-lg text-slate-400">
-        Von der Frage bis zur laufenden Session führt der Ablauf bewusst ohne unnötige Zwischenschritte. Genau das macht den Einstieg für Lehrende, Trainer:innen und Moderator:innen schnell und verlässlich.
-      </p>
+      <p class="mt-4 text-lg text-slate-400">{w.lead}</p>
     </div>
 
     <ol class="mt-12 grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
-      {steps.map((step) => (
+      {w.steps.map((step) => (
         <li class="rounded-3xl border border-slate-700 bg-slate-900/70 p-6 shadow-[0_18px_60px_rgba(15,23,42,0.28)]">
           <div class="flex items-center justify-between gap-4">
             <span class="font-display text-4xl font-bold tracking-tight text-white/90">{step.number}</span>
             <span class="rounded-full border border-brand-500/30 bg-brand-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-brand-300">
-              Schritt
+              {w.stepLabel}
             </span>
           </div>
           <h3 class="mt-6 font-display text-2xl font-semibold text-white">{step.title}</h3>

--- a/apps/landing/src/config/github.ts
+++ b/apps/landing/src/config/github.ts
@@ -9,15 +9,22 @@ export const GITHUB_REPO = repo;
 export const GITHUB_URL = `https://github.com/${repo}`;
 export const GITHUB_DOCS_URL = `${GITHUB_URL}/blob/main/docs/ARS-comparison/Kahoot-Mentimeter-Slido-arsnova.click-v3.md`;
 
-/** CTA: App (Beta) – z. B. Demo oder gleiche URL bis Server steht */
-// default points to the current production host; override via PUBLIC_APP_URL_V3
-// (e.g. set to https://arsnova.eu in CI or Vercel env vars)
-export const APP_URL_V3 = import.meta.env.PUBLIC_APP_URL_V3 || 'https://arsnova.eu';
+/** App origin without trailing slash (override via PUBLIC_APP_URL_V3). */
+export const APP_URL_V3 = (import.meta.env.PUBLIC_APP_URL_V3 || 'https://arsnova.eu').replace(
+  /\/$/,
+  '',
+);
 
-/** Locale-prefixed legal pages in the SPA (landing is DE-only). */
-export function appLegalUrl(slug: 'imprint' | 'privacy' | 'accessibility', locale = 'de'): string {
-  const base = APP_URL_V3.replace(/\/$/, '');
-  return `${base}/${locale}/legal/${slug}`;
+/** Locale-prefixed app home, e.g. https://arsnova.eu/de/ */
+export function appHomeUrl(locale: string): string {
+  return `${APP_URL_V3}/${locale}/`;
 }
 
-export const APP_ACCESSIBILITY_URL = appLegalUrl('accessibility');
+/** Locale-prefixed legal pages in the SPA. */
+export function appLegalUrl(slug: 'imprint' | 'privacy' | 'accessibility', locale = 'de'): string {
+  return `${APP_URL_V3}/${locale}/legal/${slug}`;
+}
+
+export function appAccessibilityUrl(locale: string): string {
+  return appLegalUrl('accessibility', locale);
+}

--- a/apps/landing/src/config/seo.ts
+++ b/apps/landing/src/config/seo.ts
@@ -1,5 +1,5 @@
-/** Gleiche Kernbotschaft wie App-Startseite (`@@seo.titleHome` / `@@seo.descHome`). */
-export const homeMetaTitle = 'arsnova.eu | Live-Quiz, Schätzfragen und Q&A-Fragenwand';
+/** German home meta (mirrors `@/i18n/de`). Prefer `getMessages(locale).meta` for localized pages. */
+import de from '@/i18n/de';
 
-export const homeMetaDescription =
-  'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Word Cloud und Feedback — barrierefrei nach WCAG 2.2 AA, kostenlos, self-hostbar und ohne Account startklar.';
+export const homeMetaTitle = de.meta.homeTitle;
+export const homeMetaDescription = de.meta.homeDescription;

--- a/apps/landing/src/i18n/anchors.ts
+++ b/apps/landing/src/i18n/anchors.ts
@@ -1,0 +1,41 @@
+/** Canonical, language-neutral section anchors used in all locales. */
+export const CANONICAL_ANCHORS = [
+  'workflow',
+  'numeric-estimate',
+  'confidence',
+  'qa-wall',
+  'features',
+  'accessibility',
+  'trust',
+  'comparison',
+  'faq',
+  'start',
+] as const;
+
+export type CanonicalAnchor = (typeof CANONICAL_ANCHORS)[number];
+
+/** Legacy German hash aliases → canonical anchors (must keep working). */
+export const LEGACY_ANCHOR_ALIASES: Record<string, CanonicalAnchor> = {
+  ablauf: 'workflow',
+  schaetzfrage: 'numeric-estimate',
+  selbsteinschaetzung: 'confidence',
+  fragenwand: 'qa-wall',
+  barrierefreiheit: 'accessibility',
+  vertrauen: 'trust',
+  vergleich: 'comparison',
+};
+
+/** Alias ids that should exist as empty elements next to canonical section ids. */
+export const LEGACY_ALIAS_IDS = Object.keys(LEGACY_ANCHOR_ALIASES);
+
+export function canonicalizeHash(hash: string): string {
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+  if (!raw) return '';
+  const canonical = LEGACY_ANCHOR_ALIASES[raw] ?? raw;
+  return `#${canonical}`;
+}
+
+export function localePath(locale: string, hash = ''): string {
+  const normalized = hash ? canonicalizeHash(hash) : '';
+  return `/${locale}/${normalized}`;
+}

--- a/apps/landing/src/i18n/de.ts
+++ b/apps/landing/src/i18n/de.ts
@@ -4,7 +4,7 @@ const de: Messages = {
   meta: {
     homeTitle: 'arsnova.eu | Live-Quiz, Schätzfragen und Q&A-Fragenwand',
     homeDescription:
-      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Word Cloud und Feedback — barrierefrei nach WCAG 2.2 AA, kostenlos, auf eigener Infrastruktur betreibbar und ohne Account startklar.',
+      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Wortwolke und Rückmeldung — barrierefrei nach WCAG 2.2 AA, kostenlos, auf eigener Infrastruktur betreibbar und ohne Account startklar.',
     siteNameInfo: 'arsnova.eu – Informationen',
     ogLocale: 'de_DE',
   },
@@ -48,7 +48,7 @@ const de: Messages = {
     titleLine2: 'Fragen moderieren',
     titleAccent1: 'live und kostenlos',
     titleAccent2: ' ohne Account.',
-    lead: 'arsnova.eu bündelt Live-Quiz, numerische Schätzfragen, Selbsteinschätzung bei bewertbaren Fragen, Q&A-Fragenwand, Word-Cloud-Analyse und Blitzlicht-Feedback in einer Oberfläche für Schulen, Hochschulen, Weiterbildung, Workshops und Unternehmen. Open Source, auf eigener Infrastruktur betreibbar und für DSGVO-orientierten Betrieb ausgelegt.',
+    lead: 'arsnova.eu bündelt Live-Quiz, numerische Schätzfragen, Selbsteinschätzung bei bewertbaren Fragen, Q&A-Fragenwand, Wortwolken-Analyse und Blitzlicht-Rückmeldung in einer Oberfläche für Schulen, Hochschulen, Weiterbildung, Workshops und Unternehmen. Open Source, auf eigener Infrastruktur betreibbar und für den Betrieb mit Ausrichtung auf die DSGVO ausgelegt.',
     a11yLink: 'Barrierefrei nach WCAG 2.2 AA',
     a11ySuffix: '— Tastatur, Screenreader und individuell anpassbare Bearbeitungszeit.',
     cards: [
@@ -84,7 +84,7 @@ const de: Messages = {
     plausibilityBand: 'Plausibilitätsband',
     plausibilityValue: '1500 bis 2000',
     histogramNote:
-      'Histogramm, Referenzlinie und Toleranzband erscheinen erst nach Ergebnisfreigabe. Vorher bleibt nur der neutrale Fortschritt sichtbar.',
+      'Histogramm, Referenzlinie und Toleranzband erscheinen erst nach Ergebnisfreigabe. Vorher bleibt nur ein neutraler Fortschrittsindikator sichtbar.',
     median: 'Median',
     inBand: 'im Band',
     round2: 'Runde 2',
@@ -93,7 +93,7 @@ const de: Messages = {
   confidence: {
     eyebrow: 'Didaktische Auswertung',
     title: 'Richtig oder falsch — und wie sicher?',
-    lead: 'Mit der Selbsteinschätzung erfassen Teilnehmende nach ihrer Antwort, wie sicher sie sind (1–5). Du erkennst nicht nur Trefferquote, sondern auch selbstsicher falsche Antworten — ein hilfreiches Instrument für formative Auswertung, gezielte Nachbesprechung und den Ergebnisbericht (PDF) nach Session-Ende.',
+    lead: 'Bei der Selbsteinschätzung geben Teilnehmende nach ihrer Antwort an, wie sicher sie sind (1–5). Du erkennst nicht nur Trefferquote, sondern auch falsche Antworten mit hoher Antwortsicherheit — ein hilfreiches Instrument für formative Auswertung, gezielte Nachbesprechung und den Ergebnisbericht (PDF) nach Session-Ende.',
     summary: [
       'Kein eigener Fragetyp — optional an bewertbaren Quizfragen.',
       'Skala 1–5 nach der Antwort, ohne Einfluss auf Punkte.',
@@ -115,7 +115,7 @@ const de: Messages = {
       { label: 'Falsch · mittlere Sicherheit', count: 4, tone: 'amber' },
       { label: 'Falsch · hohe Sicherheit', count: 2, tone: 'rose' },
     ],
-    falseHighTitle: '2 selbstsicher falsche Antworten',
+    falseHighTitle: '2 falsche Antworten mit hoher Antwortsicherheit',
     falseHighText:
       'Option B wurde 2× mit hoher Antwortsicherheit gewählt — ein Signal für mögliche Fehlkonzepte in der Nachbesprechung.',
     consolidated: 'Gefestigt',
@@ -135,11 +135,11 @@ const de: Messages = {
     signals: [
       {
         label: 'Vorab-Moderation',
-        text: 'Fragen erst freigeben, wenn sie in den didaktischen Moment passen.',
+        text: 'Fragen erst freigeben, wenn sie im jeweiligen didaktischen Kontext relevant sind.',
       },
       {
         label: 'Gemeinsames Abstimmen',
-        text: 'Zustimmungs- und Ablehnungsstimmen zeigen Priorität, Reibung und Klärungsbedarf.',
+        text: 'Zustimmungs- und Ablehnungsstimmen zeigen Prioritäten, Unstimmigkeiten und Klärungsbedarf.',
       },
       {
         label: 'Themen-Wortwolke',
@@ -176,7 +176,7 @@ const de: Messages = {
       },
     ],
     wordCloud: 'Q&A-Wortwolke',
-    wordCloudHint: 'Gewichtet nach positiver Resonanz und Kontroverse.',
+    wordCloudHint: 'Gewichtet nach positiver Zustimmung und Kontroverse.',
     frozenLive: 'Live-Aktualisierung pausiert',
     terms: [
       { label: 'Toleranzband', className: 'text-3xl text-brand-200' },
@@ -189,7 +189,7 @@ const de: Messages = {
       { label: 'Klärungsbedarf', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Nächster Schritt: ein deterministischer Moderationskompass, optional ergänzt durch asynchrone sprachliche Auswertung und quellengebundene Zusammenfassungen.',
+      'Nächster Schritt: ein deterministischer Moderationskompass, optional ergänzt durch asynchrone sprachliche Auswertung und Zusammenfassungen mit Bezug zu den jeweiligen Fragen.',
   },
   workflow: {
     eyebrow: 'Für Unterricht, Training und Workshops',
@@ -237,7 +237,7 @@ const de: Messages = {
       {
         title: 'Selbsteinschätzung im Live-Quiz',
         description:
-          'Teilnehmende geben nach der Antwort an, wie sicher sie sind. Du erkennst selbstsicher falsche Antworten, priorisierst die Nachbesprechung und exportierst den Lernstand im Ergebnisbericht (PDF).',
+          'Teilnehmende geben nach der Antwort an, wie sicher sie sind. Du erkennst falsche Antworten mit hoher Antwortsicherheit, priorisierst die Nachbesprechung und exportierst den Lernstand im Ergebnisbericht (PDF).',
         icon: 'confidence',
       },
       {
@@ -255,7 +255,7 @@ const de: Messages = {
       {
         title: 'Mehr als ein Standard-Quiz',
         description:
-          'MC/SC, Kurzantwort, Rating, Lesephase, Peer Instruction und Presenter-Ablauf unterstützen Lernen, Training und Live-Moderation.',
+          'MC/SC, Kurzantwort, Bewertungsskala, Lesephase, Peer Instruction und Presenter-Modus unterstützen Lernen, Training und Live-Moderation.',
         icon: 'toggle',
       },
       {
@@ -265,9 +265,9 @@ const de: Messages = {
         icon: 'qa',
       },
       {
-        title: 'Elaborierte Word Cloud',
+        title: 'Aussagekräftige Wortwolke',
         description:
-          'Freitext und Q&A werden als Wörter und Phrasen verdichtet; die Fragenwand gewichtet nach Zustimmung, belastbarer Bewertung oder Kontroverse.',
+          'Freitext und Q&A werden als Wörter und Phrasen verdichtet; die Fragenwand gewichtet nach Zustimmung, klarer Mehrheitsbewertung oder Kontroverse.',
         icon: 'cloud',
       },
       {
@@ -291,7 +291,7 @@ const de: Messages = {
       {
         title: 'Open Source mit Deployment und Betrieb',
         description:
-          'Docker, Postgres, Redis und Admin-Protokollierung machen die Plattform auch für Bereitstellung, Betrieb und Nachvollziehbarkeit belastbar.',
+          'Docker, Postgres, Redis und Admin-Protokollierung machen die Plattform auch für Bereitstellung, Betrieb und Nachvollziehbarkeit verlässlich.',
         icon: 'server',
       },
     ],
@@ -379,7 +379,7 @@ const de: Messages = {
       {
         title: 'Mehr Interaktionsformate',
         description:
-          'Neben Quiz auch numerische Schätzfragen, Lesephase, Peer Instruction, Blitzlicht, Q&A-Fragenwand und gewichtete Word Cloud in derselben Plattform statt nur Folien-Abstimmungen.',
+          'Neben Quiz auch numerische Schätzfragen, Lesephase, Peer Instruction, Blitzlicht, Q&A-Fragenwand und gewichtete Wortwolke in derselben Plattform statt nur Folien-Abstimmungen.',
       },
       {
         title: 'Mehr Kontrolle über Daten und Zugang',
@@ -413,7 +413,7 @@ const de: Messages = {
       {
         question: 'Was ist die Selbsteinschätzung im Quiz?',
         answer:
-          'Eine optionale Zusatzabfrage nach bewertbaren Fragen: Teilnehmende geben auf einer Skala von 1–5 an, wie sicher sie bei ihrer Antwort sind. Punkte bleiben unverändert; in der Host-Auswertung siehst du Korrektheit × Antwortsicherheit und markierst selbstsicher falsche Antworten als Fehlkonzept-Signal. Nach Session-Ende fließt der Lernstand in Nachbesprechung und Ergebnisbericht (PDF) ein.',
+          'Eine optionale Zusatzabfrage nach bewertbaren Fragen: Teilnehmende geben auf einer Skala von 1–5 an, wie sicher sie bei ihrer Antwort sind. Punkte bleiben unverändert; in der Host-Auswertung siehst du Korrektheit × Antwortsicherheit und markierst falsche Antworten mit hoher Antwortsicherheit als Fehlkonzept-Signal. Nach Session-Ende fließt der Lernstand in Nachbesprechung und Ergebnisbericht (PDF) ein.',
       },
       {
         question: 'Kann ich Session-Ergebnisse exportieren?',
@@ -428,12 +428,12 @@ const de: Messages = {
       {
         question: 'Was kann die Q&A-Fragenwand?',
         answer:
-          'Teilnehmende reichen Fragen ein und gewichten sie mit Zustimmungs- und Ablehnungsstimmen. Hosts können vorab moderieren, Fragen anheften, archivieren oder entfernen und die Liste nach Unterstützung, belastbarer Zustimmung oder Kontroverse sortieren.',
+          'Teilnehmende reichen Fragen ein und gewichten sie mit Zustimmungs- und Ablehnungsstimmen. Hosts können vorab moderieren, Fragen anheften, archivieren oder entfernen und die Liste nach Unterstützung, klarer Mehrheitszustimmung oder Kontroverse sortieren.',
       },
       {
         question: 'Was macht die Q&A-Wortwolke anders?',
         answer:
-          'Sie verdichtet sichtbare Fragen zu Wörtern und Phrasen und übernimmt die aktive Sortierlogik. Dadurch zeigt sie nicht nur häufige Begriffe, sondern Themencluster aus unterstützten, robust bewerteten oder kontroversen Fragen.',
+          'Sie verdichtet sichtbare Fragen zu Wörtern und Phrasen und übernimmt die aktive Sortierlogik. Dadurch zeigt sie nicht nur häufige Begriffe, sondern Themengruppen aus unterstützten, klar positiv bewerteten oder kontroversen Fragen.',
       },
       {
         question: 'Für wen ist die Plattform gedacht?',
@@ -450,12 +450,12 @@ const de: Messages = {
   },
   ctaSection: {
     title: 'Bereit für die nächste Live-Session?',
-    lead: 'Teste den Live-Ablauf direkt in der App oder wirf einen Blick auf den offenen Code, die Q&A-Logik, die Word-Cloud-Verarbeitung und die technischen Grundlagen für Bereitstellung und Betrieb.',
+    lead: 'Teste den Live-Ablauf direkt in der App oder wirf einen Blick auf den offenen Code, die Q&A-Logik, die Wortwolken-Verarbeitung und die technischen Grundlagen für Bereitstellung und Betrieb.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Informationen',
     webAppDescription:
-      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Word Cloud und Feedback — barrierefrei nach WCAG 2.2 AA, kostenlos, auf eigener Infrastruktur betreibbar und ohne Account startklar.',
+      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Wortwolke und Rückmeldung — barrierefrei nach WCAG 2.2 AA, kostenlos, auf eigener Infrastruktur betreibbar und ohne Account startklar.',
     featureList: [
       'Live-Quiz und Abstimmungen',
       'Selbsteinschätzung bei bewertbaren Fragen',
@@ -463,11 +463,11 @@ const de: Messages = {
       'Numerische Schätzfragen mit zwei Runden und Statistik',
       'Q&A-Fragenwand mit Moderation, Zustimmungs- und Ablehnungsstimmen',
       'Warteraum, Presenter, QR/Code',
-      'Fragetypen MC/SC/Kurzantwort/Freitext/Umfrage/Rating/Schätzfrage',
+      'Fragetypen MC/SC/Kurzantwort/Freitext/Umfrage/Bewertungsskala/Schätzfrage',
       'Markdown und KaTeX',
       'Lesephase und Peer Instruction',
-      'Q&A- und Freitext-Word-Cloud mit Phrasen und Gewichtung',
-      'Sortierung nach Unterstützung, belastbarer Zustimmung und Kontroverse',
+      'Q&A- und Freitext-Wortwolke mit Phrasen und Gewichtung',
+      'Sortierung nach Unterstützung, klarer Mehrheitszustimmung und Kontroverse',
       'Team-Modus und Voreinstellungen',
       'Rangliste, Serie, Bonus-Code',
       'Import/Export und Yjs-Synchronisation',
@@ -475,7 +475,7 @@ const de: Messages = {
       'UI in fünf Sprachen',
       'Barrierefreiheit nach WCAG 2.2 AA',
       'Docker-Betrieb auf eigener Infrastruktur und Admin-Protokollierung',
-      'Lokal gehaltene Quiz-Inhalte und DSGVO-orientierter Betrieb',
+      'Lokal gehaltene Quiz-Inhalte und Betrieb mit Ausrichtung auf die DSGVO',
     ],
   },
 };

--- a/apps/landing/src/i18n/de.ts
+++ b/apps/landing/src/i18n/de.ts
@@ -1,0 +1,480 @@
+import type { Messages } from './types';
+
+const de: Messages = {
+  meta: {
+    homeTitle: 'arsnova.eu | Live-Quiz, Schätzfragen und Q&A-Fragenwand',
+    homeDescription:
+      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Word Cloud und Feedback — barrierefrei nach WCAG 2.2 AA, kostenlos, self-hostbar und ohne Account startklar.',
+    siteNameInfo: 'arsnova.eu – Informationen',
+    ogLocale: 'de_DE',
+  },
+  nav: {
+    ariaLabel: 'Hauptnavigation',
+    workflow: 'Ablauf',
+    estimate: 'Schätzfrage',
+    qa: 'Q&A',
+    qaMobile: 'Q&A-Fragenwand',
+    features: 'Vorteile',
+    accessibility: 'Barrierefreiheit',
+    trust: 'Vertrauen',
+    faq: 'FAQ',
+    tryNow: 'Jetzt ausprobieren',
+    menuOpen: 'Menü öffnen',
+    menuClose: 'Menü schließen',
+    menu: 'Menü',
+    skipToContent: 'Zum Inhalt springen',
+  },
+  languageSwitcher: {
+    label: 'Sprache',
+    currentLanguage: 'Deutsch',
+    chooseLanguage: 'Sprache wählen',
+  },
+  footer: {
+    impressum: 'Impressum',
+    privacy: 'Datenschutz',
+    accessibility: 'Barrierefreiheit',
+  },
+  cta: {
+    appOpen: 'App öffnen',
+    quizCreate: 'Quiz erstellen',
+    backToApp: 'Zurück zu arsnova.eu',
+    tryLive: 'Jetzt live ausprobieren',
+    howItWorks: 'So funktioniert’s',
+    viewOpenSource: 'Open Source ansehen',
+  },
+  hero: {
+    eyebrow: 'Audience Response für Bildung und Organisationen',
+    titleLine1: 'Quizzen, schätzen,',
+    titleLine2: 'Fragen moderieren',
+    titleAccent1: 'live und kostenlos',
+    titleAccent2: ' ohne Account.',
+    lead: 'arsnova.eu bündelt Live-Quiz, numerische Schätzfragen, Selbsteinschätzung bei bewertbaren Fragen, Q&A-Fragenwand, Word-Cloud-Analyse und Blitzlicht-Feedback in einer Oberfläche für Schulen, Hochschulen, Weiterbildung, Workshops und Business. Open Source, self-hostbar und für DSGVO-orientierten Betrieb ausgelegt.',
+    a11yLink: 'Barrierefrei nach WCAG 2.2 AA',
+    a11ySuffix: '— Tastatur, Screenreader und individuell anpassbare Bearbeitungszeit.',
+    cards: [
+      { title: 'Sofort live', text: 'Session per Code oder QR teilen' },
+      { title: 'Q&A mit Fragenwand', text: 'Moderation, Voting und Themen-Wortwolke' },
+      {
+        title: 'Selbsteinschätzung & Nachbereitung',
+        text: 'Fehlkonzepte erkennen, Ergebnisbericht als PDF',
+      },
+      { title: 'Open Source & self-hostbar', text: 'Docker, Postgres, Redis und Admin-Audit' },
+    ],
+  },
+  estimate: {
+    eyebrow: 'Neu im Live-Quiz',
+    title: 'Zahlen schätzen, diskutieren und die zweite Runde sichtbar vergleichen',
+    lead: 'Die numerische Schätzfrage ist für Jahreszahlen, Größenordnungen, Messwerte und Wahrscheinlichkeiten gemacht. Lehrende legen Referenzwert, erlaubten Eingabebereich und Toleranz fest; Teilnehmende geben nur eine Zahl ab.',
+    summary: [
+      'Plausibilitätsband begrenzt erlaubte Eingaben.',
+      'Toleranzband bewertet fachlich akzeptierte Schätzungen.',
+      'Vor der Freigabe sieht niemand die Verteilung.',
+      'Runde 1 und Runde 2 werden nach der Diskussion verglichen.',
+    ],
+    docsLink: 'Fachliche Doku zur Schätzfrage öffnen',
+    demoAria: 'Beispielauswertung einer Schätzfrage zur Französischen Revolution',
+    hostView: 'Host-Ansicht nach Freigabe',
+    demoQuestion: 'Wann begann die Französische Revolution?',
+    reference: 'Referenz 1789',
+    toleranceBand: 'Toleranzband',
+    toleranceValue: '1700 bis 1900',
+    plausibilityBand: 'Plausibilitätsband',
+    plausibilityValue: '1500 bis 2000',
+    histogramNote:
+      'Histogramm, Referenzlinie und Toleranzband erscheinen erst nach Ergebnisfreigabe. Vorher bleibt nur der neutrale Fortschritt sichtbar.',
+    median: 'Median',
+    inBand: 'im Band',
+    round2: 'Runde 2',
+    round2Value: '14 näher',
+  },
+  confidence: {
+    eyebrow: 'Didaktische Auswertung',
+    title: 'Richtig oder falsch — und wie sicher?',
+    lead: 'Mit der Selbsteinschätzung erfassen Teilnehmende nach ihrer Antwort, wie sicher sie sind (1–5). Du erkennst nicht nur Trefferquote, sondern auch selbstsicher falsche Antworten — ein starker Hebel für formative Auswertung, gezielte Nachbesprechung und den Ergebnisbericht (PDF) nach Session-Ende.',
+    summary: [
+      'Kein eigener Fragetyp — optional an bewertbaren Quizfragen.',
+      'Skala 1–5 nach der Antwort, ohne Einfluss auf Punkte.',
+      'Host sieht nach Freigabe Korrektheit × Antwortsicherheit.',
+      'Selbstsicher falsch markiert mögliche Fehlkonzepte.',
+      'Nach Session-Ende: Ergebnisbericht (PDF) und Nachbesprechung.',
+    ],
+    docsConfidence: 'Doku Selbsteinschätzung',
+    docsExport: 'Doku Ergebnisbericht (PDF)',
+    demoAria: 'Beispielauswertung mit Selbsteinschätzung nach Ergebnisfreigabe',
+    hostView: 'Host-Ansicht nach Freigabe',
+    demoQuestion: 'Welche Struktur ist am stabilsten?',
+    badge: 'Selbsteinschätzung',
+    matrix: [
+      { label: 'Richtig · niedrig', count: 3, tone: 'emerald' },
+      { label: 'Richtig · mitte', count: 8, tone: 'emerald' },
+      { label: 'Richtig · hoch', count: 11, tone: 'emerald' },
+      { label: 'Falsch · niedrig', count: 2, tone: 'slate' },
+      { label: 'Falsch · mitte', count: 4, tone: 'amber' },
+      { label: 'Falsch · hoch', count: 2, tone: 'rose' },
+    ],
+    falseHighTitle: '2 selbstsicher falsche Antworten',
+    falseHighText:
+      'Option B wurde 2× mit hoher Antwortsicherheit gewählt — ein Signal für mögliche Fehlkonzepte in der Nachbesprechung.',
+    consolidated: 'Gefestigt',
+    misconceptionRisk: 'Fehlkonzept-Risiko',
+    fragile: 'Fragil',
+    afterSessionAria: 'Export nach Session-Ende',
+    afterSession: 'Nach Session-Ende',
+    debriefing: 'Nachbesprechung',
+    resultsPdf: 'Ergebnisbericht (PDF)',
+    exportNote:
+      'Druckfertiger Bericht mit Lernstand, Heatmap und Fragentexten — in der Host-Ansicht und auf der Quizkarte. CSV für Excel bleibt unter „Mehr“ verfügbar.',
+  },
+  qaWall: {
+    eyebrow: 'Live-Q&A als Moderationsfläche',
+    title: 'Fragen sammeln, priorisieren und als Themenbild lesen',
+    lead: 'Die Fragenwand ist kein Nebenchat. Sie ist ein eigener Live-Kanal für Lehrende und Vortragende: Beiträge moderieren, kollektive Prioritäten erkennen, kontroverse Punkte sichtbar machen und die wichtigsten Themen über eine gewichtete Q&A-Wortwolke in den Raum holen.',
+    signals: [
+      {
+        label: 'Vorab-Moderation',
+        text: 'Fragen erst freigeben, wenn sie in den didaktischen Moment passen.',
+      },
+      {
+        label: 'Kollektives Voting',
+        text: 'Up- und Downvotes zeigen Priorität, Reibung und Klärungsbedarf.',
+      },
+      {
+        label: 'Themen-Wortwolke',
+        text: 'Wörter und Phrasen werden nach Unterstützung, Zustimmung oder Kontroverse gewichtet.',
+      },
+      {
+        label: 'Kompass-Ausblick',
+        text: 'Deterministische Signale kommen zuerst; Q&A-NLP und Zusammenfassung bleiben optionale Ausbaustufen.',
+      },
+    ],
+    docsLink: 'Q&A-Scoring und Kontroversität auf GitHub öffnen',
+    demoAria: 'Beispiel einer Q&A-Fragenwand mit Moderation, Voting und Wortwolke',
+    hostView: 'Host-Ansicht Q&A',
+    demoTitle: 'Fragen zur Veranstaltung',
+    moderationActive: 'Vorab-Moderation aktiv',
+    sortMostSupported: 'Meist unterstützt',
+    sortBest: 'Beste Fragen',
+    sortControversial: 'Umstritten',
+    questions: [
+      {
+        score: '+18',
+        title: 'Wann ist eine Schätzung fachlich noch plausibel?',
+        meta: '15 positiv · 3 negativ · beste Frage',
+      },
+      {
+        score: '+4',
+        title: 'Sollten wir Ergebnisse vor der Diskussion wirklich ausblenden?',
+        meta: '9 positiv · 5 negativ · umstritten',
+      },
+      {
+        score: '+11',
+        title: 'Wie unterscheidet sich Q&A von Freitext im Quiz?',
+        meta: '11 positiv · 0 negativ · meist unterstützt',
+      },
+    ],
+    wordCloud: 'Q&A-Wortwolke',
+    wordCloudHint: 'Gewichtet nach positiver Resonanz und Kontroverse.',
+    frozenLive: 'Live eingefroren',
+    terms: [
+      { label: 'Toleranzband', className: 'text-3xl text-brand-200' },
+      { label: 'Diskussion', className: 'text-2xl text-emerald-200' },
+      { label: 'Q&A', className: 'text-4xl text-white' },
+      { label: 'Plausibilität', className: 'text-xl text-amber-200' },
+      { label: 'Kontroverse', className: 'text-2xl text-rose-200' },
+      { label: 'Peer Instruction', className: 'text-lg text-slate-300' },
+      { label: 'Moderation', className: 'text-3xl text-cyan-200' },
+      { label: 'Klärungsbedarf', className: 'text-xl text-violet-200' },
+    ],
+    nextStep:
+      'Nächster Schritt: deterministischer Moderationskompass, optional ergänzt durch asynchrone Q&A-NLP-Signale und quellengebundene Zusammenfassungen.',
+  },
+  workflow: {
+    eyebrow: 'Für Unterricht, Training und Workshops',
+    title: 'In wenigen Minuten von der Idee zur Live-Session',
+    lead: 'Von der Frage bis zur laufenden Session führt der Ablauf bewusst ohne unnötige Zwischenschritte. Genau das macht den Einstieg für Lehrende, Trainer:innen und Moderator:innen schnell und verlässlich.',
+    stepLabel: 'Schritt',
+    steps: [
+      {
+        number: '01',
+        title: 'Quiz vorbereiten',
+        description:
+          'Fragen direkt erstellen oder vorhandene Inhalte importieren. Markdown, KaTeX, Kurzantwort und numerische Schätzfragen sind direkt eingebaut.',
+      },
+      {
+        number: '02',
+        title: 'Session starten',
+        description:
+          'Ohne Konto loslegen: Session öffnen, Stil wählen, Code oder QR teilen und bei Bedarf Presenter-Ansicht nutzen.',
+      },
+      {
+        number: '03',
+        title: 'Live moderieren',
+        description:
+          'Teilnehmende stimmen ab, stellen Fragen und priorisieren gemeinsam. Host und Presenter zeigen Quiz, Q&A-Fragenwand, Wortwolke, Lesephase, Countdown, zweite Runde und Ergebnisansicht in einem Flow.',
+      },
+      {
+        number: '04',
+        title: 'Nachbereiten und exportieren',
+        description:
+          'Nach Session-Ende steht der Ergebnisbericht (PDF) bereit — mit Lernstand, Selbsteinschätzung und vollständigen Fragentexten. In der Quiz-Sammlung findest du Nachbesprechung und PDF für den letzten Durchlauf; CSV für Excel unter „Mehr“.',
+      },
+    ],
+  },
+  features: {
+    eyebrow: 'Warum es sich anders anfühlt',
+    title: 'Gebaut für Live-Interaktion statt nur für Abstimmungsfolien',
+    lead: 'arsnova.eu verbindet schnellen Einstieg, didaktische Stärke und einen transparenten technischen Unterbau. So bleibt die Plattform im Alltag einfach, ohne in den Möglichkeiten klein zu werden.',
+    items: [
+      {
+        title: 'Schnell im Einsatz',
+        description:
+          'Hosts starten ohne Account. Teilnehmende kommen per 6-stelligem Code oder QR direkt in die Session.',
+        icon: 'single',
+      },
+      {
+        title: 'Selbsteinschätzung im Live-Quiz',
+        description:
+          'Teilnehmende geben nach der Antwort an, wie sicher sie sind. Du erkennst selbstsicher falsche Antworten, priorisierst die Nachbesprechung und exportierst den Lernstand im Ergebnisbericht (PDF).',
+        icon: 'confidence',
+      },
+      {
+        title: 'Ergebnisbericht für die Nachbereitung',
+        description:
+          'Nach Session-Ende exportierst du einen druckfertigen PDF-Bericht mit Diagrammen, Fragentexten und Selbsteinschätzung. CSV für Excel bleibt optional unter „Mehr“.',
+        icon: 'export',
+      },
+      {
+        title: 'Didaktische Schätzfragen',
+        description:
+          'Jahreszahlen, Größenordnungen und Messwerte lassen sich mit Referenzwert, Toleranzband, Statistik und optionaler zweiter Runde schätzen.',
+        icon: 'estimate',
+      },
+      {
+        title: 'Mehr als ein Standard-Quiz',
+        description:
+          'MC/SC, Kurzantwort, Rating, Lesephase, Peer Instruction und Presenter-Flow unterstützen Lernen, Training und Live-Moderation.',
+        icon: 'toggle',
+      },
+      {
+        title: 'Fragenwand statt Nebenchat',
+        description:
+          'Q&A bietet Vorab-Moderation, Anheften, Archivieren, Up-/Downvoting sowie Sortierung nach Unterstützung, Qualität und Kontroverse.',
+        icon: 'qa',
+      },
+      {
+        title: 'Elaborierte Word Cloud',
+        description:
+          'Freitext und Q&A werden als Wörter und Phrasen verdichtet; die Fragenwand gewichtet nach Zustimmung, belastbarem Score oder Kontroverse.',
+        icon: 'cloud',
+      },
+      {
+        title: 'Für unterschiedliche Settings',
+        description:
+          'Presets, Team-Modus, anonymer Modus, Nicknames und Stilwahl helfen von Klasse und Seminar bis Workshop, Event und Meeting.',
+        icon: 'bolt',
+      },
+      {
+        title: 'Barrierefreiheit nach WCAG 2.2 AA',
+        description:
+          'Tastaturbedienung, Screenreader-Statusmeldungen, individuell anpassbare Bearbeitungszeit und PDF/UA-1-validierte Ergebnisberichte — damit mehr Lernende selbstständig an Live-Sessions teilnehmen können.',
+        icon: 'a11y',
+      },
+      {
+        title: 'Datenschutz und Kontrolle',
+        description:
+          'Local-first, Data-Stripping und self-hostbarer Betrieb geben dir mehr Kontrolle über Inhalte und Live-Daten.',
+        icon: 'tools',
+      },
+      {
+        title: 'Open Source mit Betriebspfad',
+        description:
+          'Docker, Postgres, Redis und Admin-Audit machen die Plattform auch für Hosting, Betrieb und Nachvollziehbarkeit belastbar.',
+        icon: 'server',
+      },
+    ],
+  },
+  accessibility: {
+    eyebrow: 'Barrierefreiheit',
+    title: 'WCAG 2.2 AA — damit mehr Lernende selbstständig teilnehmen können',
+    lead: 'Für Schulen, Hochschulen und Weiterbildung ist Barrierefreiheit oft ein entscheidendes Kriterium. arsnova.eu erfüllt die Web Content Accessibility Guidelines (WCAG) 2.2 auf Konformitätsstufe AA — mit Tastaturbedienung, Screenreader-Unterstützung, individuell anpassbarer Bearbeitungszeit und barrierefrei strukturierten PDF-Ergebnisberichten.',
+    benefits: [
+      {
+        title: 'Bedienung mit Tastatur',
+        description:
+          'Du und deine Teilnehmenden bedienen die zentralen Abläufe ohne Maus. Sichtbare Fokusmarkierungen und ein Sprunglink zum Inhalt erleichtern die Navigation.',
+      },
+      {
+        title: 'Screenreader-Unterstützung im Live-Betrieb',
+        description:
+          'Statusänderungen beim Beitritt zur Session, bei Abstimmungen und Phasenwechseln werden für Screenreader ausgegeben, sodass Nutzer:innen den Ablauf nachvollziehen können.',
+      },
+      {
+        title: 'Individuell anpassbare Bearbeitungszeit',
+        description:
+          'Bei zeitlich begrenzten Fragen wählst du die Standardzeit, die zehnfache Bearbeitungszeit oder eine Teilnahme ohne Zeitlimit. So lässt sich ein Nachteilsausgleich direkt in der Live-Session umsetzen.',
+      },
+      {
+        title: 'Barrierefrei strukturierter Ergebnisbericht',
+        description:
+          'Der druckfertige Bericht ist PDF/UA-1-validiert und enthält Dokumenttitel, Sprache und Tags — für die Nachbereitung und barrierefreie Weitergabe.',
+      },
+    ],
+    statementLink: 'Erklärung zur Barrierefreiheit öffnen',
+  },
+  trust: {
+    eyebrow: 'Vertrauen',
+    title: 'Glaubwürdig, weil das Produkt nicht bei null anfängt',
+    lead: 'arsnova.eu steht in der Tradition des ARSnova-Ökosystems und knüpft an wissenschaftliche, didaktische und praktische Erfahrungen aus vielen Jahren Bildungstechnologie an.',
+    proofItems: [
+      { value: 'Seit 2012', label: 'ARSnova-Tradition in Bildung und EdTech' },
+      { value: 'WCAG 2.2 AA', label: 'Geprüfte Barrierefreiheit für Lehre und Institutionen' },
+      {
+        value: '5 UI-Sprachen',
+        label: 'Deutsch, Englisch, Französisch, Spanisch, Italienisch',
+      },
+      { value: 'Open Source', label: 'Transparenter Code statt Black Box' },
+    ],
+    items: [
+      {
+        quote: 'Datenschutzkonformer Weg: keine personenbezogenen Daten dauerhaft auf dem Server.',
+        source: 'DeLFI 2017',
+        tag: 'Wissenschaft',
+      },
+      {
+        quote:
+          'UX-Evaluation im direkten Vergleich mit Kahoot! als empirischer Prüfpunkt des Designs.',
+        source: 'fnm-austria',
+        tag: 'Studie',
+      },
+      {
+        quote:
+          'Privacy-by-Design und technische Offenheit sind ein echter Differenzierungsfaktor für europäische EdTech-Kontexte.',
+        source: 'Publikationsanalyse',
+        tag: 'Architektur',
+      },
+      {
+        quote: 'In realen Bildungssettings praktisch erprobt, nicht nur als Konzept beschrieben.',
+        source: 'Nutzung in Lehr- und Trainingskontexten',
+        tag: 'Praxis',
+      },
+    ],
+    referencesPrefix:
+      'Vollständige Referenzen und die zugrundeliegende Publikationssammlung liegen in',
+    referencesLink: 'ARSnova-Recherche.pdf',
+    referencesSuffix: 'auf GitHub.',
+  },
+  comparison: {
+    eyebrow: 'Abgrenzung',
+    title: 'Nicht nur ein Ersatz für Mentimeter oder Kahoot',
+    lead: 'Im Mittelpunkt steht nicht nur Abstimmung, sondern der komplette Live-Flow: vorbereiten, moderieren, Ergebnisse sichtbar machen und dabei die Kontrolle über Inhalte und Betrieb behalten.',
+    points: [
+      {
+        title: 'Weniger Einstiegshürden',
+        description:
+          'Keine getrennte Produktlogik für „Erstellen“ und „Beitreten“. Hosts starten ohne Account, Teilnehmende kommen per Code oder QR in die Session.',
+      },
+      {
+        title: 'Mehr Interaktionsformate',
+        description:
+          'Neben Quiz auch numerische Schätzfragen, Lesephase, Peer Instruction, Blitzlicht, Q&A-Fragenwand und gewichtete Word Cloud in derselben Plattform statt nur Folien-Abstimmungen.',
+      },
+      {
+        title: 'Mehr Kontrolle über Daten und Zugang',
+        description:
+          'Open Source, self-hostbar und local-first konzipiert — plus Barrierefreiheit nach WCAG 2.2 AA. Relevant für Schulen, Hochschulen und Organisationen mit Datenschutz- und Inklusionsanforderungen.',
+      },
+    ],
+    comparePrefix: 'Den vollständigen Featurevergleich findest du weiterhin in der Doku:',
+    compareLink: 'Vergleich auf GitHub öffnen',
+  },
+  faq: {
+    eyebrow: 'FAQ',
+    title: 'Häufige Fragen vor dem ersten Einsatz',
+    answerLabel: 'Antwort',
+    items: [
+      {
+        question: 'Brauchen Hosts oder Teilnehmende einen Account?',
+        answer:
+          'Nein. Eine Session kann ohne Konto gestartet werden. Teilnehmende treten per Code oder QR bei.',
+      },
+      {
+        question: 'Wo liegen die Daten?',
+        answer:
+          'Quiz-Inhalte sind local-first konzipiert. Für Live-Sessions werden nur die technisch nötigen Sitzungsdaten verarbeitet; bei Self-Hosting liegt der Betrieb in deiner eigenen Infrastruktur.',
+      },
+      {
+        question: 'Kann ich arsnova.eu selbst hosten?',
+        answer:
+          'Ja. Die Plattform ist Open Source und für den Betrieb mit Docker, PostgreSQL und Redis ausgelegt.',
+      },
+      {
+        question: 'Was ist die Selbsteinschätzung im Quiz?',
+        answer:
+          'Eine optionale Zusatzabfrage nach bewertbaren Fragen: Teilnehmende geben auf einer Skala von 1–5 an, wie sicher sie bei ihrer Antwort sind. Punkte bleiben unverändert; in der Host-Auswertung siehst du Korrektheit × Antwortsicherheit und markierst selbstsicher falsche Antworten als Fehlkonzept-Signal. Nach Session-Ende fließt der Lernstand in Nachbesprechung und Ergebnisbericht (PDF) ein.',
+      },
+      {
+        question: 'Kann ich Session-Ergebnisse exportieren?',
+        answer:
+          'Ja. Nach Session-Ende steht der Ergebnisbericht (PDF) als primäres Format bereit — inklusive Selbsteinschätzung, Prioritäten für die Nachbesprechung und vollständiger Fragentexte. In der Quiz-Sammlung findest du Nachbesprechung und PDF für den letzten Durchlauf. Tabellarische CSV-Daten sind unter „Mehr“ für Excel verfügbar.',
+      },
+      {
+        question: 'Was ist an der numerischen Schätzfrage besonders?',
+        answer:
+          'Sie trennt erlaubte Eingaben vom fachlichen Toleranzband, zeigt während der Abstimmung keine Verteilung und kann nach einer Diskussion eine zweite Runde mit Statistik und Rundenvergleich auswerten.',
+      },
+      {
+        question: 'Was kann die Q&A-Fragenwand?',
+        answer:
+          'Teilnehmende reichen Fragen ein und gewichten sie mit Up- und Downvotes. Hosts können vorab moderieren, Fragen anheften, archivieren oder entfernen und die Liste nach Unterstützung, belastbarer Zustimmung oder Kontroverse sortieren.',
+      },
+      {
+        question: 'Was macht die Q&A-Wortwolke anders?',
+        answer:
+          'Sie verdichtet sichtbare Fragen zu Wörtern und Phrasen und übernimmt die aktive Sortierlogik. Dadurch zeigt sie nicht nur häufige Begriffe, sondern Themencluster aus unterstützten, robust bewerteten oder kontroversen Fragen.',
+      },
+      {
+        question: 'Für wen ist die Plattform gedacht?',
+        answer:
+          'Für Live-Interaktion in Bildung und Organisationen: Schule, Hochschule, Weiterbildung, Training, Workshop, Event oder Meeting.',
+      },
+      {
+        question: 'Ist arsnova.eu barrierefrei?',
+        answer:
+          'arsnova.eu erfüllt WCAG 2.2 AA. Zentrale Abläufe sind per Tastatur bedienbar, Screenreader geben Statusänderungen aus, bei zeitlich begrenzten Fragen ist die Bearbeitungszeit individuell anpassbar (Standardzeit, zehnfache Bearbeitungszeit oder ohne Zeitlimit), und der barrierefrei strukturierte Ergebnisbericht ist PDF/UA-1-validiert.',
+        linkLabel: 'Erklärung zur Barrierefreiheit öffnen',
+      },
+    ],
+  },
+  ctaSection: {
+    title: 'Bereit für die nächste Live-Session?',
+    lead: 'Teste den Live-Flow direkt in der App oder wirf einen Blick auf den offenen Code, die Q&A-Logik, die Word-Cloud-Pipeline und den Betriebspfad hinter der Plattform.',
+  },
+  jsonLd: {
+    websiteName: 'arsnova.eu – Informationen',
+    webAppDescription:
+      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Word Cloud und Feedback — barrierefrei nach WCAG 2.2 AA, kostenlos, self-hostbar und ohne Account startklar.',
+    featureList: [
+      'Live-Quiz und Abstimmungen',
+      'Selbsteinschätzung bei bewertbaren Fragen',
+      'Ergebnisbericht (PDF) und Nachbesprechung nach Session-Ende',
+      'Numerische Schätzfragen mit zwei Runden und Statistik',
+      'Q&A-Fragenwand mit Moderation, Up- und Downvoting',
+      'Lobby, Presenter, QR/Code',
+      'Fragetypen MC/SC/Kurzantwort/Freitext/Umfrage/Rating/Schätzfrage',
+      'Markdown und KaTeX',
+      'Lesephase und Peer Instruction',
+      'Q&A- und Freitext-Word-Cloud mit Phrasen und Gewichtung',
+      'Sortierung nach Unterstützung, belastbarer Zustimmung und Kontroverse',
+      'Team-Modus und Presets',
+      'Leaderboard, Streak, Bonus-Code',
+      'Import/Export und Yjs-Sync',
+      'KI-Import extern, Zod-validiert',
+      'UI in fünf Sprachen',
+      'Barrierefreiheit nach WCAG 2.2 AA',
+      'Docker Self-Host und Admin-Audit',
+      'Local-First und DSGVO-orientierter Betrieb',
+    ],
+  },
+};
+
+export default de;

--- a/apps/landing/src/i18n/de.ts
+++ b/apps/landing/src/i18n/de.ts
@@ -85,7 +85,7 @@ const de: Messages = {
     median: 'Median',
     inBand: 'im Band',
     round2: 'Runde 2',
-    round2Value: '14 näher',
+    round2Value: '14 Antworten näher am Referenzwert',
   },
   confidence: {
     eyebrow: 'Didaktische Auswertung',
@@ -105,12 +105,12 @@ const de: Messages = {
     demoQuestion: 'Welche Struktur ist am stabilsten?',
     badge: 'Selbsteinschätzung',
     matrix: [
-      { label: 'Richtig · niedrig', count: 3, tone: 'emerald' },
-      { label: 'Richtig · mitte', count: 8, tone: 'emerald' },
-      { label: 'Richtig · hoch', count: 11, tone: 'emerald' },
-      { label: 'Falsch · niedrig', count: 2, tone: 'slate' },
-      { label: 'Falsch · mitte', count: 4, tone: 'amber' },
-      { label: 'Falsch · hoch', count: 2, tone: 'rose' },
+      { label: 'Richtig · geringe Sicherheit', count: 3, tone: 'emerald' },
+      { label: 'Richtig · mittlere Sicherheit', count: 8, tone: 'emerald' },
+      { label: 'Richtig · hohe Sicherheit', count: 11, tone: 'emerald' },
+      { label: 'Falsch · geringe Sicherheit', count: 2, tone: 'slate' },
+      { label: 'Falsch · mittlere Sicherheit', count: 4, tone: 'amber' },
+      { label: 'Falsch · hohe Sicherheit', count: 2, tone: 'rose' },
     ],
     falseHighTitle: '2 selbstsicher falsche Antworten',
     falseHighText:
@@ -282,11 +282,11 @@ const de: Messages = {
       {
         title: 'Datenschutz und Kontrolle',
         description:
-          'Local-first, Data-Stripping und self-hostbarer Betrieb geben dir mehr Kontrolle über Inhalte und Live-Daten.',
+          'Local-first, optionale Datenbereinigung und self-hostbarer Betrieb geben dir mehr Kontrolle über Inhalte und Live-Daten.',
         icon: 'tools',
       },
       {
-        title: 'Open Source mit Betriebspfad',
+        title: 'Open Source mit Deployment und Betrieb',
         description:
           'Docker, Postgres, Redis und Admin-Audit machen die Plattform auch für Hosting, Betrieb und Nachvollziehbarkeit belastbar.',
         icon: 'server',
@@ -447,7 +447,7 @@ const de: Messages = {
   },
   ctaSection: {
     title: 'Bereit für die nächste Live-Session?',
-    lead: 'Teste den Live-Flow direkt in der App oder wirf einen Blick auf den offenen Code, die Q&A-Logik, die Word-Cloud-Pipeline und den Betriebspfad hinter der Plattform.',
+    lead: 'Teste den Live-Flow direkt in der App oder wirf einen Blick auf den offenen Code, die Q&A-Logik, die Word-Cloud-Verarbeitung und den Deployment- und Betriebspfad hinter der Plattform.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Informationen',

--- a/apps/landing/src/i18n/de.ts
+++ b/apps/landing/src/i18n/de.ts
@@ -4,7 +4,7 @@ const de: Messages = {
   meta: {
     homeTitle: 'arsnova.eu | Live-Quiz, Schätzfragen und Q&A-Fragenwand',
     homeDescription:
-      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Word Cloud und Feedback — barrierefrei nach WCAG 2.2 AA, kostenlos, self-hostbar und ohne Account startklar.',
+      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Word Cloud und Feedback — barrierefrei nach WCAG 2.2 AA, kostenlos, auf eigener Infrastruktur betreibbar und ohne Account startklar.',
     siteNameInfo: 'arsnova.eu – Informationen',
     ogLocale: 'de_DE',
   },
@@ -48,17 +48,20 @@ const de: Messages = {
     titleLine2: 'Fragen moderieren',
     titleAccent1: 'live und kostenlos',
     titleAccent2: ' ohne Account.',
-    lead: 'arsnova.eu bündelt Live-Quiz, numerische Schätzfragen, Selbsteinschätzung bei bewertbaren Fragen, Q&A-Fragenwand, Word-Cloud-Analyse und Blitzlicht-Feedback in einer Oberfläche für Schulen, Hochschulen, Weiterbildung, Workshops und Business. Open Source, self-hostbar und für DSGVO-orientierten Betrieb ausgelegt.',
+    lead: 'arsnova.eu bündelt Live-Quiz, numerische Schätzfragen, Selbsteinschätzung bei bewertbaren Fragen, Q&A-Fragenwand, Word-Cloud-Analyse und Blitzlicht-Feedback in einer Oberfläche für Schulen, Hochschulen, Weiterbildung, Workshops und Unternehmen. Open Source, auf eigener Infrastruktur betreibbar und für DSGVO-orientierten Betrieb ausgelegt.',
     a11yLink: 'Barrierefrei nach WCAG 2.2 AA',
     a11ySuffix: '— Tastatur, Screenreader und individuell anpassbare Bearbeitungszeit.',
     cards: [
       { title: 'Sofort live', text: 'Session per Code oder QR teilen' },
-      { title: 'Q&A mit Fragenwand', text: 'Moderation, Voting und Themen-Wortwolke' },
+      { title: 'Q&A mit Fragenwand', text: 'Moderation, Abstimmung und Themen-Wortwolke' },
       {
         title: 'Selbsteinschätzung & Nachbereitung',
         text: 'Fehlkonzepte erkennen, Ergebnisbericht als PDF',
       },
-      { title: 'Open Source & self-hostbar', text: 'Docker, Postgres, Redis und Admin-Audit' },
+      {
+        title: 'Open Source & selbst betreibbar',
+        text: 'Docker, Postgres, Redis und Admin-Protokollierung',
+      },
     ],
   },
   estimate: {
@@ -90,12 +93,12 @@ const de: Messages = {
   confidence: {
     eyebrow: 'Didaktische Auswertung',
     title: 'Richtig oder falsch — und wie sicher?',
-    lead: 'Mit der Selbsteinschätzung erfassen Teilnehmende nach ihrer Antwort, wie sicher sie sind (1–5). Du erkennst nicht nur Trefferquote, sondern auch selbstsicher falsche Antworten — ein starker Hebel für formative Auswertung, gezielte Nachbesprechung und den Ergebnisbericht (PDF) nach Session-Ende.',
+    lead: 'Mit der Selbsteinschätzung erfassen Teilnehmende nach ihrer Antwort, wie sicher sie sind (1–5). Du erkennst nicht nur Trefferquote, sondern auch selbstsicher falsche Antworten — ein hilfreiches Instrument für formative Auswertung, gezielte Nachbesprechung und den Ergebnisbericht (PDF) nach Session-Ende.',
     summary: [
       'Kein eigener Fragetyp — optional an bewertbaren Quizfragen.',
       'Skala 1–5 nach der Antwort, ohne Einfluss auf Punkte.',
       'Host sieht nach Freigabe Korrektheit × Antwortsicherheit.',
-      'Selbstsicher falsch markiert mögliche Fehlkonzepte.',
+      'Falsche Antworten mit hoher Antwortsicherheit weisen auf mögliche Fehlkonzepte hin.',
       'Nach Session-Ende: Ergebnisbericht (PDF) und Nachbesprechung.',
     ],
     docsConfidence: 'Doku Selbsteinschätzung',
@@ -123,32 +126,32 @@ const de: Messages = {
     debriefing: 'Nachbesprechung',
     resultsPdf: 'Ergebnisbericht (PDF)',
     exportNote:
-      'Druckfertiger Bericht mit Lernstand, Heatmap und Fragentexten — in der Host-Ansicht und auf der Quizkarte. CSV für Excel bleibt unter „Mehr“ verfügbar.',
+      'Druckfertiger Bericht mit Lernstand, farbcodierter Übersicht und Fragentexten — in der Host-Ansicht und auf der Quizkarte. CSV für Excel bleibt unter „Mehr“ verfügbar.',
   },
   qaWall: {
-    eyebrow: 'Live-Q&A als Moderationsfläche',
+    eyebrow: 'Live-Q&A als Moderationsraum',
     title: 'Fragen sammeln, priorisieren und als Themenbild lesen',
-    lead: 'Die Fragenwand ist kein Nebenchat. Sie ist ein eigener Live-Kanal für Lehrende und Vortragende: Beiträge moderieren, kollektive Prioritäten erkennen, kontroverse Punkte sichtbar machen und die wichtigsten Themen über eine gewichtete Q&A-Wortwolke in den Raum holen.',
+    lead: 'Die Fragenwand ist kein Chat am Rande. Sie ist ein eigener Live-Kanal für Lehrende und Vortragende: Beiträge moderieren, kollektive Prioritäten erkennen, kontroverse Punkte sichtbar machen und die wichtigsten Themen über eine gewichtete Q&A-Wortwolke in den Raum holen.',
     signals: [
       {
         label: 'Vorab-Moderation',
         text: 'Fragen erst freigeben, wenn sie in den didaktischen Moment passen.',
       },
       {
-        label: 'Kollektives Voting',
-        text: 'Up- und Downvotes zeigen Priorität, Reibung und Klärungsbedarf.',
+        label: 'Gemeinsames Abstimmen',
+        text: 'Zustimmungs- und Ablehnungsstimmen zeigen Priorität, Reibung und Klärungsbedarf.',
       },
       {
         label: 'Themen-Wortwolke',
         text: 'Wörter und Phrasen werden nach Unterstützung, Zustimmung oder Kontroverse gewichtet.',
       },
       {
-        label: 'Kompass-Ausblick',
-        text: 'Deterministische Signale kommen zuerst; Q&A-NLP und Zusammenfassung bleiben optionale Ausbaustufen.',
+        label: 'Als Nächstes: Moderationskompass',
+        text: 'Deterministische Signale kommen zuerst; optionale sprachliche Auswertung und Zusammenfassung bleiben Ausbaustufen.',
       },
     ],
-    docsLink: 'Q&A-Scoring und Kontroversität auf GitHub öffnen',
-    demoAria: 'Beispiel einer Q&A-Fragenwand mit Moderation, Voting und Wortwolke',
+    docsLink: 'Q&A-Bewertung und Kontroversität auf GitHub öffnen',
+    demoAria: 'Beispiel einer Q&A-Fragenwand mit Moderation, Abstimmung und Wortwolke',
     hostView: 'Host-Ansicht Q&A',
     demoTitle: 'Fragen zur Veranstaltung',
     moderationActive: 'Vorab-Moderation aktiv',
@@ -174,7 +177,7 @@ const de: Messages = {
     ],
     wordCloud: 'Q&A-Wortwolke',
     wordCloudHint: 'Gewichtet nach positiver Resonanz und Kontroverse.',
-    frozenLive: 'Live eingefroren',
+    frozenLive: 'Live-Aktualisierung pausiert',
     terms: [
       { label: 'Toleranzband', className: 'text-3xl text-brand-200' },
       { label: 'Diskussion', className: 'text-2xl text-emerald-200' },
@@ -186,7 +189,7 @@ const de: Messages = {
       { label: 'Klärungsbedarf', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Nächster Schritt: deterministischer Moderationskompass, optional ergänzt durch asynchrone Q&A-NLP-Signale und quellengebundene Zusammenfassungen.',
+      'Nächster Schritt: ein deterministischer Moderationskompass, optional ergänzt durch asynchrone sprachliche Auswertung und quellengebundene Zusammenfassungen.',
   },
   workflow: {
     eyebrow: 'Für Unterricht, Training und Workshops',
@@ -210,7 +213,7 @@ const de: Messages = {
         number: '03',
         title: 'Live moderieren',
         description:
-          'Teilnehmende stimmen ab, stellen Fragen und priorisieren gemeinsam. Host und Presenter zeigen Quiz, Q&A-Fragenwand, Wortwolke, Lesephase, Countdown, zweite Runde und Ergebnisansicht in einem Flow.',
+          'Teilnehmende stimmen ab, stellen Fragen und setzen gemeinsam Prioritäten. Host und Presenter zeigen Quiz, Q&A-Fragenwand, Wortwolke, Lesephase, Countdown, zweite Runde und Ergebnisansicht in einem Ablauf.',
       },
       {
         number: '04',
@@ -221,7 +224,7 @@ const de: Messages = {
     ],
   },
   features: {
-    eyebrow: 'Warum es sich anders anfühlt',
+    eyebrow: 'Was arsnova.eu auszeichnet',
     title: 'Gebaut für Live-Interaktion statt nur für Abstimmungsfolien',
     lead: 'arsnova.eu verbindet schnellen Einstieg, didaktische Stärke und einen transparenten technischen Unterbau. So bleibt die Plattform im Alltag einfach, ohne in den Möglichkeiten klein zu werden.',
     items: [
@@ -252,25 +255,25 @@ const de: Messages = {
       {
         title: 'Mehr als ein Standard-Quiz',
         description:
-          'MC/SC, Kurzantwort, Rating, Lesephase, Peer Instruction und Presenter-Flow unterstützen Lernen, Training und Live-Moderation.',
+          'MC/SC, Kurzantwort, Rating, Lesephase, Peer Instruction und Presenter-Ablauf unterstützen Lernen, Training und Live-Moderation.',
         icon: 'toggle',
       },
       {
-        title: 'Fragenwand statt Nebenchat',
+        title: 'Fragenwand statt Chat am Rande',
         description:
-          'Q&A bietet Vorab-Moderation, Anheften, Archivieren, Up-/Downvoting sowie Sortierung nach Unterstützung, Qualität und Kontroverse.',
+          'Q&A bietet Vorab-Moderation, Anheften, Archivieren, Zustimmungs- und Ablehnungsstimmen sowie Sortierung nach Unterstützung, Qualität und Kontroverse.',
         icon: 'qa',
       },
       {
         title: 'Elaborierte Word Cloud',
         description:
-          'Freitext und Q&A werden als Wörter und Phrasen verdichtet; die Fragenwand gewichtet nach Zustimmung, belastbarem Score oder Kontroverse.',
+          'Freitext und Q&A werden als Wörter und Phrasen verdichtet; die Fragenwand gewichtet nach Zustimmung, belastbarer Bewertung oder Kontroverse.',
         icon: 'cloud',
       },
       {
-        title: 'Für unterschiedliche Settings',
+        title: 'Für unterschiedliche Einsatzkontexte',
         description:
-          'Presets, Team-Modus, anonymer Modus, Nicknames und Stilwahl helfen von Klasse und Seminar bis Workshop, Event und Meeting.',
+          'Voreinstellungen, Team-Modus, anonymer Modus, Spitznamen und Stilwahl helfen von Klasse und Seminar bis Workshop, Veranstaltung und Besprechung.',
         icon: 'bolt',
       },
       {
@@ -282,13 +285,13 @@ const de: Messages = {
       {
         title: 'Datenschutz und Kontrolle',
         description:
-          'Local-first, optionale Datenbereinigung und self-hostbarer Betrieb geben dir mehr Kontrolle über Inhalte und Live-Daten.',
+          'Quiz-Inhalte bleiben lokal, optionale Datenbereinigung und Betrieb auf eigener Infrastruktur geben dir mehr Kontrolle über Inhalte und Live-Daten.',
         icon: 'tools',
       },
       {
         title: 'Open Source mit Deployment und Betrieb',
         description:
-          'Docker, Postgres, Redis und Admin-Audit machen die Plattform auch für Hosting, Betrieb und Nachvollziehbarkeit belastbar.',
+          'Docker, Postgres, Redis und Admin-Protokollierung machen die Plattform auch für Bereitstellung, Betrieb und Nachvollziehbarkeit belastbar.',
         icon: 'server',
       },
     ],
@@ -323,7 +326,7 @@ const de: Messages = {
   },
   trust: {
     eyebrow: 'Vertrauen',
-    title: 'Glaubwürdig, weil das Produkt nicht bei null anfängt',
+    title: 'Auf langjähriger Erfahrung aufgebaut',
     lead: 'arsnova.eu steht in der Tradition des ARSnova-Ökosystems und knüpft an wissenschaftliche, didaktische und praktische Erfahrungen aus vielen Jahren Bildungstechnologie an.',
     proofItems: [
       { value: 'Seit 2012', label: 'ARSnova-Tradition in Bildung und EdTech' },
@@ -332,7 +335,7 @@ const de: Messages = {
         value: '5 UI-Sprachen',
         label: 'Deutsch, Englisch, Französisch, Spanisch, Italienisch',
       },
-      { value: 'Open Source', label: 'Transparenter Code statt Black Box' },
+      { value: 'Open Source', label: 'Transparenter Code statt undurchsichtiger Systeme' },
     ],
     items: [
       {
@@ -348,7 +351,7 @@ const de: Messages = {
       },
       {
         quote:
-          'Privacy-by-Design und technische Offenheit sind ein echter Differenzierungsfaktor für europäische EdTech-Kontexte.',
+          'Datenschutz von Anfang an und technische Offenheit sind ein echter Differenzierungsfaktor für europäische EdTech-Kontexte.',
         source: 'Publikationsanalyse',
         tag: 'Architektur',
       },
@@ -366,7 +369,7 @@ const de: Messages = {
   comparison: {
     eyebrow: 'Abgrenzung',
     title: 'Nicht nur ein Ersatz für Mentimeter oder Kahoot',
-    lead: 'Im Mittelpunkt steht nicht nur Abstimmung, sondern der komplette Live-Flow: vorbereiten, moderieren, Ergebnisse sichtbar machen und dabei die Kontrolle über Inhalte und Betrieb behalten.',
+    lead: 'Im Mittelpunkt steht nicht nur Abstimmung, sondern der komplette Live-Ablauf: vorbereiten, moderieren, Ergebnisse sichtbar machen und dabei die Kontrolle über Inhalte und Betrieb behalten.',
     points: [
       {
         title: 'Weniger Einstiegshürden',
@@ -381,7 +384,7 @@ const de: Messages = {
       {
         title: 'Mehr Kontrolle über Daten und Zugang',
         description:
-          'Open Source, self-hostbar und local-first konzipiert — plus Barrierefreiheit nach WCAG 2.2 AA. Relevant für Schulen, Hochschulen und Organisationen mit Datenschutz- und Inklusionsanforderungen.',
+          'Open Source, auf eigener Infrastruktur betreibbar und mit lokal gehaltenen Quiz-Inhalten — plus Barrierefreiheit nach WCAG 2.2 AA. Relevant für Schulen, Hochschulen und Organisationen mit Datenschutz- und Inklusionsanforderungen.',
       },
     ],
     comparePrefix: 'Den vollständigen Featurevergleich findest du weiterhin in der Doku:',
@@ -400,7 +403,7 @@ const de: Messages = {
       {
         question: 'Wo liegen die Daten?',
         answer:
-          'Quiz-Inhalte sind local-first konzipiert. Für Live-Sessions werden nur die technisch nötigen Sitzungsdaten verarbeitet; bei Self-Hosting liegt der Betrieb in deiner eigenen Infrastruktur.',
+          'Quiz-Inhalte bleiben lokal auf deinem Gerät. Für Live-Sessions werden nur die technisch nötigen Sitzungsdaten verarbeitet; bei Betrieb auf eigener Infrastruktur liegt der Betrieb bei dir.',
       },
       {
         question: 'Kann ich arsnova.eu selbst hosten?',
@@ -425,7 +428,7 @@ const de: Messages = {
       {
         question: 'Was kann die Q&A-Fragenwand?',
         answer:
-          'Teilnehmende reichen Fragen ein und gewichten sie mit Up- und Downvotes. Hosts können vorab moderieren, Fragen anheften, archivieren oder entfernen und die Liste nach Unterstützung, belastbarer Zustimmung oder Kontroverse sortieren.',
+          'Teilnehmende reichen Fragen ein und gewichten sie mit Zustimmungs- und Ablehnungsstimmen. Hosts können vorab moderieren, Fragen anheften, archivieren oder entfernen und die Liste nach Unterstützung, belastbarer Zustimmung oder Kontroverse sortieren.',
       },
       {
         question: 'Was macht die Q&A-Wortwolke anders?',
@@ -435,7 +438,7 @@ const de: Messages = {
       {
         question: 'Für wen ist die Plattform gedacht?',
         answer:
-          'Für Live-Interaktion in Bildung und Organisationen: Schule, Hochschule, Weiterbildung, Training, Workshop, Event oder Meeting.',
+          'Für Live-Interaktion in Bildung und Organisationen: Schule, Hochschule, Weiterbildung, Training, Workshop, Veranstaltung oder Besprechung.',
       },
       {
         question: 'Ist arsnova.eu barrierefrei?',
@@ -447,32 +450,32 @@ const de: Messages = {
   },
   ctaSection: {
     title: 'Bereit für die nächste Live-Session?',
-    lead: 'Teste den Live-Flow direkt in der App oder wirf einen Blick auf den offenen Code, die Q&A-Logik, die Word-Cloud-Verarbeitung und den Deployment- und Betriebspfad hinter der Plattform.',
+    lead: 'Teste den Live-Ablauf direkt in der App oder wirf einen Blick auf den offenen Code, die Q&A-Logik, die Word-Cloud-Verarbeitung und die technischen Grundlagen für Bereitstellung und Betrieb.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Informationen',
     webAppDescription:
-      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Word Cloud und Feedback — barrierefrei nach WCAG 2.2 AA, kostenlos, self-hostbar und ohne Account startklar.',
+      'Open-Source Audience Response für Bildung, Training und Organisationen: Live-Quiz, Selbsteinschätzung, Ergebnisbericht (PDF), numerische Schätzfragen, moderierbare Q&A-Fragenwand, Word Cloud und Feedback — barrierefrei nach WCAG 2.2 AA, kostenlos, auf eigener Infrastruktur betreibbar und ohne Account startklar.',
     featureList: [
       'Live-Quiz und Abstimmungen',
       'Selbsteinschätzung bei bewertbaren Fragen',
       'Ergebnisbericht (PDF) und Nachbesprechung nach Session-Ende',
       'Numerische Schätzfragen mit zwei Runden und Statistik',
-      'Q&A-Fragenwand mit Moderation, Up- und Downvoting',
-      'Lobby, Presenter, QR/Code',
+      'Q&A-Fragenwand mit Moderation, Zustimmungs- und Ablehnungsstimmen',
+      'Warteraum, Presenter, QR/Code',
       'Fragetypen MC/SC/Kurzantwort/Freitext/Umfrage/Rating/Schätzfrage',
       'Markdown und KaTeX',
       'Lesephase und Peer Instruction',
       'Q&A- und Freitext-Word-Cloud mit Phrasen und Gewichtung',
       'Sortierung nach Unterstützung, belastbarer Zustimmung und Kontroverse',
-      'Team-Modus und Presets',
-      'Leaderboard, Streak, Bonus-Code',
-      'Import/Export und Yjs-Sync',
+      'Team-Modus und Voreinstellungen',
+      'Rangliste, Serie, Bonus-Code',
+      'Import/Export und Yjs-Synchronisation',
       'KI-Import extern, Zod-validiert',
       'UI in fünf Sprachen',
       'Barrierefreiheit nach WCAG 2.2 AA',
-      'Docker Self-Host und Admin-Audit',
-      'Local-First und DSGVO-orientierter Betrieb',
+      'Docker-Betrieb auf eigener Infrastruktur und Admin-Protokollierung',
+      'Lokal gehaltene Quiz-Inhalte und DSGVO-orientierter Betrieb',
     ],
   },
 };

--- a/apps/landing/src/i18n/en.ts
+++ b/apps/landing/src/i18n/en.ts
@@ -1,0 +1,478 @@
+import type { Messages } from './types';
+
+const en: Messages = {
+  meta: {
+    homeTitle: 'arsnova.eu | Live quiz, numeric estimates and Q&A wall',
+    homeDescription:
+      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numerical estimates, moderated Q&A wall, word cloud and feedback — accessible to WCAG 2.2 AA, free, self-hostable and ready without an account.',
+    siteNameInfo: 'arsnova.eu – Information',
+    ogLocale: 'en_US',
+  },
+  nav: {
+    ariaLabel: 'Main navigation',
+    workflow: 'Workflow',
+    estimate: 'Estimate',
+    qa: 'Q&A',
+    qaMobile: 'Q&A wall',
+    features: 'Benefits',
+    accessibility: 'Accessibility',
+    trust: 'Trust',
+    faq: 'FAQ',
+    tryNow: 'Try it now',
+    menuOpen: 'Open menu',
+    menuClose: 'Close menu',
+    menu: 'Menu',
+    skipToContent: 'Skip to content',
+  },
+  languageSwitcher: {
+    label: 'Language',
+    currentLanguage: 'English',
+    chooseLanguage: 'Choose language',
+  },
+  footer: {
+    impressum: 'Legal notice',
+    privacy: 'Privacy',
+    accessibility: 'Accessibility',
+  },
+  cta: {
+    appOpen: 'Open app',
+    quizCreate: 'Create a quiz',
+    backToApp: 'Back to arsnova.eu',
+    tryLive: 'Try it live now',
+    howItWorks: 'How it works',
+    viewOpenSource: 'View open source',
+  },
+  hero: {
+    eyebrow: 'Audience response for education and organisations',
+    titleLine1: 'Quiz, estimate,',
+    titleLine2: 'moderate questions',
+    titleAccent1: 'live and free',
+    titleAccent2: ' without an account.',
+    lead: 'arsnova.eu brings together live quizzes, numerical estimates, confidence ratings on scored questions, a Q&A wall, word-cloud analysis and Pulse Check feedback in one interface for schools, universities, continuing education, workshops and business. Open source, self-hostable and designed for GDPR-oriented operation.',
+    a11yLink: 'Accessible to WCAG 2.2 AA',
+    a11ySuffix: '— keyboard, screen reader and individually adjustable response time.',
+    cards: [
+      { title: 'Live in seconds', text: 'Share a session via code or QR' },
+      { title: 'Q&A with a question wall', text: 'Moderation, voting and topic word cloud' },
+      {
+        title: 'Confidence rating & follow-up',
+        text: 'Spot misconceptions, export a PDF results report',
+      },
+      { title: 'Open source & self-hostable', text: 'Docker, Postgres, Redis and admin audit' },
+    ],
+  },
+  estimate: {
+    eyebrow: 'New in the live quiz',
+    title: 'Estimate numbers, discuss, and compare the second round clearly',
+    lead: 'The numerical estimate question is built for years, orders of magnitude, measurements and probabilities. Facilitators set a reference value, allowed input range and tolerance; participants enter only a number.',
+    summary: [
+      'A plausibility band limits allowed inputs.',
+      'A tolerance band scores estimates that are acceptable in subject terms.',
+      'Nobody sees the distribution before results are released.',
+      'Round 1 and round 2 are compared after the discussion.',
+    ],
+    docsLink: 'Open the estimate question documentation',
+    demoAria: 'Sample results for an estimate question about the French Revolution',
+    hostView: 'Host view after release',
+    demoQuestion: 'When did the French Revolution begin?',
+    reference: 'Reference 1789',
+    toleranceBand: 'Tolerance band',
+    toleranceValue: '1700 to 1900',
+    plausibilityBand: 'Plausibility band',
+    plausibilityValue: '1500 to 2000',
+    histogramNote:
+      'Histogram, reference line and tolerance band appear only after results are released. Until then only neutral progress stays visible.',
+    median: 'Median',
+    inBand: 'in band',
+    round2: 'Round 2',
+    round2Value: '14 closer',
+  },
+  confidence: {
+    eyebrow: 'Didactic evaluation',
+    title: 'Right or wrong — and how sure?',
+    lead: 'With confidence rating, participants indicate how sure they are after answering (1–5). You see not only the hit rate, but also confidently wrong answers — a strong lever for formative evaluation, focused debriefing and the results report (PDF) after the session ends.',
+    summary: [
+      'Not a separate question type — optional on scored quiz questions.',
+      'Scale 1–5 after the answer, with no effect on points.',
+      'After release, the host sees correctness × confidence.',
+      'Confidently wrong flags possible misconceptions.',
+      'After the session: results report (PDF) and debriefing.',
+    ],
+    docsConfidence: 'Confidence rating docs',
+    docsExport: 'Results report (PDF) docs',
+    demoAria: 'Sample evaluation with confidence rating after results release',
+    hostView: 'Host view after release',
+    demoQuestion: 'Which structure is the most stable?',
+    badge: 'Confidence rating',
+    matrix: [
+      { label: 'Correct · low', count: 3, tone: 'emerald' },
+      { label: 'Correct · mid', count: 8, tone: 'emerald' },
+      { label: 'Correct · high', count: 11, tone: 'emerald' },
+      { label: 'Wrong · low', count: 2, tone: 'slate' },
+      { label: 'Wrong · mid', count: 4, tone: 'amber' },
+      { label: 'Wrong · high', count: 2, tone: 'rose' },
+    ],
+    falseHighTitle: '2 confidently wrong answers',
+    falseHighText:
+      'Option B was chosen twice with high confidence — a signal for possible misconceptions in the debriefing.',
+    consolidated: 'Solid',
+    misconceptionRisk: 'Misconception risk',
+    fragile: 'Fragile',
+    afterSessionAria: 'Export after the session ends',
+    afterSession: 'After the session ends',
+    debriefing: 'Debriefing',
+    resultsPdf: 'Results report (PDF)',
+    exportNote:
+      'Print-ready report with learning status, heatmap and full question text — in the host view and on the quiz card. CSV for Excel remains available under “More”.',
+  },
+  qaWall: {
+    eyebrow: 'Live Q&A as a moderation surface',
+    title: 'Collect questions, prioritise them, and read them as a topic map',
+    lead: 'The Q&A wall is not a side chat. It is a dedicated live channel for facilitators and speakers: moderate submissions, spot collective priorities, surface controversial points and bring the key themes into the room via a weighted Q&A word cloud.',
+    signals: [
+      {
+        label: 'Pre-moderation',
+        text: 'Release questions only when they fit the teaching moment.',
+      },
+      {
+        label: 'Collective voting',
+        text: 'Upvotes and downvotes show priority, friction and need for clarification.',
+      },
+      {
+        label: 'Topic word cloud',
+        text: 'Words and phrases are weighted by support, agreement or controversy.',
+      },
+      {
+        label: 'Compass outlook',
+        text: 'Deterministic signals come first; Q&A NLP and summarisation remain optional extensions.',
+      },
+    ],
+    docsLink: 'Open Q&A scoring and controversy docs on GitHub',
+    demoAria: 'Sample Q&A wall with moderation, voting and word cloud',
+    hostView: 'Host view Q&A',
+    demoTitle: 'Questions about the event',
+    moderationActive: 'Pre-moderation on',
+    sortMostSupported: 'Most supported',
+    sortBest: 'Best questions',
+    sortControversial: 'Controversial',
+    questions: [
+      {
+        score: '+18',
+        title: 'When is an estimate still plausible in subject terms?',
+        meta: '15 up · 3 down · best question',
+      },
+      {
+        score: '+4',
+        title: 'Should we really hide results before the discussion?',
+        meta: '9 up · 5 down · controversial',
+      },
+      {
+        score: '+11',
+        title: 'How does Q&A differ from free text in the quiz?',
+        meta: '11 up · 0 down · mostly supported',
+      },
+    ],
+    wordCloud: 'Q&A word cloud',
+    wordCloudHint: 'Weighted by positive resonance and controversy.',
+    frozenLive: 'Frozen live',
+    terms: [
+      { label: 'Tolerance band', className: 'text-3xl text-brand-200' },
+      { label: 'Discussion', className: 'text-2xl text-emerald-200' },
+      { label: 'Q&A', className: 'text-4xl text-white' },
+      { label: 'Plausibility', className: 'text-xl text-amber-200' },
+      { label: 'Controversy', className: 'text-2xl text-rose-200' },
+      { label: 'Peer Instruction', className: 'text-lg text-slate-300' },
+      { label: 'Moderation', className: 'text-3xl text-cyan-200' },
+      { label: 'Clarification need', className: 'text-xl text-violet-200' },
+    ],
+    nextStep:
+      'Next step: a deterministic moderation compass, optionally complemented by asynchronous Q&A NLP signals and source-bound summaries.',
+  },
+  workflow: {
+    eyebrow: 'For teaching, training and workshops',
+    title: 'From idea to live session in a few minutes',
+    lead: 'From the question to the running session, the flow deliberately avoids unnecessary steps. That is what makes getting started fast and reliable for educators, trainers and facilitators.',
+    stepLabel: 'Step',
+    steps: [
+      {
+        number: '01',
+        title: 'Prepare a quiz',
+        description:
+          'Create questions directly or import existing content. Markdown, KaTeX, short answer and numerical estimates are built in.',
+      },
+      {
+        number: '02',
+        title: 'Start a session',
+        description:
+          'Start without an account: open a session, choose a style, share a code or QR and use the presenter view if needed.',
+      },
+      {
+        number: '03',
+        title: 'Moderate live',
+        description:
+          'Participants vote, ask questions and prioritise together. Host and presenter show quiz, Q&A wall, word cloud, reading phase, countdown, second round and results in one flow.',
+      },
+      {
+        number: '04',
+        title: 'Follow up and export',
+        description:
+          'After the session ends, the results report (PDF) is ready — with learning status, confidence rating and full question text. In the quiz collection you will find debriefing and PDF for the last run; CSV for Excel under “More”.',
+      },
+    ],
+  },
+  features: {
+    eyebrow: 'Why it feels different',
+    title: 'Built for live interaction, not only for polling slides',
+    lead: 'arsnova.eu combines a fast start, didactic depth and a transparent technical foundation. The platform stays simple day to day without shrinking what you can do.',
+    items: [
+      {
+        title: 'Ready in no time',
+        description:
+          'Hosts start without an account. Participants join the session directly with a 6-digit code or QR.',
+        icon: 'single',
+      },
+      {
+        title: 'Confidence rating in the live quiz',
+        description:
+          'Participants say how sure they are after answering. You spot confidently wrong answers, prioritise the debriefing and export learning status in the results report (PDF).',
+        icon: 'confidence',
+      },
+      {
+        title: 'Results report for follow-up',
+        description:
+          'After the session ends you export a print-ready PDF report with charts, question text and confidence rating. CSV for Excel remains optional under “More”.',
+        icon: 'export',
+      },
+      {
+        title: 'Didactic estimate questions',
+        description:
+          'Years, orders of magnitude and measurements can be estimated with a reference value, tolerance band, statistics and an optional second round.',
+        icon: 'estimate',
+      },
+      {
+        title: 'More than a standard quiz',
+        description:
+          'MC/SC, short answer, rating, reading phase, Peer Instruction and presenter flow support learning, training and live facilitation.',
+        icon: 'toggle',
+      },
+      {
+        title: 'Q&A wall instead of a side chat',
+        description:
+          'Q&A offers pre-moderation, pinning, archiving, up/down voting and sorting by support, quality and controversy.',
+        icon: 'qa',
+      },
+      {
+        title: 'Rich word cloud',
+        description:
+          'Free text and Q&A are condensed into words and phrases; the wall weights by agreement, robust score or controversy.',
+        icon: 'cloud',
+      },
+      {
+        title: 'For different settings',
+        description:
+          'Presets, team mode, anonymous mode, nicknames and style choice help from class and seminar to workshop, event and meeting.',
+        icon: 'bolt',
+      },
+      {
+        title: 'Accessibility to WCAG 2.2 AA',
+        description:
+          'Keyboard use, screen-reader status updates, individually adjustable response time and PDF/UA-1-validated results reports — so more learners can join live sessions independently.',
+        icon: 'a11y',
+      },
+      {
+        title: 'Privacy and control',
+        description:
+          'Local-first, data stripping and self-hostable operation give you more control over content and live data.',
+        icon: 'tools',
+      },
+      {
+        title: 'Open source with an ops path',
+        description:
+          'Docker, Postgres, Redis and admin audit make the platform robust for hosting, operations and auditability.',
+        icon: 'server',
+      },
+    ],
+  },
+  accessibility: {
+    eyebrow: 'Accessibility',
+    title: 'WCAG 2.2 AA — so more learners can take part independently',
+    lead: 'For schools, universities and continuing education, accessibility is often a decisive criterion. arsnova.eu meets the Web Content Accessibility Guidelines (WCAG) 2.2 at conformance level AA — with keyboard use, screen-reader support, individually adjustable response time and accessibly structured PDF results reports.',
+    benefits: [
+      {
+        title: 'Keyboard operation',
+        description:
+          'You and your participants can use the core flows without a mouse. Visible focus marks and a skip link to content make navigation easier.',
+      },
+      {
+        title: 'Screen-reader support in live use',
+        description:
+          'Status changes when joining a session, during voting and at phase changes are announced for screen readers so users can follow the flow.',
+      },
+      {
+        title: 'Individually adjustable response time',
+        description:
+          'For timed questions you choose standard time, tenfold response time or participation without a time limit. Reasonable adjustments can be applied directly in the live session.',
+      },
+      {
+        title: 'Accessibly structured results report',
+        description:
+          'The print-ready report is PDF/UA-1-validated and includes document title, language and tags — for follow-up and accessible sharing.',
+      },
+    ],
+    statementLink: 'Open the accessibility statement',
+  },
+  trust: {
+    eyebrow: 'Trust',
+    title: 'Credible because the product does not start from zero',
+    lead: 'arsnova.eu continues the ARSnova ecosystem tradition and builds on scientific, didactic and practical experience from many years of education technology.',
+    proofItems: [
+      { value: 'Since 2012', label: 'ARSnova tradition in education and edtech' },
+      { value: 'WCAG 2.2 AA', label: 'Verified accessibility for teaching and institutions' },
+      {
+        value: '5 UI languages',
+        label: 'German, English, French, Spanish, Italian',
+      },
+      { value: 'Open source', label: 'Transparent code instead of a black box' },
+    ],
+    items: [
+      {
+        quote: 'A privacy-friendly path: no personal data stored permanently on the server.',
+        source: 'DeLFI 2017',
+        tag: 'Research',
+      },
+      {
+        quote: 'UX evaluation in direct comparison with Kahoot! as an empirical design checkpoint.',
+        source: 'fnm-austria',
+        tag: 'Study',
+      },
+      {
+        quote:
+          'Privacy by design and technical openness are a real differentiator for European edtech contexts.',
+        source: 'Publication analysis',
+        tag: 'Architecture',
+      },
+      {
+        quote: 'Practically proven in real education settings, not only described as a concept.',
+        source: 'Use in teaching and training contexts',
+        tag: 'Practice',
+      },
+    ],
+    referencesPrefix: 'Full references and the underlying publication collection are in',
+    referencesLink: 'ARSnova-Recherche.pdf',
+    referencesSuffix: 'on GitHub.',
+  },
+  comparison: {
+    eyebrow: 'Differentiation',
+    title: 'Not just a Mentimeter or Kahoot substitute',
+    lead: 'The focus is not only voting, but the full live flow: prepare, facilitate, make results visible and keep control of content and operations.',
+    points: [
+      {
+        title: 'Lower barriers to entry',
+        description:
+          'No separate product logic for “create” and “join”. Hosts start without an account; participants enter the session via code or QR.',
+      },
+      {
+        title: 'More interaction formats',
+        description:
+          'Alongside quizzes: numerical estimates, reading phase, Peer Instruction, Pulse Check, Q&A wall and weighted word cloud in the same platform — not only slide polls.',
+      },
+      {
+        title: 'More control over data and access',
+        description:
+          'Open source, self-hostable and local-first by design — plus accessibility to WCAG 2.2 AA. Relevant for schools, universities and organisations with privacy and inclusion requirements.',
+      },
+    ],
+    comparePrefix: 'You can still find the full feature comparison in the docs:',
+    compareLink: 'Open the comparison on GitHub',
+  },
+  faq: {
+    eyebrow: 'FAQ',
+    title: 'Common questions before the first session',
+    answerLabel: 'Answer',
+    items: [
+      {
+        question: 'Do hosts or participants need an account?',
+        answer:
+          'No. A session can be started without an account. Participants join via code or QR.',
+      },
+      {
+        question: 'Where is the data stored?',
+        answer:
+          'Quiz content is designed local-first. For live sessions only the technically necessary session data is processed; with self-hosting, operations stay in your own infrastructure.',
+      },
+      {
+        question: 'Can I self-host arsnova.eu?',
+        answer:
+          'Yes. The platform is open source and designed to run with Docker, PostgreSQL and Redis.',
+      },
+      {
+        question: 'What is confidence rating in the quiz?',
+        answer:
+          'An optional follow-up after scored questions: participants rate on a scale of 1–5 how sure they are about their answer. Points stay unchanged; in the host evaluation you see correctness × confidence and flag confidently wrong answers as a misconception signal. After the session ends, learning status flows into debriefing and the results report (PDF).',
+      },
+      {
+        question: 'Can I export session results?',
+        answer:
+          'Yes. After the session ends, the results report (PDF) is the primary format — including confidence rating, debriefing priorities and full question text. In the quiz collection you will find debriefing and PDF for the last run. Tabular CSV data is available under “More” for Excel.',
+      },
+      {
+        question: 'What makes the numerical estimate special?',
+        answer:
+          'It separates allowed inputs from the subject-matter tolerance band, shows no distribution during voting, and can evaluate a second round after discussion with statistics and round comparison.',
+      },
+      {
+        question: 'What can the Q&A wall do?',
+        answer:
+          'Participants submit questions and weight them with upvotes and downvotes. Hosts can pre-moderate, pin, archive or remove questions and sort the list by support, robust agreement or controversy.',
+      },
+      {
+        question: 'What makes the Q&A word cloud different?',
+        answer:
+          'It condenses visible questions into words and phrases and follows the active sort logic. So it shows not only frequent terms, but topic clusters from supported, robustly scored or controversial questions.',
+      },
+      {
+        question: 'Who is the platform for?',
+        answer:
+          'For live interaction in education and organisations: school, university, continuing education, training, workshop, event or meeting.',
+      },
+      {
+        question: 'Is arsnova.eu accessible?',
+        answer:
+          'arsnova.eu meets WCAG 2.2 AA. Core flows are keyboard-operable, screen readers announce status changes, response time on timed questions is individually adjustable (standard time, tenfold response time or no time limit), and the accessibly structured results report is PDF/UA-1-validated.',
+        linkLabel: 'Open the accessibility statement',
+      },
+    ],
+  },
+  ctaSection: {
+    title: 'Ready for the next live session?',
+    lead: 'Try the live flow directly in the app, or take a look at the open code, the Q&A logic, the word-cloud pipeline and the operations path behind the platform.',
+  },
+  jsonLd: {
+    websiteName: 'arsnova.eu – Information',
+    webAppDescription:
+      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numerical estimates, moderated Q&A wall, word cloud and feedback — accessible to WCAG 2.2 AA, free, self-hostable and ready without an account.',
+    featureList: [
+      'Live quiz and voting',
+      'Confidence rating on scored questions',
+      'Results report (PDF) and debriefing after the session ends',
+      'Numerical estimates with two rounds and statistics',
+      'Q&A wall with moderation, upvoting and downvoting',
+      'Lobby, presenter, QR/code',
+      'Question types MC/SC/short answer/free text/survey/rating/estimate',
+      'Markdown and KaTeX',
+      'Reading phase and Peer Instruction',
+      'Q&A and free-text word cloud with phrases and weighting',
+      'Sorting by support, robust agreement and controversy',
+      'Team mode and presets',
+      'Leaderboard, streak, bonus code',
+      'Import/export and Yjs sync',
+      'External AI import, Zod-validated',
+      'UI in five languages',
+      'Accessibility to WCAG 2.2 AA',
+      'Docker self-host and admin audit',
+      'Local-first and GDPR-oriented operation',
+    ],
+  },
+};
+
+export default en;

--- a/apps/landing/src/i18n/en.ts
+++ b/apps/landing/src/i18n/en.ts
@@ -4,7 +4,7 @@ const en: Messages = {
   meta: {
     homeTitle: 'arsnova.eu | Live quiz, numeric estimation questions and Q&A wall',
     homeDescription:
-      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numeric estimation questions, moderated Q&A wall, word cloud and feedback — conforms to WCAG 2.2 Level AA, free, self-hostable and ready without an account.',
+      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numeric estimation questions, moderated Q&A wall, word cloud and feedback — conforms to WCAG 2.2 Level AA, free, runnable on your own infrastructure and ready without an account.',
     siteNameInfo: 'arsnova.eu – Information',
     ogLocale: 'en_US',
   },
@@ -48,7 +48,7 @@ const en: Messages = {
     titleLine2: 'moderate questions',
     titleAccent1: 'live and free',
     titleAccent2: ' without an account.',
-    lead: 'arsnova.eu brings together live quizzes, numeric estimation questions, confidence ratings on scored questions, a Q&A wall, word-cloud analysis and Pulse Check feedback in one interface for schools, universities, continuing education, workshops and business. Open source, self-hostable and designed for GDPR-oriented operation.',
+    lead: 'arsnova.eu brings together live quizzes, numeric estimation questions, confidence ratings on scored questions, a Q&A wall, word-cloud analysis and Pulse Check feedback in one interface for schools, universities, continuing education, workshops and business. Open source, runnable on your own infrastructure and designed for GDPR-oriented operation.',
     a11yLink: 'Conforms to WCAG 2.2 Level AA',
     a11ySuffix: '— keyboard, screen reader and individually adjustable response time.',
     cards: [
@@ -58,7 +58,10 @@ const en: Messages = {
         title: 'Confidence rating & follow-up',
         text: 'Spot misconceptions, export a PDF results report',
       },
-      { title: 'Open source & self-hostable', text: 'Docker, Postgres, Redis and admin audit' },
+      {
+        title: 'Open source & self-operated',
+        text: 'Docker, Postgres, Redis and admin activity log',
+      },
     ],
   },
   estimate: {
@@ -73,7 +76,7 @@ const en: Messages = {
     ],
     docsLink: 'Open the numeric estimation question documentation',
     demoAria: 'Sample results for a numeric estimation question about the French Revolution',
-    hostView: 'Host view after release',
+    hostView: 'Facilitator view after release',
     demoQuestion: 'When did the French Revolution begin?',
     reference: 'Reference 1789',
     toleranceBand: 'Tolerance band',
@@ -88,20 +91,20 @@ const en: Messages = {
     round2Value: '14 answers closer to the reference',
   },
   confidence: {
-    eyebrow: 'Didactic evaluation',
+    eyebrow: 'Pedagogical analysis',
     title: 'Right or wrong — and how sure?',
-    lead: 'With confidence rating, participants indicate how sure they are after answering (1–5). You see not only the hit rate, but also confidently wrong answers — a strong lever for formative evaluation, focused debriefing and the results report (PDF) after the session ends.',
+    lead: 'With the confidence rating, participants indicate how sure they are after answering (1–5). You see not only the hit rate, but also confidently wrong answers — a useful tool for formative evaluation, focused debriefing and the results report (PDF) after the session ends.',
     summary: [
       'Not a separate question type — optional on scored quiz questions.',
       'Scale 1–5 after the answer, with no effect on points.',
-      'After release, the host sees correctness × confidence.',
-      'Confidently wrong flags possible misconceptions.',
+      'After release, the facilitator sees correctness × confidence.',
+      'Confidently wrong answers may indicate misconceptions.',
       'After the session: results report (PDF) and debriefing.',
     ],
     docsConfidence: 'Confidence rating docs',
     docsExport: 'Results report (PDF) docs',
     demoAria: 'Sample evaluation with confidence rating after results release',
-    hostView: 'Host view after release',
+    hostView: 'Facilitator view after release',
     demoQuestion: 'Which structure is the most stable?',
     badge: 'Confidence rating',
     matrix: [
@@ -123,10 +126,10 @@ const en: Messages = {
     debriefing: 'Debriefing',
     resultsPdf: 'Results report (PDF)',
     exportNote:
-      'Print-ready report with learning status, heatmap and full question text — in the host view and on the quiz card. CSV for Excel remains available under “More”.',
+      'Print-ready report with learning status, heatmap and full question text — in the facilitator view and on the quiz card. CSV for Excel remains available under “More”.',
   },
   qaWall: {
-    eyebrow: 'Live Q&A as a moderation surface',
+    eyebrow: 'Live Q&A as a moderation space',
     title: 'Collect questions, prioritise them, and read them as a topic map',
     lead: 'The Q&A wall is not a side chat. It is a dedicated live channel for facilitators and speakers: moderate submissions, spot collective priorities, surface controversial points and bring the key themes into the room via a weighted Q&A word cloud.',
     signals: [
@@ -143,13 +146,13 @@ const en: Messages = {
         text: 'Words and phrases are weighted by support, agreement or controversy.',
       },
       {
-        label: 'Moderation compass outlook',
-        text: 'Deterministic signals come first; Q&A NLP and summarisation remain optional extensions.',
+        label: 'Coming next: moderation compass',
+        text: 'Deterministic signals come first; optional language analysis and summarisation remain extensions.',
       },
     ],
     docsLink: 'Open Q&A scoring and controversy docs on GitHub',
     demoAria: 'Sample Q&A wall with moderation, voting and word cloud',
-    hostView: 'Host view Q&A',
+    hostView: 'Facilitator view Q&A',
     demoTitle: 'Questions about the event',
     moderationActive: 'Pre-moderation on',
     sortMostSupported: 'Most supported',
@@ -186,7 +189,7 @@ const en: Messages = {
       { label: 'Clarification need', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Next step: a deterministic moderation compass, optionally complemented by asynchronous Q&A NLP signals and source-bound summaries.',
+      'Next step: a deterministic moderation compass, optionally complemented by asynchronous language-analysis signals and source-bound summaries.',
   },
   workflow: {
     eyebrow: 'For teaching, training and workshops',
@@ -210,7 +213,7 @@ const en: Messages = {
         number: '03',
         title: 'Moderate live',
         description:
-          'Participants vote, ask questions and prioritise together. Host and presenter show quiz, Q&A wall, word cloud, reading phase, countdown, second round and results in one flow.',
+          'Participants vote, ask questions and prioritise together. Facilitator and presenter show quiz, Q&A wall, word cloud, reading phase, countdown, second round and results in one flow.',
       },
       {
         number: '04',
@@ -221,14 +224,14 @@ const en: Messages = {
     ],
   },
   features: {
-    eyebrow: 'What makes it feel different',
+    eyebrow: 'What sets arsnova.eu apart',
     title: 'Built for live interaction, not only for polling slides',
-    lead: 'arsnova.eu combines a fast start, didactic depth and a transparent technical foundation. The platform stays simple day to day without shrinking what you can do.',
+    lead: 'arsnova.eu combines a fast start, pedagogical depth and a transparent technical foundation. The platform stays simple day to day without shrinking what you can do.',
     items: [
       {
         title: 'Ready in no time',
         description:
-          'Hosts start without an account. Participants join the session directly with a 6-digit code or QR.',
+          'Facilitators start without an account. Participants join the session directly with a 6-digit code or QR.',
         icon: 'single',
       },
       {
@@ -282,13 +285,13 @@ const en: Messages = {
       {
         title: 'Privacy and control',
         description:
-          'Local-first design, optional data removal and self-hostable operation give you more control over content and live data.',
+          'Quiz content stays on your device, optional data removal and operation on your own infrastructure give you more control over content and live data.',
         icon: 'tools',
       },
       {
         title: 'Open source with deployment and operations',
         description:
-          'Docker, Postgres, Redis and admin audit make the platform robust for hosting, operations and auditability.',
+          'Docker, Postgres, Redis and an admin activity log make the platform robust for hosting, operations and auditability.',
         icon: 'server',
       },
     ],
@@ -323,8 +326,8 @@ const en: Messages = {
   },
   trust: {
     eyebrow: 'Trust',
-    title: 'Credible because the product does not start from zero',
-    lead: 'arsnova.eu continues the ARSnova ecosystem tradition and builds on scientific, didactic and practical experience from many years of education technology.',
+    title: 'Built on an established foundation',
+    lead: 'arsnova.eu continues the ARSnova ecosystem tradition and builds on scientific, pedagogical and practical experience from many years of education technology.',
     proofItems: [
       { value: 'Since 2012', label: 'ARSnova tradition in education and edtech' },
       { value: 'WCAG 2.2 AA', label: 'Verified accessibility for teaching and institutions' },
@@ -332,7 +335,7 @@ const en: Messages = {
         value: '5 UI languages',
         label: 'German, English, French, Spanish, Italian',
       },
-      { value: 'Open source', label: 'Transparent code instead of a black box' },
+      { value: 'Open source', label: 'Transparent code instead of opaque systems' },
     ],
     items: [
       {
@@ -347,7 +350,7 @@ const en: Messages = {
       },
       {
         quote:
-          'Privacy by design and technical openness are a real differentiator for European edtech contexts.',
+          'Privacy from the ground up and technical openness are a real differentiator for European edtech contexts.',
         source: 'Publication analysis',
         tag: 'Architecture',
       },
@@ -369,7 +372,7 @@ const en: Messages = {
       {
         title: 'Lower barriers to entry',
         description:
-          'No separate product logic for “create” and “join”. Hosts start without an account; participants enter the session via code or QR.',
+          'No separate product logic for “create” and “join”. Facilitators start without an account; participants enter the session via code or QR.',
       },
       {
         title: 'More interaction formats',
@@ -379,7 +382,7 @@ const en: Messages = {
       {
         title: 'More control over data and access',
         description:
-          'Open source, self-hostable and local-first by design — plus conformance to WCAG 2.2 Level AA. Relevant for schools, universities and organisations with privacy and inclusion requirements.',
+          'Open source, runnable on your own infrastructure and with quiz content kept locally — plus conformance to WCAG 2.2 Level AA. Relevant for schools, universities and organisations with privacy and inclusion requirements.',
       },
     ],
     comparePrefix: 'You can still find the full feature comparison in the docs:',
@@ -391,24 +394,24 @@ const en: Messages = {
     answerLabel: 'Answer',
     items: [
       {
-        question: 'Do hosts or participants need an account?',
+        question: 'Do facilitators or participants need an account?',
         answer:
           'No. A session can be started without an account. Participants join via code or QR.',
       },
       {
         question: 'Where is the data stored?',
         answer:
-          'Quiz content is designed local-first. For live sessions only the technically necessary session data is processed; with self-hosting, operations stay in your own infrastructure.',
+          'Quiz content stays on your device. For live sessions only the technically necessary session data is processed; when you run it yourself, operations stay in your own infrastructure.',
       },
       {
-        question: 'Can I self-host arsnova.eu?',
+        question: 'Can I run arsnova.eu on my own infrastructure?',
         answer:
           'Yes. The platform is open source and designed to run with Docker, PostgreSQL and Redis.',
       },
       {
         question: 'What is confidence rating in the quiz?',
         answer:
-          'An optional follow-up after scored questions: participants rate on a scale of 1–5 how sure they are about their answer. Points stay unchanged; in the host evaluation you see correctness × confidence and flag confidently wrong answers as a misconception signal. After the session ends, learning status flows into debriefing and the results report (PDF).',
+          'An optional follow-up after scored questions: participants rate on a scale of 1–5 how sure they are about their answer. Points stay unchanged; in the facilitator evaluation you see correctness × confidence and flag confidently wrong answers as a misconception signal. After the session ends, learning status flows into debriefing and the results report (PDF).',
       },
       {
         question: 'Can I export session results?',
@@ -423,7 +426,7 @@ const en: Messages = {
       {
         question: 'What can the Q&A wall do?',
         answer:
-          'Participants submit questions and weight them with upvotes and downvotes. Hosts can pre-moderate, pin, archive or remove questions and sort the list by support, robust agreement or controversy.',
+          'Participants submit questions and weight them with upvotes and downvotes. Facilitators can pre-moderate, pin, archive or remove questions and sort the list by support, robust agreement or controversy.',
       },
       {
         question: 'What makes the Q&A word cloud different?',
@@ -445,19 +448,19 @@ const en: Messages = {
   },
   ctaSection: {
     title: 'Ready for the next live session?',
-    lead: 'Try the live flow directly in the app, or take a look at the open source code, the Q&A logic, the word-cloud processing pipeline and the deployment and operations behind the platform.',
+    lead: 'Try the live flow directly in the app, or take a look at the open source code, the Q&A logic, the word-cloud processing pipeline and the technical foundations for deployment and operations.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Information',
     webAppDescription:
-      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numeric estimation questions, moderated Q&A wall, word cloud and feedback — conforms to WCAG 2.2 Level AA, free, self-hostable and ready without an account.',
+      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numeric estimation questions, moderated Q&A wall, word cloud and feedback — conforms to WCAG 2.2 Level AA, free, runnable on your own infrastructure and ready without an account.',
     featureList: [
       'Live quiz and voting',
       'Confidence rating on scored questions',
       'Results report (PDF) and debriefing after the session ends',
       'Numeric estimation questions with two rounds and statistics',
       'Q&A wall with moderation, upvoting and downvoting',
-      'Lobby, presenter, QR/code',
+      'Waiting room, presenter, QR/code',
       'Question types MC/SC/short answer/free text/survey/rating/numeric estimation',
       'Markdown and KaTeX',
       'Reading phase and Peer Instruction',
@@ -469,8 +472,8 @@ const en: Messages = {
       'External AI import, Zod-validated',
       'UI in five languages',
       'Conforms to WCAG 2.2 Level AA',
-      'Docker self-host and admin audit',
-      'Local-first and GDPR-oriented operation',
+      'Docker on your own infrastructure and admin activity log',
+      'Locally kept quiz content and GDPR-oriented operation',
     ],
   },
 };

--- a/apps/landing/src/i18n/en.ts
+++ b/apps/landing/src/i18n/en.ts
@@ -2,16 +2,16 @@ import type { Messages } from './types';
 
 const en: Messages = {
   meta: {
-    homeTitle: 'arsnova.eu | Live quiz, numeric estimates and Q&A wall',
+    homeTitle: 'arsnova.eu | Live quiz, numeric estimation questions and Q&A wall',
     homeDescription:
-      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numerical estimates, moderated Q&A wall, word cloud and feedback — accessible to WCAG 2.2 AA, free, self-hostable and ready without an account.',
+      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numeric estimation questions, moderated Q&A wall, word cloud and feedback — conforms to WCAG 2.2 Level AA, free, self-hostable and ready without an account.',
     siteNameInfo: 'arsnova.eu – Information',
     ogLocale: 'en_US',
   },
   nav: {
     ariaLabel: 'Main navigation',
     workflow: 'Workflow',
-    estimate: 'Estimate',
+    estimate: 'Estimation',
     qa: 'Q&A',
     qaMobile: 'Q&A wall',
     features: 'Benefits',
@@ -40,7 +40,7 @@ const en: Messages = {
     backToApp: 'Back to arsnova.eu',
     tryLive: 'Try it live now',
     howItWorks: 'How it works',
-    viewOpenSource: 'View open source',
+    viewOpenSource: 'View source code',
   },
   hero: {
     eyebrow: 'Audience response for education and organisations',
@@ -48,8 +48,8 @@ const en: Messages = {
     titleLine2: 'moderate questions',
     titleAccent1: 'live and free',
     titleAccent2: ' without an account.',
-    lead: 'arsnova.eu brings together live quizzes, numerical estimates, confidence ratings on scored questions, a Q&A wall, word-cloud analysis and Pulse Check feedback in one interface for schools, universities, continuing education, workshops and business. Open source, self-hostable and designed for GDPR-oriented operation.',
-    a11yLink: 'Accessible to WCAG 2.2 AA',
+    lead: 'arsnova.eu brings together live quizzes, numeric estimation questions, confidence ratings on scored questions, a Q&A wall, word-cloud analysis and Pulse Check feedback in one interface for schools, universities, continuing education, workshops and business. Open source, self-hostable and designed for GDPR-oriented operation.',
+    a11yLink: 'Conforms to WCAG 2.2 Level AA',
     a11ySuffix: '— keyboard, screen reader and individually adjustable response time.',
     cards: [
       { title: 'Live in seconds', text: 'Share a session via code or QR' },
@@ -64,15 +64,15 @@ const en: Messages = {
   estimate: {
     eyebrow: 'New in the live quiz',
     title: 'Estimate numbers, discuss, and compare the second round clearly',
-    lead: 'The numerical estimate question is built for years, orders of magnitude, measurements and probabilities. Facilitators set a reference value, allowed input range and tolerance; participants enter only a number.',
+    lead: 'The numeric estimation question is built for years, orders of magnitude, measurements and probabilities. Facilitators set a reference value, allowed input range and tolerance; participants enter only a number.',
     summary: [
       'A plausibility band limits allowed inputs.',
-      'A tolerance band scores estimates that are acceptable in subject terms.',
+      'A tolerance band scores estimates that are acceptable from a subject-matter perspective.',
       'Nobody sees the distribution before results are released.',
       'Round 1 and round 2 are compared after the discussion.',
     ],
-    docsLink: 'Open the estimate question documentation',
-    demoAria: 'Sample results for an estimate question about the French Revolution',
+    docsLink: 'Open the numeric estimation question documentation',
+    demoAria: 'Sample results for a numeric estimation question about the French Revolution',
     hostView: 'Host view after release',
     demoQuestion: 'When did the French Revolution begin?',
     reference: 'Reference 1789',
@@ -85,7 +85,7 @@ const en: Messages = {
     median: 'Median',
     inBand: 'in band',
     round2: 'Round 2',
-    round2Value: '14 closer',
+    round2Value: '14 answers closer to the reference',
   },
   confidence: {
     eyebrow: 'Didactic evaluation',
@@ -105,12 +105,12 @@ const en: Messages = {
     demoQuestion: 'Which structure is the most stable?',
     badge: 'Confidence rating',
     matrix: [
-      { label: 'Correct · low', count: 3, tone: 'emerald' },
-      { label: 'Correct · mid', count: 8, tone: 'emerald' },
-      { label: 'Correct · high', count: 11, tone: 'emerald' },
-      { label: 'Wrong · low', count: 2, tone: 'slate' },
-      { label: 'Wrong · mid', count: 4, tone: 'amber' },
-      { label: 'Wrong · high', count: 2, tone: 'rose' },
+      { label: 'Correct · low confidence', count: 3, tone: 'emerald' },
+      { label: 'Correct · medium confidence', count: 8, tone: 'emerald' },
+      { label: 'Correct · high confidence', count: 11, tone: 'emerald' },
+      { label: 'Incorrect · low confidence', count: 2, tone: 'slate' },
+      { label: 'Incorrect · medium confidence', count: 4, tone: 'amber' },
+      { label: 'Incorrect · high confidence', count: 2, tone: 'rose' },
     ],
     falseHighTitle: '2 confidently wrong answers',
     falseHighText:
@@ -143,7 +143,7 @@ const en: Messages = {
         text: 'Words and phrases are weighted by support, agreement or controversy.',
       },
       {
-        label: 'Compass outlook',
+        label: 'Moderation compass outlook',
         text: 'Deterministic signals come first; Q&A NLP and summarisation remain optional extensions.',
       },
     ],
@@ -158,7 +158,7 @@ const en: Messages = {
     questions: [
       {
         score: '+18',
-        title: 'When is an estimate still plausible in subject terms?',
+        title: 'When is an estimate still plausible from a subject-matter perspective?',
         meta: '15 up · 3 down · best question',
       },
       {
@@ -174,7 +174,7 @@ const en: Messages = {
     ],
     wordCloud: 'Q&A word cloud',
     wordCloudHint: 'Weighted by positive resonance and controversy.',
-    frozenLive: 'Frozen live',
+    frozenLive: 'Live updates paused',
     terms: [
       { label: 'Tolerance band', className: 'text-3xl text-brand-200' },
       { label: 'Discussion', className: 'text-2xl text-emerald-200' },
@@ -198,7 +198,7 @@ const en: Messages = {
         number: '01',
         title: 'Prepare a quiz',
         description:
-          'Create questions directly or import existing content. Markdown, KaTeX, short answer and numerical estimates are built in.',
+          'Create questions directly or import existing content. Markdown, KaTeX, short answer and numeric estimation questions are built in.',
       },
       {
         number: '02',
@@ -221,7 +221,7 @@ const en: Messages = {
     ],
   },
   features: {
-    eyebrow: 'Why it feels different',
+    eyebrow: 'What makes it feel different',
     title: 'Built for live interaction, not only for polling slides',
     lead: 'arsnova.eu combines a fast start, didactic depth and a transparent technical foundation. The platform stays simple day to day without shrinking what you can do.',
     items: [
@@ -244,7 +244,7 @@ const en: Messages = {
         icon: 'export',
       },
       {
-        title: 'Didactic estimate questions',
+        title: 'Numeric estimation questions for teaching',
         description:
           'Years, orders of magnitude and measurements can be estimated with a reference value, tolerance band, statistics and an optional second round.',
         icon: 'estimate',
@@ -274,7 +274,7 @@ const en: Messages = {
         icon: 'bolt',
       },
       {
-        title: 'Accessibility to WCAG 2.2 AA',
+        title: 'Conforms to WCAG 2.2 Level AA',
         description:
           'Keyboard use, screen-reader status updates, individually adjustable response time and PDF/UA-1-validated results reports — so more learners can join live sessions independently.',
         icon: 'a11y',
@@ -282,11 +282,11 @@ const en: Messages = {
       {
         title: 'Privacy and control',
         description:
-          'Local-first, data stripping and self-hostable operation give you more control over content and live data.',
+          'Local-first design, optional data removal and self-hostable operation give you more control over content and live data.',
         icon: 'tools',
       },
       {
-        title: 'Open source with an ops path',
+        title: 'Open source with deployment and operations',
         description:
           'Docker, Postgres, Redis and admin audit make the platform robust for hosting, operations and auditability.',
         icon: 'server',
@@ -296,7 +296,7 @@ const en: Messages = {
   accessibility: {
     eyebrow: 'Accessibility',
     title: 'WCAG 2.2 AA — so more learners can take part independently',
-    lead: 'For schools, universities and continuing education, accessibility is often a decisive criterion. arsnova.eu meets the Web Content Accessibility Guidelines (WCAG) 2.2 at conformance level AA — with keyboard use, screen-reader support, individually adjustable response time and accessibly structured PDF results reports.',
+    lead: 'For schools, universities and continuing education, accessibility is often a decisive criterion. arsnova.eu meets the Web Content Accessibility Guidelines (WCAG) 2.2 at Level AA — with keyboard use, screen-reader support, individually adjustable response time and accessibly structured PDF results reports.',
     benefits: [
       {
         title: 'Keyboard operation',
@@ -374,12 +374,12 @@ const en: Messages = {
       {
         title: 'More interaction formats',
         description:
-          'Alongside quizzes: numerical estimates, reading phase, Peer Instruction, Pulse Check, Q&A wall and weighted word cloud in the same platform — not only slide polls.',
+          'Alongside quizzes: numeric estimation questions, reading phase, Peer Instruction, Pulse Check, Q&A wall and weighted word cloud in the same platform — not only slide polls.',
       },
       {
         title: 'More control over data and access',
         description:
-          'Open source, self-hostable and local-first by design — plus accessibility to WCAG 2.2 AA. Relevant for schools, universities and organisations with privacy and inclusion requirements.',
+          'Open source, self-hostable and local-first by design — plus conformance to WCAG 2.2 Level AA. Relevant for schools, universities and organisations with privacy and inclusion requirements.',
       },
     ],
     comparePrefix: 'You can still find the full feature comparison in the docs:',
@@ -416,7 +416,7 @@ const en: Messages = {
           'Yes. After the session ends, the results report (PDF) is the primary format — including confidence rating, debriefing priorities and full question text. In the quiz collection you will find debriefing and PDF for the last run. Tabular CSV data is available under “More” for Excel.',
       },
       {
-        question: 'What makes the numerical estimate special?',
+        question: 'What makes the numeric estimation question special?',
         answer:
           'It separates allowed inputs from the subject-matter tolerance band, shows no distribution during voting, and can evaluate a second round after discussion with statistics and round comparison.',
       },
@@ -438,27 +438,27 @@ const en: Messages = {
       {
         question: 'Is arsnova.eu accessible?',
         answer:
-          'arsnova.eu meets WCAG 2.2 AA. Core flows are keyboard-operable, screen readers announce status changes, response time on timed questions is individually adjustable (standard time, tenfold response time or no time limit), and the accessibly structured results report is PDF/UA-1-validated.',
+          'arsnova.eu conforms to WCAG 2.2 Level AA. Core flows are keyboard-operable, screen readers announce status changes, response time on timed questions is individually adjustable (standard time, tenfold response time or no time limit), and the accessibly structured results report is PDF/UA-1-validated.',
         linkLabel: 'Open the accessibility statement',
       },
     ],
   },
   ctaSection: {
     title: 'Ready for the next live session?',
-    lead: 'Try the live flow directly in the app, or take a look at the open code, the Q&A logic, the word-cloud pipeline and the operations path behind the platform.',
+    lead: 'Try the live flow directly in the app, or take a look at the open source code, the Q&A logic, the word-cloud processing pipeline and the deployment and operations behind the platform.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Information',
     webAppDescription:
-      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numerical estimates, moderated Q&A wall, word cloud and feedback — accessible to WCAG 2.2 AA, free, self-hostable and ready without an account.',
+      'Open-source audience response for education, training and organisations: live quiz, confidence rating, results report (PDF), numeric estimation questions, moderated Q&A wall, word cloud and feedback — conforms to WCAG 2.2 Level AA, free, self-hostable and ready without an account.',
     featureList: [
       'Live quiz and voting',
       'Confidence rating on scored questions',
       'Results report (PDF) and debriefing after the session ends',
-      'Numerical estimates with two rounds and statistics',
+      'Numeric estimation questions with two rounds and statistics',
       'Q&A wall with moderation, upvoting and downvoting',
       'Lobby, presenter, QR/code',
-      'Question types MC/SC/short answer/free text/survey/rating/estimate',
+      'Question types MC/SC/short answer/free text/survey/rating/numeric estimation',
       'Markdown and KaTeX',
       'Reading phase and Peer Instruction',
       'Q&A and free-text word cloud with phrases and weighting',
@@ -468,7 +468,7 @@ const en: Messages = {
       'Import/export and Yjs sync',
       'External AI import, Zod-validated',
       'UI in five languages',
-      'Accessibility to WCAG 2.2 AA',
+      'Conforms to WCAG 2.2 Level AA',
       'Docker self-host and admin audit',
       'Local-first and GDPR-oriented operation',
     ],

--- a/apps/landing/src/i18n/en.ts
+++ b/apps/landing/src/i18n/en.ts
@@ -48,7 +48,7 @@ const en: Messages = {
     titleLine2: 'moderate questions',
     titleAccent1: 'live and free',
     titleAccent2: ' without an account.',
-    lead: 'arsnova.eu brings together live quizzes, numeric estimation questions, confidence ratings on scored questions, a Q&A wall, word-cloud analysis and Pulse Check feedback in one interface for schools, universities, continuing education, workshops and business. Open source, runnable on your own infrastructure and designed for GDPR-oriented operation.',
+    lead: 'arsnova.eu brings together live quizzes, numeric estimation questions, confidence ratings on scored questions, a Q&A wall, word-cloud analysis and Pulse Check feedback in one interface for schools, universities, continuing education, workshops and business. Open source, runnable on your own infrastructure and designed for operation with GDPR in mind.',
     a11yLink: 'Conforms to WCAG 2.2 Level AA',
     a11ySuffix: '— keyboard, screen reader and individually adjustable response time.',
     cards: [
@@ -84,7 +84,7 @@ const en: Messages = {
     plausibilityBand: 'Plausibility band',
     plausibilityValue: '1500 to 2000',
     histogramNote:
-      'Histogram, reference line and tolerance band appear only after results are released. Until then only neutral progress stays visible.',
+      'Histogram, reference line and tolerance band appear only after results are released. Until then, only a neutral progress indicator is visible.',
     median: 'Median',
     inBand: 'in band',
     round2: 'Round 2',
@@ -126,7 +126,7 @@ const en: Messages = {
     debriefing: 'Debriefing',
     resultsPdf: 'Results report (PDF)',
     exportNote:
-      'Print-ready report with learning status, heatmap and full question text — in the facilitator view and on the quiz card. CSV for Excel remains available under “More”.',
+      'Print-ready report with learning progress, heatmap and full question text — in the facilitator view and on the quiz card. CSV for Excel remains available under “More”.',
   },
   qaWall: {
     eyebrow: 'Live Q&A as a moderation space',
@@ -135,11 +135,11 @@ const en: Messages = {
     signals: [
       {
         label: 'Pre-moderation',
-        text: 'Release questions only when they fit the teaching moment.',
+        text: 'Release questions only when they are relevant in the teaching context.',
       },
       {
         label: 'Collective voting',
-        text: 'Upvotes and downvotes show priority, friction and need for clarification.',
+        text: 'Upvotes and downvotes indicate priorities, points of disagreement and needs for clarification.',
       },
       {
         label: 'Topic word cloud',
@@ -152,7 +152,7 @@ const en: Messages = {
     ],
     docsLink: 'Open Q&A scoring and controversy docs on GitHub',
     demoAria: 'Sample Q&A wall with moderation, voting and word cloud',
-    hostView: 'Facilitator view Q&A',
+    hostView: 'Facilitator’s Q&A view',
     demoTitle: 'Questions about the event',
     moderationActive: 'Pre-moderation on',
     sortMostSupported: 'Most supported',
@@ -176,7 +176,7 @@ const en: Messages = {
       },
     ],
     wordCloud: 'Q&A word cloud',
-    wordCloudHint: 'Weighted by positive resonance and controversy.',
+    wordCloudHint: 'Weighted by positive support and controversy.',
     frozenLive: 'Live updates paused',
     terms: [
       { label: 'Tolerance band', className: 'text-3xl text-brand-200' },
@@ -189,7 +189,7 @@ const en: Messages = {
       { label: 'Clarification need', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Next step: a deterministic moderation compass, optionally complemented by asynchronous language-analysis signals and source-bound summaries.',
+      'Next step: a deterministic moderation compass, optionally complemented by asynchronous language-analysis signals and summaries grounded in the submitted questions.',
   },
   workflow: {
     eyebrow: 'For teaching, training and workshops',
@@ -213,13 +213,13 @@ const en: Messages = {
         number: '03',
         title: 'Moderate live',
         description:
-          'Participants vote, ask questions and prioritise together. Facilitator and presenter show quiz, Q&A wall, word cloud, reading phase, countdown, second round and results in one flow.',
+          'Participants vote, ask questions and prioritise together. The facilitator and presenter show the quiz, Q&A wall, word cloud, reading phase, countdown, second round and results in one flow.',
       },
       {
         number: '04',
         title: 'Follow up and export',
         description:
-          'After the session ends, the results report (PDF) is ready — with learning status, confidence rating and full question text. In the quiz collection you will find debriefing and PDF for the last run; CSV for Excel under “More”.',
+          'After the session ends, the results report (PDF) is ready — with learning progress, confidence rating and full question text. In the quiz collection you will find debriefing and PDF for the last run; CSV for Excel under “More”.',
       },
     ],
   },
@@ -237,7 +237,7 @@ const en: Messages = {
       {
         title: 'Confidence rating in the live quiz',
         description:
-          'Participants say how sure they are after answering. You spot confidently wrong answers, prioritise the debriefing and export learning status in the results report (PDF).',
+          'Participants say how sure they are after answering. You spot confidently wrong answers, prioritise the debriefing and export the level of understanding in the results report (PDF).',
         icon: 'confidence',
       },
       {
@@ -255,7 +255,7 @@ const en: Messages = {
       {
         title: 'More than a standard quiz',
         description:
-          'MC/SC, short answer, rating, reading phase, Peer Instruction and presenter flow support learning, training and live facilitation.',
+          'MC/SC, short answers, ratings, reading phase, Peer Instruction and presenter mode support learning, training and live facilitation.',
         icon: 'toggle',
       },
       {
@@ -267,7 +267,7 @@ const en: Messages = {
       {
         title: 'Rich word cloud',
         description:
-          'Free text and Q&A are condensed into words and phrases; the wall weights by agreement, robust score or controversy.',
+          'Free text and Q&A are condensed into words and phrases; the wall weights by agreement, clear majority score or controversy.',
         icon: 'cloud',
       },
       {
@@ -291,7 +291,7 @@ const en: Messages = {
       {
         title: 'Open source with deployment and operations',
         description:
-          'Docker, Postgres, Redis and an admin activity log make the platform robust for hosting, operations and auditability.',
+          'Docker, Postgres, Redis and an admin activity log make the platform reliable for deployment, operations and auditability.',
         icon: 'server',
       },
     ],
@@ -411,7 +411,7 @@ const en: Messages = {
       {
         question: 'What is confidence rating in the quiz?',
         answer:
-          'An optional follow-up after scored questions: participants rate on a scale of 1–5 how sure they are about their answer. Points stay unchanged; in the facilitator evaluation you see correctness × confidence and flag confidently wrong answers as a misconception signal. After the session ends, learning status flows into debriefing and the results report (PDF).',
+          'An optional follow-up after scored questions: participants rate on a scale of 1–5 how sure they are about their answer. Points stay unchanged; in the facilitator evaluation you see correctness × confidence and flag confidently wrong answers as a misconception signal. After the session ends, learning outcomes feed into debriefing and the results report (PDF).',
       },
       {
         question: 'Can I export session results?',
@@ -426,12 +426,12 @@ const en: Messages = {
       {
         question: 'What can the Q&A wall do?',
         answer:
-          'Participants submit questions and weight them with upvotes and downvotes. Facilitators can pre-moderate, pin, archive or remove questions and sort the list by support, robust agreement or controversy.',
+          'Participants submit questions and weight them with upvotes and downvotes. Facilitators can pre-moderate, pin, archive or remove questions and sort the list by support, clear majority agreement or controversy.',
       },
       {
         question: 'What makes the Q&A word cloud different?',
         answer:
-          'It condenses visible questions into words and phrases and follows the active sort logic. So it shows not only frequent terms, but topic clusters from supported, robustly scored or controversial questions.',
+          'It condenses visible questions into words and phrases and follows the active sort logic. So it shows not only frequent terms, but topic groups from supported, clearly high-scoring or controversial questions.',
       },
       {
         question: 'Who is the platform for?',
@@ -465,7 +465,7 @@ const en: Messages = {
       'Markdown and KaTeX',
       'Reading phase and Peer Instruction',
       'Q&A and free-text word cloud with phrases and weighting',
-      'Sorting by support, robust agreement and controversy',
+      'Sorting by support, clear majority agreement and controversy',
       'Team mode and presets',
       'Leaderboard, streak, bonus code',
       'Import/export and Yjs sync',
@@ -473,7 +473,7 @@ const en: Messages = {
       'UI in five languages',
       'Conforms to WCAG 2.2 Level AA',
       'Docker on your own infrastructure and admin activity log',
-      'Locally kept quiz content and GDPR-oriented operation',
+      'Locally kept quiz content and operation with GDPR in mind',
     ],
   },
 };

--- a/apps/landing/src/i18n/es.ts
+++ b/apps/landing/src/i18n/es.ts
@@ -1,0 +1,480 @@
+import type { Messages } from './types';
+
+const es: Messages = {
+  meta: {
+    homeTitle: 'arsnova.eu | Cuestionario en vivo, estimaciones numéricas y muro Q&A',
+    homeDescription:
+      'Audience response de código abierto para educación, formación y organizaciones: cuestionario en vivo, autoevaluación, informe de resultados (PDF), estimaciones numéricas, muro Q&A moderable, nube de palabras y feedback — accesible WCAG 2.2 AA, gratuito, autoalojable y listo sin cuenta.',
+    siteNameInfo: 'arsnova.eu – Información',
+    ogLocale: 'es_ES',
+  },
+  nav: {
+    ariaLabel: 'Navegación principal',
+    workflow: 'Flujo',
+    estimate: 'Estimación',
+    qa: 'Q&A',
+    qaMobile: 'Muro de preguntas',
+    features: 'Ventajas',
+    accessibility: 'Accesibilidad',
+    trust: 'Confianza',
+    faq: 'FAQ',
+    tryNow: 'Probar ahora',
+    menuOpen: 'Abrir menú',
+    menuClose: 'Cerrar menú',
+    menu: 'Menú',
+    skipToContent: 'Ir al contenido',
+  },
+  languageSwitcher: {
+    label: 'Idioma',
+    currentLanguage: 'Español',
+    chooseLanguage: 'Elegir idioma',
+  },
+  footer: {
+    impressum: 'Aviso legal',
+    privacy: 'Privacidad',
+    accessibility: 'Accesibilidad',
+  },
+  cta: {
+    appOpen: 'Abrir la aplicación',
+    quizCreate: 'Crear un cuestionario',
+    backToApp: 'Volver a arsnova.eu',
+    tryLive: 'Probarlo en vivo ahora',
+    howItWorks: 'Cómo funciona',
+    viewOpenSource: 'Ver el código abierto',
+  },
+  hero: {
+    eyebrow: 'Audience response para educación y organizaciones',
+    titleLine1: 'Cuestionarios, estimaciones,',
+    titleLine2: 'moderación de preguntas',
+    titleAccent1: 'en vivo y gratis',
+    titleAccent2: ' sin cuenta.',
+    lead: 'arsnova.eu reúne cuestionarios en vivo, estimaciones numéricas, autoevaluación en preguntas puntuables, muro Q&A, análisis de nube de palabras y sondeo rápido en una sola interfaz para escuelas, universidades, formación continua, talleres y empresas. Código abierto, autoalojable y pensado para un funcionamiento orientado al RGPD.',
+    a11yLink: 'Accesible según WCAG 2.2 AA',
+    a11ySuffix: '— teclado, lector de pantalla y tiempo de respuesta ajustable individualmente.',
+    cards: [
+      { title: 'En vivo al instante', text: 'Comparte la sesión con código o QR' },
+      { title: 'Q&A con muro de preguntas', text: 'Moderación, votos y nube temática' },
+      {
+        title: 'Autoevaluación y seguimiento',
+        text: 'Detecta conceptos erróneos, exporta el informe PDF',
+      },
+      { title: 'Código abierto y autoalojable', text: 'Docker, Postgres, Redis y auditoría admin' },
+    ],
+  },
+  estimate: {
+    eyebrow: 'Nuevo en el cuestionario en vivo',
+    title: 'Estimar cifras, debatir y comparar con claridad la segunda ronda',
+    lead: 'La pregunta de estimación numérica está pensada para fechas, órdenes de magnitud, medidas y probabilidades. Quien facilita fija un valor de referencia, un rango de entrada y una tolerancia; los participantes solo introducen un número.',
+    summary: [
+      'La banda de plausibilidad limita las entradas permitidas.',
+      'La banda de tolerancia valora las estimaciones aceptables en el contenido.',
+      'Nadie ve la distribución antes de publicar los resultados.',
+      'La ronda 1 y la ronda 2 se comparan después del debate.',
+    ],
+    docsLink: 'Abrir la documentación de la estimación',
+    demoAria: 'Ejemplo de resultados de una estimación sobre la Revolución Francesa',
+    hostView: 'Vista de anfitrión tras publicar',
+    demoQuestion: '¿Cuándo comenzó la Revolución Francesa?',
+    reference: 'Referencia 1789',
+    toleranceBand: 'Banda de tolerancia',
+    toleranceValue: '1700 a 1900',
+    plausibilityBand: 'Banda de plausibilidad',
+    plausibilityValue: '1500 a 2000',
+    histogramNote:
+      'El histograma, la línea de referencia y la banda de tolerancia aparecen solo tras publicar los resultados. Hasta entonces solo queda visible el progreso neutro.',
+    median: 'Mediana',
+    inBand: 'en la banda',
+    round2: 'Ronda 2',
+    round2Value: '14 más cerca',
+  },
+  confidence: {
+    eyebrow: 'Evaluación didáctica',
+    title: '¿Correcto o incorrecto — y con qué grado de seguridad?',
+    lead: 'Con la autoevaluación, los participantes indican tras responder cuán seguros están (1–5). Ves no solo la tasa de aciertos, sino también respuestas incorrectas con alta seguridad — una palanca fuerte para la evaluación formativa, el plan para la puesta en común y el informe de resultados (PDF) al terminar la sesión.',
+    summary: [
+      'No es un tipo de pregunta propio — opcional en preguntas puntuables.',
+      'Escala 1–5 tras la respuesta, sin efecto en los puntos.',
+      'Tras publicar, el anfitrión ve corrección × grado de seguridad.',
+      '«Incorrecto y seguro» marca posibles conceptos erróneos.',
+      'Tras la sesión: informe de resultados (PDF) y puesta en común.',
+    ],
+    docsConfidence: 'Doc autoevaluación',
+    docsExport: 'Doc informe de resultados (PDF)',
+    demoAria: 'Ejemplo de evaluación con autoevaluación tras publicar resultados',
+    hostView: 'Vista de anfitrión tras publicar',
+    demoQuestion: '¿Qué estructura es la más estable?',
+    badge: 'Autoevaluación',
+    matrix: [
+      { label: 'Correcto · bajo', count: 3, tone: 'emerald' },
+      { label: 'Correcto · medio', count: 8, tone: 'emerald' },
+      { label: 'Correcto · alto', count: 11, tone: 'emerald' },
+      { label: 'Incorrecto · bajo', count: 2, tone: 'slate' },
+      { label: 'Incorrecto · medio', count: 4, tone: 'amber' },
+      { label: 'Incorrecto · alto', count: 2, tone: 'rose' },
+    ],
+    falseHighTitle: '2 respuestas incorrectas con alta seguridad',
+    falseHighText:
+      'La opción B se eligió 2× con alto grado de seguridad — una señal de posibles conceptos erróneos en la puesta en común.',
+    consolidated: 'Sólido',
+    misconceptionRisk: 'Riesgo de concepto erróneo',
+    fragile: 'Frágil',
+    afterSessionAria: 'Exportación al terminar la sesión',
+    afterSession: 'Al terminar la sesión',
+    debriefing: 'Puesta en común',
+    resultsPdf: 'Informe de resultados (PDF)',
+    exportNote:
+      'Informe listo para imprimir con estado de aprendizaje, mapa de calor y textos de las preguntas — en la vista de anfitrión y en la tarjeta del cuestionario. El CSV para Excel sigue disponible en «Más».',
+  },
+  qaWall: {
+    eyebrow: 'Q&A en vivo como superficie de moderación',
+    title: 'Recoger preguntas, priorizarlas y leerlas como mapa temático',
+    lead: 'El muro de preguntas no es un chat secundario. Es un canal en vivo propio para docentes y ponentes: moderar aportaciones, detectar prioridades colectivas, hacer visibles los puntos controvertidos y llevar los temas clave a la sala mediante una nube de palabras Q&A ponderada.',
+    signals: [
+      {
+        label: 'Premoderación',
+        text: 'Publica las preguntas solo cuando encajan en el momento didáctico.',
+      },
+      {
+        label: 'Voto colectivo',
+        text: 'Los votos a favor y en contra muestran prioridad, fricción y necesidad de aclaración.',
+      },
+      {
+        label: 'Nube temática',
+        text: 'Palabras y frases se ponderan según apoyo, acuerdo o controversia.',
+      },
+      {
+        label: 'Perspectiva brújula',
+        text: 'Primero llegan las señales deterministas; NLP Q&A y resumen siguen siendo extensiones opcionales.',
+      },
+    ],
+    docsLink: 'Abrir puntuación Q&A y controversia en GitHub',
+    demoAria: 'Ejemplo de muro Q&A con moderación, votos y nube de palabras',
+    hostView: 'Vista de anfitrión Q&A',
+    demoTitle: 'Preguntas sobre el evento',
+    moderationActive: 'Premoderación activa',
+    sortMostSupported: 'Más apoyadas',
+    sortBest: 'Mejores preguntas',
+    sortControversial: 'Controvertidas',
+    questions: [
+      {
+        score: '+18',
+        title: '¿Cuándo sigue siendo plausible una estimación en el contenido?',
+        meta: '15 a favor · 3 en contra · mejor pregunta',
+      },
+      {
+        score: '+4',
+        title: '¿Debemos ocultar realmente los resultados antes del debate?',
+        meta: '9 a favor · 5 en contra · controvertida',
+      },
+      {
+        score: '+11',
+        title: '¿En qué se diferencia el Q&A del texto libre en el cuestionario?',
+        meta: '11 a favor · 0 en contra · mayormente apoyada',
+      },
+    ],
+    wordCloud: 'Nube de palabras Q&A',
+    wordCloudHint: 'Ponderada por resonancia positiva y controversia.',
+    frozenLive: 'Congelada en vivo',
+    terms: [
+      { label: 'Banda de tolerancia', className: 'text-3xl text-brand-200' },
+      { label: 'Debate', className: 'text-2xl text-emerald-200' },
+      { label: 'Q&A', className: 'text-4xl text-white' },
+      { label: 'Plausibilidad', className: 'text-xl text-amber-200' },
+      { label: 'Controversia', className: 'text-2xl text-rose-200' },
+      { label: 'Peer Instruction', className: 'text-lg text-slate-300' },
+      { label: 'Moderación', className: 'text-3xl text-cyan-200' },
+      { label: 'Necesidad de aclaración', className: 'text-xl text-violet-200' },
+    ],
+    nextStep:
+      'Siguiente paso: una brújula de moderación determinista, opcionalmente complementada con señales NLP Q&A asíncronas y resúmenes ligados a las fuentes.',
+  },
+  workflow: {
+    eyebrow: 'Para docencia, formación y talleres',
+    title: 'De la idea a la sesión en vivo en pocos minutos',
+    lead: 'De la pregunta a la sesión en curso, el flujo evita a propósito pasos innecesarios. Eso hace que el arranque sea rápido y fiable para docentes, formadores y moderadores.',
+    stepLabel: 'Paso',
+    steps: [
+      {
+        number: '01',
+        title: 'Preparar un cuestionario',
+        description:
+          'Crea preguntas directamente o importa contenidos existentes. Markdown, KaTeX, respuesta corta y estimaciones numéricas están integrados.',
+      },
+      {
+        number: '02',
+        title: 'Iniciar una sesión',
+        description:
+          'Empieza sin cuenta: abre una sesión, elige un estilo, comparte código o QR y usa la vista presentador si lo necesitas.',
+      },
+      {
+        number: '03',
+        title: 'Moderar en vivo',
+        description:
+          'Los participantes votan, formular preguntas y priorizan juntos. Anfitrión y presentador muestran cuestionario, muro Q&A, nube de palabras, fase de lectura, cuenta atrás, segunda ronda y resultados en un solo flujo.',
+      },
+      {
+        number: '04',
+        title: 'Seguimiento y exportación',
+        description:
+          'Al terminar la sesión, el informe de resultados (PDF) está listo — con estado de aprendizaje, autoevaluación y textos completos de las preguntas. En la colección de cuestionarios encuentras puesta en común y PDF de la última pasada; CSV para Excel en «Más».',
+      },
+    ],
+  },
+  features: {
+    eyebrow: 'Por qué se siente distinto',
+    title: 'Hecho para la interacción en vivo, no solo para encuestas en diapositivas',
+    lead: 'arsnova.eu combina un arranque rápido, solidez didáctica y una base técnica transparente. La plataforma se mantiene sencilla en el día a día sin reducir las posibilidades.',
+    items: [
+      {
+        title: 'Listo en poco tiempo',
+        description:
+          'Los anfitriones empiezan sin cuenta. Los participantes entran en la sesión directamente con un código de 6 dígitos o un QR.',
+        icon: 'single',
+      },
+      {
+        title: 'Autoevaluación en el cuestionario en vivo',
+        description:
+          'Los participantes indican tras responder cuán seguros están. Detectas respuestas incorrectas con alta seguridad, priorizas la puesta en común y exportas el estado de aprendizaje en el informe de resultados (PDF).',
+        icon: 'confidence',
+      },
+      {
+        title: 'Informe de resultados para el seguimiento',
+        description:
+          'Al terminar la sesión exportas un informe PDF listo para imprimir con gráficos, textos de preguntas y autoevaluación. El CSV para Excel sigue siendo opcional en «Más».',
+        icon: 'export',
+      },
+      {
+        title: 'Estimaciones didácticas',
+        description:
+          'Fechas, órdenes de magnitud y medidas se pueden estimar con valor de referencia, banda de tolerancia, estadística y una segunda ronda opcional.',
+        icon: 'estimate',
+      },
+      {
+        title: 'Más que un cuestionario estándar',
+        description:
+          'MC/SC, respuesta corta, valoración, fase de lectura, Peer Instruction y flujo presentador apoyan el aprendizaje, la formación y la moderación en vivo.',
+        icon: 'toggle',
+      },
+      {
+        title: 'Muro de preguntas en lugar de un chat secundario',
+        description:
+          'El Q&A ofrece premoderación, fijar, archivar, votos a favor/en contra y ordenación por apoyo, calidad y controversia.',
+        icon: 'qa',
+      },
+      {
+        title: 'Nube de palabras elaborada',
+        description:
+          'Texto libre y Q&A se condensan en palabras y frases; el muro pondera por acuerdo, puntuación robusta o controversia.',
+        icon: 'cloud',
+      },
+      {
+        title: 'Para distintos contextos',
+        description:
+          'Ajustes previos, modo equipo, modo anónimo, apodos y elección de estilo ayudan desde clase y seminario hasta taller, evento y reunión.',
+        icon: 'bolt',
+      },
+      {
+        title: 'Accesibilidad según WCAG 2.2 AA',
+        description:
+          'Uso con teclado, anuncios de lector de pantalla, tiempo de respuesta ajustable individualmente e informes PDF/UA-1 — para que más personas puedan participar de forma autónoma en sesiones en vivo.',
+        icon: 'a11y',
+      },
+      {
+        title: 'Privacidad y control',
+        description:
+          'Local-first, data-stripping y explotación autoalojable te dan más control sobre contenidos y datos en vivo.',
+        icon: 'tools',
+      },
+      {
+        title: 'Código abierto con ruta operativa',
+        description:
+          'Docker, Postgres, Redis y auditoría admin hacen la plataforma fiable también para alojamiento, operación y trazabilidad.',
+        icon: 'server',
+      },
+    ],
+  },
+  accessibility: {
+    eyebrow: 'Accesibilidad',
+    title: 'WCAG 2.2 AA — para que más personas puedan participar de forma autónoma',
+    lead: 'Para escuelas, universidades y formación continua, la accesibilidad suele ser un criterio decisivo. arsnova.eu cumple las Web Content Accessibility Guidelines (WCAG) 2.2 en el nivel AA — con uso de teclado, apoyo de lector de pantalla, tiempo de respuesta ajustable individualmente e informes PDF estructurados de forma accesible.',
+    benefits: [
+      {
+        title: 'Uso con teclado',
+        description:
+          'Tú y tus participantes usáis los flujos centrales sin ratón. Indicadores de foco visibles y un enlace de salto al contenido facilitan la navegación.',
+      },
+      {
+        title: 'Apoyo de lector de pantalla en vivo',
+        description:
+          'Los cambios de estado al unirse a la sesión, en las votaciones y en los cambios de fase se anuncian a los lectores de pantalla para seguir el flujo.',
+      },
+      {
+        title: 'Tiempo de respuesta ajustable individualmente',
+        description:
+          'En preguntas con tiempo eliges el tiempo estándar, el tiempo multiplicado por diez o participar sin límite. Así se puede aplicar un ajuste razonable directamente en la sesión en vivo.',
+      },
+      {
+        title: 'Informe de resultados estructurado de forma accesible',
+        description:
+          'El informe listo para imprimir está validado PDF/UA-1 e incluye título, idioma y etiquetas — para el seguimiento y el intercambio accesible.',
+      },
+    ],
+    statementLink: 'Abrir la declaración de accesibilidad',
+  },
+  trust: {
+    eyebrow: 'Confianza',
+    title: 'Creíble porque el producto no parte de cero',
+    lead: 'arsnova.eu continúa la tradición del ecosistema ARSnova y se apoya en experiencias científicas, didácticas y prácticas de muchos años de tecnología educativa.',
+    proofItems: [
+      { value: 'Desde 2012', label: 'Tradición ARSnova en educación y edtech' },
+      { value: 'WCAG 2.2 AA', label: 'Accesibilidad verificada para docencia e instituciones' },
+      {
+        value: '5 idiomas de UI',
+        label: 'Alemán, inglés, francés, español, italiano',
+      },
+      { value: 'Código abierto', label: 'Código transparente en lugar de una caja negra' },
+    ],
+    items: [
+      {
+        quote:
+          'Camino respetuoso con la privacidad: sin datos personales almacenados de forma permanente en el servidor.',
+        source: 'DeLFI 2017',
+        tag: 'Investigación',
+      },
+      {
+        quote:
+          'Evaluación UX en comparación directa con Kahoot! como punto de control empírico del diseño.',
+        source: 'fnm-austria',
+        tag: 'Estudio',
+      },
+      {
+        quote:
+          'Privacy by design y apertura técnica son un verdadero factor diferencial para contextos edtech europeos.',
+        source: 'Análisis de publicaciones',
+        tag: 'Arquitectura',
+      },
+      {
+        quote: 'Probado en entornos educativos reales, no solo descrito como concepto.',
+        source: 'Uso en contextos de docencia y formación',
+        tag: 'Práctica',
+      },
+    ],
+    referencesPrefix: 'Las referencias completas y la colección de publicaciones de base están en',
+    referencesLink: 'ARSnova-Recherche.pdf',
+    referencesSuffix: 'en GitHub.',
+  },
+  comparison: {
+    eyebrow: 'Diferenciación',
+    title: 'No solo un sustituto de Mentimeter o Kahoot',
+    lead: 'El centro no es solo la votación, sino el flujo en vivo completo: preparar, moderar, hacer visibles los resultados y mantener el control sobre contenidos y operación.',
+    points: [
+      {
+        title: 'Menos barreras de entrada',
+        description:
+          'Sin lógica de producto separada para «crear» y «unirse». Los anfitriones empiezan sin cuenta; los participantes entran con código o QR.',
+      },
+      {
+        title: 'Más formatos de interacción',
+        description:
+          'Además del cuestionario: estimaciones numéricas, fase de lectura, Peer Instruction, sondeo rápido, muro Q&A y nube de palabras ponderada en la misma plataforma — no solo encuestas en diapositivas.',
+      },
+      {
+        title: 'Más control sobre datos y acceso',
+        description:
+          'Código abierto, autoalojable y local-first — más accesibilidad WCAG 2.2 AA. Relevante para escuelas, universidades y organizaciones con requisitos de privacidad e inclusión.',
+      },
+    ],
+    comparePrefix: 'La comparación completa de funciones sigue en la documentación:',
+    compareLink: 'Abrir la comparación en GitHub',
+  },
+  faq: {
+    eyebrow: 'FAQ',
+    title: 'Preguntas frecuentes antes del primer uso',
+    answerLabel: 'Respuesta',
+    items: [
+      {
+        question: '¿Necesitan cuenta anfitriones o participantes?',
+        answer:
+          'No. Una sesión puede iniciarse sin cuenta. Los participantes entran con código o QR.',
+      },
+      {
+        question: '¿Dónde están los datos?',
+        answer:
+          'Los contenidos del cuestionario están pensados local-first. En sesiones en vivo solo se procesan los datos de sesión técnicamente necesarios; con autoalojamiento, la operación permanece en tu infraestructura.',
+      },
+      {
+        question: '¿Puedo autoalojar arsnova.eu?',
+        answer:
+          'Sí. La plataforma es de código abierto y está diseñada para funcionar con Docker, PostgreSQL y Redis.',
+      },
+      {
+        question: '¿Qué es la autoevaluación en el cuestionario?',
+        answer:
+          'Una pregunta adicional opcional tras las preguntas puntuables: los participantes indican en una escala de 1 a 5 cuán seguros están de su respuesta. Los puntos no cambian; en la evaluación del anfitrión ves corrección × grado de seguridad y marcas las respuestas incorrectas con alta seguridad como señal de concepto erróneo. Al terminar la sesión, el estado de aprendizaje pasa a la puesta en común y al informe de resultados (PDF).',
+      },
+      {
+        question: '¿Puedo exportar los resultados de la sesión?',
+        answer:
+          'Sí. Al terminar la sesión, el informe de resultados (PDF) es el formato principal — con autoevaluación, prioridades para la puesta en común y textos completos de las preguntas. En la colección de cuestionarios encuentras puesta en común y PDF de la última pasada. Los datos CSV tabulares están disponibles en «Más» para Excel.',
+      },
+      {
+        question: '¿Qué tiene de especial la estimación numérica?',
+        answer:
+          'Separa las entradas permitidas de la banda de tolerancia del contenido, no muestra la distribución durante la votación y puede evaluar una segunda ronda tras el debate con estadística y comparación de rondas.',
+      },
+      {
+        question: '¿Qué puede hacer el muro Q&A?',
+        answer:
+          'Los participantes envían preguntas y las ponderan con votos a favor y en contra. Los anfitriones pueden premoderar, fijar, archivar o eliminar preguntas y ordenar la lista por apoyo, acuerdo robusto o controversia.',
+      },
+      {
+        question: '¿En qué se diferencia la nube de palabras Q&A?',
+        answer:
+          'Condensa las preguntas visibles en palabras y frases y sigue la lógica de ordenación activa. Así muestra no solo términos frecuentes, sino clústeres temáticos de preguntas apoyadas, puntuadas de forma robusta o controvertidas.',
+      },
+      {
+        question: '¿Para quién está pensada la plataforma?',
+        answer:
+          'Para la interacción en vivo en educación y organizaciones: escuela, universidad, formación continua, formación, taller, evento o reunión.',
+      },
+      {
+        question: '¿Es accesible arsnova.eu?',
+        answer:
+          'arsnova.eu cumple WCAG 2.2 AA. Los flujos centrales se pueden usar con teclado, los lectores de pantalla anuncian cambios de estado, el tiempo de respuesta en preguntas con tiempo es ajustable individualmente (tiempo estándar, tiempo ×10 o sin límite), y el informe de resultados estructurado de forma accesible está validado PDF/UA-1.',
+        linkLabel: 'Abrir la declaración de accesibilidad',
+      },
+    ],
+  },
+  ctaSection: {
+    title: '¿Listo para la próxima sesión en vivo?',
+    lead: 'Prueba el flujo en vivo directamente en la aplicación, o echa un vistazo al código abierto, a la lógica Q&A, al pipeline de la nube de palabras y a la ruta operativa detrás de la plataforma.',
+  },
+  jsonLd: {
+    websiteName: 'arsnova.eu – Información',
+    webAppDescription:
+      'Audience response de código abierto para educación, formación y organizaciones: cuestionario en vivo, autoevaluación, informe de resultados (PDF), estimaciones numéricas, muro Q&A moderable, nube de palabras y feedback — accesible WCAG 2.2 AA, gratuito, autoalojable y listo sin cuenta.',
+    featureList: [
+      'Cuestionario en vivo y votaciones',
+      'Autoevaluación en preguntas puntuables',
+      'Informe de resultados (PDF) y puesta en común al terminar la sesión',
+      'Estimaciones numéricas con dos rondas y estadística',
+      'Muro Q&A con moderación, votos a favor y en contra',
+      'Lobby, presentador, QR/código',
+      'Tipos de pregunta MC/SC/respuesta corta/texto libre/encuesta/valoración/estimación',
+      'Markdown y KaTeX',
+      'Fase de lectura y Peer Instruction',
+      'Nube de palabras Q&A y texto libre con frases y ponderación',
+      'Ordenación por apoyo, acuerdo robusto y controversia',
+      'Modo equipo y ajustes previos',
+      'Clasificación, racha, código bonus',
+      'Importación/exportación y sync Yjs',
+      'Importación IA externa, validada con Zod',
+      'Interfaz en cinco idiomas',
+      'Accesibilidad según WCAG 2.2 AA',
+      'Autoalojamiento Docker y auditoría admin',
+      'Local-first y funcionamiento orientado al RGPD',
+    ],
+  },
+};
+
+export default es;

--- a/apps/landing/src/i18n/es.ts
+++ b/apps/landing/src/i18n/es.ts
@@ -2,9 +2,10 @@ import type { Messages } from './types';
 
 const es: Messages = {
   meta: {
-    homeTitle: 'arsnova.eu | Cuestionario en vivo, estimaciones numéricas y muro Q&A',
+    homeTitle:
+      'arsnova.eu | Cuestionario en vivo, preguntas de estimación numérica y muro de preguntas',
     homeDescription:
-      'Audience response de código abierto para educación, formación y organizaciones: cuestionario en vivo, autoevaluación, informe de resultados (PDF), estimaciones numéricas, muro Q&A moderable, nube de palabras y feedback — accesible WCAG 2.2 AA, gratuito, autoalojable y listo sin cuenta.',
+      'Plataforma de respuesta interactiva de código abierto para educación, formación y organizaciones: cuestionario en vivo, autoevaluación, informe de resultados (PDF), preguntas de estimación numérica, muro de preguntas moderable, nube de palabras y sondeo rápido — cumple las WCAG 2.2, nivel AA, gratuita, autoalojable y lista sin cuenta.',
     siteNameInfo: 'arsnova.eu – Información',
     ogLocale: 'es_ES',
   },
@@ -40,22 +41,22 @@ const es: Messages = {
     backToApp: 'Volver a arsnova.eu',
     tryLive: 'Probarlo en vivo ahora',
     howItWorks: 'Cómo funciona',
-    viewOpenSource: 'Ver el código abierto',
+    viewOpenSource: 'Ver el código fuente',
   },
   hero: {
-    eyebrow: 'Audience response para educación y organizaciones',
+    eyebrow: 'Respuesta interactiva para educación y organizaciones',
     titleLine1: 'Cuestionarios, estimaciones,',
     titleLine2: 'moderación de preguntas',
     titleAccent1: 'en vivo y gratis',
     titleAccent2: ' sin cuenta.',
-    lead: 'arsnova.eu reúne cuestionarios en vivo, estimaciones numéricas, autoevaluación en preguntas puntuables, muro Q&A, análisis de nube de palabras y sondeo rápido en una sola interfaz para escuelas, universidades, formación continua, talleres y empresas. Código abierto, autoalojable y pensado para un funcionamiento orientado al RGPD.',
-    a11yLink: 'Accesible según WCAG 2.2 AA',
+    lead: 'arsnova.eu reúne cuestionarios en vivo, preguntas de estimación numérica, autoevaluación en preguntas puntuables, muro de preguntas, análisis de nube de palabras y sondeo rápido en una sola interfaz para escuelas, universidades, formación continua, talleres y empresas. Código abierto, autoalojable y pensado para un funcionamiento orientado al RGPD.',
+    a11yLink: 'Cumple las WCAG 2.2, nivel AA',
     a11ySuffix: '— teclado, lector de pantalla y tiempo de respuesta ajustable individualmente.',
     cards: [
       { title: 'En vivo al instante', text: 'Comparte la sesión con código o QR' },
       { title: 'Q&A con muro de preguntas', text: 'Moderación, votos y nube temática' },
       {
-        title: 'Autoevaluación y seguimiento',
+        title: 'Autoevaluación y análisis posterior',
         text: 'Detecta conceptos erróneos, exporta el informe PDF',
       },
       { title: 'Código abierto y autoalojable', text: 'Docker, Postgres, Redis y auditoría admin' },
@@ -71,8 +72,9 @@ const es: Messages = {
       'Nadie ve la distribución antes de publicar los resultados.',
       'La ronda 1 y la ronda 2 se comparan después del debate.',
     ],
-    docsLink: 'Abrir la documentación de la estimación',
-    demoAria: 'Ejemplo de resultados de una estimación sobre la Revolución Francesa',
+    docsLink: 'Abrir la documentación de la pregunta de estimación numérica',
+    demoAria:
+      'Ejemplo de resultados de una pregunta de estimación numérica sobre la Revolución Francesa',
     hostView: 'Vista de anfitrión tras publicar',
     demoQuestion: '¿Cuándo comenzó la Revolución Francesa?',
     reference: 'Referencia 1789',
@@ -85,7 +87,7 @@ const es: Messages = {
     median: 'Mediana',
     inBand: 'en la banda',
     round2: 'Ronda 2',
-    round2Value: '14 más cerca',
+    round2Value: '14 respuestas más próximas al valor de referencia',
   },
   confidence: {
     eyebrow: 'Evaluación didáctica',
@@ -105,12 +107,12 @@ const es: Messages = {
     demoQuestion: '¿Qué estructura es la más estable?',
     badge: 'Autoevaluación',
     matrix: [
-      { label: 'Correcto · bajo', count: 3, tone: 'emerald' },
-      { label: 'Correcto · medio', count: 8, tone: 'emerald' },
-      { label: 'Correcto · alto', count: 11, tone: 'emerald' },
-      { label: 'Incorrecto · bajo', count: 2, tone: 'slate' },
-      { label: 'Incorrecto · medio', count: 4, tone: 'amber' },
-      { label: 'Incorrecto · alto', count: 2, tone: 'rose' },
+      { label: 'Correcta · confianza baja', count: 3, tone: 'emerald' },
+      { label: 'Correcta · confianza media', count: 8, tone: 'emerald' },
+      { label: 'Correcta · confianza alta', count: 11, tone: 'emerald' },
+      { label: 'Incorrecta · confianza baja', count: 2, tone: 'slate' },
+      { label: 'Incorrecta · confianza media', count: 4, tone: 'amber' },
+      { label: 'Incorrecta · confianza alta', count: 2, tone: 'rose' },
     ],
     falseHighTitle: '2 respuestas incorrectas con alta seguridad',
     falseHighText:
@@ -143,12 +145,12 @@ const es: Messages = {
         text: 'Palabras y frases se ponderan según apoyo, acuerdo o controversia.',
       },
       {
-        label: 'Perspectiva brújula',
+        label: 'Perspectiva de la brújula de moderación',
         text: 'Primero llegan las señales deterministas; NLP Q&A y resumen siguen siendo extensiones opcionales.',
       },
     ],
     docsLink: 'Abrir puntuación Q&A y controversia en GitHub',
-    demoAria: 'Ejemplo de muro Q&A con moderación, votos y nube de palabras',
+    demoAria: 'Ejemplo de muro de preguntas con moderación, votos y nube de palabras',
     hostView: 'Vista de anfitrión Q&A',
     demoTitle: 'Preguntas sobre el evento',
     moderationActive: 'Premoderación activa',
@@ -174,7 +176,7 @@ const es: Messages = {
     ],
     wordCloud: 'Nube de palabras Q&A',
     wordCloudHint: 'Ponderada por resonancia positiva y controversia.',
-    frozenLive: 'Congelada en vivo',
+    frozenLive: 'Actualizaciones en vivo en pausa',
     terms: [
       { label: 'Banda de tolerancia', className: 'text-3xl text-brand-200' },
       { label: 'Debate', className: 'text-2xl text-emerald-200' },
@@ -198,7 +200,7 @@ const es: Messages = {
         number: '01',
         title: 'Preparar un cuestionario',
         description:
-          'Crea preguntas directamente o importa contenidos existentes. Markdown, KaTeX, respuesta corta y estimaciones numéricas están integrados.',
+          'Crea preguntas directamente o importa contenidos existentes. Markdown, KaTeX, respuesta corta y preguntas de estimación numérica están integrados.',
       },
       {
         number: '02',
@@ -210,13 +212,13 @@ const es: Messages = {
         number: '03',
         title: 'Moderar en vivo',
         description:
-          'Los participantes votan, formular preguntas y priorizan juntos. Anfitrión y presentador muestran cuestionario, muro Q&A, nube de palabras, fase de lectura, cuenta atrás, segunda ronda y resultados en un solo flujo.',
+          'Los participantes votan, formulan preguntas y priorizan juntos. Anfitrión y presentador muestran cuestionario, muro de preguntas, nube de palabras, fase de lectura, cuenta atrás, segunda ronda y resultados en un solo flujo.',
       },
       {
         number: '04',
-        title: 'Seguimiento y exportación',
+        title: 'Análisis posterior y exportación',
         description:
-          'Al terminar la sesión, el informe de resultados (PDF) está listo — con estado de aprendizaje, autoevaluación y textos completos de las preguntas. En la colección de cuestionarios encuentras puesta en común y PDF de la última pasada; CSV para Excel en «Más».',
+          'Al terminar la sesión, el informe de resultados (PDF) está listo — con estado de aprendizaje, autoevaluación y textos completos de las preguntas. En la colección de cuestionarios encuentras puesta en común y PDF de la última ejecución; CSV para Excel en «Más».',
       },
     ],
   },
@@ -238,13 +240,13 @@ const es: Messages = {
         icon: 'confidence',
       },
       {
-        title: 'Informe de resultados para el seguimiento',
+        title: 'Informe de resultados para el análisis posterior',
         description:
           'Al terminar la sesión exportas un informe PDF listo para imprimir con gráficos, textos de preguntas y autoevaluación. El CSV para Excel sigue siendo opcional en «Más».',
         icon: 'export',
       },
       {
-        title: 'Estimaciones didácticas',
+        title: 'Preguntas de estimación numérica didácticas',
         description:
           'Fechas, órdenes de magnitud y medidas se pueden estimar con valor de referencia, banda de tolerancia, estadística y una segunda ronda opcional.',
         icon: 'estimate',
@@ -274,7 +276,7 @@ const es: Messages = {
         icon: 'bolt',
       },
       {
-        title: 'Accesibilidad según WCAG 2.2 AA',
+        title: 'Cumple las WCAG 2.2, nivel AA',
         description:
           'Uso con teclado, anuncios de lector de pantalla, tiempo de respuesta ajustable individualmente e informes PDF/UA-1 — para que más personas puedan participar de forma autónoma en sesiones en vivo.',
         icon: 'a11y',
@@ -282,11 +284,11 @@ const es: Messages = {
       {
         title: 'Privacidad y control',
         description:
-          'Local-first, data-stripping y explotación autoalojable te dan más control sobre contenidos y datos en vivo.',
+          'Enfoque local-first, eliminación opcional de datos y explotación autoalojable te dan más control sobre contenidos y datos en vivo.',
         icon: 'tools',
       },
       {
-        title: 'Código abierto con ruta operativa',
+        title: 'Código abierto con despliegue y operación',
         description:
           'Docker, Postgres, Redis y auditoría admin hacen la plataforma fiable también para alojamiento, operación y trazabilidad.',
         icon: 'server',
@@ -316,7 +318,7 @@ const es: Messages = {
       {
         title: 'Informe de resultados estructurado de forma accesible',
         description:
-          'El informe listo para imprimir está validado PDF/UA-1 e incluye título, idioma y etiquetas — para el seguimiento y el intercambio accesible.',
+          'El informe listo para imprimir está validado PDF/UA-1 e incluye título, idioma y etiquetas — para el análisis posterior y el intercambio accesible.',
       },
     ],
     statementLink: 'Abrir la declaración de accesibilidad',
@@ -376,12 +378,12 @@ const es: Messages = {
       {
         title: 'Más formatos de interacción',
         description:
-          'Además del cuestionario: estimaciones numéricas, fase de lectura, Peer Instruction, sondeo rápido, muro Q&A y nube de palabras ponderada en la misma plataforma — no solo encuestas en diapositivas.',
+          'Además del cuestionario: preguntas de estimación numérica, fase de lectura, Peer Instruction, sondeo rápido, muro de preguntas y nube de palabras ponderada en la misma plataforma — no solo encuestas en diapositivas.',
       },
       {
         title: 'Más control sobre datos y acceso',
         description:
-          'Código abierto, autoalojable y local-first — más accesibilidad WCAG 2.2 AA. Relevante para escuelas, universidades y organizaciones con requisitos de privacidad e inclusión.',
+          'Código abierto, autoalojable y local-first — más cumplimiento de las WCAG 2.2, nivel AA. Relevante para escuelas, universidades y organizaciones con requisitos de privacidad e inclusión.',
       },
     ],
     comparePrefix: 'La comparación completa de funciones sigue en la documentación:',
@@ -415,15 +417,15 @@ const es: Messages = {
       {
         question: '¿Puedo exportar los resultados de la sesión?',
         answer:
-          'Sí. Al terminar la sesión, el informe de resultados (PDF) es el formato principal — con autoevaluación, prioridades para la puesta en común y textos completos de las preguntas. En la colección de cuestionarios encuentras puesta en común y PDF de la última pasada. Los datos CSV tabulares están disponibles en «Más» para Excel.',
+          'Sí. Al terminar la sesión, el informe de resultados (PDF) es el formato principal — con autoevaluación, prioridades para la puesta en común y textos completos de las preguntas. En la colección de cuestionarios encuentras puesta en común y PDF de la última ejecución. Los datos CSV tabulares están disponibles en «Más» para Excel.',
       },
       {
-        question: '¿Qué tiene de especial la estimación numérica?',
+        question: '¿Qué tiene de especial la pregunta de estimación numérica?',
         answer:
           'Separa las entradas permitidas de la banda de tolerancia del contenido, no muestra la distribución durante la votación y puede evaluar una segunda ronda tras el debate con estadística y comparación de rondas.',
       },
       {
-        question: '¿Qué puede hacer el muro Q&A?',
+        question: '¿Qué puede hacer el muro de preguntas?',
         answer:
           'Los participantes envían preguntas y las ponderan con votos a favor y en contra. Los anfitriones pueden premoderar, fijar, archivar o eliminar preguntas y ordenar la lista por apoyo, acuerdo robusto o controversia.',
       },
@@ -440,27 +442,27 @@ const es: Messages = {
       {
         question: '¿Es accesible arsnova.eu?',
         answer:
-          'arsnova.eu cumple WCAG 2.2 AA. Los flujos centrales se pueden usar con teclado, los lectores de pantalla anuncian cambios de estado, el tiempo de respuesta en preguntas con tiempo es ajustable individualmente (tiempo estándar, tiempo ×10 o sin límite), y el informe de resultados estructurado de forma accesible está validado PDF/UA-1.',
+          'arsnova.eu cumple las WCAG 2.2, nivel AA. Los flujos centrales se pueden usar con teclado, los lectores de pantalla anuncian cambios de estado, el tiempo de respuesta en preguntas con tiempo es ajustable individualmente (tiempo estándar, tiempo ×10 o sin límite), y el informe de resultados estructurado de forma accesible está validado PDF/UA-1.',
         linkLabel: 'Abrir la declaración de accesibilidad',
       },
     ],
   },
   ctaSection: {
     title: '¿Listo para la próxima sesión en vivo?',
-    lead: 'Prueba el flujo en vivo directamente en la aplicación, o echa un vistazo al código abierto, a la lógica Q&A, al pipeline de la nube de palabras y a la ruta operativa detrás de la plataforma.',
+    lead: 'Prueba el flujo en vivo directamente en la aplicación, o echa un vistazo al código fuente abierto, a la lógica Q&A, al procesamiento de la nube de palabras y al camino de despliegue y operación detrás de la plataforma.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Información',
     webAppDescription:
-      'Audience response de código abierto para educación, formación y organizaciones: cuestionario en vivo, autoevaluación, informe de resultados (PDF), estimaciones numéricas, muro Q&A moderable, nube de palabras y feedback — accesible WCAG 2.2 AA, gratuito, autoalojable y listo sin cuenta.',
+      'Plataforma de respuesta interactiva de código abierto para educación, formación y organizaciones: cuestionario en vivo, autoevaluación, informe de resultados (PDF), preguntas de estimación numérica, muro de preguntas moderable, nube de palabras y sondeo rápido — cumple las WCAG 2.2, nivel AA, gratuita, autoalojable y lista sin cuenta.',
     featureList: [
       'Cuestionario en vivo y votaciones',
       'Autoevaluación en preguntas puntuables',
       'Informe de resultados (PDF) y puesta en común al terminar la sesión',
-      'Estimaciones numéricas con dos rondas y estadística',
-      'Muro Q&A con moderación, votos a favor y en contra',
+      'Preguntas de estimación numérica con dos rondas y estadística',
+      'Muro de preguntas con moderación, votos a favor y en contra',
       'Lobby, presentador, QR/código',
-      'Tipos de pregunta MC/SC/respuesta corta/texto libre/encuesta/valoración/estimación',
+      'Tipos de pregunta MC/SC/respuesta corta/texto libre/encuesta/valoración/estimación numérica',
       'Markdown y KaTeX',
       'Fase de lectura y Peer Instruction',
       'Nube de palabras Q&A y texto libre con frases y ponderación',
@@ -470,7 +472,7 @@ const es: Messages = {
       'Importación/exportación y sync Yjs',
       'Importación IA externa, validada con Zod',
       'Interfaz en cinco idiomas',
-      'Accesibilidad según WCAG 2.2 AA',
+      'Cumple las WCAG 2.2, nivel AA',
       'Autoalojamiento Docker y auditoría admin',
       'Local-first y funcionamiento orientado al RGPD',
     ],

--- a/apps/landing/src/i18n/es.ts
+++ b/apps/landing/src/i18n/es.ts
@@ -3,9 +3,9 @@ import type { Messages } from './types';
 const es: Messages = {
   meta: {
     homeTitle:
-      'arsnova.eu | Cuestionario en vivo, preguntas de estimación numérica y muro de preguntas',
+      'arsnova.eu | Cuestionario en directo, preguntas de estimación numérica y muro de preguntas',
     homeDescription:
-      'Plataforma de respuesta interactiva de código abierto para educación, formación y organizaciones: cuestionario en vivo, autoevaluación, informe de resultados (PDF), preguntas de estimación numérica, muro de preguntas moderable, nube de palabras y sondeo rápido — cumple las WCAG 2.2, nivel AA, gratuita, autoalojable y lista sin cuenta.',
+      'Plataforma de respuesta interactiva de código abierto para educación, formación y organizaciones: cuestionario en directo, autoevaluación, informe de resultados (PDF), preguntas de estimación numérica, muro de preguntas moderable, nube de palabras y sondeo rápido — cumple las WCAG 2.2, nivel AA, gratuita, ejecutable en tu propia infraestructura y lista sin cuenta.',
     siteNameInfo: 'arsnova.eu – Información',
     ogLocale: 'es_ES',
   },
@@ -39,7 +39,7 @@ const es: Messages = {
     appOpen: 'Abrir la aplicación',
     quizCreate: 'Crear un cuestionario',
     backToApp: 'Volver a arsnova.eu',
-    tryLive: 'Probarlo en vivo ahora',
+    tryLive: 'Probarlo en directo ahora',
     howItWorks: 'Cómo funciona',
     viewOpenSource: 'Ver el código fuente',
   },
@@ -47,28 +47,31 @@ const es: Messages = {
     eyebrow: 'Respuesta interactiva para educación y organizaciones',
     titleLine1: 'Cuestionarios, estimaciones,',
     titleLine2: 'moderación de preguntas',
-    titleAccent1: 'en vivo y gratis',
+    titleAccent1: 'en directo y gratis',
     titleAccent2: ' sin cuenta.',
-    lead: 'arsnova.eu reúne cuestionarios en vivo, preguntas de estimación numérica, autoevaluación en preguntas puntuables, muro de preguntas, análisis de nube de palabras y sondeo rápido en una sola interfaz para escuelas, universidades, formación continua, talleres y empresas. Código abierto, autoalojable y pensado para un funcionamiento orientado al RGPD.',
+    lead: 'arsnova.eu reúne cuestionarios en directo, preguntas de estimación numérica, autoevaluación en preguntas puntuables, muro de preguntas, análisis de nube de palabras y sondeo rápido en una sola interfaz para escuelas, universidades, formación continua, talleres y empresas. Código abierto, ejecutable en tu propia infraestructura y pensado para un funcionamiento orientado al RGPD.',
     a11yLink: 'Cumple las WCAG 2.2, nivel AA',
     a11ySuffix: '— teclado, lector de pantalla y tiempo de respuesta ajustable individualmente.',
     cards: [
-      { title: 'En vivo al instante', text: 'Comparte la sesión con código o QR' },
+      { title: 'En directo al instante', text: 'Comparte la sesión con código o QR' },
       { title: 'Q&A con muro de preguntas', text: 'Moderación, votos y nube temática' },
       {
         title: 'Autoevaluación y análisis posterior',
         text: 'Detecta conceptos erróneos, exporta el informe PDF',
       },
-      { title: 'Código abierto y autoalojable', text: 'Docker, Postgres, Redis y auditoría admin' },
+      {
+        title: 'Código abierto y autoalojable',
+        text: 'Docker, Postgres, Redis y registro de administración',
+      },
     ],
   },
   estimate: {
-    eyebrow: 'Nuevo en el cuestionario en vivo',
+    eyebrow: 'Nuevo en el cuestionario en directo',
     title: 'Estimar cifras, debatir y comparar con claridad la segunda ronda',
-    lead: 'La pregunta de estimación numérica está pensada para fechas, órdenes de magnitud, medidas y probabilidades. Quien facilita fija un valor de referencia, un rango de entrada y una tolerancia; los participantes solo introducen un número.',
+    lead: 'La pregunta de estimación numérica está pensada para fechas, órdenes de magnitud, medidas y probabilidades. El anfitrión fija un valor de referencia, un rango de entrada y una tolerancia; los participantes solo introducen un número.',
     summary: [
       'La banda de plausibilidad limita las entradas permitidas.',
-      'La banda de tolerancia valora las estimaciones aceptables en el contenido.',
+      'La banda de tolerancia valora las estimaciones aceptables desde el punto de vista de la materia.',
       'Nadie ve la distribución antes de publicar los resultados.',
       'La ronda 1 y la ronda 2 se comparan después del debate.',
     ],
@@ -90,9 +93,9 @@ const es: Messages = {
     round2Value: '14 respuestas más próximas al valor de referencia',
   },
   confidence: {
-    eyebrow: 'Evaluación didáctica',
+    eyebrow: 'Análisis didáctico',
     title: '¿Correcto o incorrecto — y con qué grado de seguridad?',
-    lead: 'Con la autoevaluación, los participantes indican tras responder cuán seguros están (1–5). Ves no solo la tasa de aciertos, sino también respuestas incorrectas con alta seguridad — una palanca fuerte para la evaluación formativa, el plan para la puesta en común y el informe de resultados (PDF) al terminar la sesión.',
+    lead: 'Con la autoevaluación, los participantes indican tras responder cuán seguros están (1–5). Ves no solo la tasa de aciertos, sino también respuestas incorrectas con alta seguridad — un recurso útil para la evaluación formativa, el plan para la puesta en común y el informe de resultados (PDF) al terminar la sesión.',
     summary: [
       'No es un tipo de pregunta propio — opcional en preguntas puntuables.',
       'Escala 1–5 tras la respuesta, sin efecto en los puntos.',
@@ -128,9 +131,9 @@ const es: Messages = {
       'Informe listo para imprimir con estado de aprendizaje, mapa de calor y textos de las preguntas — en la vista de anfitrión y en la tarjeta del cuestionario. El CSV para Excel sigue disponible en «Más».',
   },
   qaWall: {
-    eyebrow: 'Q&A en vivo como superficie de moderación',
+    eyebrow: 'Q&A en directo como espacio de moderación',
     title: 'Recoger preguntas, priorizarlas y leerlas como mapa temático',
-    lead: 'El muro de preguntas no es un chat secundario. Es un canal en vivo propio para docentes y ponentes: moderar aportaciones, detectar prioridades colectivas, hacer visibles los puntos controvertidos y llevar los temas clave a la sala mediante una nube de palabras Q&A ponderada.',
+    lead: 'El muro de preguntas no es un chat secundario. Es un canal en directo propio para docentes y ponentes: moderar aportaciones, detectar prioridades colectivas, hacer visibles los puntos controvertidos y llevar los temas clave a la sala mediante una nube de palabras Q&A ponderada.',
     signals: [
       {
         label: 'Premoderación',
@@ -145,11 +148,11 @@ const es: Messages = {
         text: 'Palabras y frases se ponderan según apoyo, acuerdo o controversia.',
       },
       {
-        label: 'Perspectiva de la brújula de moderación',
-        text: 'Primero llegan las señales deterministas; NLP Q&A y resumen siguen siendo extensiones opcionales.',
+        label: 'Próximamente: brújula de moderación',
+        text: 'Primero llegan las señales deterministas; el análisis lingüístico opcional y el resumen siguen siendo extensiones.',
       },
     ],
-    docsLink: 'Abrir puntuación Q&A y controversia en GitHub',
+    docsLink: 'Abrir la valoración Q&A y la controversia en GitHub',
     demoAria: 'Ejemplo de muro de preguntas con moderación, votos y nube de palabras',
     hostView: 'Vista de anfitrión Q&A',
     demoTitle: 'Preguntas sobre el evento',
@@ -160,7 +163,8 @@ const es: Messages = {
     questions: [
       {
         score: '+18',
-        title: '¿Cuándo sigue siendo plausible una estimación en el contenido?',
+        title:
+          '¿Cuándo sigue siendo plausible una estimación desde el punto de vista de la materia?',
         meta: '15 a favor · 3 en contra · mejor pregunta',
       },
       {
@@ -176,7 +180,7 @@ const es: Messages = {
     ],
     wordCloud: 'Nube de palabras Q&A',
     wordCloudHint: 'Ponderada por resonancia positiva y controversia.',
-    frozenLive: 'Actualizaciones en vivo en pausa',
+    frozenLive: 'Actualizaciones en directo en pausa',
     terms: [
       { label: 'Banda de tolerancia', className: 'text-3xl text-brand-200' },
       { label: 'Debate', className: 'text-2xl text-emerald-200' },
@@ -188,11 +192,11 @@ const es: Messages = {
       { label: 'Necesidad de aclaración', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Siguiente paso: una brújula de moderación determinista, opcionalmente complementada con señales NLP Q&A asíncronas y resúmenes ligados a las fuentes.',
+      'Siguiente paso: una brújula de moderación determinista, opcionalmente complementada con señales de análisis lingüístico asíncronas y resúmenes ligados a las fuentes.',
   },
   workflow: {
     eyebrow: 'Para docencia, formación y talleres',
-    title: 'De la idea a la sesión en vivo en pocos minutos',
+    title: 'De la idea a la sesión en directo en pocos minutos',
     lead: 'De la pregunta a la sesión en curso, el flujo evita a propósito pasos innecesarios. Eso hace que el arranque sea rápido y fiable para docentes, formadores y moderadores.',
     stepLabel: 'Paso',
     steps: [
@@ -210,7 +214,7 @@ const es: Messages = {
       },
       {
         number: '03',
-        title: 'Moderar en vivo',
+        title: 'Moderar en directo',
         description:
           'Los participantes votan, formulan preguntas y priorizan juntos. Anfitrión y presentador muestran cuestionario, muro de preguntas, nube de palabras, fase de lectura, cuenta atrás, segunda ronda y resultados en un solo flujo.',
       },
@@ -223,8 +227,8 @@ const es: Messages = {
     ],
   },
   features: {
-    eyebrow: 'Por qué se siente distinto',
-    title: 'Hecho para la interacción en vivo, no solo para encuestas en diapositivas',
+    eyebrow: 'Lo que distingue a arsnova.eu',
+    title: 'Hecho para la interacción en directo, no solo para encuestas en diapositivas',
     lead: 'arsnova.eu combina un arranque rápido, solidez didáctica y una base técnica transparente. La plataforma se mantiene sencilla en el día a día sin reducir las posibilidades.',
     items: [
       {
@@ -234,7 +238,7 @@ const es: Messages = {
         icon: 'single',
       },
       {
-        title: 'Autoevaluación en el cuestionario en vivo',
+        title: 'Autoevaluación en el cuestionario en directo',
         description:
           'Los participantes indican tras responder cuán seguros están. Detectas respuestas incorrectas con alta seguridad, priorizas la puesta en común y exportas el estado de aprendizaje en el informe de resultados (PDF).',
         icon: 'confidence',
@@ -254,13 +258,13 @@ const es: Messages = {
       {
         title: 'Más que un cuestionario estándar',
         description:
-          'MC/SC, respuesta corta, valoración, fase de lectura, Peer Instruction y flujo presentador apoyan el aprendizaje, la formación y la moderación en vivo.',
+          'MC/SC, respuesta corta, valoración, fase de lectura, Peer Instruction y flujo presentador apoyan el aprendizaje, la formación y la moderación en directo.',
         icon: 'toggle',
       },
       {
         title: 'Muro de preguntas en lugar de un chat secundario',
         description:
-          'El Q&A ofrece premoderación, fijar, archivar, votos a favor/en contra y ordenación por apoyo, calidad y controversia.',
+          'El Q&A permite premoderar, fijar, archivar, votar a favor o en contra y ordenar por apoyo, calidad y controversia.',
         icon: 'qa',
       },
       {
@@ -278,19 +282,19 @@ const es: Messages = {
       {
         title: 'Cumple las WCAG 2.2, nivel AA',
         description:
-          'Uso con teclado, anuncios de lector de pantalla, tiempo de respuesta ajustable individualmente e informes PDF/UA-1 — para que más personas puedan participar de forma autónoma en sesiones en vivo.',
+          'Uso con teclado, anuncios de lector de pantalla, tiempo de respuesta ajustable individualmente e informes PDF/UA-1 — para que más personas puedan participar de forma autónoma en sesiones en directo.',
         icon: 'a11y',
       },
       {
         title: 'Privacidad y control',
         description:
-          'Enfoque local-first, eliminación opcional de datos y explotación autoalojable te dan más control sobre contenidos y datos en vivo.',
+          'Los contenidos del cuestionario permanecen en tu dispositivo, la eliminación opcional de datos y la explotación en tu propia infraestructura te dan más control sobre contenidos y datos en directo.',
         icon: 'tools',
       },
       {
         title: 'Código abierto con despliegue y operación',
         description:
-          'Docker, Postgres, Redis y auditoría admin hacen la plataforma fiable también para alojamiento, operación y trazabilidad.',
+          'Docker, Postgres, Redis y registro de administración hacen la plataforma fiable también para alojamiento, operación y trazabilidad.',
         icon: 'server',
       },
     ],
@@ -306,14 +310,14 @@ const es: Messages = {
           'Tú y tus participantes usáis los flujos centrales sin ratón. Indicadores de foco visibles y un enlace de salto al contenido facilitan la navegación.',
       },
       {
-        title: 'Apoyo de lector de pantalla en vivo',
+        title: 'Apoyo de lector de pantalla en directo',
         description:
           'Los cambios de estado al unirse a la sesión, en las votaciones y en los cambios de fase se anuncian a los lectores de pantalla para seguir el flujo.',
       },
       {
         title: 'Tiempo de respuesta ajustable individualmente',
         description:
-          'En preguntas con tiempo eliges el tiempo estándar, el tiempo multiplicado por diez o participar sin límite. Así se puede aplicar un ajuste razonable directamente en la sesión en vivo.',
+          'En preguntas con tiempo eliges el tiempo estándar, el tiempo multiplicado por diez o participar sin límite. Así se puede aplicar un ajuste razonable directamente en la sesión en directo.',
       },
       {
         title: 'Informe de resultados estructurado de forma accesible',
@@ -325,16 +329,16 @@ const es: Messages = {
   },
   trust: {
     eyebrow: 'Confianza',
-    title: 'Creíble porque el producto no parte de cero',
+    title: 'Construido sobre una base consolidada',
     lead: 'arsnova.eu continúa la tradición del ecosistema ARSnova y se apoya en experiencias científicas, didácticas y prácticas de muchos años de tecnología educativa.',
     proofItems: [
-      { value: 'Desde 2012', label: 'Tradición ARSnova en educación y edtech' },
+      { value: 'Desde 2012', label: 'Tradición ARSnova en educación y tecnología educativa' },
       { value: 'WCAG 2.2 AA', label: 'Accesibilidad verificada para docencia e instituciones' },
       {
         value: '5 idiomas de UI',
         label: 'Alemán, inglés, francés, español, italiano',
       },
-      { value: 'Código abierto', label: 'Código transparente en lugar de una caja negra' },
+      { value: 'Código abierto', label: 'Código transparente en lugar de sistemas opacos' },
     ],
     items: [
       {
@@ -345,13 +349,13 @@ const es: Messages = {
       },
       {
         quote:
-          'Evaluación UX en comparación directa con Kahoot! como punto de control empírico del diseño.',
+          'Evaluación UX en comparación directa con Kahoot! como verificación empírica del diseño.',
         source: 'fnm-austria',
         tag: 'Estudio',
       },
       {
         quote:
-          'Privacy by design y apertura técnica son un verdadero factor diferencial para contextos edtech europeos.',
+          'La privacidad desde el diseño y la apertura técnica son un verdadero factor diferencial para contextos europeos de tecnología educativa.',
         source: 'Análisis de publicaciones',
         tag: 'Arquitectura',
       },
@@ -368,7 +372,7 @@ const es: Messages = {
   comparison: {
     eyebrow: 'Diferenciación',
     title: 'No solo un sustituto de Mentimeter o Kahoot',
-    lead: 'El centro no es solo la votación, sino el flujo en vivo completo: preparar, moderar, hacer visibles los resultados y mantener el control sobre contenidos y operación.',
+    lead: 'El centro no es solo la votación, sino el flujo en directo completo: preparar, moderar, hacer visibles los resultados y mantener el control sobre contenidos y operación.',
     points: [
       {
         title: 'Menos barreras de entrada',
@@ -383,7 +387,7 @@ const es: Messages = {
       {
         title: 'Más control sobre datos y acceso',
         description:
-          'Código abierto, autoalojable y local-first — más cumplimiento de las WCAG 2.2, nivel AA. Relevante para escuelas, universidades y organizaciones con requisitos de privacidad e inclusión.',
+          'Código abierto, ejecutable en tu propia infraestructura y con contenidos del cuestionario conservados en el dispositivo — más cumplimiento de las WCAG 2.2, nivel AA. Relevante para escuelas, universidades y organizaciones con requisitos de privacidad e inclusión.',
       },
     ],
     comparePrefix: 'La comparación completa de funciones sigue en la documentación:',
@@ -402,7 +406,7 @@ const es: Messages = {
       {
         question: '¿Dónde están los datos?',
         answer:
-          'Los contenidos del cuestionario están pensados local-first. En sesiones en vivo solo se procesan los datos de sesión técnicamente necesarios; con autoalojamiento, la operación permanece en tu infraestructura.',
+          'Los contenidos del cuestionario permanecen en tu dispositivo. En sesiones en directo solo se procesan los datos de sesión técnicamente necesarios; con autoalojamiento, la operación permanece en tu infraestructura.',
       },
       {
         question: '¿Puedo autoalojar arsnova.eu?',
@@ -422,7 +426,7 @@ const es: Messages = {
       {
         question: '¿Qué tiene de especial la pregunta de estimación numérica?',
         answer:
-          'Separa las entradas permitidas de la banda de tolerancia del contenido, no muestra la distribución durante la votación y puede evaluar una segunda ronda tras el debate con estadística y comparación de rondas.',
+          'Separa las entradas permitidas de la banda de tolerancia de la materia, no muestra la distribución durante la votación y puede evaluar una segunda ronda tras el debate con estadística y comparación de rondas.',
       },
       {
         question: '¿Qué puede hacer el muro de preguntas?',
@@ -437,7 +441,7 @@ const es: Messages = {
       {
         question: '¿Para quién está pensada la plataforma?',
         answer:
-          'Para la interacción en vivo en educación y organizaciones: escuela, universidad, formación continua, formación, taller, evento o reunión.',
+          'Para la interacción en directo en educación y organizaciones: escuela, universidad, formación continua, formación, taller, evento o reunión.',
       },
       {
         question: '¿Es accesible arsnova.eu?',
@@ -448,20 +452,20 @@ const es: Messages = {
     ],
   },
   ctaSection: {
-    title: '¿Listo para la próxima sesión en vivo?',
-    lead: 'Prueba el flujo en vivo directamente en la aplicación, o echa un vistazo al código fuente abierto, a la lógica Q&A, al procesamiento de la nube de palabras y al camino de despliegue y operación detrás de la plataforma.',
+    title: '¿Listo para la próxima sesión en directo?',
+    lead: 'Prueba el flujo en directo directamente en la aplicación, o echa un vistazo al código fuente abierto, a la lógica Q&A, al procesamiento de la nube de palabras y a la infraestructura de despliegue y operación de la plataforma.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Información',
     webAppDescription:
-      'Plataforma de respuesta interactiva de código abierto para educación, formación y organizaciones: cuestionario en vivo, autoevaluación, informe de resultados (PDF), preguntas de estimación numérica, muro de preguntas moderable, nube de palabras y sondeo rápido — cumple las WCAG 2.2, nivel AA, gratuita, autoalojable y lista sin cuenta.',
+      'Plataforma de respuesta interactiva de código abierto para educación, formación y organizaciones: cuestionario en directo, autoevaluación, informe de resultados (PDF), preguntas de estimación numérica, muro de preguntas moderable, nube de palabras y sondeo rápido — cumple las WCAG 2.2, nivel AA, gratuita, ejecutable en tu propia infraestructura y lista sin cuenta.',
     featureList: [
-      'Cuestionario en vivo y votaciones',
+      'Cuestionario en directo y votaciones',
       'Autoevaluación en preguntas puntuables',
       'Informe de resultados (PDF) y puesta en común al terminar la sesión',
       'Preguntas de estimación numérica con dos rondas y estadística',
       'Muro de preguntas con moderación, votos a favor y en contra',
-      'Lobby, presentador, QR/código',
+      'Sala de espera, presentador, QR/código',
       'Tipos de pregunta MC/SC/respuesta corta/texto libre/encuesta/valoración/estimación numérica',
       'Markdown y KaTeX',
       'Fase de lectura y Peer Instruction',
@@ -469,12 +473,12 @@ const es: Messages = {
       'Ordenación por apoyo, acuerdo robusto y controversia',
       'Modo equipo y ajustes previos',
       'Clasificación, racha, código bonus',
-      'Importación/exportación y sync Yjs',
+      'Importación/exportación y sincronización Yjs',
       'Importación IA externa, validada con Zod',
       'Interfaz en cinco idiomas',
       'Cumple las WCAG 2.2, nivel AA',
-      'Autoalojamiento Docker y auditoría admin',
-      'Local-first y funcionamiento orientado al RGPD',
+      'Ejecución Docker en tu infraestructura y registro de administración',
+      'Contenidos del cuestionario conservados en el dispositivo y funcionamiento orientado al RGPD',
     ],
   },
 };

--- a/apps/landing/src/i18n/es.ts
+++ b/apps/landing/src/i18n/es.ts
@@ -49,7 +49,7 @@ const es: Messages = {
     titleLine2: 'moderación de preguntas',
     titleAccent1: 'en directo y gratis',
     titleAccent2: ' sin cuenta.',
-    lead: 'arsnova.eu reúne cuestionarios en directo, preguntas de estimación numérica, autoevaluación en preguntas puntuables, muro de preguntas, análisis de nube de palabras y sondeo rápido en una sola interfaz para escuelas, universidades, formación continua, talleres y empresas. Código abierto, ejecutable en tu propia infraestructura y pensado para un funcionamiento orientado al RGPD.',
+    lead: 'arsnova.eu reúne cuestionarios en directo, preguntas de estimación numérica, autoevaluación en preguntas puntuables, muro de preguntas, análisis de nube de palabras y sondeo rápido en una sola interfaz para escuelas, universidades, formación continua, talleres y empresas. Código abierto, ejecutable en tu propia infraestructura y pensado para un funcionamiento respetuoso con el RGPD.',
     a11yLink: 'Cumple las WCAG 2.2, nivel AA',
     a11ySuffix: '— teclado, lector de pantalla y tiempo de respuesta ajustable individualmente.',
     cards: [
@@ -86,7 +86,7 @@ const es: Messages = {
     plausibilityBand: 'Banda de plausibilidad',
     plausibilityValue: '1500 a 2000',
     histogramNote:
-      'El histograma, la línea de referencia y la banda de tolerancia aparecen solo tras publicar los resultados. Hasta entonces solo queda visible el progreso neutro.',
+      'El histograma, la línea de referencia y la banda de tolerancia aparecen solo tras publicar los resultados. Hasta entonces solo queda visible un indicador neutro de progreso.',
     median: 'Mediana',
     inBand: 'en la banda',
     round2: 'Ronda 2',
@@ -137,11 +137,11 @@ const es: Messages = {
     signals: [
       {
         label: 'Premoderación',
-        text: 'Publica las preguntas solo cuando encajan en el momento didáctico.',
+        text: 'Publica las preguntas solo cuando son relevantes en el contexto didáctico.',
       },
       {
         label: 'Voto colectivo',
-        text: 'Los votos a favor y en contra muestran prioridad, fricción y necesidad de aclaración.',
+        text: 'Los votos a favor y en contra indican las prioridades, los puntos de desacuerdo y las necesidades de aclaración.',
       },
       {
         label: 'Nube temática',
@@ -154,7 +154,7 @@ const es: Messages = {
     ],
     docsLink: 'Abrir la valoración Q&A y la controversia en GitHub',
     demoAria: 'Ejemplo de muro de preguntas con moderación, votos y nube de palabras',
-    hostView: 'Vista de anfitrión Q&A',
+    hostView: 'Vista Q&A del anfitrión',
     demoTitle: 'Preguntas sobre el evento',
     moderationActive: 'Premoderación activa',
     sortMostSupported: 'Más apoyadas',
@@ -179,7 +179,7 @@ const es: Messages = {
       },
     ],
     wordCloud: 'Nube de palabras Q&A',
-    wordCloudHint: 'Ponderada por resonancia positiva y controversia.',
+    wordCloudHint: 'Ponderada por el apoyo positivo y la controversia.',
     frozenLive: 'Actualizaciones en directo en pausa',
     terms: [
       { label: 'Banda de tolerancia', className: 'text-3xl text-brand-200' },
@@ -192,12 +192,12 @@ const es: Messages = {
       { label: 'Necesidad de aclaración', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Siguiente paso: una brújula de moderación determinista, opcionalmente complementada con señales de análisis lingüístico asíncronas y resúmenes ligados a las fuentes.',
+      'Siguiente paso: una brújula de moderación determinista, opcionalmente complementada con señales de análisis lingüístico asíncronas y resúmenes basados en las preguntas enviadas.',
   },
   workflow: {
     eyebrow: 'Para docencia, formación y talleres',
     title: 'De la idea a la sesión en directo en pocos minutos',
-    lead: 'De la pregunta a la sesión en curso, el flujo evita a propósito pasos innecesarios. Eso hace que el arranque sea rápido y fiable para docentes, formadores y moderadores.',
+    lead: 'De la pregunta a la sesión en curso, el recorrido evita a propósito pasos innecesarios. Eso hace que el arranque sea rápido y fiable para docentes, formadores y moderadores.',
     stepLabel: 'Paso',
     steps: [
       {
@@ -210,13 +210,13 @@ const es: Messages = {
         number: '02',
         title: 'Iniciar una sesión',
         description:
-          'Empieza sin cuenta: abre una sesión, elige un estilo, comparte código o QR y usa la vista presentador si lo necesitas.',
+          'Empieza sin cuenta: abre una sesión, elige un estilo, comparte código o QR y usa la vista del presentador si lo necesitas.',
       },
       {
         number: '03',
         title: 'Moderar en directo',
         description:
-          'Los participantes votan, formulan preguntas y priorizan juntos. Anfitrión y presentador muestran cuestionario, muro de preguntas, nube de palabras, fase de lectura, cuenta atrás, segunda ronda y resultados en un solo flujo.',
+          'Los participantes votan, formulan preguntas y priorizan juntos. El anfitrión y el presentador muestran el cuestionario, el muro de preguntas, la nube de palabras, la fase de lectura, la cuenta atrás, la segunda ronda y los resultados en un solo recorrido.',
       },
       {
         number: '04',
@@ -258,7 +258,7 @@ const es: Messages = {
       {
         title: 'Más que un cuestionario estándar',
         description:
-          'MC/SC, respuesta corta, valoración, fase de lectura, Peer Instruction y flujo presentador apoyan el aprendizaje, la formación y la moderación en directo.',
+          'MC/SC, respuestas cortas, valoraciones, fase de lectura, Peer Instruction y modo de presentación apoyan el aprendizaje, la formación y la moderación en directo.',
         icon: 'toggle',
       },
       {
@@ -268,9 +268,9 @@ const es: Messages = {
         icon: 'qa',
       },
       {
-        title: 'Nube de palabras elaborada',
+        title: 'Nube de palabras expresiva',
         description:
-          'Texto libre y Q&A se condensan en palabras y frases; el muro pondera por acuerdo, puntuación robusta o controversia.',
+          'Texto libre y Q&A se condensan en palabras y frases; el muro pondera por acuerdo, mayoría clara o controversia.',
         icon: 'cloud',
       },
       {
@@ -302,17 +302,17 @@ const es: Messages = {
   accessibility: {
     eyebrow: 'Accesibilidad',
     title: 'WCAG 2.2 AA — para que más personas puedan participar de forma autónoma',
-    lead: 'Para escuelas, universidades y formación continua, la accesibilidad suele ser un criterio decisivo. arsnova.eu cumple las Web Content Accessibility Guidelines (WCAG) 2.2 en el nivel AA — con uso de teclado, apoyo de lector de pantalla, tiempo de respuesta ajustable individualmente e informes PDF estructurados de forma accesible.',
+    lead: 'Para escuelas, universidades y formación continua, la accesibilidad suele ser un criterio decisivo. arsnova.eu cumple las Web Content Accessibility Guidelines (WCAG) 2.2 en el nivel AA — con uso de teclado, compatibilidad con lectores de pantalla, tiempo de respuesta ajustable individualmente e informes PDF estructurados de forma accesible.',
     benefits: [
       {
         title: 'Uso con teclado',
         description:
-          'Tú y tus participantes usáis los flujos centrales sin ratón. Indicadores de foco visibles y un enlace de salto al contenido facilitan la navegación.',
+          'Tú y tus participantes usáis los recorridos centrales sin ratón. Indicadores de foco visibles y un enlace de salto al contenido facilitan la navegación.',
       },
       {
-        title: 'Apoyo de lector de pantalla en directo',
+        title: 'Compatibilidad con lectores de pantalla en directo',
         description:
-          'Los cambios de estado al unirse a la sesión, en las votaciones y en los cambios de fase se anuncian a los lectores de pantalla para seguir el flujo.',
+          'Los cambios de estado al unirse a la sesión, en las votaciones y en los cambios de fase se anuncian a los lectores de pantalla para seguir el recorrido.',
       },
       {
         title: 'Tiempo de respuesta ajustable individualmente',
@@ -372,7 +372,7 @@ const es: Messages = {
   comparison: {
     eyebrow: 'Diferenciación',
     title: 'No solo un sustituto de Mentimeter o Kahoot',
-    lead: 'El centro no es solo la votación, sino el flujo en directo completo: preparar, moderar, hacer visibles los resultados y mantener el control sobre contenidos y operación.',
+    lead: 'El objetivo no es únicamente votar, sino cubrir todo el proceso en directo: preparar, moderar, hacer visibles los resultados y mantener el control sobre contenidos y operación.',
     points: [
       {
         title: 'Menos barreras de entrada',
@@ -431,12 +431,12 @@ const es: Messages = {
       {
         question: '¿Qué puede hacer el muro de preguntas?',
         answer:
-          'Los participantes envían preguntas y las ponderan con votos a favor y en contra. Los anfitriones pueden premoderar, fijar, archivar o eliminar preguntas y ordenar la lista por apoyo, acuerdo robusto o controversia.',
+          'Los participantes envían preguntas y las ponderan con votos a favor y en contra. Los anfitriones pueden premoderar, fijar, archivar o eliminar preguntas y ordenar la lista por apoyo, mayoría clara o controversia.',
       },
       {
         question: '¿En qué se diferencia la nube de palabras Q&A?',
         answer:
-          'Condensa las preguntas visibles en palabras y frases y sigue la lógica de ordenación activa. Así muestra no solo términos frecuentes, sino clústeres temáticos de preguntas apoyadas, puntuadas de forma robusta o controvertidas.',
+          'Condensa las preguntas visibles en palabras y frases y sigue la lógica de ordenación activa. Así muestra no solo términos frecuentes, sino agrupaciones temáticas de preguntas apoyadas, claramente bien valoradas o controvertidas.',
       },
       {
         question: '¿Para quién está pensada la plataforma?',
@@ -446,14 +446,14 @@ const es: Messages = {
       {
         question: '¿Es accesible arsnova.eu?',
         answer:
-          'arsnova.eu cumple las WCAG 2.2, nivel AA. Los flujos centrales se pueden usar con teclado, los lectores de pantalla anuncian cambios de estado, el tiempo de respuesta en preguntas con tiempo es ajustable individualmente (tiempo estándar, tiempo ×10 o sin límite), y el informe de resultados estructurado de forma accesible está validado PDF/UA-1.',
+          'arsnova.eu cumple las WCAG 2.2, nivel AA. Los recorridos centrales se pueden usar con teclado, los lectores de pantalla anuncian cambios de estado, el tiempo de respuesta en preguntas con tiempo es ajustable individualmente (tiempo estándar, tiempo ×10 o sin límite), y el informe de resultados estructurado de forma accesible está validado PDF/UA-1.',
         linkLabel: 'Abrir la declaración de accesibilidad',
       },
     ],
   },
   ctaSection: {
     title: '¿Listo para la próxima sesión en directo?',
-    lead: 'Prueba el flujo en directo directamente en la aplicación, o echa un vistazo al código fuente abierto, a la lógica Q&A, al procesamiento de la nube de palabras y a la infraestructura de despliegue y operación de la plataforma.',
+    lead: 'Prueba el recorrido en directo directamente en la aplicación, o echa un vistazo al código fuente abierto, a la lógica Q&A, al procesamiento de la nube de palabras y a la infraestructura de despliegue y operación de la plataforma.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Información',
@@ -466,11 +466,11 @@ const es: Messages = {
       'Preguntas de estimación numérica con dos rondas y estadística',
       'Muro de preguntas con moderación, votos a favor y en contra',
       'Sala de espera, presentador, QR/código',
-      'Tipos de pregunta MC/SC/respuesta corta/texto libre/encuesta/valoración/estimación numérica',
+      'Tipos de pregunta MC/SC/respuestas cortas/texto libre/encuesta/valoración/estimación numérica',
       'Markdown y KaTeX',
       'Fase de lectura y Peer Instruction',
       'Nube de palabras Q&A y texto libre con frases y ponderación',
-      'Ordenación por apoyo, acuerdo robusto y controversia',
+      'Ordenación por apoyo, mayoría clara y controversia',
       'Modo equipo y ajustes previos',
       'Clasificación, racha, código bonus',
       'Importación/exportación y sincronización Yjs',
@@ -478,7 +478,7 @@ const es: Messages = {
       'Interfaz en cinco idiomas',
       'Cumple las WCAG 2.2, nivel AA',
       'Ejecución Docker en tu infraestructura y registro de administración',
-      'Contenidos del cuestionario conservados en el dispositivo y funcionamiento orientado al RGPD',
+      'Contenidos del cuestionario conservados en el dispositivo y funcionamiento respetuoso con el RGPD',
     ],
   },
 };

--- a/apps/landing/src/i18n/fr.ts
+++ b/apps/landing/src/i18n/fr.ts
@@ -1,0 +1,484 @@
+import type { Messages } from './types';
+
+const fr: Messages = {
+  meta: {
+    homeTitle: 'arsnova.eu | Quiz en direct, estimations numériques et mur Q&A',
+    homeDescription:
+      'Audience response open source pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), estimations numériques, mur Q&A modérable, nuage de mots et feedback — accessible WCAG 2.2 AA, gratuit, auto-hébergeable et prêt sans compte.',
+    siteNameInfo: 'arsnova.eu – Informations',
+    ogLocale: 'fr_FR',
+  },
+  nav: {
+    ariaLabel: 'Navigation principale',
+    workflow: 'Déroulement',
+    estimate: 'Estimation',
+    qa: 'Q&A',
+    qaMobile: 'Mur de questions',
+    features: 'Atouts',
+    accessibility: 'Accessibilité',
+    trust: 'Confiance',
+    faq: 'FAQ',
+    tryNow: 'Essayer maintenant',
+    menuOpen: 'Ouvrir le menu',
+    menuClose: 'Fermer le menu',
+    menu: 'Menu',
+    skipToContent: 'Aller au contenu',
+  },
+  languageSwitcher: {
+    label: 'Langue',
+    currentLanguage: 'Français',
+    chooseLanguage: 'Choisir la langue',
+  },
+  footer: {
+    impressum: 'Mentions légales',
+    privacy: 'Confidentialité',
+    accessibility: 'Accessibilité',
+  },
+  cta: {
+    appOpen: 'Ouvrir l’application',
+    quizCreate: 'Créer un quiz',
+    backToApp: 'Retour à arsnova.eu',
+    tryLive: 'Essayer en direct',
+    howItWorks: 'Comment ça marche',
+    viewOpenSource: 'Voir le code open source',
+  },
+  hero: {
+    eyebrow: 'Audience response pour l’éducation et les organisations',
+    titleLine1: 'Quizzer, estimer,',
+    titleLine2: 'modérer les questions',
+    titleAccent1: 'en direct et gratuitement',
+    titleAccent2: ' sans compte.',
+    lead: 'arsnova.eu réunit quiz en direct, estimations numériques, autoévaluation sur les questions notées, mur Q&A, analyse en nuage de mots et Feedback express dans une seule interface pour les écoles, les universités, la formation continue, les ateliers et le monde professionnel. Open source, auto-hébergeable et conçu pour un fonctionnement orienté RGPD.',
+    a11yLink: 'Accessible selon WCAG 2.2 AA',
+    a11ySuffix: '— clavier, lecteur d’écran et temps de réponse ajustable individuellement.',
+    cards: [
+      { title: 'En direct immédiatement', text: 'Partager une session par code ou QR' },
+      { title: 'Q&A avec mur de questions', text: 'Modération, votes et nuage thématique' },
+      {
+        title: 'Autoévaluation et suivi',
+        text: 'Repérer les idées fausses, exporter le rapport PDF',
+      },
+      { title: 'Open source et auto-hébergeable', text: 'Docker, Postgres, Redis et audit admin' },
+    ],
+  },
+  estimate: {
+    eyebrow: 'Nouveau dans le quiz en direct',
+    title: 'Estimer des nombres, discuter et comparer clairement le second tour',
+    lead: 'La question d’estimation numérique est conçue pour les dates, ordres de grandeur, mesures et probabilités. Les animateurs fixent une valeur de référence, une plage de saisie et une tolérance ; les participants n’entrent qu’un nombre.',
+    summary: [
+      'La bande de plausibilité limite les saisies autorisées.',
+      'La bande de tolérance évalue les estimations acceptables sur le fond.',
+      'Personne ne voit la distribution avant la publication des résultats.',
+      'Le tour 1 et le tour 2 sont comparés après la discussion.',
+    ],
+    docsLink: 'Ouvrir la documentation de l’estimation',
+    demoAria: 'Exemple de résultats pour une estimation sur la Révolution française',
+    hostView: 'Vue hôte après publication',
+    demoQuestion: 'Quand a commencé la Révolution française ?',
+    reference: 'Référence 1789',
+    toleranceBand: 'Bande de tolérance',
+    toleranceValue: '1700 à 1900',
+    plausibilityBand: 'Bande de plausibilité',
+    plausibilityValue: '1500 à 2000',
+    histogramNote:
+      'L’histogramme, la ligne de référence et la bande de tolérance n’apparaissent qu’après publication des résultats. Avant cela, seule la progression neutre reste visible.',
+    median: 'Médiane',
+    inBand: 'dans la bande',
+    round2: 'Tour 2',
+    round2Value: '14 plus proches',
+  },
+  confidence: {
+    eyebrow: 'Évaluation didactique',
+    title: 'Juste ou faux — et avec quel degré de confiance ?',
+    lead: 'Avec l’autoévaluation, les participants indiquent après leur réponse à quel point ils sont sûrs (1–5). Tu vois non seulement le taux de réussite, mais aussi les réponses fausses et sûres d’elles — un levier fort pour l’évaluation formative, le plan de débriefing et le rapport de résultats (PDF) en fin de session.',
+    summary: [
+      'Pas un type de question à part — optionnel sur les questions notées.',
+      'Échelle 1–5 après la réponse, sans effet sur les points.',
+      'Après publication, l’hôte voit exactitude × degré de confiance.',
+      '« Faux et sûr » signale d’éventuelles idées fausses.',
+      'Après la session : rapport de résultats (PDF) et débriefing.',
+    ],
+    docsConfidence: 'Doc autoévaluation',
+    docsExport: 'Doc rapport de résultats (PDF)',
+    demoAria: 'Exemple d’évaluation avec autoévaluation après publication',
+    hostView: 'Vue hôte après publication',
+    demoQuestion: 'Quelle structure est la plus stable ?',
+    badge: 'Autoévaluation',
+    matrix: [
+      { label: 'Juste · bas', count: 3, tone: 'emerald' },
+      { label: 'Juste · moyen', count: 8, tone: 'emerald' },
+      { label: 'Juste · élevé', count: 11, tone: 'emerald' },
+      { label: 'Faux · bas', count: 2, tone: 'slate' },
+      { label: 'Faux · moyen', count: 4, tone: 'amber' },
+      { label: 'Faux · élevé', count: 2, tone: 'rose' },
+    ],
+    falseHighTitle: '2 réponses fausses et sûres d’elles',
+    falseHighText:
+      'L’option B a été choisie 2× avec un degré de confiance élevé — un signal d’éventuelles idées fausses pour le débriefing.',
+    consolidated: 'Solide',
+    misconceptionRisk: 'Risque d’idée fausse',
+    fragile: 'Fragile',
+    afterSessionAria: 'Export après la fin de session',
+    afterSession: 'Après la fin de session',
+    debriefing: 'Débriefing',
+    resultsPdf: 'Rapport de résultats (PDF)',
+    exportNote:
+      'Rapport prêt à imprimer avec état d’apprentissage, heatmap et textes des questions — dans la vue hôte et sur la carte quiz. Le CSV pour Excel reste disponible sous « Plus ».',
+  },
+  qaWall: {
+    eyebrow: 'Q&A en direct comme espace de modération',
+    title: 'Recueillir les questions, les prioriser et les lire comme carte thématique',
+    lead: 'Le mur de questions n’est pas un chat secondaire. C’est un canal live dédié pour les enseignant·es et intervenant·es : modérer les contributions, repérer les priorités collectives, rendre visibles les points controversés et ramener les thèmes clés dans la salle via un nuage de mots Q&A pondéré.',
+    signals: [
+      {
+        label: 'Pré-modération',
+        text: 'Publier les questions seulement quand elles collent au moment pédagogique.',
+      },
+      {
+        label: 'Vote collectif',
+        text: 'Les votes pour et contre montrent priorité, friction et besoin de clarification.',
+      },
+      {
+        label: 'Nuage thématique',
+        text: 'Mots et phrases sont pondérés selon le soutien, l’accord ou la controverse.',
+      },
+      {
+        label: 'Perspective boussole',
+        text: 'Les signaux déterministes viennent d’abord ; NLP Q&A et synthèse restent des extensions optionnelles.',
+      },
+    ],
+    docsLink: 'Ouvrir le scoring Q&A et la controverse sur GitHub',
+    demoAria: 'Exemple de mur Q&A avec modération, votes et nuage de mots',
+    hostView: 'Vue hôte Q&A',
+    demoTitle: 'Questions sur l’événement',
+    moderationActive: 'Pré-modération active',
+    sortMostSupported: 'Les plus soutenues',
+    sortBest: 'Meilleures questions',
+    sortControversial: 'Controversées',
+    questions: [
+      {
+        score: '+18',
+        title: 'Quand une estimation reste-t-elle plausible sur le fond ?',
+        meta: '15 pour · 3 contre · meilleure question',
+      },
+      {
+        score: '+4',
+        title: 'Faut-il vraiment masquer les résultats avant la discussion ?',
+        meta: '9 pour · 5 contre · controversé',
+      },
+      {
+        score: '+11',
+        title: 'En quoi le Q&A diffère-t-il du texte libre dans le quiz ?',
+        meta: '11 pour · 0 contre · surtout soutenu',
+      },
+    ],
+    wordCloud: 'Nuage de mots Q&A',
+    wordCloudHint: 'Pondéré selon la résonance positive et la controverse.',
+    frozenLive: 'Figé en direct',
+    terms: [
+      { label: 'Bande de tolérance', className: 'text-3xl text-brand-200' },
+      { label: 'Discussion', className: 'text-2xl text-emerald-200' },
+      { label: 'Q&A', className: 'text-4xl text-white' },
+      { label: 'Plausibilité', className: 'text-xl text-amber-200' },
+      { label: 'Controverse', className: 'text-2xl text-rose-200' },
+      { label: 'Peer Instruction', className: 'text-lg text-slate-300' },
+      { label: 'Modération', className: 'text-3xl text-cyan-200' },
+      { label: 'Besoin de clarification', className: 'text-xl text-violet-200' },
+    ],
+    nextStep:
+      'Prochaine étape : une boussole de modération déterministe, éventuellement complétée par des signaux NLP Q&A asynchrones et des synthèses liées aux sources.',
+  },
+  workflow: {
+    eyebrow: 'Pour l’enseignement, la formation et les ateliers',
+    title: 'De l’idée à la session en direct en quelques minutes',
+    lead: 'De la question à la session en cours, le parcours évite volontairement les étapes inutiles. C’est ce qui rend le démarrage rapide et fiable pour les enseignant·es, formateur·rices et animateur·rices.',
+    stepLabel: 'Étape',
+    steps: [
+      {
+        number: '01',
+        title: 'Préparer un quiz',
+        description:
+          'Créer des questions directement ou importer des contenus existants. Markdown, KaTeX, réponse courte et estimations numériques sont intégrés.',
+      },
+      {
+        number: '02',
+        title: 'Démarrer une session',
+        description:
+          'Commencer sans compte : ouvrir une session, choisir un style, partager un code ou un QR et utiliser la vue présentateur si besoin.',
+      },
+      {
+        number: '03',
+        title: 'Animer en direct',
+        description:
+          'Les participants votent, posent des questions et priorisent ensemble. Hôte et présentateur affichent quiz, mur Q&A, nuage de mots, phase de lecture, compte à rebours, second tour et résultats dans un seul flux.',
+      },
+      {
+        number: '04',
+        title: 'Suivre et exporter',
+        description:
+          'Après la fin de session, le rapport de résultats (PDF) est prêt — avec état d’apprentissage, autoévaluation et textes complets des questions. Dans la collection de quiz, tu trouves débriefing et PDF du dernier passage ; CSV pour Excel sous « Plus ».',
+      },
+    ],
+  },
+  features: {
+    eyebrow: 'Pourquoi ça se sent différent',
+    title: 'Conçu pour l’interaction en direct, pas seulement pour des sondages sur diapos',
+    lead: 'arsnova.eu combine démarrage rapide, force didactique et socle technique transparent. La plateforme reste simple au quotidien sans restreindre les possibilités.',
+    items: [
+      {
+        title: 'Prêt rapidement',
+        description:
+          'Les hôtes démarrent sans compte. Les participants rejoignent la session directement avec un code à 6 chiffres ou un QR.',
+        icon: 'single',
+      },
+      {
+        title: 'Autoévaluation dans le quiz en direct',
+        description:
+          'Les participants indiquent après la réponse à quel point ils sont sûrs. Tu repères les réponses fausses et sûres d’elles, priorises le débriefing et exportes l’état d’apprentissage dans le rapport de résultats (PDF).',
+        icon: 'confidence',
+      },
+      {
+        title: 'Rapport de résultats pour le suivi',
+        description:
+          'Après la fin de session, tu exportes un rapport PDF prêt à imprimer avec graphiques, textes des questions et autoévaluation. Le CSV pour Excel reste optionnel sous « Plus ».',
+        icon: 'export',
+      },
+      {
+        title: 'Estimations didactiques',
+        description:
+          'Dates, ordres de grandeur et mesures peuvent être estimés avec valeur de référence, bande de tolérance, statistiques et second tour optionnel.',
+        icon: 'estimate',
+      },
+      {
+        title: 'Plus qu’un quiz standard',
+        description:
+          'QCM/QCU, réponse courte, notation, phase de lecture, Peer Instruction et flux présentateur soutiennent l’apprentissage, la formation et l’animation en direct.',
+        icon: 'toggle',
+      },
+      {
+        title: 'Mur de questions plutôt qu’un chat secondaire',
+        description:
+          'Le Q&A offre pré-modération, épinglage, archivage, votes pour/contre et tri par soutien, qualité et controverse.',
+        icon: 'qa',
+      },
+      {
+        title: 'Nuage de mots élaboré',
+        description:
+          'Texte libre et Q&A sont condensés en mots et phrases ; le mur pondère selon l’accord, un score robuste ou la controverse.',
+        icon: 'cloud',
+      },
+      {
+        title: 'Pour des contextes variés',
+        description:
+          'Préréglages, mode équipe, mode anonyme, pseudonymes et choix de style aident de la classe et du séminaire à l’atelier, l’événement et la réunion.',
+        icon: 'bolt',
+      },
+      {
+        title: 'Accessibilité selon WCAG 2.2 AA',
+        description:
+          'Navigation clavier, annonces lecteur d’écran, temps de réponse ajustable individuellement et rapports PDF/UA-1 — pour que davantage d’apprenant·es participent en autonomie aux sessions en direct.',
+        icon: 'a11y',
+      },
+      {
+        title: 'Confidentialité et contrôle',
+        description:
+          'Local-first, data-stripping et exploitation auto-hébergeable te donnent plus de contrôle sur les contenus et les données live.',
+        icon: 'tools',
+      },
+      {
+        title: 'Open source avec chemin d’exploitation',
+        description:
+          'Docker, Postgres, Redis et audit admin rendent la plateforme fiable aussi pour l’hébergement, l’exploitation et la traçabilité.',
+        icon: 'server',
+      },
+    ],
+  },
+  accessibility: {
+    eyebrow: 'Accessibilité',
+    title: 'WCAG 2.2 AA — pour que davantage d’apprenant·es participent en autonomie',
+    lead: 'Pour les écoles, universités et la formation continue, l’accessibilité est souvent un critère décisif. arsnova.eu respecte les Web Content Accessibility Guidelines (WCAG) 2.2 au niveau AA — avec navigation clavier, support lecteur d’écran, temps de réponse ajustable individuellement et rapports PDF structurés de façon accessible.',
+    benefits: [
+      {
+        title: 'Utilisation au clavier',
+        description:
+          'Toi et tes participants utilisez les parcours centraux sans souris. Des indicateurs de focus visibles et un lien d’évitement vers le contenu facilitent la navigation.',
+      },
+      {
+        title: 'Support lecteur d’écran en direct',
+        description:
+          'Les changements d’état à l’entrée en session, lors des votes et aux changements de phase sont annoncés aux lecteurs d’écran pour suivre le déroulement.',
+      },
+      {
+        title: 'Temps de réponse ajustable individuellement',
+        description:
+          'Pour les questions chronométrées, tu choisis le temps standard, le temps décuplé ou une participation sans limite. Une compensation peut ainsi s’appliquer directement en session.',
+      },
+      {
+        title: 'Rapport de résultats structuré de façon accessible',
+        description:
+          'Le rapport prêt à imprimer est validé PDF/UA-1 et contient titre, langue et balises — pour le suivi et un partage accessible.',
+      },
+    ],
+    statementLink: 'Ouvrir la déclaration d’accessibilité',
+  },
+  trust: {
+    eyebrow: 'Confiance',
+    title: 'Crédible parce que le produit ne part pas de zéro',
+    lead: 'arsnova.eu s’inscrit dans la tradition de l’écosystème ARSnova et s’appuie sur des expériences scientifiques, didactiques et pratiques de nombreuses années de technologies éducatives.',
+    proofItems: [
+      { value: 'Depuis 2012', label: 'Tradition ARSnova dans l’éducation et l’edtech' },
+      {
+        value: 'WCAG 2.2 AA',
+        label: 'Accessibilité vérifiée pour l’enseignement et les institutions',
+      },
+      {
+        value: '5 langues UI',
+        label: 'Allemand, anglais, français, espagnol, italien',
+      },
+      { value: 'Open source', label: 'Code transparent plutôt qu’une boîte noire' },
+    ],
+    items: [
+      {
+        quote:
+          'Voie respectueuse de la vie privée : pas de données personnelles stockées durablement sur le serveur.',
+        source: 'DeLFI 2017',
+        tag: 'Recherche',
+      },
+      {
+        quote:
+          'Évaluation UX en comparaison directe avec Kahoot! comme point de contrôle empirique du design.',
+        source: 'fnm-austria',
+        tag: 'Étude',
+      },
+      {
+        quote:
+          'Privacy by design et ouverture technique sont un vrai facteur de différenciation pour les contextes edtech européens.',
+        source: 'Analyse de publications',
+        tag: 'Architecture',
+      },
+      {
+        quote: 'Éprouvé en conditions réelles d’enseignement, pas seulement décrit comme concept.',
+        source: 'Usage en contextes d’enseignement et de formation',
+        tag: 'Pratique',
+      },
+    ],
+    referencesPrefix:
+      'Les références complètes et la collection de publications sous-jacente se trouvent dans',
+    referencesLink: 'ARSnova-Recherche.pdf',
+    referencesSuffix: 'sur GitHub.',
+  },
+  comparison: {
+    eyebrow: 'Positionnement',
+    title: 'Pas seulement un substitut à Mentimeter ou Kahoot',
+    lead: 'Le centre n’est pas seulement le vote, mais le flux live complet : préparer, animer, rendre les résultats visibles et garder le contrôle sur les contenus et l’exploitation.',
+    points: [
+      {
+        title: 'Moins de freins à l’entrée',
+        description:
+          'Pas de logique produit séparée pour « créer » et « rejoindre ». Les hôtes démarrent sans compte, les participants entrent via code ou QR.',
+      },
+      {
+        title: 'Plus de formats d’interaction',
+        description:
+          'Outre le quiz : estimations numériques, phase de lecture, Peer Instruction, Feedback express, mur Q&A et nuage de mots pondéré dans la même plateforme — pas seulement des sondages sur diapos.',
+      },
+      {
+        title: 'Plus de contrôle sur les données et l’accès',
+        description:
+          'Open source, auto-hébergeable et conçu local-first — plus l’accessibilité WCAG 2.2 AA. Pertinent pour les écoles, universités et organisations avec des exigences de confidentialité et d’inclusion.',
+      },
+    ],
+    comparePrefix: 'Tu trouveras toujours la comparaison complète des fonctions dans la doc :',
+    compareLink: 'Ouvrir la comparaison sur GitHub',
+  },
+  faq: {
+    eyebrow: 'FAQ',
+    title: 'Questions fréquentes avant la première utilisation',
+    answerLabel: 'Réponse',
+    items: [
+      {
+        question: 'Les hôtes ou les participants ont-ils besoin d’un compte ?',
+        answer:
+          'Non. Une session peut démarrer sans compte. Les participants rejoignent via code ou QR.',
+      },
+      {
+        question: 'Où sont les données ?',
+        answer:
+          'Les contenus de quiz sont conçus local-first. Pour les sessions en direct, seules les données de session techniquement nécessaires sont traitées ; en auto-hébergement, l’exploitation reste dans ton infrastructure.',
+      },
+      {
+        question: 'Puis-je auto-héberger arsnova.eu ?',
+        answer:
+          'Oui. La plateforme est open source et conçue pour fonctionner avec Docker, PostgreSQL et Redis.',
+      },
+      {
+        question: 'Qu’est-ce que l’autoévaluation dans le quiz ?',
+        answer:
+          'Une question complémentaire optionnelle après les questions notées : les participants indiquent sur une échelle de 1 à 5 à quel point ils sont sûrs de leur réponse. Les points restent inchangés ; dans l’évaluation hôte, tu vois exactitude × degré de confiance et marques les réponses fausses et sûres d’elles comme signal d’idée fausse. Après la session, l’état d’apprentissage alimente le débriefing et le rapport de résultats (PDF).',
+      },
+      {
+        question: 'Puis-je exporter les résultats de session ?',
+        answer:
+          'Oui. Après la fin de session, le rapport de résultats (PDF) est le format principal — y compris autoévaluation, priorités de débriefing et textes complets des questions. Dans la collection de quiz, tu trouves débriefing et PDF du dernier passage. Les données CSV tabulaires sont disponibles sous « Plus » pour Excel.',
+      },
+      {
+        question: 'Qu’a de particulier l’estimation numérique ?',
+        answer:
+          'Elle sépare les saisies autorisées de la bande de tolérance sur le fond, n’affiche aucune distribution pendant le vote et peut évaluer un second tour après discussion avec statistiques et comparaison des tours.',
+      },
+      {
+        question: 'Que peut faire le mur Q&A ?',
+        answer:
+          'Les participants soumettent des questions et les pondèrent avec des votes pour et contre. Les hôtes peuvent pré-modérer, épingler, archiver ou retirer des questions et trier la liste par soutien, accord robuste ou controverse.',
+      },
+      {
+        question: 'En quoi le nuage de mots Q&A est-il différent ?',
+        answer:
+          'Il condense les questions visibles en mots et phrases et reprend la logique de tri active. Il montre ainsi non seulement des termes fréquents, mais des clusters thématiques issus de questions soutenues, robustement notées ou controversées.',
+      },
+      {
+        question: 'Pour qui est destinée la plateforme ?',
+        answer:
+          'Pour l’interaction en direct dans l’éducation et les organisations : école, université, formation continue, formation, atelier, événement ou réunion.',
+      },
+      {
+        question: 'arsnova.eu est-il accessible ?',
+        answer:
+          'arsnova.eu respecte WCAG 2.2 AA. Les parcours centraux sont utilisables au clavier, les lecteurs d’écran annoncent les changements d’état, le temps de réponse des questions chronométrées est ajustable individuellement (temps standard, temps décuplé ou sans limite), et le rapport de résultats structuré de façon accessible est validé PDF/UA-1.',
+        linkLabel: 'Ouvrir la déclaration d’accessibilité',
+      },
+    ],
+  },
+  ctaSection: {
+    title: 'Prêt·e pour la prochaine session en direct ?',
+    lead: 'Teste le flux live directement dans l’application, ou jette un œil au code ouvert, à la logique Q&A, au pipeline du nuage de mots et au chemin d’exploitation derrière la plateforme.',
+  },
+  jsonLd: {
+    websiteName: 'arsnova.eu – Informations',
+    webAppDescription:
+      'Audience response open source pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), estimations numériques, mur Q&A modérable, nuage de mots et feedback — accessible WCAG 2.2 AA, gratuit, auto-hébergeable et prêt sans compte.',
+    featureList: [
+      'Quiz en direct et votes',
+      'Autoévaluation sur les questions notées',
+      'Rapport de résultats (PDF) et débriefing après la session',
+      'Estimations numériques avec deux tours et statistiques',
+      'Mur Q&A avec modération, votes pour et contre',
+      'Lobby, présentateur, QR/code',
+      'Types de questions QCM/QCU/réponse courte/texte libre/sondage/notation/estimation',
+      'Markdown et KaTeX',
+      'Phase de lecture et Peer Instruction',
+      'Nuage de mots Q&A et texte libre avec phrases et pondération',
+      'Tri par soutien, accord robuste et controverse',
+      'Mode équipe et préréglages',
+      'Classement, série, code bonus',
+      'Import/export et sync Yjs',
+      'Import IA externe, validé Zod',
+      'Interface en cinq langues',
+      'Accessibilité selon WCAG 2.2 AA',
+      'Auto-hébergement Docker et audit admin',
+      'Local-first et fonctionnement orienté RGPD',
+    ],
+  },
+};
+
+export default fr;

--- a/apps/landing/src/i18n/fr.ts
+++ b/apps/landing/src/i18n/fr.ts
@@ -2,9 +2,9 @@ import type { Messages } from './types';
 
 const fr: Messages = {
   meta: {
-    homeTitle: 'arsnova.eu | Quiz en direct, estimations numériques et mur Q&A',
+    homeTitle: 'arsnova.eu | Quiz en direct, questions d’estimation numérique et mur de questions',
     homeDescription:
-      'Audience response open source pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), estimations numériques, mur Q&A modérable, nuage de mots et feedback — accessible WCAG 2.2 AA, gratuit, auto-hébergeable et prêt sans compte.',
+      'Plateforme open source de réponse interactive pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), questions d’estimation numérique, mur de questions modérable, nuage de mots et sondage express — conforme aux WCAG 2.2, niveau AA, gratuite, auto-hébergeable et prête sans compte.',
     siteNameInfo: 'arsnova.eu – Informations',
     ogLocale: 'fr_FR',
   },
@@ -40,16 +40,16 @@ const fr: Messages = {
     backToApp: 'Retour à arsnova.eu',
     tryLive: 'Essayer en direct',
     howItWorks: 'Comment ça marche',
-    viewOpenSource: 'Voir le code open source',
+    viewOpenSource: 'Voir le code source',
   },
   hero: {
-    eyebrow: 'Audience response pour l’éducation et les organisations',
+    eyebrow: 'Réponse interactive pour l’éducation et les organisations',
     titleLine1: 'Quizzer, estimer,',
     titleLine2: 'modérer les questions',
     titleAccent1: 'en direct et gratuitement',
     titleAccent2: ' sans compte.',
-    lead: 'arsnova.eu réunit quiz en direct, estimations numériques, autoévaluation sur les questions notées, mur Q&A, analyse en nuage de mots et Feedback express dans une seule interface pour les écoles, les universités, la formation continue, les ateliers et le monde professionnel. Open source, auto-hébergeable et conçu pour un fonctionnement orienté RGPD.',
-    a11yLink: 'Accessible selon WCAG 2.2 AA',
+    lead: 'arsnova.eu réunit quiz en direct, questions d’estimation numérique, autoévaluation sur les questions notées, mur de questions, analyse en nuage de mots et sondage express dans une seule interface pour les écoles, les universités, la formation continue, les ateliers et le monde professionnel. Open source, auto-hébergeable et conçu pour un fonctionnement orienté RGPD.',
+    a11yLink: 'Conforme aux WCAG 2.2, niveau AA',
     a11ySuffix: '— clavier, lecteur d’écran et temps de réponse ajustable individuellement.',
     cards: [
       { title: 'En direct immédiatement', text: 'Partager une session par code ou QR' },
@@ -71,8 +71,9 @@ const fr: Messages = {
       'Personne ne voit la distribution avant la publication des résultats.',
       'Le tour 1 et le tour 2 sont comparés après la discussion.',
     ],
-    docsLink: 'Ouvrir la documentation de l’estimation',
-    demoAria: 'Exemple de résultats pour une estimation sur la Révolution française',
+    docsLink: 'Ouvrir la documentation de la question d’estimation numérique',
+    demoAria:
+      'Exemple de résultats pour une question d’estimation numérique sur la Révolution française',
     hostView: 'Vue hôte après publication',
     demoQuestion: 'Quand a commencé la Révolution française ?',
     reference: 'Référence 1789',
@@ -85,17 +86,17 @@ const fr: Messages = {
     median: 'Médiane',
     inBand: 'dans la bande',
     round2: 'Tour 2',
-    round2Value: '14 plus proches',
+    round2Value: '14 réponses plus proches de la référence',
   },
   confidence: {
     eyebrow: 'Évaluation didactique',
     title: 'Juste ou faux — et avec quel degré de confiance ?',
-    lead: 'Avec l’autoévaluation, les participants indiquent après leur réponse à quel point ils sont sûrs (1–5). Tu vois non seulement le taux de réussite, mais aussi les réponses fausses et sûres d’elles — un levier fort pour l’évaluation formative, le plan de débriefing et le rapport de résultats (PDF) en fin de session.',
+    lead: 'Avec l’autoévaluation, les participants indiquent après leur réponse à quel point ils sont sûrs (1–5). Tu vois non seulement le taux de réussite, mais aussi les réponses erronées associées à un degré de confiance élevé — un levier fort pour l’évaluation formative, le plan de débriefing et le rapport de résultats (PDF) en fin de session.',
     summary: [
       'Pas un type de question à part — optionnel sur les questions notées.',
       'Échelle 1–5 après la réponse, sans effet sur les points.',
       'Après publication, l’hôte voit exactitude × degré de confiance.',
-      '« Faux et sûr » signale d’éventuelles idées fausses.',
+      '« Erroné et sûr » signale d’éventuelles idées fausses.',
       'Après la session : rapport de résultats (PDF) et débriefing.',
     ],
     docsConfidence: 'Doc autoévaluation',
@@ -105,14 +106,14 @@ const fr: Messages = {
     demoQuestion: 'Quelle structure est la plus stable ?',
     badge: 'Autoévaluation',
     matrix: [
-      { label: 'Juste · bas', count: 3, tone: 'emerald' },
-      { label: 'Juste · moyen', count: 8, tone: 'emerald' },
-      { label: 'Juste · élevé', count: 11, tone: 'emerald' },
-      { label: 'Faux · bas', count: 2, tone: 'slate' },
-      { label: 'Faux · moyen', count: 4, tone: 'amber' },
-      { label: 'Faux · élevé', count: 2, tone: 'rose' },
+      { label: 'Réponse correcte · confiance faible', count: 3, tone: 'emerald' },
+      { label: 'Réponse correcte · confiance moyenne', count: 8, tone: 'emerald' },
+      { label: 'Réponse correcte · confiance élevée', count: 11, tone: 'emerald' },
+      { label: 'Réponse incorrecte · confiance faible', count: 2, tone: 'slate' },
+      { label: 'Réponse incorrecte · confiance moyenne', count: 4, tone: 'amber' },
+      { label: 'Réponse incorrecte · confiance élevée', count: 2, tone: 'rose' },
     ],
-    falseHighTitle: '2 réponses fausses et sûres d’elles',
+    falseHighTitle: '2 réponses erronées associées à un degré de confiance élevé',
     falseHighText:
       'L’option B a été choisie 2× avec un degré de confiance élevé — un signal d’éventuelles idées fausses pour le débriefing.',
     consolidated: 'Solide',
@@ -123,12 +124,12 @@ const fr: Messages = {
     debriefing: 'Débriefing',
     resultsPdf: 'Rapport de résultats (PDF)',
     exportNote:
-      'Rapport prêt à imprimer avec état d’apprentissage, heatmap et textes des questions — dans la vue hôte et sur la carte quiz. Le CSV pour Excel reste disponible sous « Plus ».',
+      'Rapport prêt à imprimer avec état d’apprentissage, carte de chaleur et textes des questions — dans la vue hôte et sur la carte quiz. Le CSV pour Excel reste disponible sous « Plus ».',
   },
   qaWall: {
     eyebrow: 'Q&A en direct comme espace de modération',
     title: 'Recueillir les questions, les prioriser et les lire comme carte thématique',
-    lead: 'Le mur de questions n’est pas un chat secondaire. C’est un canal live dédié pour les enseignant·es et intervenant·es : modérer les contributions, repérer les priorités collectives, rendre visibles les points controversés et ramener les thèmes clés dans la salle via un nuage de mots Q&A pondéré.',
+    lead: 'Le mur de questions n’est pas un chat secondaire. C’est un canal en direct dédié pour les enseignant·es et intervenant·es : modérer les contributions, repérer les priorités collectives, rendre visibles les points controversés et ramener les thèmes clés dans la salle via un nuage de mots Q&A pondéré.',
     signals: [
       {
         label: 'Pré-modération',
@@ -143,12 +144,12 @@ const fr: Messages = {
         text: 'Mots et phrases sont pondérés selon le soutien, l’accord ou la controverse.',
       },
       {
-        label: 'Perspective boussole',
+        label: 'Aperçu de la boussole',
         text: 'Les signaux déterministes viennent d’abord ; NLP Q&A et synthèse restent des extensions optionnelles.',
       },
     ],
     docsLink: 'Ouvrir le scoring Q&A et la controverse sur GitHub',
-    demoAria: 'Exemple de mur Q&A avec modération, votes et nuage de mots',
+    demoAria: 'Exemple de mur de questions avec modération, votes et nuage de mots',
     hostView: 'Vue hôte Q&A',
     demoTitle: 'Questions sur l’événement',
     moderationActive: 'Pré-modération active',
@@ -174,7 +175,7 @@ const fr: Messages = {
     ],
     wordCloud: 'Nuage de mots Q&A',
     wordCloudHint: 'Pondéré selon la résonance positive et la controverse.',
-    frozenLive: 'Figé en direct',
+    frozenLive: 'Mise à jour en direct en pause',
     terms: [
       { label: 'Bande de tolérance', className: 'text-3xl text-brand-200' },
       { label: 'Discussion', className: 'text-2xl text-emerald-200' },
@@ -198,7 +199,7 @@ const fr: Messages = {
         number: '01',
         title: 'Préparer un quiz',
         description:
-          'Créer des questions directement ou importer des contenus existants. Markdown, KaTeX, réponse courte et estimations numériques sont intégrés.',
+          'Créer des questions directement ou importer des contenus existants. Markdown, KaTeX, réponse courte et questions d’estimation numérique sont intégrés.',
       },
       {
         number: '02',
@@ -210,7 +211,7 @@ const fr: Messages = {
         number: '03',
         title: 'Animer en direct',
         description:
-          'Les participants votent, posent des questions et priorisent ensemble. Hôte et présentateur affichent quiz, mur Q&A, nuage de mots, phase de lecture, compte à rebours, second tour et résultats dans un seul flux.',
+          'Les participants votent, posent des questions et priorisent ensemble. Hôte et présentateur affichent quiz, mur de questions, nuage de mots, phase de lecture, compte à rebours, second tour et résultats dans un seul flux.',
       },
       {
         number: '04',
@@ -221,7 +222,7 @@ const fr: Messages = {
     ],
   },
   features: {
-    eyebrow: 'Pourquoi ça se sent différent',
+    eyebrow: 'Ce qui fait la différence',
     title: 'Conçu pour l’interaction en direct, pas seulement pour des sondages sur diapos',
     lead: 'arsnova.eu combine démarrage rapide, force didactique et socle technique transparent. La plateforme reste simple au quotidien sans restreindre les possibilités.',
     items: [
@@ -234,7 +235,7 @@ const fr: Messages = {
       {
         title: 'Autoévaluation dans le quiz en direct',
         description:
-          'Les participants indiquent après la réponse à quel point ils sont sûrs. Tu repères les réponses fausses et sûres d’elles, priorises le débriefing et exportes l’état d’apprentissage dans le rapport de résultats (PDF).',
+          'Les participants indiquent après la réponse à quel point ils sont sûrs. Tu repères les réponses erronées associées à un degré de confiance élevé, priorises le débriefing et exportes l’état d’apprentissage dans le rapport de résultats (PDF).',
         icon: 'confidence',
       },
       {
@@ -244,7 +245,7 @@ const fr: Messages = {
         icon: 'export',
       },
       {
-        title: 'Estimations didactiques',
+        title: 'Questions d’estimation numérique didactiques',
         description:
           'Dates, ordres de grandeur et mesures peuvent être estimés avec valeur de référence, bande de tolérance, statistiques et second tour optionnel.',
         icon: 'estimate',
@@ -274,7 +275,7 @@ const fr: Messages = {
         icon: 'bolt',
       },
       {
-        title: 'Accessibilité selon WCAG 2.2 AA',
+        title: 'Conforme aux WCAG 2.2, niveau AA',
         description:
           'Navigation clavier, annonces lecteur d’écran, temps de réponse ajustable individuellement et rapports PDF/UA-1 — pour que davantage d’apprenant·es participent en autonomie aux sessions en direct.',
         icon: 'a11y',
@@ -282,11 +283,11 @@ const fr: Messages = {
       {
         title: 'Confidentialité et contrôle',
         description:
-          'Local-first, data-stripping et exploitation auto-hébergeable te donnent plus de contrôle sur les contenus et les données live.',
+          'Approche local-first, suppression optionnelle des données et exploitation auto-hébergeable te donnent plus de contrôle sur les contenus et les données en direct.',
         icon: 'tools',
       },
       {
-        title: 'Open source avec chemin d’exploitation',
+        title: 'Open source avec déploiement et exploitation',
         description:
           'Docker, Postgres, Redis et audit admin rendent la plateforme fiable aussi pour l’hébergement, l’exploitation et la traçabilité.',
         icon: 'server',
@@ -296,7 +297,7 @@ const fr: Messages = {
   accessibility: {
     eyebrow: 'Accessibilité',
     title: 'WCAG 2.2 AA — pour que davantage d’apprenant·es participent en autonomie',
-    lead: 'Pour les écoles, universités et la formation continue, l’accessibilité est souvent un critère décisif. arsnova.eu respecte les Web Content Accessibility Guidelines (WCAG) 2.2 au niveau AA — avec navigation clavier, support lecteur d’écran, temps de réponse ajustable individuellement et rapports PDF structurés de façon accessible.',
+    lead: 'Pour les écoles, universités et la formation continue, l’accessibilité est souvent un critère décisif. arsnova.eu est conforme aux Web Content Accessibility Guidelines (WCAG) 2.2, niveau AA — avec navigation clavier, support lecteur d’écran, temps de réponse ajustable individuellement et rapports PDF structurés de façon accessible.',
     benefits: [
       {
         title: 'Utilisation au clavier',
@@ -370,7 +371,7 @@ const fr: Messages = {
   comparison: {
     eyebrow: 'Positionnement',
     title: 'Pas seulement un substitut à Mentimeter ou Kahoot',
-    lead: 'Le centre n’est pas seulement le vote, mais le flux live complet : préparer, animer, rendre les résultats visibles et garder le contrôle sur les contenus et l’exploitation.',
+    lead: 'Le centre n’est pas seulement le vote, mais le flux en direct complet : préparer, animer, rendre les résultats visibles et garder le contrôle sur les contenus et l’exploitation.',
     points: [
       {
         title: 'Moins de freins à l’entrée',
@@ -380,12 +381,12 @@ const fr: Messages = {
       {
         title: 'Plus de formats d’interaction',
         description:
-          'Outre le quiz : estimations numériques, phase de lecture, Peer Instruction, Feedback express, mur Q&A et nuage de mots pondéré dans la même plateforme — pas seulement des sondages sur diapos.',
+          'Outre le quiz : questions d’estimation numérique, phase de lecture, Peer Instruction, sondage express, mur de questions et nuage de mots pondéré dans la même plateforme — pas seulement des sondages sur diapos.',
       },
       {
         title: 'Plus de contrôle sur les données et l’accès',
         description:
-          'Open source, auto-hébergeable et conçu local-first — plus l’accessibilité WCAG 2.2 AA. Pertinent pour les écoles, universités et organisations avec des exigences de confidentialité et d’inclusion.',
+          'Open source, auto-hébergeable et conçu local-first — plus la conformité aux WCAG 2.2, niveau AA. Pertinent pour les écoles, universités et organisations avec des exigences de confidentialité et d’inclusion.',
       },
     ],
     comparePrefix: 'Tu trouveras toujours la comparaison complète des fonctions dans la doc :',
@@ -414,7 +415,7 @@ const fr: Messages = {
       {
         question: 'Qu’est-ce que l’autoévaluation dans le quiz ?',
         answer:
-          'Une question complémentaire optionnelle après les questions notées : les participants indiquent sur une échelle de 1 à 5 à quel point ils sont sûrs de leur réponse. Les points restent inchangés ; dans l’évaluation hôte, tu vois exactitude × degré de confiance et marques les réponses fausses et sûres d’elles comme signal d’idée fausse. Après la session, l’état d’apprentissage alimente le débriefing et le rapport de résultats (PDF).',
+          'Une question complémentaire optionnelle après les questions notées : les participants indiquent sur une échelle de 1 à 5 à quel point ils sont sûrs de leur réponse. Les points restent inchangés ; dans l’évaluation hôte, tu vois exactitude × degré de confiance et marques les réponses erronées associées à un degré de confiance élevé comme signal d’idée fausse. Après la session, l’état d’apprentissage alimente le débriefing et le rapport de résultats (PDF).',
       },
       {
         question: 'Puis-je exporter les résultats de session ?',
@@ -422,12 +423,12 @@ const fr: Messages = {
           'Oui. Après la fin de session, le rapport de résultats (PDF) est le format principal — y compris autoévaluation, priorités de débriefing et textes complets des questions. Dans la collection de quiz, tu trouves débriefing et PDF du dernier passage. Les données CSV tabulaires sont disponibles sous « Plus » pour Excel.',
       },
       {
-        question: 'Qu’a de particulier l’estimation numérique ?',
+        question: 'Qu’a de particulier la question d’estimation numérique ?',
         answer:
           'Elle sépare les saisies autorisées de la bande de tolérance sur le fond, n’affiche aucune distribution pendant le vote et peut évaluer un second tour après discussion avec statistiques et comparaison des tours.',
       },
       {
-        question: 'Que peut faire le mur Q&A ?',
+        question: 'Que peut faire le mur de questions ?',
         answer:
           'Les participants soumettent des questions et les pondèrent avec des votes pour et contre. Les hôtes peuvent pré-modérer, épingler, archiver ou retirer des questions et trier la liste par soutien, accord robuste ou controverse.',
       },
@@ -444,27 +445,27 @@ const fr: Messages = {
       {
         question: 'arsnova.eu est-il accessible ?',
         answer:
-          'arsnova.eu respecte WCAG 2.2 AA. Les parcours centraux sont utilisables au clavier, les lecteurs d’écran annoncent les changements d’état, le temps de réponse des questions chronométrées est ajustable individuellement (temps standard, temps décuplé ou sans limite), et le rapport de résultats structuré de façon accessible est validé PDF/UA-1.',
+          'arsnova.eu est conforme aux WCAG 2.2, niveau AA. Les parcours centraux sont utilisables au clavier, les lecteurs d’écran annoncent les changements d’état, le temps de réponse des questions chronométrées est ajustable individuellement (temps standard, temps décuplé ou sans limite), et le rapport de résultats structuré de façon accessible est validé PDF/UA-1.',
         linkLabel: 'Ouvrir la déclaration d’accessibilité',
       },
     ],
   },
   ctaSection: {
     title: 'Prêt·e pour la prochaine session en direct ?',
-    lead: 'Teste le flux live directement dans l’application, ou jette un œil au code ouvert, à la logique Q&A, au pipeline du nuage de mots et au chemin d’exploitation derrière la plateforme.',
+    lead: 'Teste le flux en direct directement dans l’application, ou jette un œil au code source ouvert, à la logique Q&A, au traitement du nuage de mots et au déploiement et à l’exploitation derrière la plateforme.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Informations',
     webAppDescription:
-      'Audience response open source pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), estimations numériques, mur Q&A modérable, nuage de mots et feedback — accessible WCAG 2.2 AA, gratuit, auto-hébergeable et prêt sans compte.',
+      'Plateforme open source de réponse interactive pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), questions d’estimation numérique, mur de questions modérable, nuage de mots et sondage express — conforme aux WCAG 2.2, niveau AA, gratuite, auto-hébergeable et prête sans compte.',
     featureList: [
       'Quiz en direct et votes',
       'Autoévaluation sur les questions notées',
       'Rapport de résultats (PDF) et débriefing après la session',
-      'Estimations numériques avec deux tours et statistiques',
-      'Mur Q&A avec modération, votes pour et contre',
+      'Questions d’estimation numérique avec deux tours et statistiques',
+      'Mur de questions avec modération, votes pour et contre',
       'Lobby, présentateur, QR/code',
-      'Types de questions QCM/QCU/réponse courte/texte libre/sondage/notation/estimation',
+      'Types de questions QCM/QCU/réponse courte/texte libre/sondage/notation/estimation numérique',
       'Markdown et KaTeX',
       'Phase de lecture et Peer Instruction',
       'Nuage de mots Q&A et texte libre avec phrases et pondération',
@@ -474,7 +475,7 @@ const fr: Messages = {
       'Import/export et sync Yjs',
       'Import IA externe, validé Zod',
       'Interface en cinq langues',
-      'Accessibilité selon WCAG 2.2 AA',
+      'Conforme aux WCAG 2.2, niveau AA',
       'Auto-hébergement Docker et audit admin',
       'Local-first et fonctionnement orienté RGPD',
     ],

--- a/apps/landing/src/i18n/fr.ts
+++ b/apps/landing/src/i18n/fr.ts
@@ -4,7 +4,7 @@ const fr: Messages = {
   meta: {
     homeTitle: 'arsnova.eu | Quiz en direct, questions d’estimation numérique et mur de questions',
     homeDescription:
-      'Plateforme open source de réponse interactive pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), questions d’estimation numérique, mur de questions modérable, nuage de mots et sondage express — conforme aux WCAG 2.2, niveau AA, gratuite, auto-hébergeable et prête sans compte.',
+      'Plateforme open source de réponse interactive pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), questions d’estimation numérique, mur de questions modérable, nuage de mots et sondage express — conforme aux WCAG 2.2, niveau AA, gratuite, exploitable sur votre propre infrastructure et prête sans compte.',
     siteNameInfo: 'arsnova.eu – Informations',
     ogLocale: 'fr_FR',
   },
@@ -48,17 +48,20 @@ const fr: Messages = {
     titleLine2: 'modérer les questions',
     titleAccent1: 'en direct et gratuitement',
     titleAccent2: ' sans compte.',
-    lead: 'arsnova.eu réunit quiz en direct, questions d’estimation numérique, autoévaluation sur les questions notées, mur de questions, analyse en nuage de mots et sondage express dans une seule interface pour les écoles, les universités, la formation continue, les ateliers et le monde professionnel. Open source, auto-hébergeable et conçu pour un fonctionnement orienté RGPD.',
+    lead: 'arsnova.eu réunit quiz en direct, questions d’estimation numérique, autoévaluation sur les questions notées, mur de questions, analyse en nuage de mots et sondage express dans une seule interface pour les écoles, les universités, la formation continue, les ateliers et le monde professionnel. Open source, exploitable sur votre propre infrastructure et conçu pour un fonctionnement orienté RGPD.',
     a11yLink: 'Conforme aux WCAG 2.2, niveau AA',
     a11ySuffix: '— clavier, lecteur d’écran et temps de réponse ajustable individuellement.',
     cards: [
-      { title: 'En direct immédiatement', text: 'Partager une session par code ou QR' },
+      { title: 'Prêt en quelques secondes', text: 'Partager une session par code ou QR' },
       { title: 'Q&A avec mur de questions', text: 'Modération, votes et nuage thématique' },
       {
         title: 'Autoévaluation et suivi',
         text: 'Repérer les idées fausses, exporter le rapport PDF',
       },
-      { title: 'Open source et auto-hébergeable', text: 'Docker, Postgres, Redis et audit admin' },
+      {
+        title: 'Open source et hébergeable chez vous',
+        text: 'Docker, Postgres, Redis et journal d’administration',
+      },
     ],
   },
   estimate: {
@@ -74,7 +77,7 @@ const fr: Messages = {
     docsLink: 'Ouvrir la documentation de la question d’estimation numérique',
     demoAria:
       'Exemple de résultats pour une question d’estimation numérique sur la Révolution française',
-    hostView: 'Vue hôte après publication',
+    hostView: 'Vue de l’animateur après publication',
     demoQuestion: 'Quand a commencé la Révolution française ?',
     reference: 'Référence 1789',
     toleranceBand: 'Bande de tolérance',
@@ -89,20 +92,20 @@ const fr: Messages = {
     round2Value: '14 réponses plus proches de la référence',
   },
   confidence: {
-    eyebrow: 'Évaluation didactique',
+    eyebrow: 'Analyse pédagogique',
     title: 'Juste ou faux — et avec quel degré de confiance ?',
-    lead: 'Avec l’autoévaluation, les participants indiquent après leur réponse à quel point ils sont sûrs (1–5). Tu vois non seulement le taux de réussite, mais aussi les réponses erronées associées à un degré de confiance élevé — un levier fort pour l’évaluation formative, le plan de débriefing et le rapport de résultats (PDF) en fin de session.',
+    lead: 'Avec l’autoévaluation, les participants indiquent après leur réponse à quel point ils sont sûrs (1–5). Tu vois non seulement le taux de réussite, mais aussi les réponses erronées associées à un degré de confiance élevé — un outil utile pour l’évaluation formative, le plan de bilan et le rapport de résultats (PDF) en fin de session.',
     summary: [
       'Pas un type de question à part — optionnel sur les questions notées.',
       'Échelle 1–5 après la réponse, sans effet sur les points.',
-      'Après publication, l’hôte voit exactitude × degré de confiance.',
+      'Après publication, l’animateur voit exactitude × degré de confiance.',
       '« Erroné et sûr » signale d’éventuelles idées fausses.',
-      'Après la session : rapport de résultats (PDF) et débriefing.',
+      'Après la session : rapport de résultats (PDF) et bilan.',
     ],
     docsConfidence: 'Doc autoévaluation',
     docsExport: 'Doc rapport de résultats (PDF)',
     demoAria: 'Exemple d’évaluation avec autoévaluation après publication',
-    hostView: 'Vue hôte après publication',
+    hostView: 'Vue de l’animateur après publication',
     demoQuestion: 'Quelle structure est la plus stable ?',
     badge: 'Autoévaluation',
     matrix: [
@@ -115,16 +118,16 @@ const fr: Messages = {
     ],
     falseHighTitle: '2 réponses erronées associées à un degré de confiance élevé',
     falseHighText:
-      'L’option B a été choisie 2× avec un degré de confiance élevé — un signal d’éventuelles idées fausses pour le débriefing.',
+      'L’option B a été choisie 2× avec un degré de confiance élevé — un signal d’éventuelles idées fausses pour le bilan.',
     consolidated: 'Solide',
     misconceptionRisk: 'Risque d’idée fausse',
     fragile: 'Fragile',
     afterSessionAria: 'Export après la fin de session',
     afterSession: 'Après la fin de session',
-    debriefing: 'Débriefing',
+    debriefing: 'Bilan',
     resultsPdf: 'Rapport de résultats (PDF)',
     exportNote:
-      'Rapport prêt à imprimer avec état d’apprentissage, carte de chaleur et textes des questions — dans la vue hôte et sur la carte quiz. Le CSV pour Excel reste disponible sous « Plus ».',
+      'Rapport prêt à imprimer avec état d’apprentissage, carte de chaleur et textes des questions — dans la vue de l’animateur et sur la carte quiz. Le CSV pour Excel reste disponible sous « Plus ».',
   },
   qaWall: {
     eyebrow: 'Q&A en direct comme espace de modération',
@@ -133,7 +136,7 @@ const fr: Messages = {
     signals: [
       {
         label: 'Pré-modération',
-        text: 'Publier les questions seulement quand elles collent au moment pédagogique.',
+        text: 'Publier les questions uniquement lorsqu’elles sont pertinentes dans le contexte pédagogique.',
       },
       {
         label: 'Vote collectif',
@@ -144,13 +147,13 @@ const fr: Messages = {
         text: 'Mots et phrases sont pondérés selon le soutien, l’accord ou la controverse.',
       },
       {
-        label: 'Aperçu de la boussole',
-        text: 'Les signaux déterministes viennent d’abord ; NLP Q&A et synthèse restent des extensions optionnelles.',
+        label: 'À venir : boussole de modération',
+        text: 'Les signaux déterministes viennent d’abord ; l’analyse linguistique optionnelle et la synthèse restent des extensions.',
       },
     ],
-    docsLink: 'Ouvrir le scoring Q&A et la controverse sur GitHub',
+    docsLink: 'Ouvrir la notation Q&A et la controverse sur GitHub',
     demoAria: 'Exemple de mur de questions avec modération, votes et nuage de mots',
-    hostView: 'Vue hôte Q&A',
+    hostView: 'Vue de l’animateur Q&A',
     demoTitle: 'Questions sur l’événement',
     moderationActive: 'Pré-modération active',
     sortMostSupported: 'Les plus soutenues',
@@ -187,7 +190,7 @@ const fr: Messages = {
       { label: 'Besoin de clarification', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Prochaine étape : une boussole de modération déterministe, éventuellement complétée par des signaux NLP Q&A asynchrones et des synthèses liées aux sources.',
+      'Prochaine étape : une boussole de modération déterministe, éventuellement complétée par des signaux d’analyse linguistique asynchrones et des synthèses liées aux sources.',
   },
   workflow: {
     eyebrow: 'Pour l’enseignement, la formation et les ateliers',
@@ -211,31 +214,31 @@ const fr: Messages = {
         number: '03',
         title: 'Animer en direct',
         description:
-          'Les participants votent, posent des questions et priorisent ensemble. Hôte et présentateur affichent quiz, mur de questions, nuage de mots, phase de lecture, compte à rebours, second tour et résultats dans un seul flux.',
+          'Les participants votent, posent des questions et définissent ensemble les priorités. L’animateur et le présentateur affichent le quiz, le mur de questions, le nuage de mots, la phase de lecture, le compte à rebours, le second tour et les résultats dans un seul flux.',
       },
       {
         number: '04',
         title: 'Suivre et exporter',
         description:
-          'Après la fin de session, le rapport de résultats (PDF) est prêt — avec état d’apprentissage, autoévaluation et textes complets des questions. Dans la collection de quiz, tu trouves débriefing et PDF du dernier passage ; CSV pour Excel sous « Plus ».',
+          'Après la fin de session, le rapport de résultats (PDF) est prêt — avec état d’apprentissage, autoévaluation et textes complets des questions. Dans la collection de quiz, tu trouves bilan et PDF du dernier passage ; CSV pour Excel sous « Plus ».',
       },
     ],
   },
   features: {
-    eyebrow: 'Ce qui fait la différence',
+    eyebrow: 'Ce qui distingue arsnova.eu',
     title: 'Conçu pour l’interaction en direct, pas seulement pour des sondages sur diapos',
-    lead: 'arsnova.eu combine démarrage rapide, force didactique et socle technique transparent. La plateforme reste simple au quotidien sans restreindre les possibilités.',
+    lead: 'arsnova.eu combine démarrage rapide, force pédagogique et socle technique transparent. La plateforme reste simple au quotidien sans restreindre les possibilités.',
     items: [
       {
         title: 'Prêt rapidement',
         description:
-          'Les hôtes démarrent sans compte. Les participants rejoignent la session directement avec un code à 6 chiffres ou un QR.',
+          'Les animateurs démarrent sans compte. Les participants rejoignent la session directement avec un code à 6 chiffres ou un QR.',
         icon: 'single',
       },
       {
         title: 'Autoévaluation dans le quiz en direct',
         description:
-          'Les participants indiquent après la réponse à quel point ils sont sûrs. Tu repères les réponses erronées associées à un degré de confiance élevé, priorises le débriefing et exportes l’état d’apprentissage dans le rapport de résultats (PDF).',
+          'Les participants indiquent après la réponse à quel point ils sont sûrs. Tu repères les réponses erronées associées à un degré de confiance élevé, priorises le bilan et exportes l’état d’apprentissage dans le rapport de résultats (PDF).',
         icon: 'confidence',
       },
       {
@@ -245,7 +248,7 @@ const fr: Messages = {
         icon: 'export',
       },
       {
-        title: 'Questions d’estimation numérique didactiques',
+        title: 'Questions d’estimation numérique pédagogiques',
         description:
           'Dates, ordres de grandeur et mesures peuvent être estimés avec valeur de référence, bande de tolérance, statistiques et second tour optionnel.',
         icon: 'estimate',
@@ -265,7 +268,7 @@ const fr: Messages = {
       {
         title: 'Nuage de mots élaboré',
         description:
-          'Texte libre et Q&A sont condensés en mots et phrases ; le mur pondère selon l’accord, un score robuste ou la controverse.',
+          'Texte libre et Q&A sont condensés en mots et phrases ; le mur pondère selon l’accord, une évaluation robuste ou la controverse.',
         icon: 'cloud',
       },
       {
@@ -283,13 +286,13 @@ const fr: Messages = {
       {
         title: 'Confidentialité et contrôle',
         description:
-          'Approche local-first, suppression optionnelle des données et exploitation auto-hébergeable te donnent plus de contrôle sur les contenus et les données en direct.',
+          'Les contenus de quiz restent sur ton appareil, la suppression optionnelle des données et l’exploitation sur ta propre infrastructure te donnent plus de contrôle sur les contenus et les données en direct.',
         icon: 'tools',
       },
       {
         title: 'Open source avec déploiement et exploitation',
         description:
-          'Docker, Postgres, Redis et audit admin rendent la plateforme fiable aussi pour l’hébergement, l’exploitation et la traçabilité.',
+          'Docker, Postgres, Redis et journal d’administration rendent la plateforme fiable aussi pour l’hébergement, l’exploitation et la traçabilité.',
         icon: 'server',
       },
     ],
@@ -324,10 +327,13 @@ const fr: Messages = {
   },
   trust: {
     eyebrow: 'Confiance',
-    title: 'Crédible parce que le produit ne part pas de zéro',
-    lead: 'arsnova.eu s’inscrit dans la tradition de l’écosystème ARSnova et s’appuie sur des expériences scientifiques, didactiques et pratiques de nombreuses années de technologies éducatives.',
+    title: 'Bâti sur une expérience de longue date',
+    lead: 'arsnova.eu s’inscrit dans la tradition de l’écosystème ARSnova et s’appuie sur des expériences scientifiques, pédagogiques et pratiques de nombreuses années de technologies éducatives.',
     proofItems: [
-      { value: 'Depuis 2012', label: 'Tradition ARSnova dans l’éducation et l’edtech' },
+      {
+        value: 'Depuis 2012',
+        label: 'Tradition ARSnova dans l’éducation et les technologies éducatives',
+      },
       {
         value: 'WCAG 2.2 AA',
         label: 'Accessibilité vérifiée pour l’enseignement et les institutions',
@@ -336,7 +342,7 @@ const fr: Messages = {
         value: '5 langues UI',
         label: 'Allemand, anglais, français, espagnol, italien',
       },
-      { value: 'Open source', label: 'Code transparent plutôt qu’une boîte noire' },
+      { value: 'Open source', label: 'Code transparent plutôt que des systèmes opaques' },
     ],
     items: [
       {
@@ -347,13 +353,13 @@ const fr: Messages = {
       },
       {
         quote:
-          'Évaluation UX en comparaison directe avec Kahoot! comme point de contrôle empirique du design.',
+          'Évaluation UX en comparaison directe avec Kahoot! comme vérification empirique du design.',
         source: 'fnm-austria',
         tag: 'Étude',
       },
       {
         quote:
-          'Privacy by design et ouverture technique sont un vrai facteur de différenciation pour les contextes edtech européens.',
+          'La protection des données dès la conception et l’ouverture technique sont un vrai facteur de différenciation pour les contextes européens de technologies éducatives.',
         source: 'Analyse de publications',
         tag: 'Architecture',
       },
@@ -376,7 +382,7 @@ const fr: Messages = {
       {
         title: 'Moins de freins à l’entrée',
         description:
-          'Pas de logique produit séparée pour « créer » et « rejoindre ». Les hôtes démarrent sans compte, les participants entrent via code ou QR.',
+          'Pas de logique produit séparée pour « créer » et « rejoindre ». Les animateurs démarrent sans compte, les participants entrent via code ou QR.',
       },
       {
         title: 'Plus de formats d’interaction',
@@ -386,7 +392,7 @@ const fr: Messages = {
       {
         title: 'Plus de contrôle sur les données et l’accès',
         description:
-          'Open source, auto-hébergeable et conçu local-first — plus la conformité aux WCAG 2.2, niveau AA. Pertinent pour les écoles, universités et organisations avec des exigences de confidentialité et d’inclusion.',
+          'Open source, exploitable sur votre propre infrastructure et avec des contenus de quiz conservés localement — plus la conformité aux WCAG 2.2, niveau AA. Pertinent pour les écoles, universités et organisations avec des exigences de confidentialité et d’inclusion.',
       },
     ],
     comparePrefix: 'Tu trouveras toujours la comparaison complète des fonctions dans la doc :',
@@ -398,29 +404,29 @@ const fr: Messages = {
     answerLabel: 'Réponse',
     items: [
       {
-        question: 'Les hôtes ou les participants ont-ils besoin d’un compte ?',
+        question: 'Les animateurs ou les participants ont-ils besoin d’un compte ?',
         answer:
           'Non. Une session peut démarrer sans compte. Les participants rejoignent via code ou QR.',
       },
       {
         question: 'Où sont les données ?',
         answer:
-          'Les contenus de quiz sont conçus local-first. Pour les sessions en direct, seules les données de session techniquement nécessaires sont traitées ; en auto-hébergement, l’exploitation reste dans ton infrastructure.',
+          'Les contenus de quiz restent sur ton appareil. Pour les sessions en direct, seules les données de session techniquement nécessaires sont traitées ; si tu héberges toi-même, l’exploitation reste dans ton infrastructure.',
       },
       {
-        question: 'Puis-je auto-héberger arsnova.eu ?',
+        question: 'Puis-je héberger arsnova.eu moi-même ?',
         answer:
           'Oui. La plateforme est open source et conçue pour fonctionner avec Docker, PostgreSQL et Redis.',
       },
       {
         question: 'Qu’est-ce que l’autoévaluation dans le quiz ?',
         answer:
-          'Une question complémentaire optionnelle après les questions notées : les participants indiquent sur une échelle de 1 à 5 à quel point ils sont sûrs de leur réponse. Les points restent inchangés ; dans l’évaluation hôte, tu vois exactitude × degré de confiance et marques les réponses erronées associées à un degré de confiance élevé comme signal d’idée fausse. Après la session, l’état d’apprentissage alimente le débriefing et le rapport de résultats (PDF).',
+          'Une question complémentaire optionnelle après les questions notées : les participants indiquent sur une échelle de 1 à 5 à quel point ils sont sûrs de leur réponse. Les points restent inchangés ; dans l’évaluation de l’animateur, tu vois exactitude × degré de confiance et marques les réponses erronées associées à un degré de confiance élevé comme signal d’idée fausse. Après la session, l’état d’apprentissage alimente le bilan et le rapport de résultats (PDF).',
       },
       {
         question: 'Puis-je exporter les résultats de session ?',
         answer:
-          'Oui. Après la fin de session, le rapport de résultats (PDF) est le format principal — y compris autoévaluation, priorités de débriefing et textes complets des questions. Dans la collection de quiz, tu trouves débriefing et PDF du dernier passage. Les données CSV tabulaires sont disponibles sous « Plus » pour Excel.',
+          'Oui. Après la fin de session, le rapport de résultats (PDF) est le format principal — y compris autoévaluation, priorités de bilan et textes complets des questions. Dans la collection de quiz, tu trouves bilan et PDF du dernier passage. Les données CSV tabulaires sont disponibles sous « Plus » pour Excel.',
       },
       {
         question: 'Qu’a de particulier la question d’estimation numérique ?',
@@ -430,12 +436,12 @@ const fr: Messages = {
       {
         question: 'Que peut faire le mur de questions ?',
         answer:
-          'Les participants soumettent des questions et les pondèrent avec des votes pour et contre. Les hôtes peuvent pré-modérer, épingler, archiver ou retirer des questions et trier la liste par soutien, accord robuste ou controverse.',
+          'Les participants soumettent des questions et les pondèrent avec des votes pour et contre. Les animateurs peuvent pré-modérer, épingler, archiver ou retirer des questions et trier la liste par soutien, accord robuste ou controverse.',
       },
       {
         question: 'En quoi le nuage de mots Q&A est-il différent ?',
         answer:
-          'Il condense les questions visibles en mots et phrases et reprend la logique de tri active. Il montre ainsi non seulement des termes fréquents, mais des clusters thématiques issus de questions soutenues, robustement notées ou controversées.',
+          'Il condense les questions visibles en mots et phrases et reprend la logique de tri active. Il montre ainsi non seulement des termes fréquents, mais des regroupements thématiques issus de questions soutenues, robustement notées ou controversées.',
       },
       {
         question: 'Pour qui est destinée la plateforme ?',
@@ -452,19 +458,19 @@ const fr: Messages = {
   },
   ctaSection: {
     title: 'Prêt·e pour la prochaine session en direct ?',
-    lead: 'Teste le flux en direct directement dans l’application, ou jette un œil au code source ouvert, à la logique Q&A, au traitement du nuage de mots et au déploiement et à l’exploitation derrière la plateforme.',
+    lead: 'Teste le flux en direct directement dans l’application, ou jette un œil au code source ouvert, à la logique Q&A, au traitement du nuage de mots et aux bases techniques pour le déploiement et l’exploitation.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Informations',
     webAppDescription:
-      'Plateforme open source de réponse interactive pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), questions d’estimation numérique, mur de questions modérable, nuage de mots et sondage express — conforme aux WCAG 2.2, niveau AA, gratuite, auto-hébergeable et prête sans compte.',
+      'Plateforme open source de réponse interactive pour l’éducation, la formation et les organisations : quiz en direct, autoévaluation, rapport de résultats (PDF), questions d’estimation numérique, mur de questions modérable, nuage de mots et sondage express — conforme aux WCAG 2.2, niveau AA, gratuite, exploitable sur votre propre infrastructure et prête sans compte.',
     featureList: [
       'Quiz en direct et votes',
       'Autoévaluation sur les questions notées',
-      'Rapport de résultats (PDF) et débriefing après la session',
+      'Rapport de résultats (PDF) et bilan après la session',
       'Questions d’estimation numérique avec deux tours et statistiques',
       'Mur de questions avec modération, votes pour et contre',
-      'Lobby, présentateur, QR/code',
+      'Accueil, présentateur, QR/code',
       'Types de questions QCM/QCU/réponse courte/texte libre/sondage/notation/estimation numérique',
       'Markdown et KaTeX',
       'Phase de lecture et Peer Instruction',
@@ -472,12 +478,12 @@ const fr: Messages = {
       'Tri par soutien, accord robuste et controverse',
       'Mode équipe et préréglages',
       'Classement, série, code bonus',
-      'Import/export et sync Yjs',
+      'Import/export et synchronisation Yjs',
       'Import IA externe, validé Zod',
       'Interface en cinq langues',
       'Conforme aux WCAG 2.2, niveau AA',
-      'Auto-hébergement Docker et audit admin',
-      'Local-first et fonctionnement orienté RGPD',
+      'Exploitation Docker sur votre infrastructure et journal d’administration',
+      'Contenus de quiz conservés localement et fonctionnement orienté RGPD',
     ],
   },
 };

--- a/apps/landing/src/i18n/fr.ts
+++ b/apps/landing/src/i18n/fr.ts
@@ -48,7 +48,7 @@ const fr: Messages = {
     titleLine2: 'modérer les questions',
     titleAccent1: 'en direct et gratuitement',
     titleAccent2: ' sans compte.',
-    lead: 'arsnova.eu réunit quiz en direct, questions d’estimation numérique, autoévaluation sur les questions notées, mur de questions, analyse en nuage de mots et sondage express dans une seule interface pour les écoles, les universités, la formation continue, les ateliers et le monde professionnel. Open source, exploitable sur votre propre infrastructure et conçu pour un fonctionnement orienté RGPD.',
+    lead: 'arsnova.eu réunit quiz en direct, questions d’estimation numérique, autoévaluation sur les questions notées, mur de questions, analyse en nuage de mots et sondage express dans une seule interface pour les écoles, les universités, la formation continue, les ateliers et le monde professionnel. Open source, exploitable sur votre propre infrastructure et conçu pour un fonctionnement dans le respect du RGPD.',
     a11yLink: 'Conforme aux WCAG 2.2, niveau AA',
     a11ySuffix: '— clavier, lecteur d’écran et temps de réponse ajustable individuellement.',
     cards: [
@@ -85,7 +85,7 @@ const fr: Messages = {
     plausibilityBand: 'Bande de plausibilité',
     plausibilityValue: '1500 à 2000',
     histogramNote:
-      'L’histogramme, la ligne de référence et la bande de tolérance n’apparaissent qu’après publication des résultats. Avant cela, seule la progression neutre reste visible.',
+      'L’histogramme, la ligne de référence et la bande de tolérance n’apparaissent qu’après publication des résultats. Avant cela, seul un indicateur neutre de progression reste visible.',
     median: 'Médiane',
     inBand: 'dans la bande',
     round2: 'Tour 2',
@@ -98,7 +98,7 @@ const fr: Messages = {
     summary: [
       'Pas un type de question à part — optionnel sur les questions notées.',
       'Échelle 1–5 après la réponse, sans effet sur les points.',
-      'Après publication, l’animateur voit exactitude × degré de confiance.',
+      'Après publication, l’animateur voit le croisement entre l’exactitude des réponses et le degré de confiance.',
       '« Erroné et sûr » signale d’éventuelles idées fausses.',
       'Après la session : rapport de résultats (PDF) et bilan.',
     ],
@@ -140,7 +140,7 @@ const fr: Messages = {
       },
       {
         label: 'Vote collectif',
-        text: 'Les votes pour et contre montrent priorité, friction et besoin de clarification.',
+        text: 'Les votes pour et contre indiquent les priorités, les désaccords et les besoins de clarification.',
       },
       {
         label: 'Nuage thématique',
@@ -153,7 +153,7 @@ const fr: Messages = {
     ],
     docsLink: 'Ouvrir la notation Q&A et la controverse sur GitHub',
     demoAria: 'Exemple de mur de questions avec modération, votes et nuage de mots',
-    hostView: 'Vue de l’animateur Q&A',
+    hostView: 'Vue Q&A de l’animateur',
     demoTitle: 'Questions sur l’événement',
     moderationActive: 'Pré-modération active',
     sortMostSupported: 'Les plus soutenues',
@@ -177,7 +177,7 @@ const fr: Messages = {
       },
     ],
     wordCloud: 'Nuage de mots Q&A',
-    wordCloudHint: 'Pondéré selon la résonance positive et la controverse.',
+    wordCloudHint: 'Pondéré selon le soutien positif et la controverse.',
     frozenLive: 'Mise à jour en direct en pause',
     terms: [
       { label: 'Bande de tolérance', className: 'text-3xl text-brand-200' },
@@ -190,7 +190,7 @@ const fr: Messages = {
       { label: 'Besoin de clarification', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Prochaine étape : une boussole de modération déterministe, éventuellement complétée par des signaux d’analyse linguistique asynchrones et des synthèses liées aux sources.',
+      'Prochaine étape : une boussole de modération déterministe, éventuellement complétée par des signaux d’analyse linguistique asynchrones et des synthèses fondées sur les questions soumises.',
   },
   workflow: {
     eyebrow: 'Pour l’enseignement, la formation et les ateliers',
@@ -214,7 +214,7 @@ const fr: Messages = {
         number: '03',
         title: 'Animer en direct',
         description:
-          'Les participants votent, posent des questions et définissent ensemble les priorités. L’animateur et le présentateur affichent le quiz, le mur de questions, le nuage de mots, la phase de lecture, le compte à rebours, le second tour et les résultats dans un seul flux.',
+          'Les participants votent, posent des questions et définissent ensemble les priorités. L’animateur et le présentateur affichent le quiz, le mur de questions, le nuage de mots, la phase de lecture, le compte à rebours, le second tour et les résultats dans un seul déroulement.',
       },
       {
         number: '04',
@@ -256,7 +256,7 @@ const fr: Messages = {
       {
         title: 'Plus qu’un quiz standard',
         description:
-          'QCM/QCU, réponse courte, notation, phase de lecture, Peer Instruction et flux présentateur soutiennent l’apprentissage, la formation et l’animation en direct.',
+          'QCM/QCU, réponses courtes, évaluations, phase de lecture, Peer Instruction et mode présentateur soutiennent l’apprentissage, la formation et l’animation en direct.',
         icon: 'toggle',
       },
       {
@@ -266,9 +266,9 @@ const fr: Messages = {
         icon: 'qa',
       },
       {
-        title: 'Nuage de mots élaboré',
+        title: 'Nuage de mots expressif',
         description:
-          'Texte libre et Q&A sont condensés en mots et phrases ; le mur pondère selon l’accord, une évaluation robuste ou la controverse.',
+          'Texte libre et Q&A sont condensés en mots et phrases ; le mur pondère selon l’accord, une majorité claire ou la controverse.',
         icon: 'cloud',
       },
       {
@@ -377,7 +377,7 @@ const fr: Messages = {
   comparison: {
     eyebrow: 'Positionnement',
     title: 'Pas seulement un substitut à Mentimeter ou Kahoot',
-    lead: 'Le centre n’est pas seulement le vote, mais le flux en direct complet : préparer, animer, rendre les résultats visibles et garder le contrôle sur les contenus et l’exploitation.',
+    lead: 'L’objectif n’est pas seulement de voter, mais de couvrir tout le déroulement en direct : préparer, animer, rendre les résultats visibles et garder le contrôle sur les contenus et l’exploitation.',
     points: [
       {
         title: 'Moins de freins à l’entrée',
@@ -421,7 +421,7 @@ const fr: Messages = {
       {
         question: 'Qu’est-ce que l’autoévaluation dans le quiz ?',
         answer:
-          'Une question complémentaire optionnelle après les questions notées : les participants indiquent sur une échelle de 1 à 5 à quel point ils sont sûrs de leur réponse. Les points restent inchangés ; dans l’évaluation de l’animateur, tu vois exactitude × degré de confiance et marques les réponses erronées associées à un degré de confiance élevé comme signal d’idée fausse. Après la session, l’état d’apprentissage alimente le bilan et le rapport de résultats (PDF).',
+          'Une question complémentaire optionnelle après les questions notées : les participants indiquent sur une échelle de 1 à 5 à quel point ils sont sûrs de leur réponse. Les points restent inchangés ; l’animateur voit le croisement entre l’exactitude des réponses et le degré de confiance et marque les réponses erronées associées à un degré de confiance élevé comme signal d’idée fausse. Après la session, l’état d’apprentissage alimente le bilan et le rapport de résultats (PDF).',
       },
       {
         question: 'Puis-je exporter les résultats de session ?',
@@ -436,12 +436,12 @@ const fr: Messages = {
       {
         question: 'Que peut faire le mur de questions ?',
         answer:
-          'Les participants soumettent des questions et les pondèrent avec des votes pour et contre. Les animateurs peuvent pré-modérer, épingler, archiver ou retirer des questions et trier la liste par soutien, accord robuste ou controverse.',
+          'Les participants soumettent des questions et les pondèrent avec des votes pour et contre. Les animateurs peuvent pré-modérer, épingler, archiver ou retirer des questions et trier la liste par soutien, majorité claire ou controverse.',
       },
       {
         question: 'En quoi le nuage de mots Q&A est-il différent ?',
         answer:
-          'Il condense les questions visibles en mots et phrases et reprend la logique de tri active. Il montre ainsi non seulement des termes fréquents, mais des regroupements thématiques issus de questions soutenues, robustement notées ou controversées.',
+          'Il condense les questions visibles en mots et phrases et reprend la logique de tri active. Il montre ainsi non seulement des termes fréquents, mais des regroupements thématiques issus de questions soutenues, clairement bien notées ou controversées.',
       },
       {
         question: 'Pour qui est destinée la plateforme ?',
@@ -458,7 +458,7 @@ const fr: Messages = {
   },
   ctaSection: {
     title: 'Prêt·e pour la prochaine session en direct ?',
-    lead: 'Teste le flux en direct directement dans l’application, ou jette un œil au code source ouvert, à la logique Q&A, au traitement du nuage de mots et aux bases techniques pour le déploiement et l’exploitation.',
+    lead: 'Teste le déroulement en direct directement dans l’application, ou jette un œil au code source ouvert, à la logique Q&A, au traitement du nuage de mots et aux bases techniques pour le déploiement et l’exploitation.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Informations',
@@ -470,12 +470,12 @@ const fr: Messages = {
       'Rapport de résultats (PDF) et bilan après la session',
       'Questions d’estimation numérique avec deux tours et statistiques',
       'Mur de questions avec modération, votes pour et contre',
-      'Accueil, présentateur, QR/code',
-      'Types de questions QCM/QCU/réponse courte/texte libre/sondage/notation/estimation numérique',
+      'Salle d’attente, présentateur, QR/code',
+      'Types de questions QCM/QCU/réponses courtes/texte libre/sondage/évaluation/estimation numérique',
       'Markdown et KaTeX',
       'Phase de lecture et Peer Instruction',
       'Nuage de mots Q&A et texte libre avec phrases et pondération',
-      'Tri par soutien, accord robuste et controverse',
+      'Tri par soutien, majorité claire et controverse',
       'Mode équipe et préréglages',
       'Classement, série, code bonus',
       'Import/export et synchronisation Yjs',
@@ -483,7 +483,7 @@ const fr: Messages = {
       'Interface en cinq langues',
       'Conforme aux WCAG 2.2, niveau AA',
       'Exploitation Docker sur votre infrastructure et journal d’administration',
-      'Contenus de quiz conservés localement et fonctionnement orienté RGPD',
+      'Contenus de quiz conservés localement et fonctionnement dans le respect du RGPD',
     ],
   },
 };

--- a/apps/landing/src/i18n/index.ts
+++ b/apps/landing/src/i18n/index.ts
@@ -1,0 +1,82 @@
+import de from './de';
+import en from './en';
+import es from './es';
+import fr from './fr';
+import it from './it';
+import type { Locale, Messages } from './types';
+
+export type { Locale, Messages } from './types';
+export {
+  CANONICAL_ANCHORS,
+  LEGACY_ALIAS_IDS,
+  LEGACY_ANCHOR_ALIASES,
+  canonicalizeHash,
+  localePath,
+} from './anchors';
+
+export const LOCALES = ['de', 'en', 'fr', 'it', 'es'] as const satisfies readonly Locale[];
+
+export const LOCALE_NATIVE_NAMES: Record<Locale, string> = {
+  de: 'Deutsch',
+  en: 'English',
+  fr: 'Français',
+  it: 'Italiano',
+  es: 'Español',
+};
+
+const dictionaries: Record<Locale, Messages> = { de, en, fr, it, es };
+
+function collectPaths(value: unknown, prefix = ''): string[] {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [prefix];
+    return value.flatMap((item, index) => collectPaths(item, `${prefix}[${index}]`));
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) =>
+      collectPaths(child, prefix ? `${prefix}.${key}` : key),
+    );
+  }
+  return [prefix];
+}
+
+/** Throws at import time when any locale dictionary is missing keys or arrays diverge. */
+export function assertCompleteDictionaries(): void {
+  const reference = collectPaths(de).sort();
+  const errors: string[] = [];
+
+  for (const locale of LOCALES) {
+    if (locale === 'de') continue;
+    const paths = collectPaths(dictionaries[locale]).sort();
+    const missing = reference.filter((path) => !paths.includes(path));
+    const extra = paths.filter((path) => !reference.includes(path));
+    if (missing.length) {
+      errors.push(`[${locale}] missing: ${missing.slice(0, 20).join(', ')}`);
+    }
+    if (extra.length) {
+      errors.push(`[${locale}] extra: ${extra.slice(0, 20).join(', ')}`);
+    }
+  }
+
+  if (errors.length) {
+    throw new Error(`Landing i18n dictionaries incomplete:\n${errors.join('\n')}`);
+  }
+}
+
+assertCompleteDictionaries();
+
+export function isLocale(value: string): value is Locale {
+  return (LOCALES as readonly string[]).includes(value);
+}
+
+export function getMessages(locale: string): Messages {
+  if (!isLocale(locale)) {
+    throw new Error(`Unsupported landing locale: ${locale}`);
+  }
+  return dictionaries[locale];
+}
+
+export function getOgAlternateLocales(current: Locale): string[] {
+  return LOCALES.filter((locale) => locale !== current).map(
+    (locale) => dictionaries[locale].meta.ogLocale,
+  );
+}

--- a/apps/landing/src/i18n/it.ts
+++ b/apps/landing/src/i18n/it.ts
@@ -48,7 +48,7 @@ const it: Messages = {
     titleLine2: 'moderazione delle domande',
     titleAccent1: 'in diretta e gratis',
     titleAccent2: ' senza account.',
-    lead: 'arsnova.eu unisce quiz in diretta, domande di stima numerica, autovalutazione sulle domande valutate, bacheca delle domande, analisi a nuvola di parole e sondaggio rapido in un’unica interfaccia per scuole, università, formazione continua, workshop e imprese. Open source, eseguibile sulla propria infrastruttura e pensato per un funzionamento orientato al GDPR.',
+    lead: 'arsnova.eu unisce quiz in diretta, domande di stima numerica, autovalutazione sulle domande valutate, bacheca delle domande, analisi a nuvola di parole e sondaggio rapido in un’unica interfaccia per scuole, università, formazione continua, workshop e imprese. Open source, eseguibile sulla propria infrastruttura e pensato per un funzionamento nel rispetto del GDPR.',
     a11yLink: 'Conforme alle WCAG 2.2, livello AA',
     a11ySuffix: '— tastiera, screen reader e tempo di risposta regolabile individualmente.',
     cards: [
@@ -87,7 +87,7 @@ const it: Messages = {
     plausibilityBand: 'Fascia di plausibilità',
     plausibilityValue: '1500–2000',
     histogramNote:
-      'Istogramma, linea di riferimento e fascia di tolleranza compaiono solo dopo la pubblicazione dei risultati. Prima resta visibile solo il progresso neutrale.',
+      'Istogramma, linea di riferimento e fascia di tolleranza compaiono solo dopo la pubblicazione dei risultati. Prima resta visibile solo un indicatore neutro di avanzamento.',
     median: 'Mediana',
     inBand: 'nella fascia',
     round2: 'Turno 2',
@@ -138,15 +138,15 @@ const it: Messages = {
     signals: [
       {
         label: 'Pre-moderazione',
-        text: 'Pubblica le domande solo quando si adattano al momento didattico.',
+        text: 'Pubblica le domande solo quando sono rilevanti nel contesto didattico.',
       },
       {
         label: 'Voto collettivo',
-        text: 'I voti a favore e contro mostrano priorità, attrito e bisogno di chiarimento.',
+        text: 'I voti a favore e contro mostrano le priorità, i punti di disaccordo e le esigenze di chiarimento.',
       },
       {
         label: 'Nuvola di parole tematica',
-        text: 'Parole e frasi sono pesate per supporto, accordo o controversia.',
+        text: 'Parole e frasi sono pesate in base al sostegno, al consenso o alla controversia.',
       },
       {
         label: 'In arrivo: bussola di moderazione',
@@ -158,7 +158,7 @@ const it: Messages = {
     hostView: 'Vista Q&A di chi conduce',
     demoTitle: 'Domande sull’evento',
     moderationActive: 'Pre-moderazione attiva',
-    sortMostSupported: 'Più supportate',
+    sortMostSupported: 'Più sostenute',
     sortBest: 'Migliori domande',
     sortControversial: 'Controverse',
     questions: [
@@ -175,11 +175,11 @@ const it: Messages = {
       {
         score: '+11',
         title: 'In cosa il Q&A differisce dal testo libero nel quiz?',
-        meta: '11 positivi · 0 negativi · soprattutto supportata',
+        meta: '11 positivi · 0 negativi · soprattutto sostenuta',
       },
     ],
     wordCloud: 'Nuvola di parole Q&A',
-    wordCloudHint: 'Pesata per risonanza positiva e controversia.',
+    wordCloudHint: 'Pesata in base al sostegno positivo e alla controversia.',
     frozenLive: 'Aggiornamenti in diretta in pausa',
     terms: [
       { label: 'Fascia di tolleranza', className: 'text-3xl text-brand-200' },
@@ -192,12 +192,12 @@ const it: Messages = {
       { label: 'Bisogno di chiarimento', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Prossimo passo: una bussola di moderazione deterministica, opzionalmente integrata da segnali di analisi linguistica asincroni e sintesi legate alle fonti.',
+      'Prossimo passo: una bussola di moderazione deterministica, opzionalmente integrata da segnali di analisi linguistica asincroni e sintesi fondate sulle domande inviate.',
   },
   workflow: {
     eyebrow: 'Per didattica, formazione e workshop',
     title: 'Dall’idea alla sessione in diretta in pochi minuti',
-    lead: 'Dalla domanda alla sessione in corso, il flusso evita di proposito passaggi inutili. È questo che rende l’avvio rapido e affidabile per docenti, formatori e moderatori.',
+    lead: 'Dalla domanda alla sessione in corso, il percorso evita di proposito passaggi inutili. È questo che rende l’avvio rapido e affidabile per docenti, formatori e moderatori.',
     stepLabel: 'Passo',
     steps: [
       {
@@ -216,7 +216,7 @@ const it: Messages = {
         number: '03',
         title: 'Modera in diretta',
         description:
-          'I partecipanti votano, pongono domande e definiscono insieme le priorità. Chi conduce e il presentatore mostrano quiz, bacheca delle domande, nuvola di parole, fase di lettura, conto alla rovescia, secondo turno e risultati in un unico flusso.',
+          'I partecipanti votano, pongono domande e definiscono insieme le priorità. Chi conduce e il presentatore mostrano il quiz, la bacheca delle domande, la nuvola di parole, la fase di lettura, il conto alla rovescia, il secondo turno e i risultati in un unico percorso.',
       },
       {
         number: '04',
@@ -258,19 +258,19 @@ const it: Messages = {
       {
         title: 'Più di un quiz standard',
         description:
-          'MC/SC, risposta breve, valutazione, fase di lettura, Peer Instruction e flusso presentatore supportano apprendimento, formazione e moderazione in diretta.',
+          'MC/SC, risposte brevi, valutazioni, fase di lettura, Peer Instruction e modalità presentatore supportano apprendimento, formazione e moderazione in diretta.',
         icon: 'toggle',
       },
       {
         title: 'Bacheca delle domande invece di una chat secondaria',
         description:
-          'Il Q&A offre pre-moderazione, fissaggio, archiviazione, voti a favore/contro e ordinamento per supporto, qualità e controversia.',
+          'Il Q&A offre pre-moderazione, fissaggio, archiviazione, voti a favore/contro e ordinamento per sostegno, qualità e controversia.',
         icon: 'qa',
       },
       {
-        title: 'Nuvola di parole elaborata',
+        title: 'Nuvola di parole espressiva',
         description:
-          'Testo libero e Q&A vengono condensati in parole e frasi; la bacheca pesa per accordo, punteggio robusto o controversia.',
+          'Testo libero e Q&A vengono condensati in parole e frasi; la bacheca pesa in base al consenso, a una maggioranza chiara o alla controversia.',
         icon: 'cloud',
       },
       {
@@ -294,7 +294,7 @@ const it: Messages = {
       {
         title: 'Open source con distribuzione e gestione',
         description:
-          'Docker, Postgres, Redis e registro di amministrazione rendono la piattaforma affidabile anche per hosting, esercizio e tracciabilità.',
+          'Docker, Postgres, Redis e registro di amministrazione rendono la piattaforma affidabile anche per distribuzione, gestione operativa e tracciabilità.',
         icon: 'server',
       },
     ],
@@ -371,7 +371,7 @@ const it: Messages = {
   comparison: {
     eyebrow: 'Differenziazione',
     title: 'Non solo un sostituto di Mentimeter o Kahoot',
-    lead: 'Al centro non c’è solo il voto, ma l’intero flusso in diretta: preparare, moderare, rendere visibili i risultati e mantenere il controllo su contenuti e gestione.',
+    lead: 'L’obiettivo non è solo votare, ma coprire l’intero percorso in diretta: preparare, moderare, rendere visibili i risultati e mantenere il controllo su contenuti e gestione.',
     points: [
       {
         title: 'Meno barriere d’ingresso',
@@ -430,12 +430,12 @@ const it: Messages = {
       {
         question: 'Cosa può fare la bacheca delle domande?',
         answer:
-          'I partecipanti inviano domande e le pesano con voti a favore e contro. Chi conduce può pre-moderare, fissare, archiviare o rimuovere domande e ordinare l’elenco per supporto, accordo robusto o controversia.',
+          'I partecipanti inviano domande e le pesano con voti a favore e contro. Chi conduce può pre-moderare, fissare, archiviare o rimuovere domande e ordinare l’elenco per sostegno, maggioranza chiara o controversia.',
       },
       {
         question: 'Cosa rende diversa la nuvola di parole Q&A?',
         answer:
-          'Condensa le domande visibili in parole e frasi e segue la logica di ordinamento attiva. Così mostra non solo termini frequenti, ma cluster tematici da domande supportate, valutate in modo robusto o controverse.',
+          'Condensa le domande visibili in parole e frasi e segue la logica di ordinamento attiva. Così mostra non solo termini frequenti, ma raggruppamenti tematici da domande sostenute, chiaramente ben valutate o controverse.',
       },
       {
         question: 'Per chi è pensata la piattaforma?',
@@ -452,7 +452,7 @@ const it: Messages = {
   },
   ctaSection: {
     title: 'Pronto per la prossima sessione in diretta?',
-    lead: 'Prova il flusso in diretta direttamente nell’app, oppure dai un’occhiata al codice sorgente aperto, alla logica Q&A, all’elaborazione della nuvola di parole e alle basi tecniche per distribuzione e gestione della piattaforma.',
+    lead: 'Prova il percorso in diretta direttamente nell’app, oppure dai un’occhiata al codice sorgente aperto, alla logica Q&A, all’elaborazione della nuvola di parole e alle basi tecniche per distribuzione e gestione della piattaforma.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Informazioni',
@@ -465,11 +465,11 @@ const it: Messages = {
       'Domande di stima numerica con due turni e statistica',
       'Bacheca delle domande con moderazione, voti a favore e contro',
       'Sala d’attesa, presentatore, QR/codice',
-      'Tipi di domanda MC/SC/risposta breve/testo libero/sondaggio/valutazione/stima numerica',
+      'Tipi di domanda MC/SC/risposte brevi/testo libero/sondaggio/valutazione/stima numerica',
       'Markdown e KaTeX',
       'Fase di lettura e Peer Instruction',
       'Nuvola di parole Q&A e testo libero con frasi e pesatura',
-      'Ordinamento per supporto, accordo robusto e controversia',
+      'Ordinamento per sostegno, maggioranza chiara e controversia',
       'Modalità a squadre e impostazioni predefinite',
       'Classifica, serie, codice bonus',
       'Importazione/esportazione e sincronizzazione Yjs',
@@ -477,7 +477,7 @@ const it: Messages = {
       'Interfaccia in cinque lingue',
       'Conforme alle WCAG 2.2, livello AA',
       'Esecuzione Docker sulla propria infrastruttura e registro di amministrazione',
-      'Contenuti del quiz conservati in locale e funzionamento orientato al GDPR',
+      'Contenuti del quiz conservati in locale e funzionamento nel rispetto del GDPR',
     ],
   },
 };

--- a/apps/landing/src/i18n/it.ts
+++ b/apps/landing/src/i18n/it.ts
@@ -2,9 +2,9 @@ import type { Messages } from './types';
 
 const it: Messages = {
   meta: {
-    homeTitle: 'arsnova.eu | Quiz live, stime numeriche e bacheca Q&A',
+    homeTitle: 'arsnova.eu | Quiz in diretta, domande di stima numerica e bacheca delle domande',
     homeDescription:
-      'Audience response open source per istruzione, formazione e organizzazioni: quiz live, autovalutazione, rapporto dei risultati (PDF), stime numeriche, bacheca Q&A moderabile, word cloud e feedback — accessibile WCAG 2.2 AA, gratuito, self-hostabile e pronto senza account.',
+      'Piattaforma open source di risposta interattiva per istruzione, formazione e organizzazioni: quiz in diretta, autovalutazione, rapporto dei risultati (PDF), domande di stima numerica, bacheca delle domande moderabile, word cloud e sondaggio rapido — conforme alle WCAG 2.2, livello AA, gratuita, self-hostabile e pronta senza account.',
     siteNameInfo: 'arsnova.eu – Informazioni',
     ogLocale: 'it_IT',
   },
@@ -38,42 +38,42 @@ const it: Messages = {
     appOpen: 'Apri l’app',
     quizCreate: 'Crea un quiz',
     backToApp: 'Torna ad arsnova.eu',
-    tryLive: 'Provalo live ora',
+    tryLive: 'Provalo in diretta ora',
     howItWorks: 'Come funziona',
-    viewOpenSource: 'Vedi l’open source',
+    viewOpenSource: 'Consulta il codice sorgente',
   },
   hero: {
-    eyebrow: 'Audience response per istruzione e organizzazioni',
+    eyebrow: 'Risposta interattiva per istruzione e organizzazioni',
     titleLine1: 'Quiz, stime,',
     titleLine2: 'moderazione delle domande',
-    titleAccent1: 'live e gratis',
+    titleAccent1: 'in diretta e gratis',
     titleAccent2: ' senza account.',
-    lead: 'arsnova.eu unisce quiz live, stime numeriche, autovalutazione sulle domande valutate, bacheca Q&A, analisi word cloud e sondaggio rapido in un’unica interfaccia per scuole, università, formazione continua, workshop e business. Open source, self-hostabile e pensato per un funzionamento orientato al GDPR.',
-    a11yLink: 'Accessibile secondo WCAG 2.2 AA',
+    lead: 'arsnova.eu unisce quiz in diretta, domande di stima numerica, autovalutazione sulle domande valutate, bacheca delle domande, analisi word cloud e sondaggio rapido in un’unica interfaccia per scuole, università, formazione continua, workshop e business. Open source, self-hostabile e pensato per un funzionamento orientato al GDPR.',
+    a11yLink: 'Conforme alle WCAG 2.2, livello AA',
     a11ySuffix: '— tastiera, screen reader e tempo di risposta regolabile individualmente.',
     cards: [
-      { title: 'Live subito', text: 'Condividi la sessione con codice o QR' },
-      { title: 'Q&A con bacheca', text: 'Moderazione, voti e word cloud tematica' },
+      { title: 'In diretta subito', text: 'Condividi la sessione con codice o QR' },
+      { title: 'Q&A con bacheca delle domande', text: 'Moderazione, voti e word cloud tematica' },
       {
-        title: 'Autovalutazione e follow-up',
+        title: 'Autovalutazione e analisi successiva',
         text: 'Individua i fraintendimenti, esporta il rapporto PDF',
       },
       { title: 'Open source e self-hostabile', text: 'Docker, Postgres, Redis e audit admin' },
     ],
   },
   estimate: {
-    eyebrow: 'Novità nel quiz live',
-    title: 'Stimare numeri, discutere e confrontare chiaramente il secondo round',
+    eyebrow: 'Novità nel quiz in diretta',
+    title: 'Stimare numeri, discutere e confrontare chiaramente il secondo turno',
     lead: 'La domanda di stima numerica è pensata per date, ordini di grandezza, misure e probabilità. Chi conduce imposta valore di riferimento, intervallo di input e tolleranza; i partecipanti inseriscono solo un numero.',
     summary: [
       'La fascia di plausibilità limita gli input ammessi.',
       'La fascia di tolleranza valuta le stime accettabili sul piano disciplinare.',
       'Prima della pubblicazione nessuno vede la distribuzione.',
-      'Round 1 e round 2 vengono confrontati dopo la discussione.',
+      'Turno 1 e turno 2 vengono confrontati dopo la discussione.',
     ],
-    docsLink: 'Apri la documentazione della stima',
-    demoAria: 'Esempio di risultati per una stima sulla Rivoluzione francese',
-    hostView: 'Vista host dopo la pubblicazione',
+    docsLink: 'Apri la documentazione della domanda di stima numerica',
+    demoAria: 'Esempio di risultati per una domanda di stima numerica sulla Rivoluzione francese',
+    hostView: 'Vista conduttore dopo la pubblicazione',
     demoQuestion: 'Quando iniziò la Rivoluzione francese?',
     reference: 'Riferimento 1789',
     toleranceBand: 'Fascia di tolleranza',
@@ -84,8 +84,8 @@ const it: Messages = {
       'Istogramma, linea di riferimento e fascia di tolleranza compaiono solo dopo la pubblicazione dei risultati. Prima resta visibile solo il progresso neutrale.',
     median: 'Mediana',
     inBand: 'nella fascia',
-    round2: 'Round 2',
-    round2Value: '14 più vicini',
+    round2: 'Turno 2',
+    round2Value: '14 risposte più vicine al valore di riferimento',
   },
   confidence: {
     eyebrow: 'Valutazione didattica',
@@ -94,23 +94,23 @@ const it: Messages = {
     summary: [
       'Non è un tipo di domanda a sé — opzionale sulle domande valutate.',
       'Scala 1–5 dopo la risposta, senza effetto sui punti.',
-      'Dopo la pubblicazione l’host vede correttezza × grado di sicurezza.',
+      'Dopo la pubblicazione chi conduce vede correttezza × grado di sicurezza.',
       '«Sbagliato e sicuro» segnala possibili fraintendimenti.',
       'Dopo la sessione: rapporto dei risultati (PDF) e discussione dei risultati.',
     ],
     docsConfidence: 'Doc autovalutazione',
     docsExport: 'Doc rapporto dei risultati (PDF)',
     demoAria: 'Esempio di valutazione con autovalutazione dopo la pubblicazione',
-    hostView: 'Vista host dopo la pubblicazione',
+    hostView: 'Vista conduttore dopo la pubblicazione',
     demoQuestion: 'Quale struttura è la più stabile?',
     badge: 'Autovalutazione',
     matrix: [
-      { label: 'Corretto · basso', count: 3, tone: 'emerald' },
-      { label: 'Corretto · medio', count: 8, tone: 'emerald' },
-      { label: 'Corretto · alto', count: 11, tone: 'emerald' },
-      { label: 'Sbagliato · basso', count: 2, tone: 'slate' },
-      { label: 'Sbagliato · medio', count: 4, tone: 'amber' },
-      { label: 'Sbagliato · alto', count: 2, tone: 'rose' },
+      { label: 'Corretta · sicurezza bassa', count: 3, tone: 'emerald' },
+      { label: 'Corretta · sicurezza media', count: 8, tone: 'emerald' },
+      { label: 'Corretta · sicurezza alta', count: 11, tone: 'emerald' },
+      { label: 'Errata · sicurezza bassa', count: 2, tone: 'slate' },
+      { label: 'Errata · sicurezza media', count: 4, tone: 'amber' },
+      { label: 'Errata · sicurezza alta', count: 2, tone: 'rose' },
     ],
     falseHighTitle: '2 risposte sbagliate con alta sicurezza',
     falseHighText:
@@ -118,17 +118,17 @@ const it: Messages = {
     consolidated: 'Solido',
     misconceptionRisk: 'Rischio di fraintendimento',
     fragile: 'Fragile',
-    afterSessionAria: 'Export a fine sessione',
+    afterSessionAria: 'Esportazione a fine sessione',
     afterSession: 'A fine sessione',
     debriefing: 'Discussione dei risultati',
     resultsPdf: 'Rapporto dei risultati (PDF)',
     exportNote:
-      'Report pronto per la stampa con stato di apprendimento, heatmap e testi delle domande — nella vista host e sulla scheda quiz. Il CSV per Excel resta disponibile sotto «Altro».',
+      'Report pronto per la stampa con stato di apprendimento, mappa di calore e testi delle domande — nella vista conduttore e sulla scheda quiz. Il CSV per Excel resta disponibile sotto «Altro».',
   },
   qaWall: {
-    eyebrow: 'Q&A live come superficie di moderazione',
+    eyebrow: 'Q&A in diretta come superficie di moderazione',
     title: 'Raccogliere domande, prioritizzarle e leggerle come mappa tematica',
-    lead: 'La bacheca delle domande non è una chat secondaria. È un canale live dedicato per docenti e relatori: moderare i contributi, rilevare le priorità collettive, rendere visibili i punti controversi e portare i temi chiave in sala tramite una word cloud Q&A pesata.',
+    lead: 'La bacheca delle domande non è una chat secondaria. È un canale in diretta dedicato per docenti e relatori: moderare i contributi, rilevare le priorità collettive, rendere visibili i punti controversi e portare i temi chiave in sala tramite una word cloud Q&A pesata.',
     signals: [
       {
         label: 'Pre-moderazione',
@@ -136,20 +136,20 @@ const it: Messages = {
       },
       {
         label: 'Voto collettivo',
-        text: 'Upvote e downvote mostrano priorità, attrito e bisogno di chiarimento.',
+        text: 'I voti a favore e contro mostrano priorità, attrito e bisogno di chiarimento.',
       },
       {
         label: 'Word cloud tematica',
         text: 'Parole e frasi sono pesate per supporto, accordo o controversia.',
       },
       {
-        label: 'Prospettiva bussola',
+        label: 'Prospettiva della bussola di moderazione',
         text: 'Prima arrivano i segnali deterministici; NLP Q&A e sintesi restano estensioni opzionali.',
       },
     ],
     docsLink: 'Apri scoring Q&A e controversia su GitHub',
-    demoAria: 'Esempio di bacheca Q&A con moderazione, voti e word cloud',
-    hostView: 'Vista host Q&A',
+    demoAria: 'Esempio di bacheca delle domande con moderazione, voti e word cloud',
+    hostView: 'Vista conduttore Q&A',
     demoTitle: 'Domande sull’evento',
     moderationActive: 'Pre-moderazione attiva',
     sortMostSupported: 'Più supportate',
@@ -174,7 +174,7 @@ const it: Messages = {
     ],
     wordCloud: 'Word cloud Q&A',
     wordCloudHint: 'Pesata per risonanza positiva e controversia.',
-    frozenLive: 'Congelata live',
+    frozenLive: 'Aggiornamenti in diretta in pausa',
     terms: [
       { label: 'Fascia di tolleranza', className: 'text-3xl text-brand-200' },
       { label: 'Discussione', className: 'text-2xl text-emerald-200' },
@@ -190,103 +190,103 @@ const it: Messages = {
   },
   workflow: {
     eyebrow: 'Per didattica, formazione e workshop',
-    title: 'Dall’idea alla sessione live in pochi minuti',
-    lead: 'Dalla domanda alla sessione in corso, il flusso evita di proposito passaggi inutili. È questo che rende l’avvio rapido e affidabile per docenti, trainer e moderatori.',
+    title: 'Dall’idea alla sessione in diretta in pochi minuti',
+    lead: 'Dalla domanda alla sessione in corso, il flusso evita di proposito passaggi inutili. È questo che rende l’avvio rapido e affidabile per docenti, formatori e moderatori.',
     stepLabel: 'Passo',
     steps: [
       {
         number: '01',
         title: 'Prepara un quiz',
         description:
-          'Crea domande direttamente o importa contenuti esistenti. Markdown, KaTeX, risposta breve e stime numeriche sono integrati.',
+          'Crea domande direttamente o importa contenuti esistenti. Markdown, KaTeX, risposta breve e domande di stima numerica sono integrati.',
       },
       {
         number: '02',
         title: 'Avvia una sessione',
         description:
-          'Parti senza account: apri una sessione, scegli uno stile, condividi codice o QR e usa la vista presenter se serve.',
+          'Parti senza account: apri una sessione, scegli uno stile, condividi codice o QR e usa la vista presentatore se serve.',
       },
       {
         number: '03',
-        title: 'Modera live',
+        title: 'Modera in diretta',
         description:
-          'I partecipanti votano, pongono domande e prioritizzano insieme. Host e presenter mostrano quiz, bacheca Q&A, word cloud, fase di lettura, countdown, secondo round e risultati in un unico flusso.',
+          'I partecipanti votano, pongono domande e prioritizzano insieme. Conduttore e presentatore mostrano quiz, bacheca delle domande, word cloud, fase di lettura, conto alla rovescia, secondo turno e risultati in un unico flusso.',
       },
       {
         number: '04',
-        title: 'Follow-up ed export',
+        title: 'Analisi successiva ed esportazione',
         description:
           'A fine sessione il rapporto dei risultati (PDF) è pronto — con stato di apprendimento, autovalutazione e testi completi delle domande. Nella raccolta quiz trovi discussione dei risultati e PDF dell’ultima esecuzione; CSV per Excel sotto «Altro».',
       },
     ],
   },
   features: {
-    eyebrow: 'Perché si sente diverso',
-    title: 'Pensato per l’interazione live, non solo per sondaggi su slide',
+    eyebrow: 'Cosa rende arsnova.eu diverso',
+    title: 'Pensato per l’interazione in diretta, non solo per sondaggi su slide',
     lead: 'arsnova.eu unisce avvio rapido, solidità didattica e una base tecnica trasparente. La piattaforma resta semplice nel quotidiano senza ridurre le possibilità.',
     items: [
       {
         title: 'Pronto in poco tempo',
         description:
-          'Gli host partono senza account. I partecipanti entrano nella sessione direttamente con un codice a 6 cifre o un QR.',
+          'Chi conduce parte senza account. I partecipanti entrano nella sessione direttamente con un codice a 6 cifre o un QR.',
         icon: 'single',
       },
       {
-        title: 'Autovalutazione nel quiz live',
+        title: 'Autovalutazione nel quiz in diretta',
         description:
           'I partecipanti indicano dopo la risposta quanto sono sicuri. Individui risposte sbagliate con alta sicurezza, prioritizzi la discussione dei risultati ed esporti lo stato di apprendimento nel rapporto dei risultati (PDF).',
         icon: 'confidence',
       },
       {
-        title: 'Rapporto dei risultati per il follow-up',
+        title: 'Rapporto dei risultati per l’analisi successiva',
         description:
           'A fine sessione esporti un report PDF pronto per la stampa con diagrammi, testi delle domande e autovalutazione. Il CSV per Excel resta opzionale sotto «Altro».',
         icon: 'export',
       },
       {
-        title: 'Stime didattiche',
+        title: 'Domande di stima numerica didattiche',
         description:
-          'Date, ordini di grandezza e misure si possono stimare con valore di riferimento, fascia di tolleranza, statistica e secondo round opzionale.',
+          'Date, ordini di grandezza e misure si possono stimare con valore di riferimento, fascia di tolleranza, statistica e secondo turno opzionale.',
         icon: 'estimate',
       },
       {
         title: 'Più di un quiz standard',
         description:
-          'MC/SC, risposta breve, rating, fase di lettura, Peer Instruction e flusso presenter supportano apprendimento, formazione e moderazione live.',
+          'MC/SC, risposta breve, rating, fase di lettura, Peer Instruction e flusso presentatore supportano apprendimento, formazione e moderazione in diretta.',
         icon: 'toggle',
       },
       {
-        title: 'Bacheca invece di una chat secondaria',
+        title: 'Bacheca delle domande invece di una chat secondaria',
         description:
-          'Il Q&A offre pre-moderazione, fissaggio, archiviazione, up/downvote e ordinamento per supporto, qualità e controversia.',
+          'Il Q&A offre pre-moderazione, fissaggio, archiviazione, voti a favore/contro e ordinamento per supporto, qualità e controversia.',
         icon: 'qa',
       },
       {
         title: 'Word cloud elaborata',
         description:
-          'Testo libero e Q&A vengono condensati in parole e frasi; la bacheca pesa per accordo, score robusto o controversia.',
+          'Testo libero e Q&A vengono condensati in parole e frasi; la bacheca pesa per accordo, punteggio robusto o controversia.',
         icon: 'cloud',
       },
       {
         title: 'Per contesti diversi',
         description:
-          'Preset, modalità team, modalità anonima, nickname e scelta dello stile aiutano dalla classe e dal seminario al workshop, evento e meeting.',
+          'Preset, modalità team, modalità anonima, nickname e scelta dello stile aiutano dalla classe e dal seminario al workshop, evento e riunione.',
         icon: 'bolt',
       },
       {
-        title: 'Accessibilità secondo WCAG 2.2 AA',
+        title: 'Conforme alle WCAG 2.2, livello AA',
         description:
-          'Uso da tastiera, annunci screen reader, tempo di risposta regolabile individualmente e rapporti PDF/UA-1 — così più persone possono partecipare in autonomia alle sessioni live.',
+          'Uso da tastiera, annunci screen reader, tempo di risposta regolabile individualmente e rapporti PDF/UA-1 — così più persone possono partecipare in autonomia alle sessioni in diretta.',
         icon: 'a11y',
       },
       {
         title: 'Privacy e controllo',
         description:
-          'Local-first, data-stripping e gestione self-hostabile ti danno più controllo su contenuti e dati live.',
+          'Approccio local-first, rimozione opzionale dei dati e gestione self-hostabile ti danno più controllo su contenuti e dati in diretta.',
         icon: 'tools',
       },
       {
-        title: 'Open source con percorso operativo',
+        title: 'Open source con percorso di deployment e gestione',
         description:
           'Docker, Postgres, Redis e audit admin rendono la piattaforma affidabile anche per hosting, esercizio e tracciabilità.',
         icon: 'server',
@@ -296,27 +296,27 @@ const it: Messages = {
   accessibility: {
     eyebrow: 'Accessibilità',
     title: 'WCAG 2.2 AA — così più persone possono partecipare in autonomia',
-    lead: 'Per scuole, università e formazione continua l’accessibilità è spesso un criterio decisivo. arsnova.eu soddisfa le Web Content Accessibility Guidelines (WCAG) 2.2 al livello AA — con uso da tastiera, supporto screen reader, tempo di risposta regolabile individualmente e rapporti PDF strutturati in modo accessibile.',
+    lead: 'Per scuole, università e formazione continua l’accessibilità è spesso un criterio decisivo. arsnova.eu è conforme alle Web Content Accessibility Guidelines (WCAG) 2.2, livello AA — con uso da tastiera, supporto screen reader, tempo di risposta regolabile individualmente e rapporti PDF strutturati in modo accessibile.',
     benefits: [
       {
         title: 'Uso da tastiera',
         description:
-          'Tu e i tuoi partecipanti usate i flussi centrali senza mouse. Indicatori di focus visibili e un link salta-contenuto facilitano la navigazione.',
+          'Tu e i tuoi partecipanti usate i flussi centrali senza mouse. Indicatori di focus visibili e un link per saltare al contenuto facilitano la navigazione.',
       },
       {
-        title: 'Supporto screen reader in live',
+        title: 'Supporto screen reader in diretta',
         description:
           'I cambiamenti di stato all’ingresso in sessione, durante le votazioni e ai cambi di fase vengono annunciati agli screen reader, così si può seguire il flusso.',
       },
       {
         title: 'Tempo di risposta regolabile individualmente',
         description:
-          'Per le domande a tempo scegli tempo standard, tempo decuplicato o partecipazione senza limite. Così un’agevolazione si applica direttamente nella sessione live.',
+          'Per le domande a tempo scegli tempo standard, tempo decuplicato o partecipazione senza limite. Così un’agevolazione si applica direttamente nella sessione in diretta.',
       },
       {
         title: 'Rapporto dei risultati strutturato in modo accessibile',
         description:
-          'Il report pronto per la stampa è validato PDF/UA-1 e include titolo, lingua e tag — per il follow-up e la condivisione accessibile.',
+          'Il report pronto per la stampa è validato PDF/UA-1 e include titolo, lingua e tag — per l’analisi successiva e la condivisione accessibile.',
       },
     ],
     statementLink: 'Apri la dichiarazione di accessibilità',
@@ -366,22 +366,22 @@ const it: Messages = {
   comparison: {
     eyebrow: 'Differenziazione',
     title: 'Non solo un sostituto di Mentimeter o Kahoot',
-    lead: 'Al centro non c’è solo il voto, ma l’intero flusso live: preparare, moderare, rendere visibili i risultati e mantenere il controllo su contenuti e gestione.',
+    lead: 'Al centro non c’è solo il voto, ma l’intero flusso in diretta: preparare, moderare, rendere visibili i risultati e mantenere il controllo su contenuti e gestione.',
     points: [
       {
         title: 'Meno barriere d’ingresso',
         description:
-          'Nessuna logica di prodotto separata per «creare» e «entrare». Gli host partono senza account, i partecipanti entrano con codice o QR.',
+          'Nessuna logica di prodotto separata per «creare» e «entrare». Chi conduce parte senza account, i partecipanti entrano con codice o QR.',
       },
       {
         title: 'Più formati di interazione',
         description:
-          'Oltre al quiz: stime numeriche, fase di lettura, Peer Instruction, sondaggio rapido, bacheca Q&A e word cloud pesata nella stessa piattaforma — non solo sondaggi su slide.',
+          'Oltre al quiz: domande di stima numerica, fase di lettura, Peer Instruction, sondaggio rapido, bacheca delle domande e word cloud pesata nella stessa piattaforma — non solo sondaggi su slide.',
       },
       {
         title: 'Più controllo su dati e accesso',
         description:
-          'Open source, self-hostabile e local-first — più accessibilità WCAG 2.2 AA. Rilevante per scuole, università e organizzazioni con requisiti di privacy e inclusione.',
+          'Open source, self-hostabile e local-first — più conformità alle WCAG 2.2, livello AA. Rilevante per scuole, università e organizzazioni con requisiti di privacy e inclusione.',
       },
     ],
     comparePrefix: 'Il confronto completo delle funzioni resta nella documentazione:',
@@ -393,14 +393,14 @@ const it: Messages = {
     answerLabel: 'Risposta',
     items: [
       {
-        question: 'Host o partecipanti hanno bisogno di un account?',
+        question: 'Chi conduce o i partecipanti hanno bisogno di un account?',
         answer:
           'No. Una sessione può partire senza account. I partecipanti entrano con codice o QR.',
       },
       {
         question: 'Dove sono i dati?',
         answer:
-          'I contenuti del quiz sono pensati local-first. Per le sessioni live vengono elaborati solo i dati di sessione tecnicamente necessari; con self-hosting la gestione resta nella tua infrastruttura.',
+          'I contenuti del quiz sono pensati local-first. Per le sessioni in diretta vengono elaborati solo i dati di sessione tecnicamente necessari; con self-hosting la gestione resta nella tua infrastruttura.',
       },
       {
         question: 'Posso fare self-hosting di arsnova.eu?',
@@ -410,7 +410,7 @@ const it: Messages = {
       {
         question: 'Cos’è l’autovalutazione nel quiz?',
         answer:
-          'Una domanda aggiuntiva opzionale dopo le domande valutate: i partecipanti indicano su una scala da 1 a 5 quanto sono sicuri della risposta. I punti restano invariati; nella valutazione host vedi correttezza × grado di sicurezza e segni le risposte sbagliate con alta sicurezza come segnale di fraintendimento. A fine sessione lo stato di apprendimento confluisce nella discussione dei risultati e nel rapporto dei risultati (PDF).',
+          'Una domanda aggiuntiva opzionale dopo le domande valutate: i partecipanti indicano su una scala da 1 a 5 quanto sono sicuri della risposta. I punti restano invariati; nella valutazione di chi conduce vedi correttezza × grado di sicurezza e segni le risposte sbagliate con alta sicurezza come segnale di fraintendimento. A fine sessione lo stato di apprendimento confluisce nella discussione dei risultati e nel rapporto dei risultati (PDF).',
       },
       {
         question: 'Posso esportare i risultati della sessione?',
@@ -418,14 +418,14 @@ const it: Messages = {
           'Sì. A fine sessione il rapporto dei risultati (PDF) è il formato principale — con autovalutazione, priorità per la discussione dei risultati e testi completi delle domande. Nella raccolta quiz trovi discussione dei risultati e PDF dell’ultima esecuzione. I dati CSV tabellari sono disponibili sotto «Altro» per Excel.',
       },
       {
-        question: 'Cosa ha di speciale la stima numerica?',
+        question: 'Cosa ha di speciale la domanda di stima numerica?',
         answer:
-          'Separa gli input ammessi dalla fascia di tolleranza disciplinare, non mostra la distribuzione durante il voto e può valutare un secondo round dopo la discussione con statistica e confronto dei round.',
+          'Separa gli input ammessi dalla fascia di tolleranza disciplinare, non mostra la distribuzione durante il voto e può valutare un secondo turno dopo la discussione con statistica e confronto dei turni.',
       },
       {
-        question: 'Cosa può fare la bacheca Q&A?',
+        question: 'Cosa può fare la bacheca delle domande?',
         answer:
-          'I partecipanti inviano domande e le pesano con upvote e downvote. Gli host possono pre-moderare, fissare, archiviare o rimuovere domande e ordinare l’elenco per supporto, accordo robusto o controversia.',
+          'I partecipanti inviano domande e le pesano con voti a favore e contro. Chi conduce può pre-moderare, fissare, archiviare o rimuovere domande e ordinare l’elenco per supporto, accordo robusto o controversia.',
       },
       {
         question: 'Cosa rende diversa la word cloud Q&A?',
@@ -435,42 +435,42 @@ const it: Messages = {
       {
         question: 'Per chi è pensata la piattaforma?',
         answer:
-          'Per l’interazione live in istruzione e organizzazioni: scuola, università, formazione continua, training, workshop, evento o meeting.',
+          'Per l’interazione in diretta in istruzione e organizzazioni: scuola, università, formazione continua, training, workshop, evento o riunione.',
       },
       {
         question: 'arsnova.eu è accessibile?',
         answer:
-          'arsnova.eu soddisfa WCAG 2.2 AA. I flussi centrali sono usabili da tastiera, gli screen reader annunciano i cambiamenti di stato, il tempo di risposta delle domande a tempo è regolabile individualmente (tempo standard, tempo decuplicato o senza limite), e il rapporto dei risultati strutturato in modo accessibile è validato PDF/UA-1.',
+          'arsnova.eu è conforme alle WCAG 2.2, livello AA. I flussi centrali sono usabili da tastiera, gli screen reader annunciano i cambiamenti di stato, il tempo di risposta delle domande a tempo è regolabile individualmente (tempo standard, tempo decuplicato o senza limite), e il rapporto dei risultati strutturato in modo accessibile è validato PDF/UA-1.',
         linkLabel: 'Apri la dichiarazione di accessibilità',
       },
     ],
   },
   ctaSection: {
-    title: 'Pronto per la prossima sessione live?',
-    lead: 'Prova il flusso live direttamente nell’app, oppure dai un’occhiata al codice aperto, alla logica Q&A, alla pipeline della word cloud e al percorso operativo dietro la piattaforma.',
+    title: 'Pronto per la prossima sessione in diretta?',
+    lead: 'Prova il flusso in diretta direttamente nell’app, oppure dai un’occhiata al codice sorgente aperto, alla logica Q&A, all’elaborazione della word cloud e al percorso di deployment e gestione dietro la piattaforma.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Informazioni',
     webAppDescription:
-      'Audience response open source per istruzione, formazione e organizzazioni: quiz live, autovalutazione, rapporto dei risultati (PDF), stime numeriche, bacheca Q&A moderabile, word cloud e feedback — accessibile WCAG 2.2 AA, gratuito, self-hostabile e pronto senza account.',
+      'Piattaforma open source di risposta interattiva per istruzione, formazione e organizzazioni: quiz in diretta, autovalutazione, rapporto dei risultati (PDF), domande di stima numerica, bacheca delle domande moderabile, word cloud e sondaggio rapido — conforme alle WCAG 2.2, livello AA, gratuita, self-hostabile e pronta senza account.',
     featureList: [
-      'Quiz live e votazioni',
+      'Quiz in diretta e votazioni',
       'Autovalutazione sulle domande valutate',
       'Rapporto dei risultati (PDF) e discussione dei risultati a fine sessione',
-      'Stime numeriche con due round e statistica',
-      'Bacheca Q&A con moderazione, upvote e downvote',
-      'Lobby, presenter, QR/codice',
-      'Tipi di domanda MC/SC/risposta breve/testo libero/sondaggio/rating/stima',
+      'Domande di stima numerica con due turni e statistica',
+      'Bacheca delle domande con moderazione, voti a favore e contro',
+      'Lobby, presentatore, QR/codice',
+      'Tipi di domanda MC/SC/risposta breve/testo libero/sondaggio/rating/stima numerica',
       'Markdown e KaTeX',
       'Fase di lettura e Peer Instruction',
       'Word cloud Q&A e testo libero con frasi e pesatura',
       'Ordinamento per supporto, accordo robusto e controversia',
       'Modalità team e preset',
-      'Classifica, streak, codice bonus',
+      'Classifica, serie, codice bonus',
       'Import/export e sync Yjs',
       'Import IA esterno, validato Zod',
       'Interfaccia in cinque lingue',
-      'Accessibilità secondo WCAG 2.2 AA',
+      'Conforme alle WCAG 2.2, livello AA',
       'Self-host Docker e audit admin',
       'Local-first e funzionamento orientato al GDPR',
     ],

--- a/apps/landing/src/i18n/it.ts
+++ b/apps/landing/src/i18n/it.ts
@@ -1,0 +1,480 @@
+import type { Messages } from './types';
+
+const it: Messages = {
+  meta: {
+    homeTitle: 'arsnova.eu | Quiz live, stime numeriche e bacheca Q&A',
+    homeDescription:
+      'Audience response open source per istruzione, formazione e organizzazioni: quiz live, autovalutazione, rapporto dei risultati (PDF), stime numeriche, bacheca Q&A moderabile, word cloud e feedback — accessibile WCAG 2.2 AA, gratuito, self-hostabile e pronto senza account.',
+    siteNameInfo: 'arsnova.eu – Informazioni',
+    ogLocale: 'it_IT',
+  },
+  nav: {
+    ariaLabel: 'Navigazione principale',
+    workflow: 'Flusso',
+    estimate: 'Stima',
+    qa: 'Q&A',
+    qaMobile: 'Bacheca delle domande',
+    features: 'Vantaggi',
+    accessibility: 'Accessibilità',
+    trust: 'Fiducia',
+    faq: 'FAQ',
+    tryNow: 'Provalo ora',
+    menuOpen: 'Apri menu',
+    menuClose: 'Chiudi menu',
+    menu: 'Menu',
+    skipToContent: 'Vai al contenuto',
+  },
+  languageSwitcher: {
+    label: 'Lingua',
+    currentLanguage: 'Italiano',
+    chooseLanguage: 'Scegli la lingua',
+  },
+  footer: {
+    impressum: 'Note legali',
+    privacy: 'Privacy',
+    accessibility: 'Accessibilità',
+  },
+  cta: {
+    appOpen: 'Apri l’app',
+    quizCreate: 'Crea un quiz',
+    backToApp: 'Torna ad arsnova.eu',
+    tryLive: 'Provalo live ora',
+    howItWorks: 'Come funziona',
+    viewOpenSource: 'Vedi l’open source',
+  },
+  hero: {
+    eyebrow: 'Audience response per istruzione e organizzazioni',
+    titleLine1: 'Quiz, stime,',
+    titleLine2: 'moderazione delle domande',
+    titleAccent1: 'live e gratis',
+    titleAccent2: ' senza account.',
+    lead: 'arsnova.eu unisce quiz live, stime numeriche, autovalutazione sulle domande valutate, bacheca Q&A, analisi word cloud e sondaggio rapido in un’unica interfaccia per scuole, università, formazione continua, workshop e business. Open source, self-hostabile e pensato per un funzionamento orientato al GDPR.',
+    a11yLink: 'Accessibile secondo WCAG 2.2 AA',
+    a11ySuffix: '— tastiera, screen reader e tempo di risposta regolabile individualmente.',
+    cards: [
+      { title: 'Live subito', text: 'Condividi la sessione con codice o QR' },
+      { title: 'Q&A con bacheca', text: 'Moderazione, voti e word cloud tematica' },
+      {
+        title: 'Autovalutazione e follow-up',
+        text: 'Individua i fraintendimenti, esporta il rapporto PDF',
+      },
+      { title: 'Open source e self-hostabile', text: 'Docker, Postgres, Redis e audit admin' },
+    ],
+  },
+  estimate: {
+    eyebrow: 'Novità nel quiz live',
+    title: 'Stimare numeri, discutere e confrontare chiaramente il secondo round',
+    lead: 'La domanda di stima numerica è pensata per date, ordini di grandezza, misure e probabilità. Chi conduce imposta valore di riferimento, intervallo di input e tolleranza; i partecipanti inseriscono solo un numero.',
+    summary: [
+      'La fascia di plausibilità limita gli input ammessi.',
+      'La fascia di tolleranza valuta le stime accettabili sul piano disciplinare.',
+      'Prima della pubblicazione nessuno vede la distribuzione.',
+      'Round 1 e round 2 vengono confrontati dopo la discussione.',
+    ],
+    docsLink: 'Apri la documentazione della stima',
+    demoAria: 'Esempio di risultati per una stima sulla Rivoluzione francese',
+    hostView: 'Vista host dopo la pubblicazione',
+    demoQuestion: 'Quando iniziò la Rivoluzione francese?',
+    reference: 'Riferimento 1789',
+    toleranceBand: 'Fascia di tolleranza',
+    toleranceValue: '1700–1900',
+    plausibilityBand: 'Fascia di plausibilità',
+    plausibilityValue: '1500–2000',
+    histogramNote:
+      'Istogramma, linea di riferimento e fascia di tolleranza compaiono solo dopo la pubblicazione dei risultati. Prima resta visibile solo il progresso neutrale.',
+    median: 'Mediana',
+    inBand: 'nella fascia',
+    round2: 'Round 2',
+    round2Value: '14 più vicini',
+  },
+  confidence: {
+    eyebrow: 'Valutazione didattica',
+    title: 'Giusto o sbagliato — e quanto sicuri?',
+    lead: 'Con l’autovalutazione i partecipanti indicano dopo la risposta quanto sono sicuri (1–5). Vedi non solo il tasso di risposte corrette, ma anche le risposte sbagliate con alta sicurezza — una leva forte per la valutazione formativa, il piano per la discussione dei risultati e il rapporto dei risultati (PDF) a fine sessione.',
+    summary: [
+      'Non è un tipo di domanda a sé — opzionale sulle domande valutate.',
+      'Scala 1–5 dopo la risposta, senza effetto sui punti.',
+      'Dopo la pubblicazione l’host vede correttezza × grado di sicurezza.',
+      '«Sbagliato e sicuro» segnala possibili fraintendimenti.',
+      'Dopo la sessione: rapporto dei risultati (PDF) e discussione dei risultati.',
+    ],
+    docsConfidence: 'Doc autovalutazione',
+    docsExport: 'Doc rapporto dei risultati (PDF)',
+    demoAria: 'Esempio di valutazione con autovalutazione dopo la pubblicazione',
+    hostView: 'Vista host dopo la pubblicazione',
+    demoQuestion: 'Quale struttura è la più stabile?',
+    badge: 'Autovalutazione',
+    matrix: [
+      { label: 'Corretto · basso', count: 3, tone: 'emerald' },
+      { label: 'Corretto · medio', count: 8, tone: 'emerald' },
+      { label: 'Corretto · alto', count: 11, tone: 'emerald' },
+      { label: 'Sbagliato · basso', count: 2, tone: 'slate' },
+      { label: 'Sbagliato · medio', count: 4, tone: 'amber' },
+      { label: 'Sbagliato · alto', count: 2, tone: 'rose' },
+    ],
+    falseHighTitle: '2 risposte sbagliate con alta sicurezza',
+    falseHighText:
+      'L’opzione B è stata scelta 2× con alto grado di sicurezza — un segnale di possibili fraintendimenti nella discussione dei risultati.',
+    consolidated: 'Solido',
+    misconceptionRisk: 'Rischio di fraintendimento',
+    fragile: 'Fragile',
+    afterSessionAria: 'Export a fine sessione',
+    afterSession: 'A fine sessione',
+    debriefing: 'Discussione dei risultati',
+    resultsPdf: 'Rapporto dei risultati (PDF)',
+    exportNote:
+      'Report pronto per la stampa con stato di apprendimento, heatmap e testi delle domande — nella vista host e sulla scheda quiz. Il CSV per Excel resta disponibile sotto «Altro».',
+  },
+  qaWall: {
+    eyebrow: 'Q&A live come superficie di moderazione',
+    title: 'Raccogliere domande, prioritizzarle e leggerle come mappa tematica',
+    lead: 'La bacheca delle domande non è una chat secondaria. È un canale live dedicato per docenti e relatori: moderare i contributi, rilevare le priorità collettive, rendere visibili i punti controversi e portare i temi chiave in sala tramite una word cloud Q&A pesata.',
+    signals: [
+      {
+        label: 'Pre-moderazione',
+        text: 'Pubblica le domande solo quando si adattano al momento didattico.',
+      },
+      {
+        label: 'Voto collettivo',
+        text: 'Upvote e downvote mostrano priorità, attrito e bisogno di chiarimento.',
+      },
+      {
+        label: 'Word cloud tematica',
+        text: 'Parole e frasi sono pesate per supporto, accordo o controversia.',
+      },
+      {
+        label: 'Prospettiva bussola',
+        text: 'Prima arrivano i segnali deterministici; NLP Q&A e sintesi restano estensioni opzionali.',
+      },
+    ],
+    docsLink: 'Apri scoring Q&A e controversia su GitHub',
+    demoAria: 'Esempio di bacheca Q&A con moderazione, voti e word cloud',
+    hostView: 'Vista host Q&A',
+    demoTitle: 'Domande sull’evento',
+    moderationActive: 'Pre-moderazione attiva',
+    sortMostSupported: 'Più supportate',
+    sortBest: 'Migliori domande',
+    sortControversial: 'Controverse',
+    questions: [
+      {
+        score: '+18',
+        title: 'Quando una stima è ancora plausibile sul piano disciplinare?',
+        meta: '15 positivi · 3 negativi · migliore domanda',
+      },
+      {
+        score: '+4',
+        title: 'Dobbiamo davvero nascondere i risultati prima della discussione?',
+        meta: '9 positivi · 5 negativi · controversa',
+      },
+      {
+        score: '+11',
+        title: 'In cosa il Q&A differisce dal testo libero nel quiz?',
+        meta: '11 positivi · 0 negativi · soprattutto supportata',
+      },
+    ],
+    wordCloud: 'Word cloud Q&A',
+    wordCloudHint: 'Pesata per risonanza positiva e controversia.',
+    frozenLive: 'Congelata live',
+    terms: [
+      { label: 'Fascia di tolleranza', className: 'text-3xl text-brand-200' },
+      { label: 'Discussione', className: 'text-2xl text-emerald-200' },
+      { label: 'Q&A', className: 'text-4xl text-white' },
+      { label: 'Plausibilità', className: 'text-xl text-amber-200' },
+      { label: 'Controversia', className: 'text-2xl text-rose-200' },
+      { label: 'Peer Instruction', className: 'text-lg text-slate-300' },
+      { label: 'Moderazione', className: 'text-3xl text-cyan-200' },
+      { label: 'Bisogno di chiarimento', className: 'text-xl text-violet-200' },
+    ],
+    nextStep:
+      'Prossimo passo: una bussola di moderazione deterministica, opzionalmente integrata da segnali NLP Q&A asincroni e sintesi legate alle fonti.',
+  },
+  workflow: {
+    eyebrow: 'Per didattica, formazione e workshop',
+    title: 'Dall’idea alla sessione live in pochi minuti',
+    lead: 'Dalla domanda alla sessione in corso, il flusso evita di proposito passaggi inutili. È questo che rende l’avvio rapido e affidabile per docenti, trainer e moderatori.',
+    stepLabel: 'Passo',
+    steps: [
+      {
+        number: '01',
+        title: 'Prepara un quiz',
+        description:
+          'Crea domande direttamente o importa contenuti esistenti. Markdown, KaTeX, risposta breve e stime numeriche sono integrati.',
+      },
+      {
+        number: '02',
+        title: 'Avvia una sessione',
+        description:
+          'Parti senza account: apri una sessione, scegli uno stile, condividi codice o QR e usa la vista presenter se serve.',
+      },
+      {
+        number: '03',
+        title: 'Modera live',
+        description:
+          'I partecipanti votano, pongono domande e prioritizzano insieme. Host e presenter mostrano quiz, bacheca Q&A, word cloud, fase di lettura, countdown, secondo round e risultati in un unico flusso.',
+      },
+      {
+        number: '04',
+        title: 'Follow-up ed export',
+        description:
+          'A fine sessione il rapporto dei risultati (PDF) è pronto — con stato di apprendimento, autovalutazione e testi completi delle domande. Nella raccolta quiz trovi discussione dei risultati e PDF dell’ultima esecuzione; CSV per Excel sotto «Altro».',
+      },
+    ],
+  },
+  features: {
+    eyebrow: 'Perché si sente diverso',
+    title: 'Pensato per l’interazione live, non solo per sondaggi su slide',
+    lead: 'arsnova.eu unisce avvio rapido, solidità didattica e una base tecnica trasparente. La piattaforma resta semplice nel quotidiano senza ridurre le possibilità.',
+    items: [
+      {
+        title: 'Pronto in poco tempo',
+        description:
+          'Gli host partono senza account. I partecipanti entrano nella sessione direttamente con un codice a 6 cifre o un QR.',
+        icon: 'single',
+      },
+      {
+        title: 'Autovalutazione nel quiz live',
+        description:
+          'I partecipanti indicano dopo la risposta quanto sono sicuri. Individui risposte sbagliate con alta sicurezza, prioritizzi la discussione dei risultati ed esporti lo stato di apprendimento nel rapporto dei risultati (PDF).',
+        icon: 'confidence',
+      },
+      {
+        title: 'Rapporto dei risultati per il follow-up',
+        description:
+          'A fine sessione esporti un report PDF pronto per la stampa con diagrammi, testi delle domande e autovalutazione. Il CSV per Excel resta opzionale sotto «Altro».',
+        icon: 'export',
+      },
+      {
+        title: 'Stime didattiche',
+        description:
+          'Date, ordini di grandezza e misure si possono stimare con valore di riferimento, fascia di tolleranza, statistica e secondo round opzionale.',
+        icon: 'estimate',
+      },
+      {
+        title: 'Più di un quiz standard',
+        description:
+          'MC/SC, risposta breve, rating, fase di lettura, Peer Instruction e flusso presenter supportano apprendimento, formazione e moderazione live.',
+        icon: 'toggle',
+      },
+      {
+        title: 'Bacheca invece di una chat secondaria',
+        description:
+          'Il Q&A offre pre-moderazione, fissaggio, archiviazione, up/downvote e ordinamento per supporto, qualità e controversia.',
+        icon: 'qa',
+      },
+      {
+        title: 'Word cloud elaborata',
+        description:
+          'Testo libero e Q&A vengono condensati in parole e frasi; la bacheca pesa per accordo, score robusto o controversia.',
+        icon: 'cloud',
+      },
+      {
+        title: 'Per contesti diversi',
+        description:
+          'Preset, modalità team, modalità anonima, nickname e scelta dello stile aiutano dalla classe e dal seminario al workshop, evento e meeting.',
+        icon: 'bolt',
+      },
+      {
+        title: 'Accessibilità secondo WCAG 2.2 AA',
+        description:
+          'Uso da tastiera, annunci screen reader, tempo di risposta regolabile individualmente e rapporti PDF/UA-1 — così più persone possono partecipare in autonomia alle sessioni live.',
+        icon: 'a11y',
+      },
+      {
+        title: 'Privacy e controllo',
+        description:
+          'Local-first, data-stripping e gestione self-hostabile ti danno più controllo su contenuti e dati live.',
+        icon: 'tools',
+      },
+      {
+        title: 'Open source con percorso operativo',
+        description:
+          'Docker, Postgres, Redis e audit admin rendono la piattaforma affidabile anche per hosting, esercizio e tracciabilità.',
+        icon: 'server',
+      },
+    ],
+  },
+  accessibility: {
+    eyebrow: 'Accessibilità',
+    title: 'WCAG 2.2 AA — così più persone possono partecipare in autonomia',
+    lead: 'Per scuole, università e formazione continua l’accessibilità è spesso un criterio decisivo. arsnova.eu soddisfa le Web Content Accessibility Guidelines (WCAG) 2.2 al livello AA — con uso da tastiera, supporto screen reader, tempo di risposta regolabile individualmente e rapporti PDF strutturati in modo accessibile.',
+    benefits: [
+      {
+        title: 'Uso da tastiera',
+        description:
+          'Tu e i tuoi partecipanti usate i flussi centrali senza mouse. Indicatori di focus visibili e un link salta-contenuto facilitano la navigazione.',
+      },
+      {
+        title: 'Supporto screen reader in live',
+        description:
+          'I cambiamenti di stato all’ingresso in sessione, durante le votazioni e ai cambi di fase vengono annunciati agli screen reader, così si può seguire il flusso.',
+      },
+      {
+        title: 'Tempo di risposta regolabile individualmente',
+        description:
+          'Per le domande a tempo scegli tempo standard, tempo decuplicato o partecipazione senza limite. Così un’agevolazione si applica direttamente nella sessione live.',
+      },
+      {
+        title: 'Rapporto dei risultati strutturato in modo accessibile',
+        description:
+          'Il report pronto per la stampa è validato PDF/UA-1 e include titolo, lingua e tag — per il follow-up e la condivisione accessibile.',
+      },
+    ],
+    statementLink: 'Apri la dichiarazione di accessibilità',
+  },
+  trust: {
+    eyebrow: 'Fiducia',
+    title: 'Credibile perché il prodotto non parte da zero',
+    lead: 'arsnova.eu si inserisce nella tradizione dell’ecosistema ARSnova e si basa su esperienze scientifiche, didattiche e pratiche di molti anni di tecnologie educative.',
+    proofItems: [
+      { value: 'Dal 2012', label: 'Tradizione ARSnova in istruzione ed edtech' },
+      { value: 'WCAG 2.2 AA', label: 'Accessibilità verificata per didattica e istituzioni' },
+      {
+        value: '5 lingue UI',
+        label: 'Tedesco, inglese, francese, spagnolo, italiano',
+      },
+      { value: 'Open source', label: 'Codice trasparente invece di una black box' },
+    ],
+    items: [
+      {
+        quote:
+          'Percorso privacy-friendly: nessun dato personale memorizzato in modo permanente sul server.',
+        source: 'DeLFI 2017',
+        tag: 'Ricerca',
+      },
+      {
+        quote:
+          'Valutazione UX a confronto diretto con Kahoot! come checkpoint empirico del design.',
+        source: 'fnm-austria',
+        tag: 'Studio',
+      },
+      {
+        quote:
+          'Privacy by design e apertura tecnica sono un vero fattore distintivo per i contesti edtech europei.',
+        source: 'Analisi delle pubblicazioni',
+        tag: 'Architettura',
+      },
+      {
+        quote: 'Sperimentato in contesti educativi reali, non solo descritto come concetto.',
+        source: 'Uso in contesti di insegnamento e formazione',
+        tag: 'Pratica',
+      },
+    ],
+    referencesPrefix: 'I riferimenti completi e la raccolta di pubblicazioni di base sono in',
+    referencesLink: 'ARSnova-Recherche.pdf',
+    referencesSuffix: 'su GitHub.',
+  },
+  comparison: {
+    eyebrow: 'Differenziazione',
+    title: 'Non solo un sostituto di Mentimeter o Kahoot',
+    lead: 'Al centro non c’è solo il voto, ma l’intero flusso live: preparare, moderare, rendere visibili i risultati e mantenere il controllo su contenuti e gestione.',
+    points: [
+      {
+        title: 'Meno barriere d’ingresso',
+        description:
+          'Nessuna logica di prodotto separata per «creare» e «entrare». Gli host partono senza account, i partecipanti entrano con codice o QR.',
+      },
+      {
+        title: 'Più formati di interazione',
+        description:
+          'Oltre al quiz: stime numeriche, fase di lettura, Peer Instruction, sondaggio rapido, bacheca Q&A e word cloud pesata nella stessa piattaforma — non solo sondaggi su slide.',
+      },
+      {
+        title: 'Più controllo su dati e accesso',
+        description:
+          'Open source, self-hostabile e local-first — più accessibilità WCAG 2.2 AA. Rilevante per scuole, università e organizzazioni con requisiti di privacy e inclusione.',
+      },
+    ],
+    comparePrefix: 'Il confronto completo delle funzioni resta nella documentazione:',
+    compareLink: 'Apri il confronto su GitHub',
+  },
+  faq: {
+    eyebrow: 'FAQ',
+    title: 'Domande frequenti prima del primo utilizzo',
+    answerLabel: 'Risposta',
+    items: [
+      {
+        question: 'Host o partecipanti hanno bisogno di un account?',
+        answer:
+          'No. Una sessione può partire senza account. I partecipanti entrano con codice o QR.',
+      },
+      {
+        question: 'Dove sono i dati?',
+        answer:
+          'I contenuti del quiz sono pensati local-first. Per le sessioni live vengono elaborati solo i dati di sessione tecnicamente necessari; con self-hosting la gestione resta nella tua infrastruttura.',
+      },
+      {
+        question: 'Posso fare self-hosting di arsnova.eu?',
+        answer:
+          'Sì. La piattaforma è open source e progettata per funzionare con Docker, PostgreSQL e Redis.',
+      },
+      {
+        question: 'Cos’è l’autovalutazione nel quiz?',
+        answer:
+          'Una domanda aggiuntiva opzionale dopo le domande valutate: i partecipanti indicano su una scala da 1 a 5 quanto sono sicuri della risposta. I punti restano invariati; nella valutazione host vedi correttezza × grado di sicurezza e segni le risposte sbagliate con alta sicurezza come segnale di fraintendimento. A fine sessione lo stato di apprendimento confluisce nella discussione dei risultati e nel rapporto dei risultati (PDF).',
+      },
+      {
+        question: 'Posso esportare i risultati della sessione?',
+        answer:
+          'Sì. A fine sessione il rapporto dei risultati (PDF) è il formato principale — con autovalutazione, priorità per la discussione dei risultati e testi completi delle domande. Nella raccolta quiz trovi discussione dei risultati e PDF dell’ultima esecuzione. I dati CSV tabellari sono disponibili sotto «Altro» per Excel.',
+      },
+      {
+        question: 'Cosa ha di speciale la stima numerica?',
+        answer:
+          'Separa gli input ammessi dalla fascia di tolleranza disciplinare, non mostra la distribuzione durante il voto e può valutare un secondo round dopo la discussione con statistica e confronto dei round.',
+      },
+      {
+        question: 'Cosa può fare la bacheca Q&A?',
+        answer:
+          'I partecipanti inviano domande e le pesano con upvote e downvote. Gli host possono pre-moderare, fissare, archiviare o rimuovere domande e ordinare l’elenco per supporto, accordo robusto o controversia.',
+      },
+      {
+        question: 'Cosa rende diversa la word cloud Q&A?',
+        answer:
+          'Condensa le domande visibili in parole e frasi e segue la logica di ordinamento attiva. Così mostra non solo termini frequenti, ma cluster tematici da domande supportate, valutate in modo robusto o controverse.',
+      },
+      {
+        question: 'Per chi è pensata la piattaforma?',
+        answer:
+          'Per l’interazione live in istruzione e organizzazioni: scuola, università, formazione continua, training, workshop, evento o meeting.',
+      },
+      {
+        question: 'arsnova.eu è accessibile?',
+        answer:
+          'arsnova.eu soddisfa WCAG 2.2 AA. I flussi centrali sono usabili da tastiera, gli screen reader annunciano i cambiamenti di stato, il tempo di risposta delle domande a tempo è regolabile individualmente (tempo standard, tempo decuplicato o senza limite), e il rapporto dei risultati strutturato in modo accessibile è validato PDF/UA-1.',
+        linkLabel: 'Apri la dichiarazione di accessibilità',
+      },
+    ],
+  },
+  ctaSection: {
+    title: 'Pronto per la prossima sessione live?',
+    lead: 'Prova il flusso live direttamente nell’app, oppure dai un’occhiata al codice aperto, alla logica Q&A, alla pipeline della word cloud e al percorso operativo dietro la piattaforma.',
+  },
+  jsonLd: {
+    websiteName: 'arsnova.eu – Informazioni',
+    webAppDescription:
+      'Audience response open source per istruzione, formazione e organizzazioni: quiz live, autovalutazione, rapporto dei risultati (PDF), stime numeriche, bacheca Q&A moderabile, word cloud e feedback — accessibile WCAG 2.2 AA, gratuito, self-hostabile e pronto senza account.',
+    featureList: [
+      'Quiz live e votazioni',
+      'Autovalutazione sulle domande valutate',
+      'Rapporto dei risultati (PDF) e discussione dei risultati a fine sessione',
+      'Stime numeriche con due round e statistica',
+      'Bacheca Q&A con moderazione, upvote e downvote',
+      'Lobby, presenter, QR/codice',
+      'Tipi di domanda MC/SC/risposta breve/testo libero/sondaggio/rating/stima',
+      'Markdown e KaTeX',
+      'Fase di lettura e Peer Instruction',
+      'Word cloud Q&A e testo libero con frasi e pesatura',
+      'Ordinamento per supporto, accordo robusto e controversia',
+      'Modalità team e preset',
+      'Classifica, streak, codice bonus',
+      'Import/export e sync Yjs',
+      'Import IA esterno, validato Zod',
+      'Interfaccia in cinque lingue',
+      'Accessibilità secondo WCAG 2.2 AA',
+      'Self-host Docker e audit admin',
+      'Local-first e funzionamento orientato al GDPR',
+    ],
+  },
+};
+
+export default it;

--- a/apps/landing/src/i18n/it.ts
+++ b/apps/landing/src/i18n/it.ts
@@ -4,7 +4,7 @@ const it: Messages = {
   meta: {
     homeTitle: 'arsnova.eu | Quiz in diretta, domande di stima numerica e bacheca delle domande',
     homeDescription:
-      'Piattaforma open source di risposta interattiva per istruzione, formazione e organizzazioni: quiz in diretta, autovalutazione, rapporto dei risultati (PDF), domande di stima numerica, bacheca delle domande moderabile, word cloud e sondaggio rapido — conforme alle WCAG 2.2, livello AA, gratuita, self-hostabile e pronta senza account.',
+      'Piattaforma open source di risposta interattiva per istruzione, formazione e organizzazioni: quiz in diretta, autovalutazione, rapporto dei risultati (PDF), domande di stima numerica, bacheca delle domande moderabile, nuvola di parole e sondaggio rapido — conforme alle WCAG 2.2, livello AA, gratuita, eseguibile sulla propria infrastruttura e pronta senza account.',
     siteNameInfo: 'arsnova.eu – Informazioni',
     ogLocale: 'it_IT',
   },
@@ -48,32 +48,38 @@ const it: Messages = {
     titleLine2: 'moderazione delle domande',
     titleAccent1: 'in diretta e gratis',
     titleAccent2: ' senza account.',
-    lead: 'arsnova.eu unisce quiz in diretta, domande di stima numerica, autovalutazione sulle domande valutate, bacheca delle domande, analisi word cloud e sondaggio rapido in un’unica interfaccia per scuole, università, formazione continua, workshop e business. Open source, self-hostabile e pensato per un funzionamento orientato al GDPR.',
+    lead: 'arsnova.eu unisce quiz in diretta, domande di stima numerica, autovalutazione sulle domande valutate, bacheca delle domande, analisi a nuvola di parole e sondaggio rapido in un’unica interfaccia per scuole, università, formazione continua, workshop e imprese. Open source, eseguibile sulla propria infrastruttura e pensato per un funzionamento orientato al GDPR.',
     a11yLink: 'Conforme alle WCAG 2.2, livello AA',
     a11ySuffix: '— tastiera, screen reader e tempo di risposta regolabile individualmente.',
     cards: [
       { title: 'In diretta subito', text: 'Condividi la sessione con codice o QR' },
-      { title: 'Q&A con bacheca delle domande', text: 'Moderazione, voti e word cloud tematica' },
+      {
+        title: 'Q&A con bacheca delle domande',
+        text: 'Moderazione, voti e nuvola di parole tematica',
+      },
       {
         title: 'Autovalutazione e analisi successiva',
         text: 'Individua i fraintendimenti, esporta il rapporto PDF',
       },
-      { title: 'Open source e self-hostabile', text: 'Docker, Postgres, Redis e audit admin' },
+      {
+        title: 'Open source ed eseguibile in autonomia',
+        text: 'Docker, Postgres, Redis e registro di amministrazione',
+      },
     ],
   },
   estimate: {
     eyebrow: 'Novità nel quiz in diretta',
     title: 'Stimare numeri, discutere e confrontare chiaramente il secondo turno',
-    lead: 'La domanda di stima numerica è pensata per date, ordini di grandezza, misure e probabilità. Chi conduce imposta valore di riferimento, intervallo di input e tolleranza; i partecipanti inseriscono solo un numero.',
+    lead: 'La domanda di stima numerica è pensata per date, ordini di grandezza, misure e probabilità. Chi conduce imposta un valore di riferimento, un intervallo di immissione e una tolleranza; i partecipanti inseriscono solo un numero.',
     summary: [
-      'La fascia di plausibilità limita gli input ammessi.',
+      'La fascia di plausibilità limita le immissioni ammesse.',
       'La fascia di tolleranza valuta le stime accettabili sul piano disciplinare.',
       'Prima della pubblicazione nessuno vede la distribuzione.',
       'Turno 1 e turno 2 vengono confrontati dopo la discussione.',
     ],
     docsLink: 'Apri la documentazione della domanda di stima numerica',
     demoAria: 'Esempio di risultati per una domanda di stima numerica sulla Rivoluzione francese',
-    hostView: 'Vista conduttore dopo la pubblicazione',
+    hostView: 'Vista di chi conduce dopo la pubblicazione',
     demoQuestion: 'Quando iniziò la Rivoluzione francese?',
     reference: 'Riferimento 1789',
     toleranceBand: 'Fascia di tolleranza',
@@ -88,9 +94,9 @@ const it: Messages = {
     round2Value: '14 risposte più vicine al valore di riferimento',
   },
   confidence: {
-    eyebrow: 'Valutazione didattica',
+    eyebrow: 'Analisi didattica',
     title: 'Giusto o sbagliato — e quanto sicuri?',
-    lead: 'Con l’autovalutazione i partecipanti indicano dopo la risposta quanto sono sicuri (1–5). Vedi non solo il tasso di risposte corrette, ma anche le risposte sbagliate con alta sicurezza — una leva forte per la valutazione formativa, il piano per la discussione dei risultati e il rapporto dei risultati (PDF) a fine sessione.',
+    lead: 'Con l’autovalutazione i partecipanti indicano dopo la risposta quanto sono sicuri (1–5). Vedi non solo il tasso di risposte corrette, ma anche le risposte sbagliate con alta sicurezza — uno strumento utile per la valutazione formativa, il piano per la discussione dei risultati e il rapporto dei risultati (PDF) a fine sessione.',
     summary: [
       'Non è un tipo di domanda a sé — opzionale sulle domande valutate.',
       'Scala 1–5 dopo la risposta, senza effetto sui punti.',
@@ -101,7 +107,7 @@ const it: Messages = {
     docsConfidence: 'Doc autovalutazione',
     docsExport: 'Doc rapporto dei risultati (PDF)',
     demoAria: 'Esempio di valutazione con autovalutazione dopo la pubblicazione',
-    hostView: 'Vista conduttore dopo la pubblicazione',
+    hostView: 'Vista di chi conduce dopo la pubblicazione',
     demoQuestion: 'Quale struttura è la più stabile?',
     badge: 'Autovalutazione',
     matrix: [
@@ -123,12 +129,12 @@ const it: Messages = {
     debriefing: 'Discussione dei risultati',
     resultsPdf: 'Rapporto dei risultati (PDF)',
     exportNote:
-      'Report pronto per la stampa con stato di apprendimento, mappa di calore e testi delle domande — nella vista conduttore e sulla scheda quiz. Il CSV per Excel resta disponibile sotto «Altro».',
+      'Rapporto pronto per la stampa con stato di apprendimento, mappa di calore e testi delle domande — nella vista di chi conduce e sulla scheda quiz. Il CSV per Excel resta disponibile sotto «Altro».',
   },
   qaWall: {
-    eyebrow: 'Q&A in diretta come superficie di moderazione',
-    title: 'Raccogliere domande, prioritizzarle e leggerle come mappa tematica',
-    lead: 'La bacheca delle domande non è una chat secondaria. È un canale in diretta dedicato per docenti e relatori: moderare i contributi, rilevare le priorità collettive, rendere visibili i punti controversi e portare i temi chiave in sala tramite una word cloud Q&A pesata.',
+    eyebrow: 'Q&A in diretta come spazio di moderazione',
+    title: 'Raccogliere domande, ordinarle per priorità e leggerle come mappa tematica',
+    lead: 'La bacheca delle domande non è una chat secondaria. È un canale in diretta dedicato per docenti e relatori: moderare i contributi, rilevare le priorità collettive, rendere visibili i punti controversi e portare i temi chiave in sala tramite una nuvola di parole Q&A pesata.',
     signals: [
       {
         label: 'Pre-moderazione',
@@ -139,17 +145,17 @@ const it: Messages = {
         text: 'I voti a favore e contro mostrano priorità, attrito e bisogno di chiarimento.',
       },
       {
-        label: 'Word cloud tematica',
+        label: 'Nuvola di parole tematica',
         text: 'Parole e frasi sono pesate per supporto, accordo o controversia.',
       },
       {
-        label: 'Prospettiva della bussola di moderazione',
-        text: 'Prima arrivano i segnali deterministici; NLP Q&A e sintesi restano estensioni opzionali.',
+        label: 'In arrivo: bussola di moderazione',
+        text: 'Prima arrivano i segnali deterministici; l’analisi linguistica opzionale e la sintesi restano estensioni.',
       },
     ],
-    docsLink: 'Apri scoring Q&A e controversia su GitHub',
-    demoAria: 'Esempio di bacheca delle domande con moderazione, voti e word cloud',
-    hostView: 'Vista conduttore Q&A',
+    docsLink: 'Apri la valutazione Q&A e la controversia su GitHub',
+    demoAria: 'Esempio di bacheca delle domande con moderazione, voti e nuvola di parole',
+    hostView: 'Vista Q&A di chi conduce',
     demoTitle: 'Domande sull’evento',
     moderationActive: 'Pre-moderazione attiva',
     sortMostSupported: 'Più supportate',
@@ -172,7 +178,7 @@ const it: Messages = {
         meta: '11 positivi · 0 negativi · soprattutto supportata',
       },
     ],
-    wordCloud: 'Word cloud Q&A',
+    wordCloud: 'Nuvola di parole Q&A',
     wordCloudHint: 'Pesata per risonanza positiva e controversia.',
     frozenLive: 'Aggiornamenti in diretta in pausa',
     terms: [
@@ -186,7 +192,7 @@ const it: Messages = {
       { label: 'Bisogno di chiarimento', className: 'text-xl text-violet-200' },
     ],
     nextStep:
-      'Prossimo passo: una bussola di moderazione deterministica, opzionalmente integrata da segnali NLP Q&A asincroni e sintesi legate alle fonti.',
+      'Prossimo passo: una bussola di moderazione deterministica, opzionalmente integrata da segnali di analisi linguistica asincroni e sintesi legate alle fonti.',
   },
   workflow: {
     eyebrow: 'Per didattica, formazione e workshop',
@@ -210,7 +216,7 @@ const it: Messages = {
         number: '03',
         title: 'Modera in diretta',
         description:
-          'I partecipanti votano, pongono domande e prioritizzano insieme. Conduttore e presentatore mostrano quiz, bacheca delle domande, word cloud, fase di lettura, conto alla rovescia, secondo turno e risultati in un unico flusso.',
+          'I partecipanti votano, pongono domande e definiscono insieme le priorità. Chi conduce e il presentatore mostrano quiz, bacheca delle domande, nuvola di parole, fase di lettura, conto alla rovescia, secondo turno e risultati in un unico flusso.',
       },
       {
         number: '04',
@@ -221,7 +227,7 @@ const it: Messages = {
     ],
   },
   features: {
-    eyebrow: 'Cosa rende arsnova.eu diverso',
+    eyebrow: 'Cosa distingue arsnova.eu',
     title: 'Pensato per l’interazione in diretta, non solo per sondaggi su slide',
     lead: 'arsnova.eu unisce avvio rapido, solidità didattica e una base tecnica trasparente. La piattaforma resta semplice nel quotidiano senza ridurre le possibilità.',
     items: [
@@ -234,13 +240,13 @@ const it: Messages = {
       {
         title: 'Autovalutazione nel quiz in diretta',
         description:
-          'I partecipanti indicano dopo la risposta quanto sono sicuri. Individui risposte sbagliate con alta sicurezza, prioritizzi la discussione dei risultati ed esporti lo stato di apprendimento nel rapporto dei risultati (PDF).',
+          'I partecipanti indicano dopo la risposta quanto sono sicuri. Individui risposte sbagliate con alta sicurezza, dai priorità alla discussione dei risultati ed esporti lo stato di apprendimento nel rapporto dei risultati (PDF).',
         icon: 'confidence',
       },
       {
         title: 'Rapporto dei risultati per l’analisi successiva',
         description:
-          'A fine sessione esporti un report PDF pronto per la stampa con diagrammi, testi delle domande e autovalutazione. Il CSV per Excel resta opzionale sotto «Altro».',
+          'A fine sessione esporti un rapporto PDF pronto per la stampa con diagrammi, testi delle domande e autovalutazione. Il CSV per Excel resta opzionale sotto «Altro».',
         icon: 'export',
       },
       {
@@ -252,7 +258,7 @@ const it: Messages = {
       {
         title: 'Più di un quiz standard',
         description:
-          'MC/SC, risposta breve, rating, fase di lettura, Peer Instruction e flusso presentatore supportano apprendimento, formazione e moderazione in diretta.',
+          'MC/SC, risposta breve, valutazione, fase di lettura, Peer Instruction e flusso presentatore supportano apprendimento, formazione e moderazione in diretta.',
         icon: 'toggle',
       },
       {
@@ -262,7 +268,7 @@ const it: Messages = {
         icon: 'qa',
       },
       {
-        title: 'Word cloud elaborata',
+        title: 'Nuvola di parole elaborata',
         description:
           'Testo libero e Q&A vengono condensati in parole e frasi; la bacheca pesa per accordo, punteggio robusto o controversia.',
         icon: 'cloud',
@@ -270,7 +276,7 @@ const it: Messages = {
       {
         title: 'Per contesti diversi',
         description:
-          'Preset, modalità team, modalità anonima, nickname e scelta dello stile aiutano dalla classe e dal seminario al workshop, evento e riunione.',
+          'Impostazioni predefinite, modalità a squadre, modalità anonima, pseudonimi e scelta dello stile si adattano a contesti che vanno dalla classe e dal seminario al workshop, all’evento e alla riunione.',
         icon: 'bolt',
       },
       {
@@ -282,13 +288,13 @@ const it: Messages = {
       {
         title: 'Privacy e controllo',
         description:
-          'Approccio local-first, rimozione opzionale dei dati e gestione self-hostabile ti danno più controllo su contenuti e dati in diretta.',
+          'I contenuti del quiz restano sul tuo dispositivo, la rimozione opzionale dei dati e la gestione sulla propria infrastruttura ti danno più controllo su contenuti e dati in diretta.',
         icon: 'tools',
       },
       {
-        title: 'Open source con percorso di deployment e gestione',
+        title: 'Open source con distribuzione e gestione',
         description:
-          'Docker, Postgres, Redis e audit admin rendono la piattaforma affidabile anche per hosting, esercizio e tracciabilità.',
+          'Docker, Postgres, Redis e registro di amministrazione rendono la piattaforma affidabile anche per hosting, esercizio e tracciabilità.',
         icon: 'server',
       },
     ],
@@ -316,40 +322,39 @@ const it: Messages = {
       {
         title: 'Rapporto dei risultati strutturato in modo accessibile',
         description:
-          'Il report pronto per la stampa è validato PDF/UA-1 e include titolo, lingua e tag — per l’analisi successiva e la condivisione accessibile.',
+          'Il rapporto pronto per la stampa è validato PDF/UA-1 e include titolo, lingua e tag — per l’analisi successiva e la condivisione accessibile.',
       },
     ],
     statementLink: 'Apri la dichiarazione di accessibilità',
   },
   trust: {
     eyebrow: 'Fiducia',
-    title: 'Credibile perché il prodotto non parte da zero',
+    title: 'Costruito su un’esperienza consolidata',
     lead: 'arsnova.eu si inserisce nella tradizione dell’ecosistema ARSnova e si basa su esperienze scientifiche, didattiche e pratiche di molti anni di tecnologie educative.',
     proofItems: [
-      { value: 'Dal 2012', label: 'Tradizione ARSnova in istruzione ed edtech' },
+      { value: 'Dal 2012', label: 'Tradizione ARSnova in istruzione e tecnologie educative' },
       { value: 'WCAG 2.2 AA', label: 'Accessibilità verificata per didattica e istituzioni' },
       {
         value: '5 lingue UI',
         label: 'Tedesco, inglese, francese, spagnolo, italiano',
       },
-      { value: 'Open source', label: 'Codice trasparente invece di una black box' },
+      { value: 'Open source', label: 'Codice trasparente invece di sistemi opachi' },
     ],
     items: [
       {
         quote:
-          'Percorso privacy-friendly: nessun dato personale memorizzato in modo permanente sul server.',
+          'Percorso rispettoso della privacy: nessun dato personale memorizzato in modo permanente sul server.',
         source: 'DeLFI 2017',
         tag: 'Ricerca',
       },
       {
-        quote:
-          'Valutazione UX a confronto diretto con Kahoot! come checkpoint empirico del design.',
+        quote: 'Valutazione UX a confronto diretto con Kahoot! come verifica empirica del design.',
         source: 'fnm-austria',
         tag: 'Studio',
       },
       {
         quote:
-          'Privacy by design e apertura tecnica sono un vero fattore distintivo per i contesti edtech europei.',
+          'La protezione dei dati fin dalla progettazione e l’apertura tecnica sono un vero fattore distintivo per i contesti europei di tecnologie educative.',
         source: 'Analisi delle pubblicazioni',
         tag: 'Architettura',
       },
@@ -376,12 +381,12 @@ const it: Messages = {
       {
         title: 'Più formati di interazione',
         description:
-          'Oltre al quiz: domande di stima numerica, fase di lettura, Peer Instruction, sondaggio rapido, bacheca delle domande e word cloud pesata nella stessa piattaforma — non solo sondaggi su slide.',
+          'Oltre al quiz: domande di stima numerica, fase di lettura, Peer Instruction, sondaggio rapido, bacheca delle domande e nuvola di parole pesata nella stessa piattaforma — non solo sondaggi su slide.',
       },
       {
         title: 'Più controllo su dati e accesso',
         description:
-          'Open source, self-hostabile e local-first — più conformità alle WCAG 2.2, livello AA. Rilevante per scuole, università e organizzazioni con requisiti di privacy e inclusione.',
+          'Open source, eseguibile sulla propria infrastruttura e con contenuti del quiz conservati in locale — più conformità alle WCAG 2.2, livello AA. Rilevante per scuole, università e organizzazioni con requisiti di privacy e inclusione.',
       },
     ],
     comparePrefix: 'Il confronto completo delle funzioni resta nella documentazione:',
@@ -400,10 +405,10 @@ const it: Messages = {
       {
         question: 'Dove sono i dati?',
         answer:
-          'I contenuti del quiz sono pensati local-first. Per le sessioni in diretta vengono elaborati solo i dati di sessione tecnicamente necessari; con self-hosting la gestione resta nella tua infrastruttura.',
+          'I contenuti del quiz restano sul tuo dispositivo. Per le sessioni in diretta vengono elaborati solo i dati di sessione tecnicamente necessari; con gestione sulla propria infrastruttura il controllo resta a te.',
       },
       {
-        question: 'Posso fare self-hosting di arsnova.eu?',
+        question: 'Posso eseguire arsnova.eu sulla mia infrastruttura?',
         answer:
           'Sì. La piattaforma è open source e progettata per funzionare con Docker, PostgreSQL e Redis.',
       },
@@ -420,7 +425,7 @@ const it: Messages = {
       {
         question: 'Cosa ha di speciale la domanda di stima numerica?',
         answer:
-          'Separa gli input ammessi dalla fascia di tolleranza disciplinare, non mostra la distribuzione durante il voto e può valutare un secondo turno dopo la discussione con statistica e confronto dei turni.',
+          'Separa le immissioni ammesse dalla fascia di tolleranza disciplinare, non mostra la distribuzione durante il voto e può valutare un secondo turno dopo la discussione con statistica e confronto dei turni.',
       },
       {
         question: 'Cosa può fare la bacheca delle domande?',
@@ -428,14 +433,14 @@ const it: Messages = {
           'I partecipanti inviano domande e le pesano con voti a favore e contro. Chi conduce può pre-moderare, fissare, archiviare o rimuovere domande e ordinare l’elenco per supporto, accordo robusto o controversia.',
       },
       {
-        question: 'Cosa rende diversa la word cloud Q&A?',
+        question: 'Cosa rende diversa la nuvola di parole Q&A?',
         answer:
           'Condensa le domande visibili in parole e frasi e segue la logica di ordinamento attiva. Così mostra non solo termini frequenti, ma cluster tematici da domande supportate, valutate in modo robusto o controverse.',
       },
       {
         question: 'Per chi è pensata la piattaforma?',
         answer:
-          'Per l’interazione in diretta in istruzione e organizzazioni: scuola, università, formazione continua, training, workshop, evento o riunione.',
+          'Per l’interazione in diretta in istruzione e organizzazioni: scuola, università, formazione continua, formazione, workshop, evento o riunione.',
       },
       {
         question: 'arsnova.eu è accessibile?',
@@ -447,32 +452,32 @@ const it: Messages = {
   },
   ctaSection: {
     title: 'Pronto per la prossima sessione in diretta?',
-    lead: 'Prova il flusso in diretta direttamente nell’app, oppure dai un’occhiata al codice sorgente aperto, alla logica Q&A, all’elaborazione della word cloud e al percorso di deployment e gestione dietro la piattaforma.',
+    lead: 'Prova il flusso in diretta direttamente nell’app, oppure dai un’occhiata al codice sorgente aperto, alla logica Q&A, all’elaborazione della nuvola di parole e alle basi tecniche per distribuzione e gestione della piattaforma.',
   },
   jsonLd: {
     websiteName: 'arsnova.eu – Informazioni',
     webAppDescription:
-      'Piattaforma open source di risposta interattiva per istruzione, formazione e organizzazioni: quiz in diretta, autovalutazione, rapporto dei risultati (PDF), domande di stima numerica, bacheca delle domande moderabile, word cloud e sondaggio rapido — conforme alle WCAG 2.2, livello AA, gratuita, self-hostabile e pronta senza account.',
+      'Piattaforma open source di risposta interattiva per istruzione, formazione e organizzazioni: quiz in diretta, autovalutazione, rapporto dei risultati (PDF), domande di stima numerica, bacheca delle domande moderabile, nuvola di parole e sondaggio rapido — conforme alle WCAG 2.2, livello AA, gratuita, eseguibile sulla propria infrastruttura e pronta senza account.',
     featureList: [
       'Quiz in diretta e votazioni',
       'Autovalutazione sulle domande valutate',
       'Rapporto dei risultati (PDF) e discussione dei risultati a fine sessione',
       'Domande di stima numerica con due turni e statistica',
       'Bacheca delle domande con moderazione, voti a favore e contro',
-      'Lobby, presentatore, QR/codice',
-      'Tipi di domanda MC/SC/risposta breve/testo libero/sondaggio/rating/stima numerica',
+      'Sala d’attesa, presentatore, QR/codice',
+      'Tipi di domanda MC/SC/risposta breve/testo libero/sondaggio/valutazione/stima numerica',
       'Markdown e KaTeX',
       'Fase di lettura e Peer Instruction',
-      'Word cloud Q&A e testo libero con frasi e pesatura',
+      'Nuvola di parole Q&A e testo libero con frasi e pesatura',
       'Ordinamento per supporto, accordo robusto e controversia',
-      'Modalità team e preset',
+      'Modalità a squadre e impostazioni predefinite',
       'Classifica, serie, codice bonus',
-      'Import/export e sync Yjs',
+      'Importazione/esportazione e sincronizzazione Yjs',
       'Import IA esterno, validato Zod',
       'Interfaccia in cinque lingue',
       'Conforme alle WCAG 2.2, livello AA',
-      'Self-host Docker e audit admin',
-      'Local-first e funzionamento orientato al GDPR',
+      'Esecuzione Docker sulla propria infrastruttura e registro di amministrazione',
+      'Contenuti del quiz conservati in locale e funzionamento orientato al GDPR',
     ],
   },
 };

--- a/apps/landing/src/i18n/types.ts
+++ b/apps/landing/src/i18n/types.ts
@@ -1,0 +1,206 @@
+/** Locale codes for info.arsnova.eu (aligned with the app). */
+export type Locale = 'de' | 'en' | 'fr' | 'it' | 'es';
+
+export interface NavMessages {
+  ariaLabel: string;
+  workflow: string;
+  estimate: string;
+  qa: string;
+  qaMobile: string;
+  features: string;
+  accessibility: string;
+  trust: string;
+  faq: string;
+  tryNow: string;
+  menuOpen: string;
+  menuClose: string;
+  menu: string;
+  skipToContent: string;
+}
+
+export interface LanguageSwitcherMessages {
+  label: string;
+  currentLanguage: string;
+  chooseLanguage: string;
+}
+
+export interface FooterMessages {
+  impressum: string;
+  privacy: string;
+  accessibility: string;
+}
+
+export interface MetaMessages {
+  homeTitle: string;
+  homeDescription: string;
+  siteNameInfo: string;
+  ogLocale: string;
+}
+
+export interface CtaMessages {
+  appOpen: string;
+  quizCreate: string;
+  backToApp: string;
+  tryLive: string;
+  howItWorks: string;
+  viewOpenSource: string;
+}
+
+export interface HeroMessages {
+  eyebrow: string;
+  titleLine1: string;
+  titleLine2: string;
+  titleAccent1: string;
+  titleAccent2: string;
+  lead: string;
+  a11yLink: string;
+  a11ySuffix: string;
+  cards: Array<{ title: string; text: string }>;
+}
+
+export interface EstimateMessages {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  summary: string[];
+  docsLink: string;
+  demoAria: string;
+  hostView: string;
+  demoQuestion: string;
+  reference: string;
+  toleranceBand: string;
+  toleranceValue: string;
+  plausibilityBand: string;
+  plausibilityValue: string;
+  histogramNote: string;
+  median: string;
+  inBand: string;
+  round2: string;
+  round2Value: string;
+}
+
+export interface ConfidenceMessages {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  summary: string[];
+  docsConfidence: string;
+  docsExport: string;
+  demoAria: string;
+  hostView: string;
+  demoQuestion: string;
+  badge: string;
+  matrix: Array<{ label: string; count: number; tone: 'emerald' | 'slate' | 'amber' | 'rose' }>;
+  falseHighTitle: string;
+  falseHighText: string;
+  consolidated: string;
+  misconceptionRisk: string;
+  fragile: string;
+  afterSessionAria: string;
+  afterSession: string;
+  debriefing: string;
+  resultsPdf: string;
+  exportNote: string;
+}
+
+export interface QaWallMessages {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  signals: Array<{ label: string; text: string }>;
+  docsLink: string;
+  demoAria: string;
+  hostView: string;
+  demoTitle: string;
+  moderationActive: string;
+  sortMostSupported: string;
+  sortBest: string;
+  sortControversial: string;
+  questions: Array<{ score: string; title: string; meta: string }>;
+  wordCloud: string;
+  wordCloudHint: string;
+  frozenLive: string;
+  terms: Array<{ label: string; className: string }>;
+  nextStep: string;
+}
+
+export interface WorkflowMessages {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  stepLabel: string;
+  steps: Array<{ number: string; title: string; description: string }>;
+}
+
+export interface FeaturesMessages {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  items: Array<{ title: string; description: string; icon: string }>;
+}
+
+export interface AccessibilityMessages {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  benefits: Array<{ title: string; description: string }>;
+  statementLink: string;
+}
+
+export interface TrustMessages {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  proofItems: Array<{ value: string; label: string }>;
+  items: Array<{ quote: string; source: string; tag: string }>;
+  referencesPrefix: string;
+  referencesLink: string;
+  referencesSuffix: string;
+}
+
+export interface ComparisonMessages {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  points: Array<{ title: string; description: string }>;
+  comparePrefix: string;
+  compareLink: string;
+}
+
+export interface FaqMessages {
+  eyebrow: string;
+  title: string;
+  answerLabel: string;
+  items: Array<{ question: string; answer: string; linkLabel?: string }>;
+}
+
+export interface CtaSectionMessages {
+  title: string;
+  lead: string;
+}
+
+export interface JsonLdMessages {
+  websiteName: string;
+  webAppDescription: string;
+  featureList: string[];
+}
+
+export interface Messages {
+  meta: MetaMessages;
+  nav: NavMessages;
+  languageSwitcher: LanguageSwitcherMessages;
+  footer: FooterMessages;
+  cta: CtaMessages;
+  hero: HeroMessages;
+  estimate: EstimateMessages;
+  confidence: ConfidenceMessages;
+  qaWall: QaWallMessages;
+  workflow: WorkflowMessages;
+  features: FeaturesMessages;
+  accessibility: AccessibilityMessages;
+  trust: TrustMessages;
+  comparison: ComparisonMessages;
+  faq: FaqMessages;
+  ctaSection: CtaSectionMessages;
+  jsonLd: JsonLdMessages;
+}

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -1,162 +1,245 @@
 ---
 import '@/styles/global.css';
-import { APP_ACCESSIBILITY_URL, APP_URL_V3, GITHUB_URL } from '@/config/github';
-import { homeMetaDescription, homeMetaTitle } from '@/config/seo';
-import { SITE_URL, toAbsoluteUrl } from '@/config/site';
+import LanguageSwitcher from '@/components/LanguageSwitcher.astro';
+import { appAccessibilityUrl, GITHUB_URL } from '@/config/github';
+import { toAbsoluteUrl } from '@/config/site';
+import {
+  getMessages,
+  getOgAlternateLocales,
+  isLocale,
+  LOCALES,
+  type Locale,
+} from '@/i18n';
 
 export interface Props {
-  title: string;
-  description: string;
-  canonical?: string;
+  locale: Locale;
+  title?: string;
+  description?: string;
+  canonicalPath?: string;
   noindex?: boolean;
+  /** When true, title is used as-is (legal pages). Otherwise home meta title is used for "home". */
+  isHome?: boolean;
 }
 
-const { title, description, canonical, noindex = false } = Astro.props;
-/** Base path für interne Links; auf der Custom Domain ist dies `/`. */
+const {
+  locale,
+  title,
+  description,
+  canonicalPath,
+  noindex = false,
+  isHome = false,
+} = Astro.props;
+
+if (!isLocale(locale)) {
+  throw new Error(`Invalid locale for BaseLayout: ${locale}`);
+}
+
+const t = getMessages(locale);
 const base = (typeof import.meta.env.BASE_URL === 'string' && import.meta.env.BASE_URL) || '/';
-const fullTitle = title === 'Start' ? homeMetaTitle : `${title} · arsnova.eu`;
-const url = canonical ? toAbsoluteUrl(canonical) : SITE_URL;
+const localeHome = `${base}${locale}/`.replace(/\/{2,}/g, '/');
+const fullTitle = isHome || !title ? t.meta.homeTitle : `${title} · arsnova.eu`;
+const metaDescription = description ?? t.meta.homeDescription;
+const path = canonicalPath ?? `/${locale}/`;
+const url = toAbsoluteUrl(path.startsWith('/') ? path.slice(1) : path);
 const ogImage = toAbsoluteUrl('og.png');
+const alternateLocales = getOgAlternateLocales(locale);
+const a11yUrl = appAccessibilityUrl(locale);
+const impressumHref = `${base}impressum/`.replace(/\/{2,}/g, '/');
+const privacyHref = `${base}datenschutz/`.replace(/\/{2,}/g, '/');
+
+const navItems = [
+  { href: `${localeHome}#workflow`, label: t.nav.workflow },
+  { href: `${localeHome}#numeric-estimate`, label: t.nav.estimate },
+  { href: `${localeHome}#qa-wall`, label: t.nav.qa, mobileLabel: t.nav.qaMobile },
+  { href: `${localeHome}#features`, label: t.nav.features },
+  { href: `${localeHome}#accessibility`, label: t.nav.accessibility },
+  { href: `${localeHome}#trust`, label: t.nav.trust },
+  { href: `${localeHome}#faq`, label: t.nav.faq },
+] as const;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      name: t.jsonLd.websiteName,
+      url: toAbsoluteUrl(`${locale}/`),
+      description: metaDescription,
+      inLanguage: locale,
+    },
+    {
+      '@type': 'WebApplication',
+      name: 'arsnova.eu',
+      description: t.jsonLd.webAppDescription,
+      url: `https://arsnova.eu/${locale}/`,
+      inLanguage: locale,
+      applicationCategory: 'EducationalApplication',
+      operatingSystem: 'Web',
+      offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+      featureList: t.jsonLd.featureList,
+    },
+  ],
+};
 ---
 
 <!doctype html>
-<html lang="de">
+<html lang={locale}>
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <title>{fullTitle}</title>
-    <meta name="description" content={description} />
+    <meta name="description" content={metaDescription} />
     {noindex ? <meta name="robots" content="noindex,nofollow" /> : null}
     <link rel="canonical" href={url} />
+
+    {
+      LOCALES.map((code) => (
+        <link rel="alternate" hreflang={code} href={toAbsoluteUrl(`${code}/`)} />
+      ))
+    }
+    <link rel="alternate" hreflang="x-default" href={toAbsoluteUrl('de/')} />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content={fullTitle} />
-    <meta property="og:description" content={description} />
+    <meta property="og:description" content={metaDescription} />
     <meta property="og:url" content={url} />
     <meta property="og:image" content={ogImage} />
-    <meta property="og:locale" content="de_DE" />
+    <meta property="og:locale" content={t.meta.ogLocale} />
+    {alternateLocales.map((ogLocale) => (
+      <meta property="og:locale:alternate" content={ogLocale} />
+    ))}
     <meta property="og:site_name" content="arsnova.eu" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={fullTitle} />
-    <meta name="twitter:description" content={description} />
+    <meta name="twitter:description" content={metaDescription} />
     <meta name="twitter:image" content={ogImage} />
 
-    <!-- Keine Google Fonts – System-Schriften, kein Tracking. -->
-
-    <!-- JSON-LD: Landing-Website und Live-Anwendung haben getrennte URLs. -->
-    <script is:inline type="application/ld+json" set:html={JSON.stringify({
-      '@context': 'https://schema.org',
-      '@graph': [
-        {
-          '@type': 'WebSite',
-          name: 'arsnova.eu – Informationen',
-          url: SITE_URL,
-          description: title === 'Start' ? homeMetaDescription : description,
-        },
-        {
-          '@type': 'WebApplication',
-          name: 'arsnova.eu',
-          description: homeMetaDescription,
-          url: APP_URL_V3,
-          applicationCategory: 'EducationalApplication',
-          operatingSystem: 'Web',
-          offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
-          featureList: [
-            'Live-Quiz und Abstimmungen',
-            'Selbsteinschätzung bei bewertbaren Fragen',
-            'Ergebnisbericht (PDF) und Nachbesprechung nach Session-Ende',
-            'Numerische Schätzfragen mit zwei Runden und Statistik',
-            'Q&A-Fragenwand mit Moderation, Up- und Downvoting',
-            'Lobby, Presenter, QR/Code',
-            'Fragetypen MC/SC/Kurzantwort/Freitext/Umfrage/Rating/Schätzfrage',
-            'Markdown und KaTeX',
-            'Lesephase und Peer Instruction',
-            'Q&A- und Freitext-Word-Cloud mit Phrasen und Gewichtung',
-            'Sortierung nach Unterstützung, belastbarer Zustimmung und Kontroverse',
-            'Team-Modus und Presets',
-            'Leaderboard, Streak, Bonus-Code',
-            'Import/Export und Yjs-Sync',
-            'KI-Import extern, Zod-validiert',
-            'UI in fünf Sprachen',
-            'Barrierefreiheit nach WCAG 2.2 AA',
-            'Docker Self-Host und Admin-Audit',
-            'Local-First und DSGVO-orientierter Betrieb',
-          ],
-        },
-      ],
-    })} />
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   </head>
   <body class="min-h-screen overflow-x-hidden bg-slate-900 text-slate-100 font-sans antialiased">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[60] focus:rounded-lg focus:bg-white focus:px-4 focus:py-2 focus:text-slate-950">
-      Zum Inhalt springen
+      {t.nav.skipToContent}
     </a>
     <header class="sticky top-0 z-50 border-b border-slate-700/80 bg-slate-900/95 backdrop-blur-sm" id="main-header">
-      <nav class="mx-auto max-w-6xl px-4 py-3 sm:px-6" aria-label="Hauptnavigation">
+      <nav class="mx-auto max-w-6xl px-4 py-3 sm:px-6" aria-label={t.nav.ariaLabel}>
         <div class="flex items-center justify-between gap-4">
-          <a href={base} class="inline-flex items-center gap-2 font-display text-xl font-bold tracking-tight text-white">
+          <a href={localeHome} class="inline-flex items-center gap-2 font-display text-xl font-bold tracking-tight text-white">
             <img src={`${base}favicon.svg`} alt="" class="h-7 w-7 shrink-0" width="28" height="28" />
             arsnova.eu
           </a>
-          <!-- Desktop: Links in einer Zeile -->
-          <div class="hidden items-center gap-6 lg:flex">
-            <a href={`${base}#ablauf`} class="inline-flex min-h-6 items-center px-1 text-sm font-medium text-slate-400 hover:text-white">Ablauf</a>
-            <a href={`${base}#schaetzfrage`} class="inline-flex min-h-6 items-center px-1 text-sm font-medium text-slate-400 hover:text-white">Schätzfrage</a>
-            <a href={`${base}#fragenwand`} class="inline-flex min-h-6 items-center px-1 text-sm font-medium text-slate-400 hover:text-white">Q&amp;A</a>
-            <a href={`${base}#features`} class="inline-flex min-h-6 items-center px-1 text-sm font-medium text-slate-400 hover:text-white">Vorteile</a>
-            <a href={`${base}#barrierefreiheit`} class="inline-flex min-h-6 items-center px-1 text-sm font-medium text-slate-400 hover:text-white">Barrierefreiheit</a>
-            <a href={`${base}#vertrauen`} class="inline-flex min-h-6 items-center px-1 text-sm font-medium text-slate-400 hover:text-white">Vertrauen</a>
-            <a href={`${base}#faq`} class="inline-flex min-h-6 items-center px-1 text-sm font-medium text-slate-400 hover:text-white">FAQ</a>
+          <div class="hidden items-center gap-4 xl:gap-5 lg:flex">
+            {navItems.map((item) => (
+              <a href={item.href} class="inline-flex min-h-6 items-center px-1 text-sm font-medium text-slate-400 hover:text-white">{item.label}</a>
+            ))}
             <a href={GITHUB_URL} class="inline-flex min-h-6 items-center px-1 text-sm font-medium text-slate-400 hover:text-white" target="_blank" rel="noopener noreferrer">GitHub</a>
-            <a href={`${base}#start`} class="rounded-lg bg-brand-700 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-600">Jetzt ausprobieren</a>
+            <LanguageSwitcher locale={locale} t={t} idPrefix="lang-desktop" />
+            <a href={`${localeHome}#start`} class="rounded-lg bg-brand-700 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-600">{t.nav.tryNow}</a>
           </div>
-          <!-- Mobile: Hamburger-Button -->
-          <button
-            type="button"
-            class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-slate-400 hover:bg-slate-800 hover:text-white lg:hidden"
-            aria-expanded="false"
-            aria-controls="nav-menu"
-            aria-label="Menü öffnen"
-            id="nav-toggle"
-          >
-            <span class="sr-only">Menü</span>
-            <svg class="h-6 w-6 menu-icon-open" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-            </svg>
-            <svg class="h-6 w-6 hidden menu-icon-close" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <div class="flex items-center gap-2 lg:hidden">
+            <LanguageSwitcher locale={locale} t={t} idPrefix="lang-mobile" />
+            <button
+              type="button"
+              class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-slate-400 hover:bg-slate-800 hover:text-white"
+              aria-expanded="false"
+              aria-controls="nav-menu"
+              aria-label={t.nav.menuOpen}
+              id="nav-toggle"
+              data-label-open={t.nav.menuOpen}
+              data-label-close={t.nav.menuClose}
+            >
+              <span class="sr-only">{t.nav.menu}</span>
+              <svg class="h-6 w-6 menu-icon-open" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+              </svg>
+              <svg class="h-6 w-6 hidden menu-icon-close" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
         </div>
-        <!-- Mobile: ausklappbares Menü -->
         <ul id="nav-menu" class="hidden flex flex-col gap-1 border-t border-slate-700 pt-4 lg:hidden">
-          <li><a href={`${base}#ablauf`} class="block min-h-11 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-400 hover:bg-slate-800 hover:text-white">Ablauf</a></li>
-          <li><a href={`${base}#schaetzfrage`} class="block min-h-11 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-400 hover:bg-slate-800 hover:text-white">Schätzfrage</a></li>
-          <li><a href={`${base}#fragenwand`} class="block min-h-11 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-400 hover:bg-slate-800 hover:text-white">Q&amp;A-Fragenwand</a></li>
-          <li><a href={`${base}#features`} class="block min-h-11 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-400 hover:bg-slate-800 hover:text-white">Vorteile</a></li>
-          <li><a href={`${base}#barrierefreiheit`} class="block min-h-11 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-400 hover:bg-slate-800 hover:text-white">Barrierefreiheit</a></li>
-          <li><a href={`${base}#vertrauen`} class="block min-h-11 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-400 hover:bg-slate-800 hover:text-white">Vertrauen</a></li>
-          <li><a href={`${base}#faq`} class="block min-h-11 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-400 hover:bg-slate-800 hover:text-white">FAQ</a></li>
+          {navItems.map((item) => (
+            <li>
+              <a href={item.href} class="block min-h-11 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-400 hover:bg-slate-800 hover:text-white">
+                {'mobileLabel' in item && item.mobileLabel ? item.mobileLabel : item.label}
+              </a>
+            </li>
+          ))}
           <li><a href={GITHUB_URL} class="block min-h-11 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-400 hover:bg-slate-800 hover:text-white" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href={`${base}#start`} class="mt-2 block min-h-11 rounded-lg bg-brand-700 px-3 py-2.5 text-sm font-semibold text-white hover:bg-brand-600">Jetzt ausprobieren</a></li>
+          <li><a href={`${localeHome}#start`} class="mt-2 block min-h-11 rounded-lg bg-brand-700 px-3 py-2.5 text-sm font-semibold text-white hover:bg-brand-600">{t.nav.tryNow}</a></li>
         </ul>
       </nav>
     </header>
     <script is:inline>
       (function () {
+        var ALIASES = {
+          ablauf: 'workflow',
+          schaetzfrage: 'numeric-estimate',
+          selbsteinschaetzung: 'confidence',
+          fragenwand: 'qa-wall',
+          barrierefreiheit: 'accessibility',
+          vertrauen: 'trust',
+          vergleich: 'comparison'
+        };
+
+        function canonicalizeHash(hash) {
+          if (!hash) return '';
+          var raw = hash.charAt(0) === '#' ? hash.slice(1) : hash;
+          if (!raw) return '';
+          return '#' + (ALIASES[raw] || raw);
+        }
+
+        document.querySelectorAll('[data-language-switcher]').forEach(function (root) {
+          var button = root.querySelector('button');
+          var menu = root.querySelector('[data-lang-menu]');
+          if (!button || !menu) return;
+
+          function setOpen(open) {
+            menu.classList.toggle('hidden', !open);
+            button.setAttribute('aria-expanded', open ? 'true' : 'false');
+          }
+
+          button.addEventListener('click', function (event) {
+            event.stopPropagation();
+            setOpen(menu.classList.contains('hidden'));
+          });
+
+          menu.querySelectorAll('a[data-locale-link]').forEach(function (link) {
+            link.addEventListener('click', function () {
+              var code = link.getAttribute('data-locale-link');
+              var hash = canonicalizeHash(window.location.hash || '');
+              link.setAttribute('href', '/' + code + '/' + hash);
+            });
+          });
+
+          document.addEventListener('click', function (event) {
+            if (!root.contains(event.target)) setOpen(false);
+          });
+
+          document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape') {
+              setOpen(false);
+              button.focus();
+            }
+          });
+        });
+
         var toggle = document.getElementById('nav-toggle');
         var menu = document.getElementById('nav-menu');
         var openIcon = document.querySelector('.menu-icon-open');
         var closeIcon = document.querySelector('.menu-icon-close');
         if (!toggle || !menu) return;
+        var labelOpen = toggle.getAttribute('data-label-open') || 'Open menu';
+        var labelClose = toggle.getAttribute('data-label-close') || 'Close menu';
         toggle.addEventListener('click', function () {
           var open = menu.classList.toggle('hidden');
           toggle.setAttribute('aria-expanded', open ? 'false' : 'true');
-          toggle.setAttribute('aria-label', open ? 'Menü öffnen' : 'Menü schließen');
+          toggle.setAttribute('aria-label', open ? labelOpen : labelClose);
           if (openIcon && closeIcon) {
             openIcon.classList.toggle('hidden', !open);
             closeIcon.classList.toggle('hidden', open);
@@ -166,7 +249,7 @@ const ogImage = toAbsoluteUrl('og.png');
           a.addEventListener('click', function () {
             menu.classList.add('hidden');
             toggle.setAttribute('aria-expanded', 'false');
-            toggle.setAttribute('aria-label', 'Menü öffnen');
+            toggle.setAttribute('aria-label', labelOpen);
             if (openIcon && closeIcon) {
               openIcon.classList.remove('hidden');
               closeIcon.classList.add('hidden');
@@ -185,10 +268,10 @@ const ogImage = toAbsoluteUrl('og.png');
         <div class="flex flex-col items-center justify-between gap-4 sm:flex-row">
           <p class="text-sm text-slate-400">© {new Date().getFullYear()} arsnova.eu · Open Source · MIT</p>
           <div class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
-            <a href={`${base}impressum/`} class="inline-flex min-h-6 items-center px-1 text-sm text-slate-400 hover:text-slate-200">Impressum</a>
-            <a href={`${base}datenschutz/`} class="inline-flex min-h-6 items-center px-1 text-sm text-slate-400 hover:text-slate-200">Datenschutz</a>
-            <a href={APP_ACCESSIBILITY_URL} class="inline-flex min-h-6 items-center px-1 text-sm text-slate-400 hover:text-slate-200">Barrierefreiheit</a>
-            <a href={GITHUB_URL} class="inline-flex min-h-6 items-center px-1 text-sm text-slate-400 hover:text-slate-200" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a href={impressumHref} class="inline-flex min-h-11 items-center px-1 text-sm text-slate-400 hover:text-slate-200">{t.footer.impressum}</a>
+            <a href={privacyHref} class="inline-flex min-h-11 items-center px-1 text-sm text-slate-400 hover:text-slate-200">{t.footer.privacy}</a>
+            <a href={a11yUrl} class="inline-flex min-h-11 items-center px-1 text-sm text-slate-400 hover:text-slate-200">{t.footer.accessibility}</a>
+            <a href={GITHUB_URL} class="inline-flex min-h-11 items-center px-1 text-sm text-slate-400 hover:text-slate-200" target="_blank" rel="noopener noreferrer">GitHub</a>
           </div>
         </div>
       </div>

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -208,23 +208,29 @@ const jsonLd = {
           if (!button || !menu) return;
           var baseUrl = root.getAttribute('data-base-url') || '/';
           if (baseUrl.charAt(baseUrl.length - 1) !== '/') baseUrl += '/';
+          var links = menu.querySelectorAll('a[data-locale-link]');
+
+          function syncLocaleHrefs() {
+            var hash = canonicalizeHash(window.location.hash || '');
+            links.forEach(function (link) {
+              var code = link.getAttribute('data-locale-link');
+              if (!code) return;
+              link.setAttribute('href', baseUrl + code + '/' + hash);
+            });
+          }
 
           function setOpen(open) {
             menu.classList.toggle('hidden', !open);
             button.setAttribute('aria-expanded', open ? 'true' : 'false');
           }
 
+          syncLocaleHrefs();
+          window.addEventListener('hashchange', syncLocaleHrefs);
+
           button.addEventListener('click', function (event) {
             event.stopPropagation();
+            syncLocaleHrefs();
             setOpen(menu.classList.contains('hidden'));
-          });
-
-          menu.querySelectorAll('a[data-locale-link]').forEach(function (link) {
-            link.addEventListener('click', function () {
-              var code = link.getAttribute('data-locale-link');
-              var hash = canonicalizeHash(window.location.hash || '');
-              link.setAttribute('href', baseUrl + code + '/' + hash);
-            });
           });
 
           document.addEventListener('click', function (event) {

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -95,11 +95,15 @@ const jsonLd = {
     <link rel="canonical" href={url} />
 
     {
-      LOCALES.map((code) => (
-        <link rel="alternate" hreflang={code} href={toAbsoluteUrl(`${code}/`)} />
-      ))
+      isHome ? (
+        <>
+          {LOCALES.map((code) => (
+            <link rel="alternate" hreflang={code} href={toAbsoluteUrl(`${code}/`)} />
+          ))}
+          <link rel="alternate" hreflang="x-default" href={toAbsoluteUrl('de/')} />
+        </>
+      ) : null
     }
-    <link rel="alternate" hreflang="x-default" href={toAbsoluteUrl('de/')} />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
@@ -108,9 +112,13 @@ const jsonLd = {
     <meta property="og:url" content={url} />
     <meta property="og:image" content={ogImage} />
     <meta property="og:locale" content={t.meta.ogLocale} />
-    {alternateLocales.map((ogLocale) => (
-      <meta property="og:locale:alternate" content={ogLocale} />
-    ))}
+    {
+      isHome
+        ? alternateLocales.map((ogLocale) => (
+            <meta property="og:locale:alternate" content={ogLocale} />
+          ))
+        : null
+    }
     <meta property="og:site_name" content="arsnova.eu" />
 
     <!-- Twitter -->
@@ -198,6 +206,8 @@ const jsonLd = {
           var button = root.querySelector('button');
           var menu = root.querySelector('[data-lang-menu]');
           if (!button || !menu) return;
+          var baseUrl = root.getAttribute('data-base-url') || '/';
+          if (baseUrl.charAt(baseUrl.length - 1) !== '/') baseUrl += '/';
 
           function setOpen(open) {
             menu.classList.toggle('hidden', !open);
@@ -213,7 +223,7 @@ const jsonLd = {
             link.addEventListener('click', function () {
               var code = link.getAttribute('data-locale-link');
               var hash = canonicalizeHash(window.location.hash || '');
-              link.setAttribute('href', '/' + code + '/' + hash);
+              link.setAttribute('href', baseUrl + code + '/' + hash);
             });
           });
 
@@ -222,10 +232,10 @@ const jsonLd = {
           });
 
           document.addEventListener('keydown', function (event) {
-            if (event.key === 'Escape') {
-              setOpen(false);
-              button.focus();
-            }
+            if (event.key !== 'Escape') return;
+            var wasOpen = !menu.classList.contains('hidden');
+            setOpen(false);
+            if (wasOpen) button.focus();
           });
         });
 

--- a/apps/landing/src/pages/[locale]/index.astro
+++ b/apps/landing/src/pages/[locale]/index.astro
@@ -1,0 +1,40 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import Hero from '../../components/Hero.astro';
+import EstimateSpotlight from '../../components/EstimateSpotlight.astro';
+import ConfidenceSpotlight from '../../components/ConfidenceSpotlight.astro';
+import QaWallSpotlight from '../../components/QaWallSpotlight.astro';
+import Workflow from '../../components/Workflow.astro';
+import Features from '../../components/Features.astro';
+import Accessibility from '../../components/Accessibility.astro';
+import Trust from '../../components/Trust.astro';
+import Comparison from '../../components/Comparison.astro';
+import Faq from '../../components/Faq.astro';
+import Cta from '../../components/Cta.astro';
+import { getMessages, isLocale, LOCALES, type Locale } from '@/i18n';
+
+export function getStaticPaths() {
+  return LOCALES.map((locale) => ({ params: { locale } }));
+}
+
+const { locale: localeParam } = Astro.params;
+if (!localeParam || !isLocale(localeParam)) {
+  throw new Error(`Unsupported locale route: ${localeParam}`);
+}
+const locale = localeParam as Locale;
+const t = getMessages(locale);
+---
+
+<BaseLayout locale={locale} isHome canonicalPath={`/${locale}/`}>
+  <Hero locale={locale} t={t} />
+  <EstimateSpotlight locale={locale} t={t} />
+  <ConfidenceSpotlight locale={locale} t={t} />
+  <QaWallSpotlight locale={locale} t={t} />
+  <Workflow locale={locale} t={t} />
+  <Features locale={locale} t={t} />
+  <Accessibility locale={locale} t={t} />
+  <Trust locale={locale} t={t} />
+  <Comparison locale={locale} t={t} />
+  <Faq locale={locale} t={t} />
+  <Cta locale={locale} t={t} />
+</BaseLayout>

--- a/apps/landing/src/pages/datenschutz.astro
+++ b/apps/landing/src/pages/datenschutz.astro
@@ -4,11 +4,12 @@ import { legal, site } from '../config/legal';
 ---
 
 <BaseLayout
+  locale="de"
   title="Datenschutz"
   description="Datenschutzerklärung für arsnova.eu – Informationen zur Verarbeitung personenbezogener Daten."
-  canonical="/datenschutz/"
+  canonicalPath="/datenschutz/"
 >
-  <article class="mx-auto max-w-3xl px-4 py-16 sm:px-6">
+  <article class="mx-auto max-w-3xl px-4 py-16 sm:px-6" lang="de">
     <h1 class="font-display text-3xl font-bold text-white">Datenschutzerklärung</h1>
     <p class="mt-2 text-slate-400">Informationen gemäß Art. 13 und 14 DSGVO</p>
 

--- a/apps/landing/src/pages/impressum.astro
+++ b/apps/landing/src/pages/impressum.astro
@@ -4,11 +4,12 @@ import { legal, site } from '../config/legal';
 ---
 
 <BaseLayout
+  locale="de"
   title="Impressum"
   description="Impressum und Anbieterkennzeichnung für arsnova.eu."
-  canonical="/impressum/"
+  canonicalPath="/impressum/"
 >
-  <article class="mx-auto max-w-3xl px-4 py-16 sm:px-6">
+  <article class="mx-auto max-w-3xl px-4 py-16 sm:px-6" lang="de">
     <h1 class="font-display text-3xl font-bold text-white">Impressum</h1>
     <p class="mt-2 text-slate-400">Angaben gemäß § 5 DDG</p>
 

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -1,6 +1,31 @@
 ---
 /**
- * Placeholder required by Astro when `redirectToDefaultLocale` + `prefixDefaultLocale`
- * are enabled. Astro generates the `/` → `/de/` redirect from this route.
+ * Root compatibility entry: redirect to the default locale while preserving
+ * legacy client-side fragments (e.g. `/#schaetzfrage` → `/de/#schaetzfrage`).
+ * Astro's static i18n redirect cannot carry `window.location.hash`, so this
+ * page owns the root route instead of `redirectToDefaultLocale`.
  */
+const base = (typeof import.meta.env.BASE_URL === 'string' && import.meta.env.BASE_URL) || '/';
+const defaultLocaleHome = `${base}de/`.replace(/\/{2,}/g, '/');
 ---
+
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>arsnova.eu</title>
+    <meta http-equiv="refresh" content={`0;url=${defaultLocaleHome}`} />
+    <script is:inline define:vars={{ defaultLocaleHome }}>
+      (function () {
+        var target = defaultLocaleHome + (window.location.hash || '');
+        window.location.replace(target);
+      })();
+    </script>
+  </head>
+  <body>
+    <p>
+      <a href={defaultLocaleHome}>Weiter zur deutschen Startseite / Continue to German homepage</a>
+    </p>
+  </body>
+</html>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -1,32 +1,6 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import { homeMetaDescription } from '@/config/seo';
-import Hero from '../components/Hero.astro';
-import EstimateSpotlight from '../components/EstimateSpotlight.astro';
-import ConfidenceSpotlight from '../components/ConfidenceSpotlight.astro';
-import QaWallSpotlight from '../components/QaWallSpotlight.astro';
-import Workflow from '../components/Workflow.astro';
-import Features from '../components/Features.astro';
-import Accessibility from '../components/Accessibility.astro';
-import Trust from '../components/Trust.astro';
-import Comparison from '../components/Comparison.astro';
-import Faq from '../components/Faq.astro';
-import Cta from '../components/Cta.astro';
+/**
+ * Placeholder required by Astro when `redirectToDefaultLocale` + `prefixDefaultLocale`
+ * are enabled. Astro generates the `/` → `/de/` redirect from this route.
+ */
 ---
-
-<BaseLayout
-  title="Start"
-  description={homeMetaDescription}
->
-  <Hero />
-  <EstimateSpotlight />
-  <ConfidenceSpotlight />
-  <QaWallSpotlight />
-  <Workflow />
-  <Features />
-  <Accessibility />
-  <Trust />
-  <Comparison />
-  <Faq />
-  <Cta />
-</BaseLayout>

--- a/apps/landing/src/pages/sitemap.xml.ts
+++ b/apps/landing/src/pages/sitemap.xml.ts
@@ -1,24 +1,27 @@
 import type { APIRoute } from 'astro';
 
 import { toAbsoluteUrl } from '@/config/site';
+import { LOCALES } from '@/i18n';
 
 export const prerender = true;
 
-const pages = [
-  { path: '', lastmod: '2026-07-27', changefreq: 'weekly', priority: '1.0' },
+const legalPages = [
   { path: 'impressum/', lastmod: '2026-07-19', changefreq: 'monthly', priority: '0.5' },
   { path: 'datenschutz/', lastmod: '2026-07-19', changefreq: 'monthly', priority: '0.5' },
 ];
 
 export const GET: APIRoute = () => {
-  const urls = pages
-    .map(
-      (page) =>
-        `<url><loc>${toAbsoluteUrl(page.path)}</loc><lastmod>${page.lastmod}</lastmod><changefreq>${page.changefreq}</changefreq><priority>${page.priority}</priority></url>`,
-    )
-    .join('');
+  const localeUrls = LOCALES.map(
+    (locale) =>
+      `<url><loc>${toAbsoluteUrl(`${locale}/`)}</loc><lastmod>2026-08-01</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>`,
+  );
 
-  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`;
+  const legalUrls = legalPages.map(
+    (page) =>
+      `<url><loc>${toAbsoluteUrl(page.path)}</loc><lastmod>${page.lastmod}</lastmod><changefreq>${page.changefreq}</changefreq><priority>${page.priority}</priority></url>`,
+  );
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${[...localeUrls, ...legalUrls].join('')}</urlset>`;
 
   return new Response(body, {
     headers: {


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** `info.arsnova.eu` war nur deutsch und aus der App kaum auffindbar; Landing, Hilfe und App-Rollen überschnitten sich unklar. Zusätzlich fehlte ein abschließendes idiomatisches Lektorat aller fünf Fassungen.
- **Lösung:** Landingpage in `de/en/fr/it/es` mit typisierten Dictionaries, Sprachumschalter, kanonischen Deep Links sowie locale-sicheren Verweisen aus Footer, Home, Hilfe, Quiz-Edit und Session-Host; vollständiger redaktioneller Durchgang gemäß Issue #194.
- **Bewusste Nicht-Ziele:** Kein CMS, keine Auto-Übersetzung, kein MOTD-Dauerwerbung, kein Session-/Teilnahme-Flow-Redesign, keine vollständige Hilfe-Neustrukturierung, keine Design-/Anker-/Routen-Änderung im Lektorat.

Closes #192
Closes #194

## Risiko und Verträge

- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

- Issue #192 (Rollen: App nutzen / Hilfe bedienen / Landing Nutzen & Vertrauen)
- Issue #194 (vollständiges idiomatisches Lektorat DE/EN/FR/IT/ES inkl. Reststellenliste)
- ADR-0008 / `docs/I18N-ANGULAR.md` für App-i18n; Astro-i18n für Landing
- Keine Landingpage-Hinweise in Beitritt, Abstimmung oder laufender Session

**Betroffene externe Verträge:**

- Öffentliche URLs `https://info.arsnova.eu/{locale}/` inkl. kanonischer Anker und Legacy-Hash-Aliases
- Externe App-Links: `target="_blank"`, `rel="noopener noreferrer"`, zugänglicher „öffnet in neuem Tab“-Hinweis

## Implementierung

- Astro-i18n mit Prefixen `/de/`…`/es/`, Root-Redirect nach `/de/`
- Gemeinsame Landing-Komponenten + typisierte Dictionaries unter `apps/landing/src/i18n/`
- Disclosure-Sprachumschalter ohne `aria-haspopup`; Hash bereits im DOM-`href`
- App-Links: Q&A-Info nur Lobby; Confidence-Info nach Export-Aktionen
- Footer „Was arsnova.eu kann“: externes Icon als Material-Trailing-Icon (`iconPositionEnd`)
- Issue #194: linearer redaktioneller Durchgang aller fünf Dictionaries inkl. Meta/ARIA/FAQ/JSON-LD; Matrix/Runde-2/WCAG und Fachterminologie geschützt; ES durchgängig `en directo`
- Landing-Checks: `test:i18n` und `test:language-switcher` (String-Smoke nur nach redaktioneller Freigabe aktualisiert; kein alleiniger Qualitätsnachweis)

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| Pre-commit `typecheck` + `npm test` (`dafdab4b`) | grün (Frontend 1113 Tests) |
| `npm run build -w @arsnova/landing` | grün |
| `npm run test:i18n -w @arsnova/landing` | grün |
| `npm run check -w @arsnova/landing` | grün (0/0/0) |
| Footer Trailing-Icon-Test | grün |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [ ] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Neue mehrsprachige Landing-Routen und zusätzliche externe Links in der App; kein Session-/Vote-Pfad geändert.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Landing wie bisher deployen; Domain `info.arsnova.eu` muss die neuen Locale-Pfade ausliefern.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Metriken.
- **Rollback:** Branch/PR revertieren; Landing auf vorherigen Build zurücksetzen.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Issue #192 Spezifikation und Issue #194 Lektoratsvorgaben inkl. Reststellenliste
- `dafdab4b`: redaktioneller Durchgang DE/EN/FR/IT/ES; alle genannten Reststellen und sinngleiche Varianten; Footer-Icon-Ausrichtung
- Automatisierte String-Smokes sichern freigegebene Phrasen ab, ersetzen aber keine menschliche Sprachabnahme

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Kein Realtime-/Migrations-/Lastpfad; `build:prod`/`build:localize` nicht erneut ausgeführt.
- **Verbleibende Risiken:** Menschliche sprachliche Abnahme bleibt maßgeblich.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft