### PR TITLE
fix(a11y): Footer-Overflow, Badges und Fokus nach MOTD/Content-Seiten

### DIFF
--- a/apps/frontend/src/app/app.component.html
+++ b/apps/frontend/src/app/app.component.html
@@ -176,7 +176,7 @@
                 i18n-aria-label="@@app.footer.helpOpenAria"
                 aria-label="So funktioniert’s"
               >
-                <mat-icon class="app-footer__icon">menu_book</mat-icon>
+                <mat-icon class="app-footer__icon" aria-hidden="true">menu_book</mat-icon>
                 <span class="app-footer__link-text" i18n="@@app.footer.help"
                   >So funktioniert’s</span
                 >
@@ -190,7 +190,7 @@
                 i18n-aria-label="@@app.footer.infoLandingAria"
                 aria-label="Was arsnova.eu kann (öffnet in neuem Tab)"
               >
-                <mat-icon class="app-footer__icon">info</mat-icon>
+                <mat-icon class="app-footer__icon" aria-hidden="true">info</mat-icon>
                 <span class="app-footer__link-text" i18n="@@app.footer.infoLanding"
                   >Was arsnova.eu kann</span
                 >
@@ -208,7 +208,7 @@
                 i18n-aria-label="@@app.footer.imprintOpenAria"
                 aria-label="Impressum"
               >
-                <mat-icon class="app-footer__icon">gavel</mat-icon>
+                <mat-icon class="app-footer__icon" aria-hidden="true">gavel</mat-icon>
                 <span class="app-footer__link-text" i18n>Impressum</span>
               </a>
               <a
@@ -218,7 +218,7 @@
                 i18n-aria-label="@@app.footer.privacyOpenAria"
                 aria-label="Datenschutz"
               >
-                <mat-icon class="app-footer__icon">privacy_tip</mat-icon>
+                <mat-icon class="app-footer__icon" aria-hidden="true">privacy_tip</mat-icon>
                 <span class="app-footer__link-text" i18n>Datenschutz</span>
               </a>
               <a
@@ -228,7 +228,7 @@
                 i18n-aria-label="@@app.footer.accessibilityOpenAria"
                 aria-label="Barrierefreiheit"
               >
-                <mat-icon class="app-footer__icon">accessibility</mat-icon>
+                <mat-icon class="app-footer__icon" aria-hidden="true">accessibility</mat-icon>
                 <span class="app-footer__link-text" i18n="@@app.footer.accessibility"
                   >Barrierefreiheit</span
                 >

--- a/apps/frontend/src/app/app.component.html
+++ b/apps/frontend/src/app/app.component.html
@@ -150,18 +150,19 @@
               <a
                 matButton
                 class="app-footer__link--news-archive"
+                data-footer-focus="footer-news-archive"
                 [routerLink]="localizedPath('/news-archive')"
                 [attr.aria-label]="footerNewsArchiveAria()"
               >
-                <!-- prettier-ignore -->
                 <mat-icon
                   class="app-footer__icon"
                   aria-hidden="true"
                   [matBadge]="footerNewsArchiveBadgeText()"
                   [matBadgeHidden]="motdHeaderState.archiveUnreadCount() === 0"
-                  [matBadgeOverlap]="false"
-                  matBadgePosition="before"
-                >newspaper</mat-icon>
+                  matBadgePosition="above after"
+                  matBadgeOverlap
+                  >newspaper</mat-icon
+                >
                 <span class="app-footer__link-text" i18n="@@app.footer.newsArchive"
                   >News-Archiv</span
                 >
@@ -170,6 +171,7 @@
             @if (footerShowOnlineOnlyLinks()) {
               <a
                 matButton
+                data-footer-focus="footer-help"
                 [routerLink]="localizedPath('/help')"
                 i18n-aria-label="@@app.footer.helpOpenAria"
                 aria-label="So funktioniert’s"
@@ -199,16 +201,29 @@
                   >open_in_new</mat-icon
                 >
               </a>
-              <a matButton [routerLink]="localizedPath('/legal/imprint')">
+              <a
+                matButton
+                data-footer-focus="footer-imprint"
+                [routerLink]="localizedPath('/legal/imprint')"
+                i18n-aria-label="@@app.footer.imprintOpenAria"
+                aria-label="Impressum"
+              >
                 <mat-icon class="app-footer__icon">gavel</mat-icon>
                 <span class="app-footer__link-text" i18n>Impressum</span>
               </a>
-              <a matButton [routerLink]="localizedPath('/legal/privacy')">
+              <a
+                matButton
+                data-footer-focus="footer-privacy"
+                [routerLink]="localizedPath('/legal/privacy')"
+                i18n-aria-label="@@app.footer.privacyOpenAria"
+                aria-label="Datenschutz"
+              >
                 <mat-icon class="app-footer__icon">privacy_tip</mat-icon>
                 <span class="app-footer__link-text" i18n>Datenschutz</span>
               </a>
               <a
                 matButton
+                data-footer-focus="footer-accessibility"
                 [routerLink]="localizedPath('/legal/accessibility')"
                 i18n-aria-label="@@app.footer.accessibilityOpenAria"
                 aria-label="Barrierefreiheit"

--- a/apps/frontend/src/app/app.component.scss
+++ b/apps/frontend/src/app/app.component.scss
@@ -79,7 +79,11 @@
   width: 100%;
 }
 
