### PR TITLE
Darstellungsmodus beim Wechsel zu info.arsnova.eu übernehmen (#207)

### DIFF
--- a/apps/frontend/src/app/app.component.html
+++ b/apps/frontend/src/app/app.component.html
@@ -150,7 +150,7 @@
               <a
                 matButton
                 class="app-footer__primary app-footer__link--external"
-                [href]="infoLandingFeaturesUrl"
+                [href]="infoLandingFeaturesUrl()"
                 target="_blank"
                 rel="noopener noreferrer"
                 i18n-aria-label="@@app.footer.infoLandingAria"

--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -6,6 +6,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { SwUpdate } from '@angular/service-worker';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppComponent } from './app.component';
+import { ThemePresetService } from './core/theme-preset.service';
 import { markContentPageFocusReturn } from './shared/content-page-nav';
 import { TopToolbarComponent } from './shared/top-toolbar/top-toolbar.component';
 
@@ -536,9 +537,37 @@ describe('AppComponent', () => {
     expect(link?.textContent ?? '').toContain('Was arsnova.eu kann');
     expect(link?.target).toBe('_blank');
     expect(link?.rel).toContain('noopener');
+    expect(link?.href).toContain('?theme=');
     expect(link?.href).toContain('#features');
     expect(link?.getAttribute('aria-label') ?? '').toContain('öffnet in neuem Tab');
     expect(link?.querySelector('.app-footer__primary-stack')).toBeTruthy();
+
+    fixture.destroy();
+  });
+
+  it('aktualisiert den Info-Landing-Footer-Link reaktiv bei Theme-Wechsel', async () => {
+    configureAppTestBed();
+    const fixture = TestBed.createComponent(AppComponent);
+    const themePreset = TestBed.inject(ThemePresetService);
+    themePreset.setTheme('light');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const link = () =>
+      (fixture.nativeElement as HTMLElement).querySelector(
+        'a.app-footer__link--external',
+      ) as HTMLAnchorElement | null;
+
+    expect(link()?.getAttribute('href')).toBe('https://info.arsnova.eu/de/?theme=light#features');
+
+    themePreset.setTheme('dark');
+    fixture.detectChanges();
+    expect(link()?.getAttribute('href')).toBe('https://info.arsnova.eu/de/?theme=dark#features');
+
+    themePreset.setPreset('serious', { silent: true });
+    fixture.detectChanges();
+    expect(link()?.getAttribute('href')).toBe('https://info.arsnova.eu/de/?theme=dark#features');
 
     fixture.destroy();
   });

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -105,8 +105,11 @@ class ConnectionBannerHostDirective {
 })
 export class AppComponent implements OnInit, OnDestroy {
   readonly localizedPath = localizePath;
-  /** Footer-Deep-Link zur Informationsseite (Features). */
-  readonly infoLandingFeaturesUrl = infoLandingUrl(INFO_LANDING_ANCHORS.features);
+  readonly themePreset = inject(ThemePresetService);
+  /** Footer-Deep-Link zur Informationsseite (Features); Theme reaktiv (Issue #207). */
+  readonly infoLandingFeaturesUrl = computed(() =>
+    infoLandingUrl(INFO_LANDING_ANCHORS.features, undefined, this.themePreset.theme()),
+  );
   isOnline = signal(true);
   updateAvailable = signal(false);
   updateReloading = signal(false);
@@ -147,7 +150,6 @@ export class AppComponent implements OnInit, OnDestroy {
     this.onBeforeInstallPrompt(e as BeforeInstallPromptEvent);
   private appInstalledListener = (): void => this.onAppInstalled();
 
-  readonly themePreset = inject(ThemePresetService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly swUpdate = inject(SwUpdate, { optional: true });

--- a/apps/frontend/src/app/core/info-landing-url.spec.ts
+++ b/apps/frontend/src/app/core/info-landing-url.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { INFO_LANDING_ANCHORS, infoLandingUrl } from './info-landing-url';
+import { INFO_LANDING_ANCHORS, infoLandingUrl, type InfoLandingTheme } from './info-landing-url';
+import { SUPPORTED_LOCALES } from './locale-from-path';
 
 describe('infoLandingUrl', () => {
   it('baut immer einen Locale-Pfad und nie nur die Domainwurzel', () => {
@@ -16,5 +17,41 @@ describe('infoLandingUrl', () => {
     expect(infoLandingUrl(INFO_LANDING_ANCHORS.confidence, 'es')).toBe(
       'https://info.arsnova.eu/es/#confidence',
     );
+  });
+
+  it('setzt theme als Query vor dem Hash für alle erlaubten Werte', () => {
+    const themes: InfoLandingTheme[] = ['system', 'light', 'dark'];
+    for (const theme of themes) {
+      expect(infoLandingUrl(INFO_LANDING_ANCHORS.features, 'de', theme)).toBe(
+        `https://info.arsnova.eu/de/?theme=${theme}#features`,
+      );
+      expect(infoLandingUrl(null, 'en', theme)).toBe(`https://info.arsnova.eu/en/?theme=${theme}`);
+    }
+  });
+
+  it('hält Locale-Pfad und kanonische Anker mit Theme für alle fünf Sprachen', () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(infoLandingUrl(INFO_LANDING_ANCHORS.workflow, locale, 'dark')).toBe(
+        `https://info.arsnova.eu/${locale}/?theme=dark#workflow`,
+      );
+      expect(infoLandingUrl(INFO_LANDING_ANCHORS.features, locale, 'light')).toBe(
+        `https://info.arsnova.eu/${locale}/?theme=light#features`,
+      );
+      expect(infoLandingUrl(INFO_LANDING_ANCHORS.accessibility, locale, 'system')).toBe(
+        `https://info.arsnova.eu/${locale}/?theme=system#accessibility`,
+      );
+    }
+  });
+
+  it('ignoriert ungültige Theme-Werte und lässt den Query weg', () => {
+    expect(infoLandingUrl(INFO_LANDING_ANCHORS.features, 'de', undefined)).toBe(
+      'https://info.arsnova.eu/de/#features',
+    );
+    expect(infoLandingUrl(INFO_LANDING_ANCHORS.features, 'de', 'serious' as InfoLandingTheme)).toBe(
+      'https://info.arsnova.eu/de/#features',
+    );
+    expect(
+      infoLandingUrl(INFO_LANDING_ANCHORS.features, 'de', 'spielerisch' as InfoLandingTheme),
+    ).toBe('https://info.arsnova.eu/de/#features');
   });
 });

--- a/apps/frontend/src/app/core/info-landing-url.ts
+++ b/apps/frontend/src/app/core/info-landing-url.ts
@@ -18,17 +18,27 @@ export const INFO_LANDING_ANCHORS = {
 
 export type InfoLandingAnchor = (typeof INFO_LANDING_ANCHORS)[keyof typeof INFO_LANDING_ANCHORS];
 
+/** Darstellungsmodus für Cross-Origin-Übergabe an die Informationsseite (Issue #207). */
+export type InfoLandingTheme = 'system' | 'light' | 'dark';
+
+const INFO_LANDING_THEMES: readonly InfoLandingTheme[] = ['system', 'light', 'dark'];
+
+function isInfoLandingTheme(value: unknown): value is InfoLandingTheme {
+  return typeof value === 'string' && (INFO_LANDING_THEMES as readonly string[]).includes(value);
+}
+
 /**
  * Locale-sichere URL zur Informationsseite.
- * Niemals nur die Domainwurzel — immer `/{locale}/` (+ optionaler kanonischer Hash).
+ * Niemals nur die Domainwurzel — immer `/{locale}/` (+ optionaler Theme-Query und kanonischer Hash).
+ * Query steht vor dem Hash: `/{locale}/?theme=dark#features`.
  */
 export function infoLandingUrl(
   anchor?: InfoLandingAnchor | null,
   locale: SupportedLocale = getEffectiveLocale(),
+  theme?: InfoLandingTheme,
 ): string {
   const path = `${INFO_LANDING_ORIGIN.replace(/\/$/, '')}/${locale}/`;
-  if (!anchor) {
-    return path;
-  }
-  return `${path}#${anchor}`;
+  const query = isInfoLandingTheme(theme) ? `?theme=${theme}` : '';
+  const hash = anchor ? `#${anchor}` : '';
+  return `${path}${query}${hash}`;
 }

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -314,7 +314,7 @@ describe('HelpComponent', () => {
 
     const link = infoAside!.querySelector<HTMLAnchorElement>('a.info-landing-link');
     expect(link).toBeTruthy();
-    expect(link!.getAttribute('href')).toBe(infoLandingUrl('features'));
+    expect(link!.getAttribute('href')).toBe(infoLandingUrl('features', undefined, 'system'));
     expect(link!.getAttribute('target')).toBe('_blank');
     expect(link!.getAttribute('rel')).toBe('noopener noreferrer');
     expect(link!.getAttribute('aria-label') ?? '').toContain('öffnet in neuem Tab');

--- a/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.spec.ts
+++ b/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.spec.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { INFO_LANDING_ANCHORS } from '../../core/info-landing-url';
+import { ThemePresetService } from '../../core/theme-preset.service';
+import { InfoLandingLinkComponent } from './info-landing-link.component';
+
+@Component({
+  selector: 'app-info-landing-link-host',
+  imports: [InfoLandingLinkComponent],
+  template: `<app-info-landing-link [anchor]="anchor" [label]="label" />`,
+})
+class InfoLandingLinkHostComponent {
+  anchor = INFO_LANDING_ANCHORS.workflow;
+  label = 'Einsatzmöglichkeiten entdecken';
+}
+
+describe('InfoLandingLinkComponent', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [InfoLandingLinkHostComponent],
+    });
+  });
+
+  it('bindet href reaktiv an ThemePresetService.theme und ignoriert das Preset', () => {
+    const fixture = TestBed.createComponent(InfoLandingLinkHostComponent);
+    const themePreset = TestBed.inject(ThemePresetService);
+    themePreset.setTheme('system');
+    themePreset.setPreset('spielerisch', { silent: true });
+    fixture.detectChanges();
+
+    const link = () =>
+      (fixture.nativeElement as HTMLElement).querySelector(
+        'a.info-landing-link',
+      ) as HTMLAnchorElement | null;
+
+    expect(link()?.getAttribute('href')).toBe('https://info.arsnova.eu/de/?theme=system#workflow');
+    expect(link()?.target).toBe('_blank');
+    expect(link()?.rel).toBe('noopener noreferrer');
+
+    themePreset.setTheme('dark');
+    fixture.detectChanges();
+    expect(link()?.getAttribute('href')).toBe('https://info.arsnova.eu/de/?theme=dark#workflow');
+
+    themePreset.setTheme('light');
+    fixture.detectChanges();
+    expect(link()?.getAttribute('href')).toBe('https://info.arsnova.eu/de/?theme=light#workflow');
+
+    themePreset.setPreset('serious', { silent: true });
+    fixture.detectChanges();
+    expect(link()?.getAttribute('href')).toBe('https://info.arsnova.eu/de/?theme=light#workflow');
+  });
+});

--- a/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.ts
+++ b/apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.ts
@@ -1,10 +1,11 @@
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { infoLandingUrl, type InfoLandingAnchor } from '../../core/info-landing-url';
+import { ThemePresetService } from '../../core/theme-preset.service';
 
 /**
- * Kontextueller Link zur mehrsprachigen Informationsseite (Issue #192).
- * Öffnet immer in neuem Tab; kein Tracking.
+ * Kontextueller Link zur mehrsprachigen Informationsseite (Issue #192 / #207).
+ * Öffnet immer in neuem Tab; kein Tracking. Überträgt den aktuellen Darstellungsmodus.
  */
 @Component({
   selector: 'app-info-landing-link',
@@ -13,6 +14,8 @@ import { infoLandingUrl, type InfoLandingAnchor } from '../../core/info-landing-
   styleUrl: './info-landing-link.component.scss',
 })
 export class InfoLandingLinkComponent {
+  private readonly themePreset = inject(ThemePresetService);
+
   /** Kanonischer Anker ohne `#`. */
   readonly anchor = input.required<InfoLandingAnchor>();
   /** Sichtbarer Linktext (lokalisiert vom Aufrufer). */
@@ -20,7 +23,9 @@ export class InfoLandingLinkComponent {
   /** Optional dichtere Darstellung (z. B. unter Formularfeldern). */
   readonly dense = input(false);
 
-  protected readonly href = computed(() => infoLandingUrl(this.anchor()));
+  protected readonly href = computed(() =>
+    infoLandingUrl(this.anchor(), undefined, this.themePreset.theme()),
+  );
 
   protected readonly newTabHint = $localize`:@@infoLanding.openInNewTab:öffnet in neuem Tab`;
 }

--- a/apps/landing/scripts/check-theme-static.mjs
+++ b/apps/landing/scripts/check-theme-static.mjs
@@ -238,6 +238,15 @@ function checkBuiltThemeArtifacts() {
     fail('Built /de/ missing aria-pressed on theme options');
   }
   if (!html.includes('__arsnovaLandingTheme')) fail('Built /de/ missing theme runtime');
+  if (
+    !html.includes("URLSearchParams(window.location.search).get('theme')") &&
+    !html.includes('URLSearchParams(window.location.search).get("theme")')
+  ) {
+    fail('Built /de/ missing ?theme= query transfer (Issue #207)');
+  }
+  if (!html.includes('searchParams.delete') || !html.includes('replaceState')) {
+    fail('Built /de/ missing theme query cleanup via history.replaceState');
+  }
   if (html.includes('aria-haspopup')) {
     fail('Built /de/ must not use aria-haspopup on disclosure controls');
   }

--- a/apps/landing/scripts/check-theme-static.mjs
+++ b/apps/landing/scripts/check-theme-static.mjs
@@ -14,29 +14,63 @@ const errors = [];
 const fail = (message) => errors.push(message);
 
 /**
- * Theme-/Style-Einstiegspunkte: bei Diff hier muss apps/frontend unberührt bleiben.
- * Exportiert für Unit-Regressionstests.
+ * Style-/Token-Einstiegspunkte: bei Diff hier muss apps/frontend unberührt bleiben
+ * (Issue #199 – keine Angular-Material-/Frontend-Vermischung in Landing-Tokens).
  */
-export const LANDING_THEME_SCOPE = [
+export const LANDING_THEME_STYLE_SCOPE = [
   'apps/landing/src/styles/landing-theme.css',
   'apps/landing/src/styles/global.css',
   'apps/landing/src/components/ThemeSwitcher.astro',
   'apps/landing/src/components/LanguageSwitcher.astro',
-  'apps/landing/src/layouts/BaseLayout.astro',
   'apps/landing/tailwind.config.mjs',
 ];
 
 /**
- * Pure Prüfung: Theme-Scope + Frontend gleichzeitig geändert?
+ * Vollständiger Theme-Scope inkl. FOUC-/Layout-Skript.
+ * Exportiert für Unit-Regressionstests.
+ */
+export const LANDING_THEME_SCOPE = [
+  ...LANDING_THEME_STYLE_SCOPE,
+  'apps/landing/src/layouts/BaseLayout.astro',
+];
+
+/**
+ * Erlaubte Frontend-Brücke für Cross-Origin-Theme-Übergabe (Issue #207).
+ * Nur wirksam zusammen mit BaseLayout, nicht mit Style-/Token-Dateien.
+ */
+export const INFO_LANDING_THEME_BRIDGE_FRONTEND = [
+  'apps/frontend/src/app/core/info-landing-url.ts',
+  'apps/frontend/src/app/core/info-landing-url.spec.ts',
+  'apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.ts',
+  'apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.spec.ts',
+  'apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.html',
+  'apps/frontend/src/app/shared/info-landing-link/info-landing-link.component.scss',
+  'apps/frontend/src/app/app.component.ts',
+  'apps/frontend/src/app/app.component.html',
+  'apps/frontend/src/app/app.component.spec.ts',
+  'apps/frontend/src/app/features/help/help.component.spec.ts',
+];
+
+/**
+ * Pure Prüfung: unzulässige Theme-/Frontend-Vermischung?
+ * Style-Scope + jedes Frontend = Verstoß.
+ * BaseLayout + nur Info-Landing-Bridge-Frontend = erlaubt (Issue #207).
  * @param {string[]} changedPaths relative Repo-Pfade aus git diff --name-only
  */
 export function frontendIsolationViolation(changedPaths) {
   const paths = Array.isArray(changedPaths) ? changedPaths : [];
-  const themeTouched = paths.some((path) => LANDING_THEME_SCOPE.includes(path));
-  const frontendTouched = paths.some(
+  const frontendPaths = paths.filter(
     (path) => path === 'apps/frontend' || path.startsWith('apps/frontend/'),
   );
-  return themeTouched && frontendTouched;
+  if (frontendPaths.length === 0) return false;
+
+  const styleTouched = paths.some((path) => LANDING_THEME_STYLE_SCOPE.includes(path));
+  if (styleTouched) return true;
+
+  const themeTouched = paths.some((path) => LANDING_THEME_SCOPE.includes(path));
+  if (!themeTouched) return false;
+
+  return frontendPaths.some((path) => !INFO_LANDING_THEME_BRIDGE_FRONTEND.includes(path));
 }
 
 function walk(dir, files = []) {

--- a/apps/landing/scripts/check-theme-static.test.mjs
+++ b/apps/landing/scripts/check-theme-static.test.mjs
@@ -1,10 +1,16 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { LANDING_THEME_SCOPE, frontendIsolationViolation } from './check-theme-static.mjs';
+import {
+  INFO_LANDING_THEME_BRIDGE_FRONTEND,
+  LANDING_THEME_SCOPE,
+  LANDING_THEME_STYLE_SCOPE,
+  frontendIsolationViolation,
+} from './check-theme-static.mjs';
 
 test('Theme-Scope enthält global.css und landing-theme.css', () => {
   assert.ok(LANDING_THEME_SCOPE.includes('apps/landing/src/styles/global.css'));
   assert.ok(LANDING_THEME_SCOPE.includes('apps/landing/src/styles/landing-theme.css'));
+  assert.ok(LANDING_THEME_STYLE_SCOPE.includes('apps/landing/src/styles/global.css'));
 });
 
 test('reine Frontend-Änderungen lösen keine Isolation aus', () => {
@@ -39,4 +45,34 @@ test('ThemeSwitcher + apps/frontend ist eine verbotene Kombination', () => {
 
 test('nur Landing-Theme ohne Frontend ist erlaubt', () => {
   assert.equal(frontendIsolationViolation(['apps/landing/src/styles/global.css']), false);
+});
+
+test('BaseLayout + Info-Landing-Bridge-Frontend ist für Issue #207 erlaubt', () => {
+  assert.equal(
+    frontendIsolationViolation([
+      'apps/landing/src/layouts/BaseLayout.astro',
+      ...INFO_LANDING_THEME_BRIDGE_FRONTEND,
+    ]),
+    false,
+  );
+});
+
+test('BaseLayout + fremdes Frontend bleibt verboten', () => {
+  assert.equal(
+    frontendIsolationViolation([
+      'apps/landing/src/layouts/BaseLayout.astro',
+      'apps/frontend/src/app/features/home/home.component.ts',
+    ]),
+    true,
+  );
+});
+
+test('Style-Scope + Bridge-Frontend bleibt verboten', () => {
+  assert.equal(
+    frontendIsolationViolation([
+      'apps/landing/src/styles/landing-theme.css',
+      'apps/frontend/src/app/core/info-landing-url.ts',
+    ]),
+    true,
+  );
 });

--- a/apps/landing/scripts/check-theme-switcher.mjs
+++ b/apps/landing/scripts/check-theme-switcher.mjs
@@ -701,7 +701,10 @@ async function runViewport(browser, viewport, buttonId, label) {
  * Validates FOUC-free apply, storage precedence, URL cleanup, and invalid ignore.
  */
 async function assertThemeQueryTransfer(browser) {
-  async function openWith(path, { colorScheme = 'light', stored = null, viewport = { width: 1280, height: 900 } } = {}) {
+  async function openWith(
+    path,
+    { colorScheme = 'light', stored = null, viewport = { width: 1280, height: 900 } } = {},
+  ) {
     const context = await browser.newContext({
       colorScheme,
       viewport,
@@ -727,15 +730,18 @@ async function assertThemeQueryTransfer(browser) {
   {
     const { context, page } = await openWith('/de/?theme=dark#features', { stored: 'light' });
     try {
-      const state = await page.evaluate((key) => ({
-        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
-        className: document.documentElement.className,
-        colorScheme: getComputedStyle(document.documentElement).colorScheme,
-        stored: localStorage.getItem(key),
-        href: location.href,
-        search: location.search,
-        hash: location.hash,
-      }), STORAGE_KEY);
+      const state = await page.evaluate(
+        (key) => ({
+          scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+          className: document.documentElement.className,
+          colorScheme: getComputedStyle(document.documentElement).colorScheme,
+          stored: localStorage.getItem(key),
+          href: location.href,
+          search: location.search,
+          hash: location.hash,
+        }),
+        STORAGE_KEY,
+      );
       if (state.scheme !== 'dark') {
         throw new Error(`theme=dark: expected data-landing-color-scheme=dark, got ${state.scheme}`);
       }
@@ -756,11 +762,13 @@ async function assertThemeQueryTransfer(browser) {
       }
 
       await page.locator('#theme-desktop-button').click();
-      const pressed = await page.locator('#theme-desktop-menu [data-theme-option="dark"]').getAttribute(
-        'aria-pressed',
-      );
+      const pressed = await page
+        .locator('#theme-desktop-menu [data-theme-option="dark"]')
+        .getAttribute('aria-pressed');
       if (pressed !== 'true') {
-        throw new Error(`theme=dark: ThemeSwitcher dark option not pressed (aria-pressed=${pressed})`);
+        throw new Error(
+          `theme=dark: ThemeSwitcher dark option not pressed (aria-pressed=${pressed})`,
+        );
       }
     } finally {
       await context.close();
@@ -774,13 +782,16 @@ async function assertThemeQueryTransfer(browser) {
       stored: 'dark',
     });
     try {
-      const state = await page.evaluate((key) => ({
-        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
-        className: document.documentElement.className,
-        stored: localStorage.getItem(key),
-        search: location.search,
-        hash: location.hash,
-      }), STORAGE_KEY);
+      const state = await page.evaluate(
+        (key) => ({
+          scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+          className: document.documentElement.className,
+          stored: localStorage.getItem(key),
+          search: location.search,
+          hash: location.hash,
+        }),
+        STORAGE_KEY,
+      );
       if (state.scheme !== 'light' || !state.className.includes('light')) {
         throw new Error(`theme=light: expected light mode, got ${JSON.stringify(state)}`);
       }
@@ -802,13 +813,16 @@ async function assertThemeQueryTransfer(browser) {
       stored: 'light',
     });
     try {
-      const state = await page.evaluate((key) => ({
-        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
-        className: document.documentElement.className,
-        colorScheme: getComputedStyle(document.documentElement).colorScheme,
-        stored: localStorage.getItem(key),
-        hash: location.hash,
-      }), STORAGE_KEY);
+      const state = await page.evaluate(
+        (key) => ({
+          scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+          className: document.documentElement.className,
+          colorScheme: getComputedStyle(document.documentElement).colorScheme,
+          stored: localStorage.getItem(key),
+          hash: location.hash,
+        }),
+        STORAGE_KEY,
+      );
       if (state.scheme !== 'system') {
         throw new Error(`theme=system: expected scheme system, got ${state.scheme}`);
       }
@@ -833,12 +847,15 @@ async function assertThemeQueryTransfer(browser) {
   {
     const { context, page } = await openWith('/de/#features', { stored: 'dark' });
     try {
-      const state = await page.evaluate((key) => ({
-        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
-        stored: localStorage.getItem(key),
-        search: location.search,
-        hash: location.hash,
-      }), STORAGE_KEY);
+      const state = await page.evaluate(
+        (key) => ({
+          scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+          stored: localStorage.getItem(key),
+          search: location.search,
+          hash: location.hash,
+        }),
+        STORAGE_KEY,
+      );
       if (state.scheme !== 'dark' || state.stored !== 'dark') {
         throw new Error(`no theme param: expected stored dark, got ${JSON.stringify(state)}`);
       }
@@ -854,12 +871,15 @@ async function assertThemeQueryTransfer(browser) {
   {
     const { context, page } = await openWith('/de/?theme=neon&ref=app#faq', { stored: 'light' });
     try {
-      const state = await page.evaluate((key) => ({
-        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
-        stored: localStorage.getItem(key),
-        search: location.search,
-        hash: location.hash,
-      }), STORAGE_KEY);
+      const state = await page.evaluate(
+        (key) => ({
+          scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+          stored: localStorage.getItem(key),
+          search: location.search,
+          hash: location.hash,
+        }),
+        STORAGE_KEY,
+      );
       if (state.scheme !== 'light' || state.stored !== 'light') {
         throw new Error(`invalid theme: must keep light preference, got ${JSON.stringify(state)}`);
       }
@@ -882,12 +902,15 @@ async function assertThemeQueryTransfer(browser) {
       stored: 'light',
     });
     try {
-      const state = await page.evaluate((key) => ({
-        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
-        stored: localStorage.getItem(key),
-        search: location.search,
-        hash: location.hash,
-      }), STORAGE_KEY);
+      const state = await page.evaluate(
+        (key) => ({
+          scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+          stored: localStorage.getItem(key),
+          search: location.search,
+          hash: location.hash,
+        }),
+        STORAGE_KEY,
+      );
       if (state.scheme !== 'dark' || state.stored !== 'dark') {
         throw new Error(`cleanup: expected dark applied, got ${JSON.stringify(state)}`);
       }
@@ -917,7 +940,11 @@ async function assertThemeQueryTransfer(browser) {
         className: document.documentElement.className,
         hash: location.hash,
       }));
-      if (state.scheme !== 'dark' || !state.className.includes('dark') || state.hash !== '#features') {
+      if (
+        state.scheme !== 'dark' ||
+        !state.className.includes('dark') ||
+        state.hash !== '#features'
+      ) {
         throw new Error(`320px theme transfer failed: ${JSON.stringify(state)}`);
       }
       await page.locator('#theme-mobile-button').waitFor({ state: 'visible' });

--- a/apps/landing/scripts/check-theme-switcher.mjs
+++ b/apps/landing/scripts/check-theme-switcher.mjs
@@ -696,6 +696,237 @@ async function runViewport(browser, viewport, buttonId, label) {
   }
 }
 
+/**
+ * Cross-Origin theme transfer from Angular via ?theme= (Issue #207).
+ * Validates FOUC-free apply, storage precedence, URL cleanup, and invalid ignore.
+ */
+async function assertThemeQueryTransfer(browser) {
+  async function openWith(path, { colorScheme = 'light', stored = null, viewport = { width: 1280, height: 900 } } = {}) {
+    const context = await browser.newContext({
+      colorScheme,
+      viewport,
+      reducedMotion: 'reduce',
+    });
+    const page = await context.newPage();
+    await page.addInitScript(
+      ({ key, value }) => {
+        try {
+          if (value == null) localStorage.removeItem(key);
+          else localStorage.setItem(key, value);
+        } catch {
+          // ignore
+        }
+      },
+      { key: STORAGE_KEY, value: stored },
+    );
+    await page.goto(`${BASE_URL}${path}`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+    return { context, page };
+  }
+
+  // dark + hash: apply before paint semantics, persist, strip theme only
+  {
+    const { context, page } = await openWith('/de/?theme=dark#features', { stored: 'light' });
+    try {
+      const state = await page.evaluate((key) => ({
+        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+        className: document.documentElement.className,
+        colorScheme: getComputedStyle(document.documentElement).colorScheme,
+        stored: localStorage.getItem(key),
+        href: location.href,
+        search: location.search,
+        hash: location.hash,
+      }), STORAGE_KEY);
+      if (state.scheme !== 'dark') {
+        throw new Error(`theme=dark: expected data-landing-color-scheme=dark, got ${state.scheme}`);
+      }
+      if (!state.className.includes('dark')) {
+        throw new Error(`theme=dark: expected html.dark, got ${state.className}`);
+      }
+      if (!state.colorScheme.includes('dark')) {
+        throw new Error(`theme=dark: expected color-scheme dark, got ${state.colorScheme}`);
+      }
+      if (state.stored !== 'dark') {
+        throw new Error(`theme=dark: expected storage dark (override light), got ${state.stored}`);
+      }
+      if (state.search.includes('theme=')) {
+        throw new Error(`theme=dark: theme query not cleaned (${state.search})`);
+      }
+      if (state.hash !== '#features') {
+        throw new Error(`theme=dark: hash must remain #features, got ${state.hash}`);
+      }
+
+      await page.locator('#theme-desktop-button').click();
+      const pressed = await page.locator('#theme-desktop-menu [data-theme-option="dark"]').getAttribute(
+        'aria-pressed',
+      );
+      if (pressed !== 'true') {
+        throw new Error(`theme=dark: ThemeSwitcher dark option not pressed (aria-pressed=${pressed})`);
+      }
+    } finally {
+      await context.close();
+    }
+  }
+
+  // light + workflow hash
+  {
+    const { context, page } = await openWith('/en/?theme=light#workflow', {
+      colorScheme: 'dark',
+      stored: 'dark',
+    });
+    try {
+      const state = await page.evaluate((key) => ({
+        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+        className: document.documentElement.className,
+        stored: localStorage.getItem(key),
+        search: location.search,
+        hash: location.hash,
+      }), STORAGE_KEY);
+      if (state.scheme !== 'light' || !state.className.includes('light')) {
+        throw new Error(`theme=light: expected light mode, got ${JSON.stringify(state)}`);
+      }
+      if (state.stored !== 'light') {
+        throw new Error(`theme=light: expected storage light, got ${state.stored}`);
+      }
+      if (state.search.includes('theme=') || state.hash !== '#workflow') {
+        throw new Error(`theme=light: cleanup/hash wrong (${state.search} ${state.hash})`);
+      }
+    } finally {
+      await context.close();
+    }
+  }
+
+  // system stays semantic system and follows OS
+  {
+    const { context, page } = await openWith('/fr/?theme=system#accessibility', {
+      colorScheme: 'dark',
+      stored: 'light',
+    });
+    try {
+      const state = await page.evaluate((key) => ({
+        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+        className: document.documentElement.className,
+        colorScheme: getComputedStyle(document.documentElement).colorScheme,
+        stored: localStorage.getItem(key),
+        hash: location.hash,
+      }), STORAGE_KEY);
+      if (state.scheme !== 'system') {
+        throw new Error(`theme=system: expected scheme system, got ${state.scheme}`);
+      }
+      if (/\b(light|dark)\b/.test(state.className)) {
+        throw new Error(`theme=system: expected no explicit class, got ${state.className}`);
+      }
+      if (!state.colorScheme.includes('dark')) {
+        throw new Error(`theme=system: OS dark should resolve dark, got ${state.colorScheme}`);
+      }
+      if (state.stored !== 'system') {
+        throw new Error(`theme=system: expected storage system, got ${state.stored}`);
+      }
+      if (state.hash !== '#accessibility') {
+        throw new Error(`theme=system: hash lost (${state.hash})`);
+      }
+    } finally {
+      await context.close();
+    }
+  }
+
+  // without theme param: local preference wins
+  {
+    const { context, page } = await openWith('/de/#features', { stored: 'dark' });
+    try {
+      const state = await page.evaluate((key) => ({
+        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+        stored: localStorage.getItem(key),
+        search: location.search,
+        hash: location.hash,
+      }), STORAGE_KEY);
+      if (state.scheme !== 'dark' || state.stored !== 'dark') {
+        throw new Error(`no theme param: expected stored dark, got ${JSON.stringify(state)}`);
+      }
+      if (state.hash !== '#features') {
+        throw new Error(`no theme param: hash changed (${state.hash})`);
+      }
+    } finally {
+      await context.close();
+    }
+  }
+
+  // invalid theme ignored and not persisted; other params + hash kept
+  {
+    const { context, page } = await openWith('/de/?theme=neon&ref=app#faq', { stored: 'light' });
+    try {
+      const state = await page.evaluate((key) => ({
+        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+        stored: localStorage.getItem(key),
+        search: location.search,
+        hash: location.hash,
+      }), STORAGE_KEY);
+      if (state.scheme !== 'light' || state.stored !== 'light') {
+        throw new Error(`invalid theme: must keep light preference, got ${JSON.stringify(state)}`);
+      }
+      if (!state.search.includes('theme=neon') || !state.search.includes('ref=app')) {
+        throw new Error(
+          `invalid theme: must not strip params when theme invalid (${state.search})`,
+        );
+      }
+      if (state.hash !== '#faq') {
+        throw new Error(`invalid theme: hash lost (${state.hash})`);
+      }
+    } finally {
+      await context.close();
+    }
+  }
+
+  // valid theme cleanup keeps sibling query params + hash
+  {
+    const { context, page } = await openWith('/de/?utm=1&theme=dark&ref=app#features', {
+      stored: 'light',
+    });
+    try {
+      const state = await page.evaluate((key) => ({
+        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+        stored: localStorage.getItem(key),
+        search: location.search,
+        hash: location.hash,
+      }), STORAGE_KEY);
+      if (state.scheme !== 'dark' || state.stored !== 'dark') {
+        throw new Error(`cleanup: expected dark applied, got ${JSON.stringify(state)}`);
+      }
+      if (state.search.includes('theme=')) {
+        throw new Error(`cleanup: theme still present (${state.search})`);
+      }
+      if (!state.search.includes('utm=1') || !state.search.includes('ref=app')) {
+        throw new Error(`cleanup: sibling params lost (${state.search})`);
+      }
+      if (state.hash !== '#features') {
+        throw new Error(`cleanup: hash lost (${state.hash})`);
+      }
+    } finally {
+      await context.close();
+    }
+  }
+
+  // 320px mobile viewport still applies transfer
+  {
+    const { context, page } = await openWith('/it/?theme=dark#features', {
+      viewport: { width: 320, height: 720 },
+      stored: 'light',
+    });
+    try {
+      const state = await page.evaluate(() => ({
+        scheme: document.documentElement.getAttribute('data-landing-color-scheme'),
+        className: document.documentElement.className,
+        hash: location.hash,
+      }));
+      if (state.scheme !== 'dark' || !state.className.includes('dark') || state.hash !== '#features') {
+        throw new Error(`320px theme transfer failed: ${JSON.stringify(state)}`);
+      }
+      await page.locator('#theme-mobile-button').waitFor({ state: 'visible' });
+    } finally {
+      await context.close();
+    }
+  }
+}
+
 async function main() {
   await waitForServer();
   const browser = await chromium.launch({ headless: true });
@@ -703,6 +934,7 @@ async function main() {
     await runViewport(browser, { width: 1280, height: 900 }, 'theme-desktop-button', 'desktop');
     await runViewport(browser, { width: 390, height: 844 }, 'theme-mobile-button', 'mobile');
     await assertFallbackWithoutStoredValue(browser);
+    await assertThemeQueryTransfer(browser);
     await assertNoJsPrefersColorScheme(browser);
     await assertReducedMotion(browser);
     await assertOverflow(browser);
@@ -711,7 +943,7 @@ async function main() {
     await browser.close();
   }
   console.log(
-    'Theme switcher checks passed (desktop + mobile + fallback + no-js + motion + overflow + focus).',
+    'Theme switcher checks passed (desktop + mobile + fallback + theme-query + no-js + motion + overflow + focus).',
   );
 }
 

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -145,8 +145,32 @@ const jsonLd = {
         } catch (_e) {}
         var preference =
           stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system';
+        // Cross-Origin-Übergabe von arsnova.eu (Issue #207): gültiges ?theme= hat Vorrang.
+        var transferred = null;
+        try {
+          var rawTheme = new URLSearchParams(window.location.search).get('theme');
+          if (rawTheme === 'light' || rawTheme === 'dark' || rawTheme === 'system') {
+            transferred = rawTheme;
+          }
+        } catch (_e) {}
+        if (transferred) {
+          preference = transferred;
+          try {
+            localStorage.setItem(KEY, transferred);
+          } catch (_e) {}
+        }
         apply(preference);
         root.setAttribute('data-landing-color-scheme', preference);
+        if (transferred) {
+          try {
+            var url = new URL(window.location.href);
+            url.searchParams.delete('theme');
+            var cleanedSearch = url.searchParams.toString();
+            var next =
+              url.pathname + (cleanedSearch ? '?' + cleanedSearch : '') + url.hash;
+            history.replaceState(null, '', next);
+          } catch (_e) {}
+        }
         window.__arsnovaLandingTheme = {
           key: KEY,
           get: function () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zusammenfassung

- **Problem:** Beim Wechsel von `arsnova.eu` nach `info.arsnova.eu` blieb die Sprache erhalten, der Darstellungsmodus `system|light|dark` jedoch nicht — unterschiedliche Origins teilen kein `localStorage`.
- **Lösung:** Angular Info-Links übertragen den aktuellen Modus als strikt validierten Query-Parameter `?theme=` vor dem Hash; Astro übernimmt ihn vor dem ersten Paint, persistiert ihn unter `arsnova-info-color-scheme-v1` und entfernt nur `theme` per `history.replaceState`.
- **Bewusste Nicht-Ziele:** Keine Übertragung des Presets „Spielerisch/Seriös“, kein Cookie/Cross-Origin-Rückkanal, keine neuen Übersetzungstexte, keine Design-Token-/Material-Umstellung der Landingpage.

Closes #207

## Risiko und Verträge

- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Issue #207 (verbindliches URL-Verhalten `/{locale}/?theme=…#anker`), bestehendes FOUC-Inline-Skript in `BaseLayout.astro`, Locale-Pfad als alleinige Sprachinformation, Participant-/Security-Grenzen unverändert.

**Betroffene externe Verträge:**

Browser-URL/`URLSearchParams`, `history.replaceState`, `localStorage` (nur Landing-Origin `arsnova-info-color-scheme-v1`). Kein Server-/API-Vertrag.

## Implementierung

- `infoLandingUrl(...)` um optionalen, typisierten Parameter `theme` erweitert; Query steht vor dem Hash.
- Footer-Link und `InfoLandingLinkComponent` binden `href` reaktiv an `ThemePresetService.theme()` via `computed`.
- Astro-Inline-Skript liest `?theme=`, validiert `system|light|dark`, gibt dem Wert Vorrang vor lokaler Präferenz, speichert und bereinigt nur `theme`.
- Landing-Theme-Static-Isolation: Style-/Token-Scope bleibt gegen Frontend isoliert; BaseLayout plus Info-Landing-URL-Brücke ist für #207 erlaubt.
- Unit-/Komponententests (Angular) und Theme-Static-/Switcher-Checks (Astro) ergänzt.
- Review-Nachzug: Prettier-Formatierung von `apps/landing/scripts/check-theme-switcher.mjs` (CI „Changed Files Format“).

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [x] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` | bestanden |
| `npm test` | bestanden (shared-types, session-export-report, backend, frontend 1142) |
| `npm run lint` | bestanden |
| `npm run build:prod` | bestanden |
| `npm run build:landing` | bestanden |
| `npm run test:theme-static -w @arsnova/landing` | bestanden |
| `BASE_URL=http://localhost:4321 npm run test:theme-switcher -w @arsnova/landing` | bestanden (inkl. theme-query Transferfälle, 320 px) |
| `npx prettier --write apps/landing/scripts/check-theme-switcher.mjs` | angewendet |
| `npm run format:check:changed` | bestanden |
| `git diff --check` | bestanden |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

Mobile/Desktop sowie 320-px-Transfer über Landing-Theme-Switcher-Checks. Keine neuen sichtbaren Texte; bestehende `target`/`rel`/`aria-label`-Eigenschaften der Info-Links unverändert. Kontrast-/Token-Architektur unverändert (bestehende Theme-Checks bleiben maßgeblich). Ungültige `theme`-Werte werden ignoriert und nicht persistiert.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Nach Deploy von Frontend und Landing übernehmen Info-Links den App-Darstellungsmodus; ohne `theme` bleibt das bisherige Landing-Verhalten.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine; Frontend- und Landing-Deploy wie bisher.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Logs/Telemetrie; `theme` ist kein Tracking-Parameter.
- **Rollback:** Vorherige Frontend-/Landing-Versionen deployen; Query ohne Auswertung ist harmlos.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Unit-Tests: `info-landing-url.spec.ts`, `info-landing-link.component.spec.ts`, Footer-Reaktivität in `app.component.spec.ts`
- Astro: erweiterte Checks in `check-theme-static.mjs` und `check-theme-switcher.mjs` (`?theme=`-Übernahme, Override, Cleanup, ungültige Werte, 320 px)
- Review-Korrektur: Prettier-Fix für `check-theme-switcher.mjs` (Commit `b7d92feb`)
- PR: https://github.com/kqc-real/arsnova.eu/pull/208

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Prisma/Migration, Realtime/WebSocket/Yjs, Lastbudget, asynchrone DOM-/Fokus-Ersetzung (keine Fokusverschiebung), neue i18n-Texte (keine).
- **Verbleibende Risiken:** Echter Cross-Origin-Klick von Produktion zu Produktion ist manuell zu bestätigen; FOUC-Freiheit stützt sich auf das Head-Inline-Skript (wie bisher bei lokaler Präferenz). CI auf dem neuen Head-SHA muss den vorherigen Format-Blocker und ggf. weitere Pflichtchecks erneut bestätigen.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae48f798-9eec-452f-a178-8c9d0420679e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae48f798-9eec-452f-a178-8c9d0420679e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

