### PR TITLE
fix(help): Einstiegs-Akkordeons standardmäßig geschlossen halten

### DIFF
--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -104,7 +104,12 @@
 
           <h3 class="help-experience-title" i18n="@@help.newUserTitle">Neu bei arsnova.eu</h3>
           <mat-accordion class="help-accordion" [multi]="true">
-            <mat-expansion-panel #hostCapabilitiesPanel class="help-panel" [expanded]="true">
+            <mat-expansion-panel
+              #hostCapabilitiesPanel
+              class="help-panel"
+              [expanded]="hostEntryExpanded()"
+              (expandedChange)="hostEntryExpanded.set($event)"
+            >
               <mat-expansion-panel-header>
                 <mat-panel-title i18n="@@help.hostCapabilitiesTitle"
                   >Was kann ich mit arsnova.eu machen?</mat-panel-title
@@ -262,7 +267,12 @@
 
           <h3 class="help-experience-title" i18n="@@help.newUserTitle">Neu bei arsnova.eu</h3>
           <mat-accordion class="help-accordion" [multi]="true">
-            <mat-expansion-panel #participantJoinPanel class="help-panel" [expanded]="true">
+            <mat-expansion-panel
+              #participantJoinPanel
+              class="help-panel"
+              [expanded]="participantEntryExpanded()"
+              (expandedChange)="participantEntryExpanded.set($event)"
+            >
               <mat-expansion-panel-header>
                 <mat-panel-title i18n="@@help.participantJoinTitle"
                   >Wie trete ich einer Session bei?</mat-panel-title

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -316,28 +316,117 @@ describe('HelpComponent', () => {
     expect(root.querySelectorAll('mat-accordion').length).toBe(5);
   });
 