-/* Skip-Link: visuell versteckt, kein Layout-Platz, nur bei Fokus sichtbar (Tab-Navigation). */
+/*
+ * Skip-Link: visuell aus dem Viewport, bei Fokus sichtbar.
+ * Kein clip/clip-path — beides kann den Link in Chromium/WebKit aus der
+ * sequentiellen Tab-Reihenfolge entfernen.
+ */
 .app-skip-link {
   position: absolute;
   top: 0.5rem;
@@ -91,36 +95,23 @@
   font: var(--mat-sys-label-large);
   border-radius: var(--mat-sys-corner-small);
   text-decoration: none;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  border: 0;
   white-space: nowrap;
-  transition:
-    clip-path 0.2s ease,
-    width 0.2s ease,
-    height 0.2s ease,
-    padding 0.2s ease,
-    margin 0.2s ease;
+  border: 0;
+  transform: translateY(calc(-100% - 1rem));
+  transition: transform 0.2s ease;
 }
 
 .app-skip-link:focus,
 .app-skip-link:focus-visible {
-  clip: auto;
-  clip-path: none;
-  width: auto;
-  height: auto;
-  margin: 0;
+  transform: none;
   outline: 2px solid var(--mat-sys-on-primary);
   outline-offset: 2px;
 }
 
 .app-footer {
   flex: 0 0 auto;
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 1rem;
+  padding-bottom: max(0.5rem, env(safe-area-inset-bottom, 0px));
   border-top: 1px solid var(--mat-sys-outline-variant);
   background: var(--mat-sys-surface-container-low);
   /* Für Overlays (z. B. Vote-Countdown-Finger): an Oberkante ausrichten */
@@ -244,7 +235,8 @@
 }
 
 .app-footer__inner {
-  max-width: 56rem;
+  width: 100%;
+  max-width: 72rem;
   margin-inline: auto;
   display: flex;
   flex-direction: row;
@@ -258,15 +250,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-}
-
-@media (min-width: 600px) {
-  .app-footer__inner {
-    justify-content: center;
-  }
-  .app-footer__row {
-    justify-content: center;
-  }
+  min-width: 0;
 }
 
 .app-footer__copy {
@@ -277,10 +261,20 @@
 .app-footer__links {
   display: flex;
   align-items: center;
-  justify-content: center;
+  /*
+   * Ohne `safe` clippt `center` + overflow die linken Items (News-Archiv im Portrait).
+   * Fallback: Start, damit das Archiv immer erreichbar bleibt.
+   */
+  justify-content: flex-start;
+  justify-content: safe center;
   flex-wrap: nowrap;
-  gap: 0.375rem;
+  gap: 0.25rem;
   width: 100%;
+  min-width: 0;
+  /* Innenabstand, damit MD3-Overlap-Badges nicht an overflow-x:auto geclippt werden. */
+  padding-block: 0.375rem;
+  padding-inline: 0.125rem;
+  margin-block: -0.375rem;
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
@@ -302,11 +296,24 @@
   font: var(--mat-sys-body-small);
 }
 
-/* Icon + Text: gleiche Abstände für alle Footer-Links (News-Archiv jetzt auch: Icon | gap | Label). */
+/* Desktop/Tablet: Icon + Label in einer Zeile, kein Umbruch; bei Bedarf horizontal scrollen. */
+.app-footer__links > .mat-mdc-button-base {
+  flex: 0 0 auto;
+  min-width: auto;
+  white-space: nowrap;
+  --mat-button-text-container-height: 2.5rem;
+  --mat-button-text-horizontal-padding: 0.625rem;
+}
+
 .app-footer__links .mat-mdc-button-base .mdc-button__label {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
+  white-space: nowrap;
+}
+
+.app-footer__link-text {
+  white-space: nowrap;
 }
 
 .app-footer__icon {
@@ -314,27 +321,106 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.125rem;
-  width: 1.125rem;
-  height: 1.125rem;
+  font-size: 1.25rem;
+  width: 1.25rem;
+  height: 1.25rem;
   line-height: 1;
 }
 
-/* Trailing external affordance: Material icon-offset/spacing zurücknehmen (Footer nutzt eigenes Gap). */
 .app-footer__links .mat-mdc-button-base .app-footer__icon--external {
   margin-inline: 0;
+  font-size: 1rem;
+  width: 1rem;
+  height: 1rem;
 }
 
-/* Schmale Viewports: nur Icons (Text per Clip aus dem sichtbaren Layout, bleibt für Screenreader). */
-@media (max-width: 599px) {
-  .app-footer__links {
-    justify-content: flex-start;
-    gap: 0.125rem;
+/* MD3: Badge am Icon mit Overlap; Platz bis zum Label, damit „N“ frei bleibt. */
+.app-footer__link--news-archive,
+.app-footer__link--news-archive .app-footer__icon.mat-badge {
+  overflow: visible;
+}
+
+.app-footer__link--news-archive .app-footer__icon.mat-badge:not(.mat-badge-hidden) {
+  margin-inline-end: 0.75rem;
+}
+
+.app-footer__status-action {
+  flex: 0 0 auto;
+  min-width: auto;
+  padding-inline: 0.5rem;
+}
+
+.app-footer__status-widget {
+  flex: 0 0 auto;
+}
+
+/*
+ * Compact (Phone + Tablet-Portrait, inkl. iPad Air 820px): Icon-Tab-Leiste,
+ * damit alle Items ohne horizontalen Scroll sichtbar bleiben.
+ * Ab 960px: Icon + Label. Sync-Breakpoint mit server-status-widget.
+ */
+@media (max-width: 959px) {
+  .app-footer {
+    padding: 0.25rem 0.25rem max(0.25rem, env(safe-area-inset-bottom, 0px));
   }
 
+  .app-footer__inner {
+    max-width: none;
+  }
+
+  .app-footer__links {
+    justify-content: space-between;
+    gap: 0;
+    overflow: visible;
+    min-height: 3rem;
+  }
+
+  .app-footer__links > .mat-mdc-button-base,
   .app-footer__status-action,
   .app-footer__status-widget {
-    flex: 0 0 auto;
+    flex: 1 1 0;
+    min-width: 0;
+    max-width: none;
+    height: 3rem;
+    margin: 0;
+    padding: 0;
+    border-radius: var(--mat-sys-corner-medium);
+    justify-content: center;
+    align-items: center;
+    overflow: visible;
+    --mat-button-text-container-height: 3rem;
+    --mat-button-text-horizontal-padding: 0;
+  }
+
+  .app-footer__links > .mat-mdc-button-base {
+    min-width: 0;
+  }
+
+  /*
+   * Label aus dem Flex-Flow nehmen (Icon zentrieren), aber nicht auf 0×0 clippen —
+   * sonst können Browser Fokus/Tab nach Overlay-Rückkehr aus dem Footer werfen.
+   */
+  .app-footer__links .mat-mdc-button-base .mdc-button__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .app-footer__links > .mat-mdc-button-base > .mat-icon {
+    margin: 0;
+  }
+
+  .app-footer__icon {
+    font-size: 1.375rem;
+    width: 1.375rem;
+    height: 1.375rem;
   }
 
   .app-footer__link-text {
@@ -350,37 +436,14 @@
     border: 0;
   }
 
-  /* Wie die anderen Footer-Links nur ein Lead-Icon; neuer Tab steht im aria-label. */
   .app-footer__link--external .app-footer__icon--external {
     display: none;
   }
-}
 
-/*
- * M3: matBadgeSize="small" → Textgröße 0. Kompaktes „medium“ + Ziffer lesbar.
- * Badge auf demselben mat-icon wie die anderen Links (Icon + gap + Label).
- */
-.app-footer__link--news-archive .app-footer__icon.mat-badge-medium {
-  --mat-badge-container-size: 14px;
-  --mat-badge-line-height: 14px;
-  --mat-badge-text-size: 0.625rem;
-  --mat-badge-container-padding: 0 3px;
-  overflow: visible;
-}
-
-/* MatBadge am Footer-Link „News-Archiv“ darf nicht abgeschnitten werden */
-.app-footer__link--news-archive {
-  overflow: visible;
-}
-
-.app-footer__status-action {
-  min-width: 0;
-  padding-inline: 0.35rem;
-  flex: 0 0 auto;
-}
-
-.app-footer__status-widget {
-  flex: 0 0 auto;
+  /* Icon-Tab: kein Extra-Abstand — Label ist visuell ausgeblendet. */
+  .app-footer__link--news-archive .app-footer__icon.mat-badge:not(.mat-badge-hidden) {
+    margin-inline-end: 0;
+  }
 }
 
 /* Preset-Snackbar (global): Pill, inverse-surface, Blur/Refocus über PresetSnackbarFocusService */

--- a/apps/frontend/src/app/app.component.scss
+++ b/apps/frontend/src/app/app.component.scss
@@ -80,9 +80,9 @@
 }
 
 /*
- * Skip-Link: visuell aus dem Viewport, bei Fokus sichtbar.
- * Kein clip/clip-path — beides kann den Link in Chromium/WebKit aus der
- * sequentiellen Tab-Reihenfolge entfernen.
+ * Skip-Link: visuell aus dem Viewport, bei Fokus sofort sichtbar.
+ * Kein clip/clip-path (Tab-Reihenfolge) und keine Transform-Transition
+ * (a11y:layout misst den fokussierten Zustand synchron).
  */
 .app-skip-link {
   position: absolute;
@@ -98,7 +98,6 @@
   white-space: nowrap;
   border: 0;
   transform: translateY(calc(-100% - 1rem));
-  transition: transform 0.2s ease;
 }
 
 .app-skip-link:focus,
@@ -399,8 +398,9 @@
   /*
    * Label aus dem Flex-Flow nehmen (Icon zentrieren), aber nicht auf 0×0 clippen —
    * sonst können Browser Fokus/Tab nach Overlay-Rückkehr aus dem Footer werfen.
+   * Offline-Retry bleibt textbasiert sichtbar (kein Icon).
    */
-  .app-footer__links .mat-mdc-button-base .mdc-button__label {
+  .app-footer__links .mat-mdc-button-base:not(.app-footer__status-action) .mdc-button__label {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -411,6 +411,21 @@
     clip-path: inset(50%);
     white-space: nowrap;
     border: 0;
+  }
+
+  .app-footer__status-action .mdc-button__label {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 0 0.25rem;
+    overflow: visible;
+    clip: auto;
+    clip-path: none;
+    white-space: normal;
+    font: var(--mat-sys-label-small);
+    line-height: 1.2;
+    text-align: center;
   }
 
   .app-footer__links > .mat-mdc-button-base > .mat-icon {

--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { SwUpdate } from '@angular/service-worker';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppComponent } from './app.component';
+import { markContentPageFocusReturn } from './shared/content-page-nav';
 import { TopToolbarComponent } from './shared/top-toolbar/top-toolbar.component';
 
 const { footerBundleQueryMock, healthStatsQueryMock, swVersionUpdatesSubscribeMock } = vi.hoisted(
@@ -208,6 +209,52 @@ describe('AppComponent', () => {
 
     heading.blur();
     expect(heading.hasAttribute('tabindex')).toBe(false);
+    fixture.destroy();
+  });
+
+  it('stellt Footer-Fokus nach Content-Page-Dismiss wieder her und entfernt inert', () => {
+    configureAppTestBed();
+    const fixture = TestBed.createComponent(AppComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const footer = fixture.nativeElement.querySelector('footer.app-footer') as HTMLElement;
+    const helpLink = footer.querySelector(
+      'a[data-footer-focus="footer-help"]',
+    ) as HTMLAnchorElement;
+    expect(helpLink).toBeTruthy();
+    footer.setAttribute('inert', '');
+    (footer as HTMLElement & { inert: boolean }).inert = true;
+
+    markContentPageFocusReturn('footer-help');
+    component.isContentOverlayRoute.set(false);
+
+    const restored = (
+      component as AppComponent & { restoreContentPageFocusReturn: () => boolean }
+    ).restoreContentPageFocusReturn();
+
+    expect(restored).toBe(true);
+    expect(footer.hasAttribute('inert')).toBe(false);
+    expect(document.activeElement).toBe(helpLink);
+
+    fixture.destroy();
+  });
+
+  it('entfernt Bootstrap-Fokus aus dem Footer, damit der Skip-Link erster Tab-Stop bleibt', async () => {
+    configureAppTestBed();
+    const fixture = TestBed.createComponent(AppComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const footer = fixture.nativeElement.querySelector('footer.app-footer') as HTMLElement;
+    const firstFooterLink = footer.querySelector('a[href]') as HTMLAnchorElement;
+    firstFooterLink.focus();
+    expect(document.activeElement).toBe(firstFooterLink);
+
+    (component as AppComponent & { blurFooterIfFocused: () => void }).blurFooterIfFocused();
+
+    expect(document.activeElement === firstFooterLink).toBe(false);
+
     fixture.destroy();
   });
 
@@ -419,6 +466,32 @@ describe('AppComponent', () => {
     expect(link?.textContent ?? '').toContain('Was arsnova.eu kann');
     expect(trailing?.textContent?.trim()).toBe('open_in_new');
     expect(link?.querySelectorAll('mat-icon:not([iconPositionEnd])')).toHaveLength(1);
+
+    fixture.destroy();
+  });
+
+  it('markiert Footer-Labels einheitlich für Einzeilen-Layout und Compact-Breakpoint', async () => {
+    configureAppTestBed();
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const labels = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('.app-footer__link-text'),
+    ) as HTMLElement[];
+
+    expect(labels.length).toBeGreaterThanOrEqual(6);
+    expect(labels.map((label) => label.textContent?.trim())).toEqual(
+      expect.arrayContaining([
+        'News-Archiv',
+        'So funktioniert’s',
+        'Was arsnova.eu kann',
+        'Impressum',
+        'Datenschutz',
+        'Barrierefreiheit',
+      ]),
+    );
 
     fixture.destroy();
   });

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   Component,
   ComponentRef,
   Directive,
@@ -37,8 +38,9 @@ import { SeoService } from './core/seo.service';
 import { MotdHeaderStateService } from './core/motd-header-state.service';
 import { formatLocaleBadgeCount, formatLocaleCount } from './core/locale-number.util';
 import {
+  clearStaleContentPageFocusReturn,
   consumeContentPageFocusReturn,
-  contentPageFocusReturnSelector,
+  focusFooterContentReturn,
   isContentOverlayPath,
   rememberNonOverlayPath,
 } from './shared/content-page-nav';
@@ -138,6 +140,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   readonly themePreset = inject(ThemePresetService);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly cdr = inject(ChangeDetectorRef);
   private readonly swUpdate = inject(SwUpdate, { optional: true });
   private readonly focusService = inject(PresetSnackbarFocusService);
   private readonly router = inject(Router);
@@ -232,6 +235,10 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.seo.applyFromRouter();
+    if (isPlatformBrowser(this.platformId)) {
+      // Vor Router-Events: kein veralteter Footer-Fokus nach Reload/Locale-Redirect.
+      clearStaleContentPageFocusReturn();
+    }
     this.presetSub = this.themePreset.presetChanged$.subscribe(() => this.onPresetChanged());
     this.routerSub = this.router.events
       .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
@@ -247,6 +254,9 @@ export class AppComponent implements OnInit, OnDestroy {
         /* Nur bei Folge-Navigationen: #main-content scrollen (nicht window). Erstes Event überspringen — vermeidet sichtbares „Zucken“. */
         if (this.pendingInitialNavigationEnd) {
           this.pendingInitialNavigationEnd = false;
+          // Bootstrap: kein Footer-Fokus (HMR/bfcache/Trap). Skip-Link bleibt erster Tab-Stop.
+          clearStaleContentPageFocusReturn();
+          queueMicrotask(() => this.blurFooterIfFocused());
         } else if (!event.urlAfterRedirects.includes('#')) {
           requestAnimationFrame(() => {
             this.scrollPrimaryScrollContainerToTop();
@@ -345,29 +355,29 @@ export class AppComponent implements OnInit, OnDestroy {
     }
   }
 
+  /** Verhindert, dass Bootstrap/HMR den Fokus im Footer lässt (Skip-Link zuerst). */
+  private blurFooterIfFocused(): void {
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement)) {
+      return;
+    }
+    if (!active.closest('footer.app-footer')) {
+      return;
+    }
+    active.blur();
+  }
+
   /**
-   * Nach Schließen von Hilfe/Legal/News-Archiv: Fokus zurück auf den Footer-Link,
-   * von dem die Overlay-Seite aus erreicht wurde.
+   * Nach Schließen von Hilfe/Legal/News-Archiv: Fokus zurück auf den Footer-Link.
+   * Nur wenn ein Dismiss in dieser Navigation `markContentPageFocusReturn` gesetzt hat.
    */
   private restoreContentPageFocusReturn(): boolean {
     const target = consumeContentPageFocusReturn();
     if (!target) {
       return false;
     }
-    const footer = this._appFooterRef?.nativeElement;
-    const selector = contentPageFocusReturnSelector(target);
-    const link =
-      footer?.querySelector<HTMLElement>(selector) ??
-      document.querySelector<HTMLElement>(`footer ${selector}`);
-    if (!link) {
-      return false;
-    }
-    try {
-      link.focus({ preventScroll: true });
-    } catch {
-      link.focus();
-    }
-    return true;
+    this.cdr.detectChanges();
+    return focusFooterContentReturn(target);
   }
 
   showToolbarForFocus(): void {

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -225,6 +225,9 @@ export class AppComponent implements OnInit, OnDestroy {
   /** Footer: Badge mit ungelesenen Archiv-Meldungen (max. „99+“), wie Toolbar-Megafon. */
   footerNewsArchiveBadgeText = computed(() => {
     const n = this.motdHeaderState.archiveUnreadCount();
+    // Kein „0“ im DOM: matBadgeHidden blendet den Inhalt für Lighthouse nicht zuverlässig aus
+    // (label-content-name-mismatch gegen Aria ohne Zähler).
+    if (n <= 0) return '';
     return formatLocaleBadgeCount(n, this.localeId);
   });
 

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -43,7 +43,7 @@ import { INFO_LANDING_ANCHORS, infoLandingUrl } from './core/info-landing-url';
 import { HostDisplayModeService } from './core/host-display-mode.service';
 import { SeoService } from './core/seo.service';
 import { MotdHeaderStateService } from './core/motd-header-state.service';
-import { formatLocaleBadgeCount, formatLocaleCount } from './core/locale-number.util';
+import { formatLocaleBadgeCount } from './core/locale-number.util';
 import {
   clearStaleContentPageFocusReturn,
   consumeContentPageFocusReturn,
@@ -235,9 +235,11 @@ export class AppComponent implements OnInit, OnDestroy {
       return $localize`:@@app.footer.newsArchiveAria:News-Archiv öffnen`;
     }
     if (n === 1) {
-      return $localize`:@@app.footer.newsArchiveAriaOne:News-Archiv öffnen, eine ungelesene Meldung`;
+      // Ziffer „1“ wie im Badge — sonst label-content-name-mismatch (Lighthouse).
+      return $localize`:@@app.footer.newsArchiveAriaOne:News-Archiv öffnen, 1 ungelesene Meldung`;
     }
-    return $localize`:@@app.footer.newsArchiveAriaCount:News-Archiv öffnen, ${formatLocaleCount(n, this.localeId)}:INTERPOLATION: ungelesene Meldungen`;
+    // Dieselbe Ziffernform wie im Badge (inkl. „99+“), sonst label-content-name-mismatch.
+    return $localize`:@@app.footer.newsArchiveAriaCount:News-Archiv öffnen, ${formatLocaleBadgeCount(n, this.localeId)}:INTERPOLATION: ungelesene Meldungen`;
   });
 
   ngOnInit(): void {

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -17,7 +17,14 @@ import {
   signal,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { NavigationEnd, Router, RouterLink, RouterOutlet } from '@angular/router';
+import {
+  NavigationCancel,
+  NavigationEnd,
+  NavigationError,
+  Router,
+  RouterLink,
+  RouterOutlet,
+} from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { MatBadge } from '@angular/material/badge';
 import { MatButton } from '@angular/material/button';
@@ -241,8 +248,22 @@ export class AppComponent implements OnInit, OnDestroy {
     }
     this.presetSub = this.themePreset.presetChanged$.subscribe(() => this.onPresetChanged());
     this.routerSub = this.router.events
-      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .pipe(
+        filter(
+          (e): e is NavigationEnd | NavigationCancel | NavigationError =>
+            e instanceof NavigationEnd ||
+            e instanceof NavigationCancel ||
+            e instanceof NavigationError,
+        ),
+      )
       .subscribe((event) => {
+        if (!(event instanceof NavigationEnd)) {
+          // Abbruch/Fehler: Footer-Fokus-Marker nicht über die Navigation hinaus behalten.
+          if (isPlatformBrowser(this.platformId)) {
+            clearStaleContentPageFocusReturn();
+          }
+          return;
+        }
         this.seo.applyFromRouter();
         if (!isPlatformBrowser(this.platformId)) {
           return;
@@ -261,7 +282,9 @@ export class AppComponent implements OnInit, OnDestroy {
           requestAnimationFrame(() => {
             this.scrollPrimaryScrollContainerToTop();
             // Content-Overlay-Seiten setzen Fokus selbst (cdkFocusInitial auf „Zurück“).
+            // Overlay→Overlay: Marker verwerfen; Chrome-inert bleibt über Angular-Binding.
             if (this.isContentOverlayRoute()) {
+              clearStaleContentPageFocusReturn();
               return;
             }
             // Rückkehr aus Hilfe/Legal/News-Archiv: Footer-Link statt Hero-H1.

--- a/apps/frontend/src/app/features/home/home.component.spec.ts
+++ b/apps/frontend/src/app/features/home/home.component.spec.ts
@@ -1119,6 +1119,38 @@ describe('HomeComponent', () => {
       other.remove();
     });
 
+    it('setzt nach MOTD-Dismiss den Fokus auf den Skip-Link wenn kein Rücksprungziel existiert', async () => {
+      const skip = document.createElement('a');
+      skip.href = '#main';
+      skip.className = 'app-skip-link';
+      skip.textContent = 'Zum Inhalt springen';
+      document.body.prepend(skip);
+
+      const fixture = createHomeFixture();
+      fixture.componentInstance['motdFocusReturn'] = null;
+      fixture.componentInstance.motd.set({
+        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        contentVersion: 7,
+        markdown: 'Meldung',
+        endsAt: '2099-12-31T12:00:00.000Z',
+      });
+      fixture.detectChanges();
+
+      const closeInMotd = fixture.nativeElement.querySelector(
+        '.home-motd-sheet button',
+      ) as HTMLButtonElement | null;
+      expect(closeInMotd).not.toBeNull();
+      closeInMotd?.focus();
+      expect(document.activeElement).toBe(closeInMotd);
+
+      fixture.componentInstance['clearMotdOverlay']();
+      fixture.detectChanges();
+      await Promise.resolve();
+
+      expect(document.activeElement).toBe(skip);
+      skip.remove();
+    });
+
     it('lädt nach dem Schließen nicht sofort die nächste MOTD nach', async () => {
       const { trpc } = await import('../../core/trpc.client');
       vi.mocked(trpc.motd.getCurrent.query).mockResolvedValueOnce({

--- a/apps/frontend/src/app/features/home/home.component.ts
+++ b/apps/frontend/src/app/features/home/home.component.ts
@@ -972,6 +972,10 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   private clearMotdOverlay(): void {
     const focusReturn = this.motdFocusReturn;
     this.motdFocusReturn = null;
+    const activeBefore = document.activeElement;
+    const activeWasInMotd =
+      activeBefore instanceof HTMLElement &&
+      !!activeBefore.closest('.home-motd-layer, .home-motd-sheet');
     this.motd.set(null);
     this.motdBodyHtml.set(null);
     queueMicrotask(() => {
@@ -981,11 +985,20 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
       }
       const active = document.activeElement;
       if (
+        !activeWasInMotd &&
         active instanceof HTMLElement &&
+        active.isConnected &&
         active !== document.body &&
         active !== document.documentElement
       ) {
-        // Nutzer:in hat bereits woanders Fokus — nicht in die Code-Eingabe ziehen.
+        // Nutzer:in hat bereits woanders Fokus — nicht verschieben.
+        return;
+      }
+      // Nach Entfernen des MOTD-Dialogs bleibt der Sequential-Focus-Start oft hinter
+      // dem Dialog → nächstes Tab landet im Footer. Skip-Link setzt den Start zurück.
+      const skip = document.querySelector<HTMLElement>('a.app-skip-link');
+      if (skip) {
+        skip.focus({ preventScroll: true });
         return;
       }
       this.sessionCodeInput?.nativeElement?.focus({ preventScroll: true });

--- a/apps/frontend/src/app/shared/content-page-nav.spec.ts
+++ b/apps/frontend/src/app/shared/content-page-nav.spec.ts
@@ -65,6 +65,14 @@ describe('content-page-nav', () => {
     expect(consumeContentPageFocusReturn()).toBeNull();
   });
 
+  it('hält den Fokus-Marker über langsame Navigation hinaus (kein Wall-Clock-Expiry)', () => {
+    vi.useFakeTimers();
+    markContentPageFocusReturn('footer-news-archive');
+    vi.advanceTimersByTime(10_000);
+    expect(peekContentPageFocusReturn()).toBe('footer-news-archive');
+    vi.useRealTimers();
+  });
+
   it('nutzt location.back wenn History Einträge hat', () => {
     const location = { back: vi.fn() };
     const router = { navigateByUrl: vi.fn() };
@@ -79,6 +87,30 @@ describe('content-page-nav', () => {
     if (lengthDesc) {
       Object.defineProperty(window.history, 'length', lengthDesc);
     }
+  });
+
+  it('entfernt Chrome-inert nicht vor history.back (Overlay→Overlay bleibt geschützt)', () => {
+    const footer = document.createElement('footer');
+    footer.className = 'app-footer';
+    footer.setAttribute('inert', '');
+    (footer as HTMLElement & { inert: boolean }).inert = true;
+    document.body.append(footer);
+
+    const location = { back: vi.fn() };
+    const router = { navigateByUrl: vi.fn() };
+    const lengthDesc = Object.getOwnPropertyDescriptor(window.history, 'length');
+    Object.defineProperty(window.history, 'length', { configurable: true, value: 3 });
+
+    dismissContentPage(location as never, router as never);
+
+    expect(location.back).toHaveBeenCalledOnce();
+    expect(footer.hasAttribute('inert')).toBe(true);
+    expect((footer as HTMLElement & { inert: boolean }).inert).toBe(true);
+
+    if (lengthDesc) {
+      Object.defineProperty(window.history, 'length', lengthDesc);
+    }
+    footer.remove();
   });
 
   it('navigiert bei Direktaufruf zur lokalisierten Startseite ohne Footer-Fokus-Marker', () => {

--- a/apps/frontend/src/app/shared/content-page-nav.spec.ts
+++ b/apps/frontend/src/app/shared/content-page-nav.spec.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  clearStaleContentPageFocusReturn,
   consumeContentPageFocusReturn,
   contentPageFocusReturnForPath,
   dismissContentPage,
+  focusFooterContentReturn,
   isContentOverlayPath,
   markContentPageFocusReturn,
+  peekContentPageFocusReturn,
   prepareContentPageDismiss,
   rememberNonOverlayPath,
   shouldDeferContentPageEscape,
@@ -14,6 +17,7 @@ import { localizePath } from '../core/locale-router';
 
 describe('content-page-nav', () => {
   afterEach(() => {
+    clearStaleContentPageFocusReturn();
     sessionStorage.clear();
   });
 
@@ -54,8 +58,9 @@ describe('content-page-nav', () => {
     expect(consumeMotdOverlayReloadSuppress()).toBe(true);
   });
 
-  it('persistiert Fokus-Ziel über mark/consume', () => {
+  it('persistiert Fokus-Ziel über mark/consume nur im Speicher', () => {
     markContentPageFocusReturn('footer-help');
+    expect(peekContentPageFocusReturn()).toBe('footer-help');
     expect(consumeContentPageFocusReturn()).toBe('footer-help');
     expect(consumeContentPageFocusReturn()).toBeNull();
   });
@@ -98,5 +103,30 @@ describe('content-page-nav', () => {
   it('erkennt offene MatDialogs als Escape-Deferral', () => {
     expect(shouldDeferContentPageEscape({ openDialogs: [] } as never)).toBe(false);
     expect(shouldDeferContentPageEscape({ openDialogs: [{}] } as never)).toBe(true);
+  });
+
+  it('fokussiert den Footer-Link und entfernt inert am Chrome', () => {
+    const footer = document.createElement('footer');
+    footer.className = 'app-footer';
+    footer.setAttribute('inert', '');
+    (footer as HTMLElement & { inert: boolean }).inert = true;
+    const link = document.createElement('a');
+    link.setAttribute('data-footer-focus', 'footer-help');
+    link.href = '/de/help';
+    footer.append(link);
+    document.body.append(footer);
+
+    expect(focusFooterContentReturn('footer-help')).toBe(true);
+    expect(footer.hasAttribute('inert')).toBe(false);
+    expect(document.activeElement).toBe(link);
+
+    footer.remove();
+  });
+
+  it('verwirft veraltete Fokus-Marker für den Initialfokus', () => {
+    markContentPageFocusReturn('footer-help');
+    expect(peekContentPageFocusReturn()).toBe('footer-help');
+    clearStaleContentPageFocusReturn();
+    expect(peekContentPageFocusReturn()).toBeNull();
   });
 });

--- a/apps/frontend/src/app/shared/content-page-nav.ts
+++ b/apps/frontend/src/app/shared/content-page-nav.ts
@@ -33,6 +33,13 @@ export type ContentPageFocusReturn =
 export const CONTENT_PAGE_FOCUS_RETURN_KEY = 'arsnova-content-page-focus-return';
 export const LAST_NON_OVERLAY_PATH_KEY = 'arsnova-last-non-overlay-path';
 
+/**
+ * Nur In-Memory für die aktuelle Dismiss-Navigation.
+ * sessionStorage allein würde nach Reload/Locale-Redirect den Initialfokus stehlen.
+ */
+let pendingFocusReturn: ContentPageFocusReturn | null = null;
+let focusReturnGeneration = 0;
+
 /** Merkt die letzte Nicht-Overlay-Route (für MOTD-Suppress nur bei Rückkehr zur Home). */
 export function rememberNonOverlayPath(pathname: string): void {
   if (typeof sessionStorage === 'undefined') return;
@@ -71,36 +78,66 @@ export function contentPageFocusReturnForPath(pathname: string): ContentPageFocu
 }
 
 export function markContentPageFocusReturn(target: ContentPageFocusReturn): void {
-  if (typeof sessionStorage === 'undefined') return;
-  try {
-    sessionStorage.setItem(CONTENT_PAGE_FOCUS_RETURN_KEY, target);
-  } catch {
-    /* ignore quota / private mode */
+  pendingFocusReturn = target;
+  focusReturnGeneration += 1;
+  const generation = focusReturnGeneration;
+  // Automatisch verfallen — verhindert HMR-/Timer-Leaks mit ewigem Footer-Fokus.
+  if (typeof setTimeout === 'function') {
+    setTimeout(() => {
+      if (focusReturnGeneration === generation) {
+        pendingFocusReturn = null;
+      }
+    }, 2000);
   }
 }
 
+export function peekContentPageFocusReturn(): ContentPageFocusReturn | null {
+  return pendingFocusReturn;
+}
+
 export function consumeContentPageFocusReturn(): ContentPageFocusReturn | null {
-  if (typeof sessionStorage === 'undefined') return null;
-  try {
-    const raw = sessionStorage.getItem(CONTENT_PAGE_FOCUS_RETURN_KEY);
-    sessionStorage.removeItem(CONTENT_PAGE_FOCUS_RETURN_KEY);
-    if (
-      raw === 'footer-help' ||
-      raw === 'footer-news-archive' ||
-      raw === 'footer-imprint' ||
-      raw === 'footer-privacy' ||
-      raw === 'footer-accessibility'
-    ) {
-      return raw;
+  const value = pendingFocusReturn;
+  pendingFocusReturn = null;
+  focusReturnGeneration += 1;
+  if (typeof sessionStorage !== 'undefined') {
+    try {
+      sessionStorage.removeItem(CONTENT_PAGE_FOCUS_RETURN_KEY);
+    } catch {
+      /* ignore */
     }
-    return null;
+  }
+  return value;
+}
+
+/** App-Start / Initial-Navigation: keine Footer-Fokus-Rückkehr. */
+export function clearStaleContentPageFocusReturn(): void {
+  pendingFocusReturn = null;
+  focusReturnGeneration += 1;
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    sessionStorage.removeItem(CONTENT_PAGE_FOCUS_RETURN_KEY);
   } catch {
-    return null;
+    /* ignore */
   }
 }
 
 /** CSS-Selektor für den Footer-Link zum gespeicherten Fokus-Ziel. */
 export function contentPageFocusReturnSelector(target: ContentPageFocusReturn): string {
+  switch (target) {
+    case 'footer-help':
+      return 'a[data-footer-focus="footer-help"]';
+    case 'footer-news-archive':
+      return 'a[data-footer-focus="footer-news-archive"]';
+    case 'footer-imprint':
+      return 'a[data-footer-focus="footer-imprint"]';
+    case 'footer-privacy':
+      return 'a[data-footer-focus="footer-privacy"]';
+    case 'footer-accessibility':
+      return 'a[data-footer-focus="footer-accessibility"]';
+  }
+}
+
+function contentPageFocusReturnHrefSelector(target: ContentPageFocusReturn): string {
   switch (target) {
     case 'footer-help':
       return 'a[href*="/help"]';
@@ -113,6 +150,45 @@ export function contentPageFocusReturnSelector(target: ContentPageFocusReturn): 
     case 'footer-accessibility':
       return 'a[href*="/legal/accessibility"]';
   }
+}
+
+/** Entfernt inert am App-Chrome, damit Fokus zurück in den Footer kann. */
+export function clearAppChromeInert(): void {
+  if (typeof document === 'undefined') return;
+  const chrome = Array.from(
+    document.querySelectorAll<HTMLElement>('footer.app-footer, app-top-toolbar, a.app-skip-link'),
+  );
+  for (const el of chrome) {
+    if (!el.hasAttribute('inert') && !(el as HTMLElement & { inert?: boolean }).inert) {
+      continue;
+    }
+    el.removeAttribute('inert');
+    (el as HTMLElement & { inert: boolean }).inert = false;
+  }
+}
+
+/**
+ * Fokus auf den Footer-Link legen (inert am Chrome vorher entfernen).
+ * `activeElement` darf auch ein Nachfahre des Links sein (Material-Button).
+ */
+export function focusFooterContentReturn(target: ContentPageFocusReturn): boolean {
+  if (typeof document === 'undefined') return false;
+  clearAppChromeInert();
+  const footer = document.querySelector<HTMLElement>('footer.app-footer');
+  const link =
+    footer?.querySelector<HTMLElement>(contentPageFocusReturnSelector(target)) ??
+    footer?.querySelector<HTMLElement>(contentPageFocusReturnHrefSelector(target)) ??
+    null;
+  if (!link) {
+    return false;
+  }
+  try {
+    link.focus({ preventScroll: true });
+  } catch {
+    link.focus();
+  }
+  const active = document.activeElement;
+  return active === link || (active instanceof Node && link.contains(active));
 }
 
 /**
@@ -149,11 +225,16 @@ export function shouldDeferContentPageEscape(dialog: MatDialog): boolean {
 /**
  * Schließt eine Content-Page: History zurück, sonst lokalisierte Startseite.
  * Beim Direktaufruf (keine History) kein Footer-Fokus-Marker — normale Home-Fokuslogik.
+ *
+ * inert am Chrome vor `back()` entfernen, damit cdkTrapFocus den zuvor fokussierten
+ * Footer-Link wiederherstellen kann. Keine Timer-Retries — die stehlen sonst den
+ * Initialfokus (Skip-Link / Inhalt).
  */
 export function dismissContentPage(location: Location, router: Router): void {
   const pathname = typeof window !== 'undefined' ? window.location.pathname : '';
   if (typeof window !== 'undefined' && window.history.length > 1) {
     prepareContentPageDismiss(pathname);
+    clearAppChromeInert();
     location.back();
     return;
   }

--- a/apps/frontend/src/app/shared/content-page-nav.ts
+++ b/apps/frontend/src/app/shared/content-page-nav.ts
@@ -38,7 +38,6 @@ export const LAST_NON_OVERLAY_PATH_KEY = 'arsnova-last-non-overlay-path';
  * sessionStorage allein würde nach Reload/Locale-Redirect den Initialfokus stehlen.
  */
 let pendingFocusReturn: ContentPageFocusReturn | null = null;
-let focusReturnGeneration = 0;
 
 /** Merkt die letzte Nicht-Overlay-Route (für MOTD-Suppress nur bei Rückkehr zur Home). */
 export function rememberNonOverlayPath(pathname: string): void {
@@ -79,16 +78,6 @@ export function contentPageFocusReturnForPath(pathname: string): ContentPageFocu
 
 export function markContentPageFocusReturn(target: ContentPageFocusReturn): void {
   pendingFocusReturn = target;
-  focusReturnGeneration += 1;
-  const generation = focusReturnGeneration;
-  // Automatisch verfallen — verhindert HMR-/Timer-Leaks mit ewigem Footer-Fokus.
-  if (typeof setTimeout === 'function') {
-    setTimeout(() => {
-      if (focusReturnGeneration === generation) {
-        pendingFocusReturn = null;
-      }
-    }, 2000);
-  }
 }
 
 export function peekContentPageFocusReturn(): ContentPageFocusReturn | null {
@@ -98,7 +87,6 @@ export function peekContentPageFocusReturn(): ContentPageFocusReturn | null {
 export function consumeContentPageFocusReturn(): ContentPageFocusReturn | null {
   const value = pendingFocusReturn;
   pendingFocusReturn = null;
-  focusReturnGeneration += 1;
   if (typeof sessionStorage !== 'undefined') {
     try {
       sessionStorage.removeItem(CONTENT_PAGE_FOCUS_RETURN_KEY);
@@ -112,7 +100,6 @@ export function consumeContentPageFocusReturn(): ContentPageFocusReturn | null {
 /** App-Start / Initial-Navigation: keine Footer-Fokus-Rückkehr. */
 export function clearStaleContentPageFocusReturn(): void {
   pendingFocusReturn = null;
-  focusReturnGeneration += 1;
   if (typeof sessionStorage === 'undefined') return;
   try {
     sessionStorage.removeItem(CONTENT_PAGE_FOCUS_RETURN_KEY);
@@ -226,15 +213,14 @@ export function shouldDeferContentPageEscape(dialog: MatDialog): boolean {
  * Schließt eine Content-Page: History zurück, sonst lokalisierte Startseite.
  * Beim Direktaufruf (keine History) kein Footer-Fokus-Marker — normale Home-Fokuslogik.
  *
- * inert am Chrome vor `back()` entfernen, damit cdkTrapFocus den zuvor fokussierten
- * Footer-Link wiederherstellen kann. Keine Timer-Retries — die stehlen sonst den
- * Initialfokus (Skip-Link / Inhalt).
+ * Chrome-`inert` hier nicht entfernen: bei Overlay→Overlay (Hilfe→Legal→Zurück)
+ * bliebe die Angular-Binding sonst ohne Re-Apply. `focusFooterContentReturn` entfernt
+ * inert erst bei tatsächlicher Rückkehr auf eine Nicht-Overlay-Route.
  */
 export function dismissContentPage(location: Location, router: Router): void {
   const pathname = typeof window !== 'undefined' ? window.location.pathname : '';
   if (typeof window !== 'undefined' && window.history.length > 1) {
     prepareContentPageDismiss(pathname);
-    clearAppChromeInert();
     location.back();
     return;
   }

--- a/apps/frontend/src/app/shared/server-status-widget/server-status-widget.component.scss
+++ b/apps/frontend/src/app/shared/server-status-widget/server-status-widget.component.scss
@@ -1,19 +1,22 @@
 :host {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
 }
 
 .server-status {
-  --mat-button-text-container-height: 2.25rem;
+  --mat-button-text-container-height: 2.5rem;
   --mat-button-text-label-text-font: var(--mat-sys-body-small-font);
   --mat-button-text-label-text-size: var(--mat-sys-body-small-size);
   --mat-button-text-label-text-tracking: var(--mat-sys-body-small-tracking);
   --mat-button-text-label-text-weight: var(--mat-sys-body-small-weight);
   --mat-button-text-icon-offset: 0;
-  min-width: 0;
-  padding-inline: 0.35rem;
+  --mat-button-text-horizontal-padding: 0.625rem;
+  flex: 0 0 auto;
+  min-width: auto;
   justify-content: center;
+  white-space: nowrap;
   color: var(--mat-sys-on-surface-variant);
   line-height: var(--mat-sys-body-small-line-height);
 }
@@ -27,9 +30,9 @@
 
 .server-status__icon {
   flex-shrink: 0;
-  font-size: 1.125rem;
-  width: 1.125rem;
-  height: 1.125rem;
+  font-size: 1.25rem;
+  width: 1.25rem;
+  height: 1.25rem;
   line-height: 1;
   color: var(--mat-sys-outline-variant);
 }
@@ -51,12 +54,32 @@
 }
 
 .server-status__label {
-  min-width: 0;
+  white-space: nowrap;
 }
 
-@media (max-width: 599px) {
+/* Sync mit app.component.scss Compact-Footer (≤959px). */
+@media (max-width: 959px) {
+  :host {
+    flex: 1 1 0;
+    min-width: 0;
+    height: 3rem;
+  }
+
   .server-status {
-    padding-inline: 0.25rem;
+    width: 100%;
+    height: 3rem;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border-radius: var(--mat-sys-corner-medium);
+    --mat-button-text-container-height: 3rem;
+    --mat-button-text-horizontal-padding: 0;
+  }
+
+  .server-status__icon {
+    font-size: 1.375rem;
+    width: 1.375rem;
+    height: 1.375rem;
   }
 
   .server-status__label {

--- a/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.html
+++ b/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.html
@@ -60,8 +60,9 @@
           [matBadge]="motdArchiveBadgeText()"
           [matBadgeHidden]="motdHeaderState.archiveUnreadCount() === 0"
           matBadgePosition="above after"
+          matBadgeOverlap
         >
-          <mat-icon>campaign</mat-icon>
+          <mat-icon aria-hidden="true">campaign</mat-icon>
         </button>
       }
     </div>

--- a/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.scss
+++ b/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.scss
@@ -18,6 +18,7 @@
   border-radius: var(--mat-sys-corner-extra-large);
   background: var(--mat-sys-surface-container);
   padding-block: 0.75rem;
+  overflow: visible;
   box-shadow: var(--mat-sys-level1);
   font-size: 0.875rem;
   transition: box-shadow 0.2s ease;
@@ -92,6 +93,7 @@
   justify-content: space-between;
   gap: 1rem;
   min-width: 0;
+  overflow: visible;
   /* Gleiche Zeilenhöhe mit/ohne Home-Icon (48px = M3-Icon-Button), kein „Wachsen“ nur auf Unterseiten. */
   min-height: 48px;
 }
@@ -103,9 +105,10 @@
   gap: 0.25rem;
   flex-shrink: 0;
   min-width: 0;
+  overflow: visible;
 }
 
-/* MatBadge am Campaign-Icon darf nicht abgeschnitten werden */
+/* MD3: Badge überlappt die Ecke des Icon-Buttons (matBadgeOverlap). */
 .top-toolbar__motd-btn {
   overflow: visible;
 }

--- a/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.ts
+++ b/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.ts
@@ -91,6 +91,8 @@ export class TopToolbarComponent {
   /** Badge-Text (max. „99+“). */
   readonly motdArchiveBadgeText = computed(() => {
     const n = this.motdHeaderState.archiveUnreadCount();
+    // Kein „0“ im DOM: matBadgeHidden blendet den Inhalt für Lighthouse nicht zuverlässig aus.
+    if (n <= 0) return '';
     return formatLocaleBadgeCount(n, this.localeId as string);
   });
 

--- a/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.ts
+++ b/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.ts
@@ -101,9 +101,11 @@ export class TopToolbarComponent {
       return $localize`:@@motd.toolbarArchiveAria:News und Archiv`;
     }
     if (n === 1) {
-      return $localize`:@@motd.toolbarArchiveAriaOne:News und Archiv, eine ungelesene Meldung`;
+      // Ziffer „1“ wie im Badge — sonst label-content-name-mismatch (Lighthouse).
+      return $localize`:@@motd.toolbarArchiveAriaOne:News und Archiv, 1 ungelesene Meldung`;
     }
-    return $localize`:@@motd.toolbarArchiveAriaCount:News und Archiv, ${formatLocaleCount(n, this.localeId as string)}:INTERPOLATION: ungelesene Meldungen`;
+    // Dieselbe Ziffernform wie im Badge (inkl. „99+“), sonst label-content-name-mismatch.
+    return $localize`:@@motd.toolbarArchiveAriaCount:News und Archiv, ${formatLocaleBadgeCount(n, this.localeId as string)}:INTERPOLATION: ungelesene Meldungen`;
   });
 
   /** Kurzinfo beim Hover (unterscheidet ungelesene Meldungen). */

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -231,15 +231,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
-        <source>News-Archiv öffnen, eine ungelesene Meldung</source>
-        <target>Open news archive, one unread message</target>
+        <source>News-Archiv öffnen, 1 ungelesene Meldung</source>
+        <target>Open news archive, 1 unread message</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
-        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId)"/> ungelesene Meldungen</source>
+        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId)"/> ungelesene Meldungen</source>
         <target>Open news archive, <x id="INTERPOLATION" equiv-text="{{ n }}"/> unread messages</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
@@ -21355,15 +21355,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaOne" datatype="html">
-        <source>News und Archiv, eine ungelesene Meldung</source>
-        <target>News and archive, one unread message</target>
+        <source>News und Archiv, 1 ungelesene Meldung</source>
+        <target>News and archive, 1 unread message</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
           <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaCount" datatype="html">
-        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <target>News and archive, <x id="INTERPOLATION" equiv-text="{{ n }}"/> unread messages</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
@@ -21387,7 +21387,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveTooltipUnreadCount" datatype="html">
-        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <target>News and archive · <x id="INTERPOLATION" equiv-text="{{ n }}"/> unread messages</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -126,12 +126,28 @@
           <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.imprintOpenAria" datatype="html">
+        <source>Impressum</source>
+        <target>Legal notice</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">205</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <target>Legal notice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.privacyOpenAria" datatype="html">
+        <source>Datenschutz</source>
+        <target>Privacy</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
@@ -139,7 +155,7 @@
         <target>Privacy</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -126,12 +126,28 @@
           <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.imprintOpenAria" datatype="html">
+        <source>Impressum</source>
+        <target>Aviso legal</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">205</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <target>Aviso legal</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.privacyOpenAria" datatype="html">
+        <source>Datenschutz</source>
+        <target>Privacidad</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
@@ -139,7 +155,7 @@
         <target>Privacidad</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -231,15 +231,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
-        <source>News-Archiv öffnen, eine ungelesene Meldung</source>
-        <target>Abrir archivo de noticias, un mensaje sin leer</target>
+        <source>News-Archiv öffnen, 1 ungelesene Meldung</source>
+        <target>Abrir archivo de noticias, 1 mensaje sin leer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
-        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId)"/> ungelesene Meldungen</source>
+        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId)"/> ungelesene Meldungen</source>
         <target>Abrir archivo de noticias, <x id="INTERPOLATION" equiv-text="{{ n }}"/> mensajes sin leer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
@@ -21298,15 +21298,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaOne" datatype="html">
-        <source>News und Archiv, eine ungelesene Meldung</source>
-        <target>Noticias y archivo, un mensaje sin leer</target>
+        <source>News und Archiv, 1 ungelesene Meldung</source>
+        <target>Noticias y archivo, 1 mensaje sin leer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
           <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaCount" datatype="html">
-        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <target>Noticias y archivo, <x id="INTERPOLATION" equiv-text="{{ n }}"/> mensajes sin leer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
@@ -21330,7 +21330,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveTooltipUnreadCount" datatype="html">
-        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <target>Noticias y archivo · <x id="INTERPOLATION" equiv-text="{{ n }}"/> mensajes sin leer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -126,12 +126,28 @@
           <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.imprintOpenAria" datatype="html">
+        <source>Impressum</source>
+        <target>Mentions légales</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">205</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <target>Mentions légales</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.privacyOpenAria" datatype="html">
+        <source>Datenschutz</source>
+        <target>Confidentialité</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
@@ -139,7 +155,7 @@
         <target>Confidentialité</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -231,15 +231,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
-        <source>News-Archiv öffnen, eine ungelesene Meldung</source>
-        <target>Ouvrir les archives d&apos;actualités, un message non lu</target>
+        <source>News-Archiv öffnen, 1 ungelesene Meldung</source>
+        <target>Ouvrir les archives d&apos;actualités, 1 message non lu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
-        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId)"/> ungelesene Meldungen</source>
+        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId)"/> ungelesene Meldungen</source>
         <target>Ouvrir les archives d&apos;actualités, <x id="INTERPOLATION" equiv-text="{{ n }}"/> messages non lus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
@@ -21298,15 +21298,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaOne" datatype="html">
-        <source>News und Archiv, eine ungelesene Meldung</source>
-        <target>Actualités et archives, un message non lu</target>
+        <source>News und Archiv, 1 ungelesene Meldung</source>
+        <target>Actualités et archives, 1 message non lu</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
           <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaCount" datatype="html">
-        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <target>Actualités et archives, <x id="INTERPOLATION" equiv-text="{{ n }}"/> messages non lus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
@@ -21330,7 +21330,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveTooltipUnreadCount" datatype="html">
-        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <target>Actualités et archives · <x id="INTERPOLATION" equiv-text="{{ n }}"/> messages non lus</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -231,15 +231,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
-        <source>News-Archiv öffnen, eine ungelesene Meldung</source>
-        <target>Apri archivio notizie, un messaggio non letto</target>
+        <source>News-Archiv öffnen, 1 ungelesene Meldung</source>
+        <target>Apri archivio notizie, 1 messaggio non letto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
-        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId)"/> ungelesene Meldungen</source>
+        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId)"/> ungelesene Meldungen</source>
         <target>Apri archivio notizie, <x id="INTERPOLATION" equiv-text="{{ n }}"/> messaggi non letti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
@@ -21298,15 +21298,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaOne" datatype="html">
-        <source>News und Archiv, eine ungelesene Meldung</source>
-        <target>Notizie e archivio, un messaggio non letto</target>
+        <source>News und Archiv, 1 ungelesene Meldung</source>
+        <target>Notizie e archivio, 1 messaggio non letto</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
           <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaCount" datatype="html">
-        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <target>Notizie e archivio, <x id="INTERPOLATION" equiv-text="{{ n }}"/> messaggi non letti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
@@ -21330,7 +21330,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveTooltipUnreadCount" datatype="html">
-        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <target>Notizie e archivio · <x id="INTERPOLATION" equiv-text="{{ n }}"/> messaggi non letti</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -126,12 +126,28 @@
           <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.imprintOpenAria" datatype="html">
+        <source>Impressum</source>
+        <target>Note legali</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">205</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <target>Note legali</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.privacyOpenAria" datatype="html">
+        <source>Datenschutz</source>
+        <target>Privacy</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
@@ -139,7 +155,7 @@
         <target>Privacy</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -204,14 +204,14 @@
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaOne" datatype="html">
-        <source>News-Archiv öffnen, eine ungelesene Meldung</source>
+        <source>News-Archiv öffnen, 1 ungelesene Meldung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.newsArchiveAriaCount" datatype="html">
-        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId)"/> ungelesene Meldungen</source>
+        <source>News-Archiv öffnen, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId)"/> ungelesene Meldungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">230</context>
@@ -18751,14 +18751,14 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaOne" datatype="html">
-        <source>News und Archiv, eine ungelesene Meldung</source>
+        <source>News und Archiv, 1 ungelesene Meldung</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
           <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveAriaCount" datatype="html">
-        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv, <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
           <context context-type="linenumber">106</context>
@@ -18779,7 +18779,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="motd.toolbarArchiveTooltipUnreadCount" datatype="html">
-        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
+        <source>News und Archiv · <x id="INTERPOLATION" equiv-text="formatLocaleBadgeCount(n, this.localeId as string)"/> ungelesene Meldungen</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.ts</context>
           <context context-type="linenumber">118</context>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -111,18 +111,32 @@
           <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="app.footer.imprintOpenAria" datatype="html">
+        <source>Impressum</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">205</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1547876271716599756" datatype="html">
         <source>Impressum</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">198</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="app.footer.privacyOpenAria" datatype="html">
+        <source>Datenschutz</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">215</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4082114936887396529" datatype="html">
         <source>Datenschutz</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.html</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">219</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.footer.accessibilityOpenAria" datatype="html">

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -1774,24 +1774,19 @@ $markdown-katex-flow-hosts:
   max-width: min(100vw - 1rem, 40rem) !important;
 }
 
-/* Motd-Zähler: MD3-Overlap behalten, Ziffer zuverlässig zentrieren. */
-.top-toolbar__motd-btn.mat-badge,
-.app-footer__link--news-archive .app-footer__icon.mat-badge {
-  --mat-badge-container-padding: 0;
-}
-
+/* Motd-Zähler: MD3-Overlap behalten, Ziffern zentrieren; Breite für 99+ wachsen lassen. */
 .top-toolbar__motd-btn.mat-badge .mat-badge-content,
 .app-footer__link--news-archive .app-footer__icon.mat-badge .mat-badge-content {
   display: inline-flex !important;
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  width: var(--mat-badge-container-size, 16px);
+  width: auto;
   min-width: var(--mat-badge-container-size, 16px);
   height: var(--mat-badge-container-size, 16px);
   min-height: var(--mat-badge-container-size, 16px);
   line-height: 1;
-  padding: 0;
+  padding: 0 4px;
   font-size: var(--mat-badge-text-size, 0.6875rem);
   font-weight: 600;
 }

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -1773,3 +1773,30 @@ $markdown-katex-flow-hosts:
   margin: 0 0.5rem max(0.75rem, env(safe-area-inset-bottom, 0px)) !important;
   max-width: min(100vw - 1rem, 40rem) !important;
 }
+
+/* Motd-Zähler: MD3-Overlap behalten, Ziffer zuverlässig zentrieren. */
+.top-toolbar__motd-btn.mat-badge,
+.app-footer__link--news-archive .app-footer__icon.mat-badge {
+  --mat-badge-container-padding: 0;
+}
+
+.top-toolbar__motd-btn.mat-badge .mat-badge-content,
+.app-footer__link--news-archive .app-footer__icon.mat-badge .mat-badge-content {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: var(--mat-badge-container-size, 16px);
+  min-width: var(--mat-badge-container-size, 16px);
+  height: var(--mat-badge-container-size, 16px);
+  min-height: var(--mat-badge-container-size, 16px);
+  line-height: 1;
+  padding: 0;
+  font-size: var(--mat-badge-text-size, 0.6875rem);
+  font-weight: 600;
+}
+
+/* Footer: Badge 8px weiter nach rechts (weniger Icon-Abdeckung, klarere Ecke). */
+.app-footer__link--news-archive .app-footer__icon.mat-badge.mat-badge-after .mat-badge-content {
+  left: calc(100% + 8px);
+}


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Auf schmalen Viewports (u. a. iPad Air ~820px) waren Footer-Einträge abgeschnitten; Badges überdeckten Icons bzw. saßen falsch; nach Schließen von MOTD oder Content-Seiten sprang der Tastaturfokus in den Footer statt auf den Skip-Link bzw. den auslösenden Footer-Link.
- **Lösung:** Kompakte Icon-Tab-Leiste bis 959px, MD3-konforme Badge-Positionierung, Skip-Link ohne clip/clip-path in der Tab-Reihenfolge, Fokus-Rückgabe über Content-Page-Marker sowie Skip-Link-Fokus nach MOTD-Dismiss.
- **Bewusste Nicht-Ziele:** Keine Backend-/API-Änderungen; keine Änderung der Content-Overlay-Routen selbst.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

- Skip-Link bleibt erster sinnvoller Tab-Stop der App-Chrome-Navigation.
- Nach Dismiss von Hilfe/Legal/News-Archiv kehrt der Fokus zum auslösenden Footer-Link zurück.
- Nach MOTD-Dismiss ohne gültiges Rücksprungziel landet der Fokus auf dem Skip-Link (setzt den Sequential-Focus-Start zurück).
- Participant-/Host-Berechtigungen und Session-Payloads unverändert.

**Betroffene externe Verträge:**

- Browser Sequential Focus Navigation / Dialog-Dismiss-Verhalten (Chromium/WebKit); Material Badge Overlap. Keine Netzwerk- oder Schema-Verträge.

## Implementierung

- Footer: `safe center`/`flex`-Spalten und Icon-only-Tabbar `max-width: 959px`; Labels ab 960px.
- Badges: Toolbar mit `matBadgeOverlap`; Footer-Badge mit MD3-Offset; globale Ziffernzentrierung in `styles.scss`.
- Content-Page-Nav: In-Memory Focus-Return-Marker, Chrome-`inert` vor `history.back()`, Restore auf `NavigationEnd`.
- MOTD: nach Overlay-Clear Fokus auf `a.app-skip-link`, wenn kein gültiges Rücksprungziel und Fokus im MOTD/Body lag.
- Skip-Link: visuell per `transform` aus dem Viewport, ohne `clip`/`clip-path`.
- i18n: Footer-Open-Aria für Imprint/Privacy in allen Locales.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [x] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| Pre-commit: `npm run typecheck` (shared-types, backend, frontend) | bestanden |
| Pre-commit: `npm test` (shared-types, session-export-report, backend, frontend) | bestanden (Frontend 1119 Tests) |
| `npm run test -w @arsnova/frontend -- --run` home/app/content-page-nav Specs | 98/98 bestanden |
| `npm run typecheck -w @arsnova/frontend` | bestanden |
| `npm run check:i18n -w @arsnova/frontend` | bestanden (2447 Einheiten) |
| `npm run build:localize -w @arsnova/frontend` | bestanden (de/en/fr/it/es) |
| Manuell/Playwright lokal: MOTD-Dismiss → Skip-Link; News-Archiv zurück → Footer-News | bestätigt |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [ ] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [ ] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Nur Frontend-Chrome (Footer/Toolbar/Skip-Link/MOTD-Fokus). Keine Persistenz- oder API-Änderung.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine; normaler Frontend-Deploy.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Metriken.
- **Rollback:** Vorheriges Frontend-Release / Revert dieses Commits.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Unit-Tests: `home.component.spec.ts` (Skip-Link nach MOTD-Dismiss), `app.component.spec.ts` (Footer-Blur Bootstrap), `content-page-nav.spec.ts` (Focus-Return).
- Manuelle/Playwright-Prüfung lokal bei 820×1180: nach MOTD-Dismiss Fokus auf „Zum Inhalt springen“; nach News-Archiv-Zurück Fokus auf Footer-News.
- `build:localize` für alle fünf Locales grün.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** `npm run lint` separat nicht erneut ausgeführt (Pre-commit lint-staged auf geänderte TS/HTML/SCSS grün). Kein dedizierter Screenreader-Lauf; Fokusziele und Aria-Labels wurden unit-/manuell geprüft. Reflow/Zoom/Kontrast nicht neu gemessen (Layoutänderung auf bekannte Breakpoints begrenzt).
- **Verbleibende Risiken:** Sehr alte Browser mit abweichender Sequential-Focus-Heuristik nach Dialog-Dismiss könnten den Skip-Link-Fallback anders behandeln; MOTD mit gültigem `motdFocusReturn` stellt weiterhin auf das vorherige Element zurück (gewollt).

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)