-  it('öffnet das erste Anfängerpanel pro Rolle und hält Referenzpanels geschlossen', async () => {
+  it('lässt auf der Übersichtsansicht alle Akkordeons geschlossen', async () => {
     const fixture = await createFixture();
     const root = fixture.nativeElement as HTMLElement;
+    const panels = root.querySelectorAll('mat-expansion-panel.help-panel');
+    expect(panels.length).toBe(17);
+    for (const panel of Array.from(panels)) {
+      expect(panel.classList.contains('mat-expanded')).toBe(false);
+    }
+  });
+
+  it('öffnet bei Rollenkarten-Klick nur das Einstiegspanel der gewählten Rolle', async () => {
+    const fixture = await createFixture();
+    const root = fixture.nativeElement as HTMLElement;
+    const hostCard = root.querySelector<HTMLAnchorElement>('a.help-role-card[href$="#help-host"]');
+    const participantCard = root.querySelector<HTMLAnchorElement>(
+      'a.help-role-card[href$="#help-participant"]',
+    );
+    const hostSection = root.querySelector('#help-host') as HTMLElement;
+    const participantSection = root.querySelector('#help-participant') as HTMLElement;
+    Object.defineProperty(hostSection, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(participantSection, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
     const hostPanels = root.querySelectorAll('#help-host mat-expansion-panel.help-panel');
     const participantPanels = root.querySelectorAll(
       '#help-participant mat-expansion-panel.help-panel',
     );
-    const commonPanels = root.querySelectorAll('#help-common mat-expansion-panel.help-panel');
+
+    hostCard!.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }),
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
 
     expect(hostPanels[0]?.classList.contains('mat-expanded')).toBe(true);
     for (let i = 1; i < hostPanels.length; i++) {
       expect(hostPanels[i]?.classList.contains('mat-expanded')).toBe(false);
     }
+    for (const panel of Array.from(participantPanels)) {
+      expect(panel.classList.contains('mat-expanded')).toBe(false);
+    }
+
+    participantCard!.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }),
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
 
     expect(participantPanels[0]?.classList.contains('mat-expanded')).toBe(true);
     for (let i = 1; i < participantPanels.length; i++) {
       expect(participantPanels[i]?.classList.contains('mat-expanded')).toBe(false);
     }
-
-    for (const panel of Array.from(commonPanels)) {
+    for (const panel of Array.from(hostPanels)) {
       expect(panel.classList.contains('mat-expanded')).toBe(false);
     }
+  });
+
+  it('öffnet bei initialem Fragmentaufruf nur das Einstiegspanel der Deep-Link-Rolle', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [HelpRouterHostComponent, HelpComponent],
+      providers: [
+        provideRouter(
+          [
+            { path: 'de/help', component: HelpComponent },
+            { path: 'help', component: HelpComponent },
+          ],
+          withInMemoryScrolling({ scrollPositionRestoration: 'top' }),
+        ),
+        { provide: MatDialog, useValue: { openDialogs: [] } },
+      ],
+    });
+
+    const hostFixture = TestBed.createComponent(HelpRouterHostComponent);
+    document.body.appendChild(hostFixture.nativeElement);
+    hostFixture.detectChanges();
+
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+    const router = TestBed.inject(Router);
+    window.history.replaceState(window.history.state, '', '/de/help#help-participant');
+    const navigated = await router.navigateByUrl('/de/help#help-participant');
+    expect(navigated).toBe(true);
+    hostFixture.detectChanges();
+    await hostFixture.whenStable();
+    hostFixture.detectChanges();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    hostFixture.detectChanges();
+    await hostFixture.whenStable();
+
+    const hostPanels = document.querySelectorAll('#help-host mat-expansion-panel.help-panel');
+    const participantPanels = document.querySelectorAll(
+      '#help-participant mat-expansion-panel.help-panel',
+    );
+    expect(participantPanels[0]?.classList.contains('mat-expanded')).toBe(true);
+    for (let i = 1; i < participantPanels.length; i++) {
+      expect(participantPanels[i]?.classList.contains('mat-expanded')).toBe(false);
+    }
+    for (const panel of Array.from(hostPanels)) {
+      expect(panel.classList.contains('mat-expanded')).toBe(false);
+    }
+    Reflect.deleteProperty(Element.prototype, 'scrollIntoView');
   });
 
   it('lässt Panels öffnen und schließen und aktualisiert aria-expanded', async () => {
@@ -346,8 +435,14 @@ describe('HelpComponent', () => {
     const hostPanels = root.querySelectorAll('#help-host mat-expansion-panel.help-panel');
     const firstHeader = hostPanels[0]?.querySelector<HTMLElement>('.mat-expansion-panel-header');
     const secondHeader = hostPanels[1]?.querySelector<HTMLElement>('.mat-expansion-panel-header');
-    expect(firstHeader?.getAttribute('aria-expanded')).toBe('true');
+    expect(firstHeader?.getAttribute('aria-expanded')).toBe('false');
     expect(secondHeader?.getAttribute('aria-expanded')).toBe('false');
+
+    firstHeader!.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(firstHeader?.getAttribute('aria-expanded')).toBe('true');
 
     secondHeader!.click();
     fixture.detectChanges();

--- a/apps/frontend/src/app/features/help/help.component.ts
+++ b/apps/frontend/src/app/features/help/help.component.ts
@@ -6,6 +6,7 @@ import {
   HostListener,
   inject,
   PLATFORM_ID,
+  signal,
 } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { CdkTrapFocus } from '@angular/cdk/a11y';
@@ -63,6 +64,13 @@ export class HelpComponent implements AfterViewInit {
    * sonst gewinnt der Focus-Trap gegen den Abschnittstitel.
    */
   readonly trapAutoCapture = this.hashSectionOnInit === null;
+
+  /**
+   * Einstiegs-Akkordeons: auf der Übersicht zu, bei aktiver Rolle nur das der gewählten Rolle.
+   * Manuelles Auf/Zu bleibt über expandedChange synchron.
+   */
+  readonly hostEntryExpanded = signal(this.hashSectionOnInit === 'help-host');
+  readonly participantEntryExpanded = signal(this.hashSectionOnInit === 'help-participant');
 
   readonly localizedPath = localizePath;
   readonly infoLandingFeaturesAnchor = INFO_LANDING_ANCHORS.features;
@@ -137,6 +145,7 @@ export class HelpComponent implements AfterViewInit {
 
   /** Scrollt und fokussiert einen erlaubten Rollenabschnitt (Klick und initialer Hash). */
   private focusHelpSection(sectionId: HelpRoleSectionId): void {
+    this.applyRoleEntryExpanded(sectionId);
     const section = document.getElementById(sectionId);
     if (!section) {
       return;
@@ -147,6 +156,12 @@ export class HelpComponent implements AfterViewInit {
     // Nach In-Page-Sprung Fokus verschieben; sonst bleibt er auf der Rollenkarte und Tab
     // läuft wieder durch die Karten oberhalb des Ziels.
     heading.focus({ preventScroll: true });
+  }
+
+  /** Nur das Einstiegspanel der aktiven Rolle öffnen — nie beide Rollen parallel. */
+  private applyRoleEntryExpanded(sectionId: HelpRoleSectionId): void {
+    this.hostEntryExpanded.set(sectionId === 'help-host');
+    this.participantEntryExpanded.set(sectionId === 'help-participant');
   }
 
   private readAllowedHelpSectionHash(): HelpRoleSectionId | null {


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Beim Einstieg auf der Hilfeseite waren die Einstiegs-Akkordeons für Host und Teilnehmer gleichzeitig geöffnet — unruhig und inhaltlich überladen.
- **Lösung:** Auf der Übersicht bleiben beide Einstiege geschlossen. Bei Rollenwahl oder Deep-Link (`#help-host` / `#help-participant`) öffnet sich nur das Einstiegspanel der aktiven Rolle; manuelles Auf/Zu bleibt möglich.
- **Bewusste Nicht-Ziele:** Kein aktiver Abschnittsindikator / „Nach oben“ auf der Info-Landing-Seite (später bei Bedarf). Keine Änderungen an Deep-Link-Scroll/Fokus jenseits des Expanded-Zustands.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

- Hilfeseite Rollen-/Deep-Link-Verhalten (`HelpComponent`): erlaubte Abschnitte `help-host` / `help-participant`; Scroll + Heading-Fokus unverändert.
- Expansion Panels: `expanded`/`expandedChange` synchron zu Signals; nie beide Rollen-Einstiege parallel automatisch offen.

**Betroffene externe Verträge:**

Keine.

## Implementierung

- Signals `hostEntryExpanded` / `participantEntryExpanded` (Initialzustand aus Hash).
- `applyRoleEntryExpanded` bei Rollenfokus öffnet nur die aktive Rolle.
- Template: `[expanded]` + `(expandedChange)` statt hartem `[expanded]="true"`.
- Specs für Übersicht geschlossen, Rollenklick, Deep-Link und manuelles Toggle.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| Pre-commit: `npm run typecheck` | bestanden |
| Pre-commit: `npm test` | bestanden (Frontend 1135 Tests) |
| `npm run test -w @arsnova/frontend -- src/app/features/help/help.component.spec.ts` | 19/19 bestanden |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [ ] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [ ] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Hilfeseite zeigt beim Einstieg weniger offenen Inhalt; Rollen-/Deep-Link öffnet nur den passenden Einstieg.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Nicht betroffen.
- **Rollback:** Revert dieses PR-Commits.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Unit-Tests in `help.component.spec.ts` (Übersicht geschlossen, Rollenwahl, Deep-Link, Toggle)
- Pre-commit Typecheck + Full-Test-Suite grün

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** `build:prod` und separates `lint` lokal nicht nachgezogen (Pre-commit Typecheck/Tests; CI prüft Lint/Build). Screenreader nicht mit AT neu geprüft — Expansion-Panel-Semantik unverändert, nur Default-`expanded`. Mobile nur über Specs/Komponentenlogik, nicht visuell fotografiert. Neuladen ohne Hash bleibt „alles zu“ (beabsichtigt).
- **Verbleibende Risiken:** Nutzer, die bisher beide Einstiege sofort sahen, müssen einmal aufklappen oder eine Rolle wählen.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)