### PR TITLE
ci(docker): Produktionsimage einmal bauen, scannen und auf main nach GHCR pushen (Slice 1B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,9 @@ jobs:
         run: |
           bash -n scripts/backup/*.sh
           bash -n scripts/backup/tests/*.sh
-          shellcheck scripts/backup/*.sh scripts/backup/tests/*.sh
+          bash -n scripts/ci/*.sh
+          shellcheck scripts/backup/*.sh scripts/backup/tests/*.sh scripts/ci/*.sh
+          node --test scripts/ci/image-artifact-meta.test.mjs
           python3 -m py_compile scripts/monitoring/arsnova_monitor.py
           python3 -m unittest discover -s scripts/monitoring/tests -p 'test_*.py'
           docker run --rm \
@@ -1543,11 +1545,18 @@ jobs:
           retention-days: 7
 
   # ─── Security Scan (Docker Image) ──────────────────────────────────────────
+  # Scannt genau das vom Job „Docker Build“ exportierte Artefakt (kein zweiter Build).
+  # GHCR-Push nur bei push auf main und nur nach erfolgreichem Scan.
   trivy-image:
     name: Trivy Image Scan
     runs-on: ubuntu-latest
     needs: [changes, docker]
     if: github.event_name != 'schedule'
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.push_ghcr.outputs.image_ref }}
 
     steps:
       - name: Docs-only fast pass
@@ -1562,21 +1571,33 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
-      - name: Build Docker image for scanning
+      - name: Download production image artifact
         if: needs.changes.outputs.docs_only != 'true'
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          context: .
-          push: false
-          load: true
-          tags: arsnova-eu:scan-${{ github.sha }}
-          cache-from: type=gha
+          name: production-image-${{ github.sha }}
+          path: ${{ runner.temp }}/production-image
+
+      - name: Load production image artifact
+        if: needs.changes.outputs.docs_only != 'true'
+        id: load_image
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci/load-production-image.sh
+          # Bewusst kein docker build / build-push-action in diesem Job.
+          echo "Trivy Image Scan lädt das Docker-Build-Artefakt; es findet kein zweiter Image-Build statt."
+          scripts/ci/load-production-image.sh \
+            "${{ runner.temp }}/production-image" \
+            "${{ github.sha }}"
+          IMAGE_ID="$(docker image inspect --format '{{.Id}}' arsnova-eu:production)"
+          echo "Gescanntes Image: arsnova-eu:production imageId=$IMAGE_ID"
+          echo "image_id=$IMAGE_ID" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy image scan
         if: needs.changes.outputs.docs_only != 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
-          image-ref: arsnova-eu:scan-${{ github.sha }}
+          image-ref: arsnova-eu:production
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: '1'
@@ -1585,7 +1606,7 @@ jobs:
         if: always() && needs.changes.outputs.docs_only != 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
-          image-ref: arsnova-eu:scan-${{ github.sha }}
+          image-ref: arsnova-eu:production
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           format: sarif
@@ -1601,7 +1622,52 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      - name: Log in to GHCR
+        if: >-
+          needs.changes.outputs.docs_only != 'true'
+          && github.event_name == 'push'
+          && github.ref == 'refs/heads/main'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push scanned image to GHCR
+        if: >-
+          needs.changes.outputs.docs_only != 'true'
+          && github.event_name == 'push'
+          && github.ref == 'refs/heads/main'
+        id: push_ghcr
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LOCAL_TAG='arsnova-eu:production'
+          LOCAL_ID="$(docker image inspect --format '{{.Id}}' "$LOCAL_TAG")"
+          COMMIT_TAG="${IMAGE_NAME}:${GITHUB_SHA}"
+
+          echo "Push des bereits gebauten und gescannten Images (kein Rebuild)."
+          echo "localTag=$LOCAL_TAG localImageId=$LOCAL_ID"
+          echo "commitTag=$COMMIT_TAG"
+
+          docker tag "$LOCAL_TAG" "$COMMIT_TAG"
+          docker push "$COMMIT_TAG"
+
+          DIGEST="$(docker buildx imagetools inspect "$COMMIT_TAG" --format '{{.Manifest.Digest}}')"
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Ungültiger Registry-Digest: $DIGEST" >&2
+            exit 1
+          fi
+
+          IMAGE_REF="${IMAGE_NAME}@${DIGEST}"
+          echo "image_ref=$IMAGE_REF" >> "$GITHUB_OUTPUT"
+          echo "Registry-Referenz (kanonisch): $IMAGE_REF"
+          echo "Commit-Tag zusätzlich: $COMMIT_TAG"
+
   # ─── Docker Build (inkl. lokalisiertem Frontend-Build) ──────────────────────
+  # Baut das Produktionsimage genau einmal, führt Runtime-Smokes aus und exportiert
+  # dasselbe lokale Image als kurzlebiges Actions-Artefakt für Trivy/GHCR.
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
@@ -1736,6 +1802,27 @@ jobs:
             -e CLIENTS=30 \
             -e UPDATE_CONCURRENCY=15 \
             app node --input-type=module < scripts/load/yjs-sync-load.mjs
+
+      - name: Export production image artifact
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          set -euo pipefail
+          IMAGE_ID="$(docker image inspect --format '{{.Id}}' arsnova-eu:production)"
+          echo "Einziger Produktionsimage-Build dieses Workflows: imageId=$IMAGE_ID"
+          chmod +x scripts/ci/save-production-image.sh
+          scripts/ci/save-production-image.sh \
+            arsnova-eu:production \
+            "${{ runner.temp }}/production-image" \
+            "${{ github.sha }}"
+
+      - name: Upload production image artifact
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: production-image-${{ github.sha }}
+          path: ${{ runner.temp }}/production-image/
+          if-no-files-found: error
+          retention-days: 1
 
   # ─── Deploy Freshness Check (nur aktueller main-HEAD darf deployen) ──────────
   deploy-freshness:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           bash -n scripts/backup/tests/*.sh
           bash -n scripts/ci/*.sh
           shellcheck scripts/backup/*.sh scripts/backup/tests/*.sh scripts/ci/*.sh
-          node --test scripts/ci/image-artifact-meta.test.mjs
+          node --test scripts/ci/*.test.mjs
           python3 -m py_compile scripts/monitoring/arsnova_monitor.py
           python3 -m unittest discover -s scripts/monitoring/tests -p 'test_*.py'
           docker run --rm \
@@ -1546,7 +1546,7 @@ jobs:
 
   # ─── Security Scan (Docker Image) ──────────────────────────────────────────
   # Scannt genau das vom Job „Docker Build“ exportierte Artefakt (kein zweiter Build).
-  # GHCR-Push nur bei push auf main und nur nach erfolgreichem Scan.
+  # Read-only: kein packages:write, kein GHCR-Login/Push (siehe publish-image).
   trivy-image:
     name: Trivy Image Scan
     runs-on: ubuntu-latest
@@ -1554,9 +1554,6 @@ jobs:
     if: github.event_name != 'schedule'
     permissions:
       contents: read
-      packages: write
-    outputs:
-      image_ref: ${{ steps.push_ghcr.outputs.image_ref }}
 
     steps:
       - name: Docs-only fast pass
@@ -1566,10 +1563,6 @@ jobs:
       - name: Checkout
         if: needs.changes.outputs.docs_only != 'true'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-
-      - name: Set up Docker Buildx
-        if: needs.changes.outputs.docs_only != 'true'
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Download production image artifact
         if: needs.changes.outputs.docs_only != 'true'
@@ -1622,11 +1615,48 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # ─── GHCR publish (nur main, nach erfolgreichem Scan) ───────────────────────
+  # Separater Job: packages:write kommt nicht mit PR-Checkout/Trivy-Skripten zusammen.
+  # Check-Name ist neu und bewusst kein Required-Check-Rename (#221).
+  publish-image:
+    name: Publish Scanned Image
+    runs-on: ubuntu-latest
+    needs: [changes, trivy-image]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.push_ghcr.outputs.image_ref }}
+
+    steps:
+      - name: Docs-only fast pass
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Docs-only change — skipping GHCR publish."
+
+      - name: Checkout
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+
+      - name: Download production image artifact
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: production-image-${{ github.sha }}
+          path: ${{ runner.temp }}/production-image
+
+      - name: Load scanned production image
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci/load-production-image.sh scripts/ci/resolve-pushed-image-ref.sh
+          echo "Publish lädt dasselbe Docker-Build-Artefakt erneut; kein Image-Build."
+          scripts/ci/load-production-image.sh \
+            "${{ runner.temp }}/production-image" \
+            "${{ github.sha }}"
+
       - name: Log in to GHCR
-        if: >-
-          needs.changes.outputs.docs_only != 'true'
-          && github.event_name == 'push'
-          && github.ref == 'refs/heads/main'
+        if: needs.changes.outputs.docs_only != 'true'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
@@ -1634,10 +1664,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push scanned image to GHCR
-        if: >-
-          needs.changes.outputs.docs_only != 'true'
-          && github.event_name == 'push'
-          && github.ref == 'refs/heads/main'
+        if: needs.changes.outputs.docs_only != 'true'
         id: push_ghcr
         env:
           IMAGE_NAME: ghcr.io/${{ github.repository }}
@@ -1646,21 +1673,16 @@ jobs:
           LOCAL_TAG='arsnova-eu:production'
           LOCAL_ID="$(docker image inspect --format '{{.Id}}' "$LOCAL_TAG")"
           COMMIT_TAG="${IMAGE_NAME}:${GITHUB_SHA}"
+          PUSH_LOG="${RUNNER_TEMP}/ghcr-push.log"
 
           echo "Push des bereits gebauten und gescannten Images (kein Rebuild)."
           echo "localTag=$LOCAL_TAG localImageId=$LOCAL_ID"
           echo "commitTag=$COMMIT_TAG"
 
           docker tag "$LOCAL_TAG" "$COMMIT_TAG"
-          docker push "$COMMIT_TAG"
+          docker push "$COMMIT_TAG" | tee "$PUSH_LOG"
 
-          DIGEST="$(docker buildx imagetools inspect "$COMMIT_TAG" --format '{{.Manifest.Digest}}')"
-          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "Ungültiger Registry-Digest: $DIGEST" >&2
-            exit 1
-          fi
-
-          IMAGE_REF="${IMAGE_NAME}@${DIGEST}"
+          IMAGE_REF="$(scripts/ci/resolve-pushed-image-ref.sh "$IMAGE_NAME" "$COMMIT_TAG" "$PUSH_LOG")"
           echo "image_ref=$IMAGE_REF" >> "$GITHUB_OUTPUT"
           echo "Registry-Referenz (kanonisch): $IMAGE_REF"
           echo "Commit-Tag zusätzlich: $COMMIT_TAG"
@@ -1823,6 +1845,7 @@ jobs:
           path: ${{ runner.temp }}/production-image/
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
   # ─── Deploy Freshness Check (nur aktueller main-HEAD darf deployen) ──────────
   deploy-freshness:
@@ -1846,6 +1869,7 @@ jobs:
         audit,
         trivy-fs,
         trivy-image,
+        publish-image,
       ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DEPLOY_ENABLED == 'true' && needs.changes.outputs.docs_only != 'true'
     outputs:

--- a/docs/CI-WORKFLOW.md
+++ b/docs/CI-WORKFLOW.md
@@ -80,8 +80,8 @@ flowchart TD
   D --> J[lighthouse]
   D --> K[e2e smoke]
   D --> K2[classroom smokes]
-  D --> L[docker build]
-  D --> M[trivy-image]
+  D --> L[docker build<br/>ein Image + Artefakt]
+  L --> M[trivy-image<br/>load/scan; GHCR nur main]
 
   H --> Q[deploy-freshness<br/>nur aktueller main-HEAD]
   I --> Q
@@ -298,17 +298,30 @@ nicht die offene S6.5-Zielhostabnahme.
 
 ### 4.14 trivy-image
 
-- **Was?** Baut ein Scan-Image und führt Trivy-Image-Scan aus (HIGH/CRITICAL).
-- **Wo?** In [../.github/workflows/ci.yml](../.github/workflows/ci.yml).
-- **Wann?** Nach `build`, außer bei `schedule`.
-- **Warum?** Findet container-spezifische Risiken vor Deployment.
+- **Was?** Lädt das vom Job `docker` exportierte Produktionsimage-Artefakt, prüft
+  Archiv-SHA-256 sowie Image-ID, führt Trivy-Image-Scan aus (HIGH/CRITICAL) und
+  pusht bei `push` auf `main` nach erfolgreichem Scan genau dieses Image nach
+  `ghcr.io/kqc-real/arsnova.eu`. Job-Output `image_ref` ist die kanonische
+  Digest-Referenz `ghcr.io/kqc-real/arsnova.eu@sha256:…`. Pull Requests loggen
+  sich nicht an GHCR an und pushen nicht. Der Job enthält keinen Image-Build.
+- **Wo?** In [../.github/workflows/ci.yml](../.github/workflows/ci.yml); Hilfsskript
+  [../scripts/ci/load-production-image.sh](../scripts/ci/load-production-image.sh).
+- **Wann?** Nach `docker`, außer bei `schedule`.
+- **Warum?** Stellt sicher, dass Scan und ggf. Registry-Veröffentlichung dasselbe
+  Artefakt betreffen wie Build und Runtime-Smokes.
 
 ### 4.15 docker
 
-- **Was?** Docker-Image-Build (ohne Push).
-- **Wo?** Job in [../.github/workflows/ci.yml](../.github/workflows/ci.yml), Build-Definition in [../Dockerfile](../Dockerfile).
+- **Was?** Baut das Produktionsimage genau einmal, führt Compose-/Runtime-Smokes
+  aus und exportiert dasselbe lokale Image als kurzlebiges Actions-Artefakt
+  (`production-image-<github.sha>`, Retention 1 Tag) inkl. Image-ID und
+  Archiv-SHA-256.
+- **Wo?** Job in [../.github/workflows/ci.yml](../.github/workflows/ci.yml),
+  Build-Definition in [../Dockerfile](../Dockerfile); Export über
+  [../scripts/ci/save-production-image.sh](../scripts/ci/save-production-image.sh).
 - **Wann?** Nach `build`, außer bei `schedule`.
-- **Warum?** Prüft, dass das Release-Artefakt (Container) tatsächlich baubar ist.
+- **Warum?** Prüft Bau- und Laufzeitfähigkeit und übergibt ein unverändertes
+  Artefakt an Trivy/GHCR (kein zweiter Build).
 
 ### 4.16 deploy-freshness
 
@@ -413,15 +426,16 @@ In GitHub findest du Artefakte so:
 3. Gewünschten CI-Run öffnen
 4. Unten im Bereich Artifacts die Downloads auswählen
 
-| Artefaktname            | Erzeugender Job | Inhalt                                                        | Fundstelle im Runner                                                | Retention |
-| ----------------------- | --------------- | ------------------------------------------------------------- | ------------------------------------------------------------------- | --------- |
-| `frontend-dist-browser` | `build`         | Lokalisierter Frontend-Produktionsbuild                       | `apps/frontend/dist/browser`                                        | 1 Tag     |
-| `coverage-reports`      | `test`          | Backend- und Frontend-Coverage (HTML + Textsummary-Dateien)   | `apps/backend/coverage`, `apps/frontend/coverage`                   | 7 Tage    |
-| `verapdf-ua1-report`    | `pdfua`         | veraPDF-Textbericht der fünf PDF/UA-1-Locale-Demos            | `tmp/pdfua-validation/verapdf-ua1.txt`                              | 30 Tage   |
-| `lighthouse-reports`    | `lighthouse`    | Lighthouse-Ausgabe (A11y/Performance/SEO/Best-Practices)      | `.lighthouseci`, `.lighthouseci-a11y`                               | 7 Tage    |
-| `e2e-service-logs`      | `e2e`           | Laufzeitlogs von Backend und Frontend während des Smoke-Tests | `${{ runner.temp }}/backend.log`, `${{ runner.temp }}/frontend.log` | 7 Tage    |
-| `trivy-fs-report`       | `trivy-fs`      | Trivy Filesystem Security Report (SARIF)                      | `trivy-fs.sarif`                                                    | 7 Tage    |
-| `trivy-image-report`    | `trivy-image`   | Trivy Container Image Security Report (SARIF)                 | `trivy-image.sarif`                                                 | 7 Tage    |
+| Artefaktname             | Erzeugender Job | Inhalt                                                        | Fundstelle im Runner                                                | Retention |
+| ------------------------ | --------------- | ------------------------------------------------------------- | ------------------------------------------------------------------- | --------- |
+| `frontend-dist-browser`  | `build`         | Lokalisierter Frontend-Produktionsbuild                       | `apps/frontend/dist/browser`                                        | 1 Tag     |
+| `coverage-reports`       | `test`          | Backend- und Frontend-Coverage (HTML + Textsummary-Dateien)   | `apps/backend/coverage`, `apps/frontend/coverage`                   | 7 Tage    |
+| `verapdf-ua1-report`     | `pdfua`         | veraPDF-Textbericht der fünf PDF/UA-1-Locale-Demos            | `tmp/pdfua-validation/verapdf-ua1.txt`                              | 30 Tage   |
+| `lighthouse-reports`     | `lighthouse`    | Lighthouse-Ausgabe (A11y/Performance/SEO/Best-Practices)      | `.lighthouseci`, `.lighthouseci-a11y`                               | 7 Tage    |
+| `e2e-service-logs`       | `e2e`           | Laufzeitlogs von Backend und Frontend während des Smoke-Tests | `${{ runner.temp }}/backend.log`, `${{ runner.temp }}/frontend.log` | 7 Tage    |
+| `trivy-fs-report`        | `trivy-fs`      | Trivy Filesystem Security Report (SARIF)                      | `trivy-fs.sarif`                                                    | 7 Tage    |
+| `production-image-<sha>` | `docker`        | Komprimiertes Produktionsimage + Integritätsmeta              | `arsnova-eu-production.tar.gz`, `arsnova-eu-production.meta.json`   | 1 Tag     |
+| `trivy-image-report`     | `trivy-image`   | Trivy Container Image Security Report (SARIF)                 | `trivy-image.sarif`                                                 | 7 Tage    |
 
 Hinweise:
 

--- a/docs/CI-WORKFLOW.md
+++ b/docs/CI-WORKFLOW.md
@@ -81,7 +81,8 @@ flowchart TD
   D --> K[e2e smoke]
   D --> K2[classroom smokes]
   D --> L[docker build<br/>ein Image + Artefakt]
-  L --> M[trivy-image<br/>load/scan; GHCR nur main]
+  L --> M[trivy-image<br/>load/scan, read-only]
+  M --> P[publish-image<br/>GHCR nur main]
 
   H --> Q[deploy-freshness<br/>nur aktueller main-HEAD]
   I --> Q
@@ -95,6 +96,7 @@ flowchart TD
   G2 --> Q
   PUA --> Q
   M --> Q
+  P --> Q
 
   Q --> N[deploy]
 
@@ -299,23 +301,36 @@ nicht die offene S6.5-Zielhostabnahme.
 ### 4.14 trivy-image
 
 - **Was?** Lädt das vom Job `docker` exportierte Produktionsimage-Artefakt, prüft
-  Archiv-SHA-256 sowie Image-ID, führt Trivy-Image-Scan aus (HIGH/CRITICAL) und
-  pusht bei `push` auf `main` nach erfolgreichem Scan genau dieses Image nach
-  `ghcr.io/kqc-real/arsnova.eu`. Job-Output `image_ref` ist die kanonische
-  Digest-Referenz `ghcr.io/kqc-real/arsnova.eu@sha256:…`. Pull Requests loggen
-  sich nicht an GHCR an und pushen nicht. Der Job enthält keinen Image-Build.
+  Archiv-SHA-256 sowie Image-ID und führt Trivy-Image-Scan aus (HIGH/CRITICAL).
+  Der Job ist read-only (`contents: read`), enthält keinen Image-Build und kein
+  GHCR-Login/Push.
 - **Wo?** In [../.github/workflows/ci.yml](../.github/workflows/ci.yml); Hilfsskript
   [../scripts/ci/load-production-image.sh](../scripts/ci/load-production-image.sh).
 - **Wann?** Nach `docker`, außer bei `schedule`.
-- **Warum?** Stellt sicher, dass Scan und ggf. Registry-Veröffentlichung dasselbe
-  Artefakt betreffen wie Build und Runtime-Smokes.
+- **Warum?** Stellt sicher, dass der Scan dasselbe Artefakt betrifft wie Build und
+  Runtime-Smokes, ohne PR-Code `packages: write` zu geben.
+
+### 4.14b publish-image
+
+- **Was?** Nur bei `push` auf `main` und nur nach erfolgreichem `trivy-image`:
+  lädt dasselbe Produktionsimage-Artefakt erneut, pusht es nach
+  `ghcr.io/kqc-real/arsnova.eu:<github.sha>` und setzt Job-Output `image_ref` auf
+  die kanonische Digest-Referenz `ghcr.io/kqc-real/arsnova.eu@sha256:…`. Der Digest
+  kommt aus dem `docker push`-Log (Fallback: `RepoDigests`), nicht aus einem
+  ungültigen `imagetools`-Templatefeld.
+- **Wo?** Job `Publish Scanned Image` in
+  [../.github/workflows/ci.yml](../.github/workflows/ci.yml); Hilfsskript
+  [../scripts/ci/resolve-pushed-image-ref.sh](../scripts/ci/resolve-pushed-image-ref.sh).
+- **Wann?** Nur `push` auf `main`, nach `trivy-image`.
+- **Warum?** `packages: write` bleibt vom PR-/Scan-Job isoliert; unveröffentlichte
+  PRs können GHCR nicht beschreiben.
 
 ### 4.15 docker
 
 - **Was?** Baut das Produktionsimage genau einmal, führt Compose-/Runtime-Smokes
   aus und exportiert dasselbe lokale Image als kurzlebiges Actions-Artefakt
-  (`production-image-<github.sha>`, Retention 1 Tag) inkl. Image-ID und
-  Archiv-SHA-256.
+  (`production-image-<github.sha>`, Retention 1 Tag, `overwrite: true` für
+  Job-Reruns) inkl. Image-ID und Archiv-SHA-256.
 - **Wo?** Job in [../.github/workflows/ci.yml](../.github/workflows/ci.yml),
   Build-Definition in [../Dockerfile](../Dockerfile); Export über
   [../scripts/ci/save-production-image.sh](../scripts/ci/save-production-image.sh).

--- a/scripts/ci/image-artifact-meta.test.mjs
+++ b/scripts/ci/image-artifact-meta.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+
+function writeMeta(dir, meta) {
+  writeFileSync(join(dir, 'arsnova-eu-production.meta.json'), `${JSON.stringify(meta, null, 2)}\n`);
+}
+
+function runLoad(dir, sha) {
+  return spawnSync('bash', [join(repoRoot, 'scripts/ci/load-production-image.sh'), dir, sha], {
+    encoding: 'utf8',
+  });
+}
+
+const validImageId =
+  'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+test('load-production-image rejects missing archive', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'arsnova-image-meta-'));
+  writeMeta(dir, {
+    githubSha: 'abc123',
+    localTag: 'arsnova-eu:production',
+    imageId: validImageId,
+    archiveFile: 'arsnova-eu-production.tar.gz',
+    archiveSha256: '0'.repeat(64),
+  });
+
+  const result = runLoad(dir, 'abc123');
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Archiv fehlt/);
+});
+
+test('load-production-image rejects archive sha mismatch', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'arsnova-image-meta-'));
+  writeFileSync(join(dir, 'arsnova-eu-production.tar.gz'), 'not-a-real-image');
+  writeMeta(dir, {
+    githubSha: 'abc123',
+    localTag: 'arsnova-eu:production',
+    imageId: validImageId,
+    archiveFile: 'arsnova-eu-production.tar.gz',
+    archiveSha256: 'f'.repeat(64),
+  });
+
+  const result = runLoad(dir, 'abc123');
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Archiv-SHA-256 stimmt nicht/);
+});
+
+test('load-production-image rejects unexpected github sha', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'arsnova-image-meta-'));
+  writeMeta(dir, {
+    githubSha: 'expected-sha',
+    localTag: 'arsnova-eu:production',
+    imageId: validImageId,
+    archiveFile: 'arsnova-eu-production.tar.gz',
+    archiveSha256: '0'.repeat(64),
+  });
+
+  const result = runLoad(dir, 'other-sha');
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /githubSha stimmt nicht/);
+});
+
+test('archive sha256 helper length is 64 hex chars', () => {
+  const digest = createHash('sha256').update('arsnova-ci-image-fixture').digest('hex');
+  assert.equal(digest.length, 64);
+  assert.match(digest, /^[0-9a-f]{64}$/);
+});

--- a/scripts/ci/image-artifact-meta.test.mjs
+++ b/scripts/ci/image-artifact-meta.test.mjs
@@ -19,8 +19,7 @@ function runLoad(dir, sha) {
   });
 }
 
-const validImageId =
-  'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const validImageId = 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
 test('load-production-image rejects missing archive', () => {
   const dir = mkdtempSync(join(tmpdir(), 'arsnova-image-meta-'));

--- a/scripts/ci/load-production-image.sh
+++ b/scripts/ci/load-production-image.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Lädt ein zuvor exportiertes Produktionsimage und prüft Image-ID sowie Archiv-SHA-256.
+# Usage: load-production-image.sh <in-dir> <expected-github-sha>
+set -euo pipefail
+
+IN_DIR="${1:?input directory required}"
+EXPECTED_GITHUB_SHA="${2:?expected github sha required}"
+META_PATH="$IN_DIR/arsnova-eu-production.meta.json"
+
+if [[ ! -f "$META_PATH" ]]; then
+  echo "Metadatei fehlt: $META_PATH" >&2
+  exit 1
+fi
+
+eval "$(
+  python3 - "$META_PATH" "$EXPECTED_GITHUB_SHA" <<'PY'
+import json
+import sys
+
+meta_path, expected_sha = sys.argv[1], sys.argv[2]
+with open(meta_path, encoding="utf-8") as handle:
+    meta = json.load(handle)
+
+required = ("githubSha", "localTag", "imageId", "archiveFile", "archiveSha256")
+missing = [key for key in required if not meta.get(key)]
+if missing:
+    raise SystemExit(f"Metadatei unvollständig, fehlt: {', '.join(missing)}")
+
+if meta["githubSha"] != expected_sha:
+    raise SystemExit(
+        f"githubSha stimmt nicht: erwartet {expected_sha}, gefunden {meta['githubSha']}"
+    )
+
+if not str(meta["imageId"]).startswith("sha256:") or len(meta["imageId"]) < 70:
+    raise SystemExit(f"Ungültige imageId: {meta['imageId']}")
+
+if len(meta["archiveSha256"]) != 64:
+    raise SystemExit(f"Ungültige archiveSha256: {meta['archiveSha256']}")
+
+def emit(key: str, value: str) -> None:
+    # Sichere Shell-Zuweisung ohne Newlines.
+    if any(ch in value for ch in ("\n", "\r", "'")):
+        raise SystemExit(f"Ungültiger Meta-Wert für {key}")
+    print(f"{key}='{value}'")
+
+emit("LOCAL_TAG", meta["localTag"])
+emit("EXPECTED_IMAGE_ID", meta["imageId"])
+emit("ARCHIVE_NAME", meta["archiveFile"])
+emit("EXPECTED_ARCHIVE_SHA256", meta["archiveSha256"])
+PY
+)"
+
+ARCHIVE_PATH="$IN_DIR/$ARCHIVE_NAME"
+if [[ ! -f "$ARCHIVE_PATH" ]]; then
+  echo "Archiv fehlt: $ARCHIVE_PATH" >&2
+  exit 1
+fi
+
+ACTUAL_ARCHIVE_SHA256="$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
+if [[ "$ACTUAL_ARCHIVE_SHA256" != "$EXPECTED_ARCHIVE_SHA256" ]]; then
+  echo "Archiv-SHA-256 stimmt nicht:" >&2
+  echo "  erwartet: $EXPECTED_ARCHIVE_SHA256" >&2
+  echo "  gefunden: $ACTUAL_ARCHIVE_SHA256" >&2
+  exit 1
+fi
+
+echo "Integrität Archiv ok (sha256=$ACTUAL_ARCHIVE_SHA256)."
+echo "Lade Image aus Artefakt — kein docker build / build-push in diesem Job."
+
+gzip -dc "$ARCHIVE_PATH" | docker load
+
+LOADED_IMAGE_ID="$(docker image inspect --format '{{.Id}}' "$LOCAL_TAG")"
+if [[ "$LOADED_IMAGE_ID" != "$EXPECTED_IMAGE_ID" ]]; then
+  echo "Image-ID nach docker load stimmt nicht:" >&2
+  echo "  erwartet: $EXPECTED_IMAGE_ID" >&2
+  echo "  gefunden: $LOADED_IMAGE_ID" >&2
+  exit 1
+fi
+
+echo "Image geladen: tag=$LOCAL_TAG imageId=$LOADED_IMAGE_ID"
+echo "LOADED_TAG=$LOCAL_TAG"
+echo "LOADED_IMAGE_ID=$LOADED_IMAGE_ID"

--- a/scripts/ci/resolve-pushed-image-ref.sh
+++ b/scripts/ci/resolve-pushed-image-ref.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Ermittelt die kanonische Digest-Referenz nach docker push.
+# Primär aus dem Push-Log (digest: sha256:…), sonst aus RepoDigests.
+# Usage: resolve-pushed-image-ref.sh <image-name> <pushed-tag> [push-log-file]
+# Prints: <image-name>@sha256:<64-hex>
+set -euo pipefail
+
+IMAGE_NAME="${1:?image name required (e.g. ghcr.io/org/repo)}"
+PUSHED_TAG="${2:?pushed tag required}"
+PUSH_LOG_FILE="${3:-}"
+
+DIGEST=''
+
+if [[ -n "$PUSH_LOG_FILE" && -f "$PUSH_LOG_FILE" ]]; then
+  DIGEST="$(
+    grep -Eo 'digest: sha256:[0-9a-f]{64}' "$PUSH_LOG_FILE" \
+      | awk '{print $2}' \
+      | tail -1 \
+      || true
+  )"
+fi
+
+if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    if [[ "$entry" == "${IMAGE_NAME}@sha256:"* ]]; then
+      DIGEST="${entry##*@}"
+      break
+    fi
+  done < <(docker image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$PUSHED_TAG")
+fi
+
+if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "Konnte keinen Registry-Digest für $PUSHED_TAG ermitteln." >&2
+  if [[ -n "$PUSH_LOG_FILE" && -f "$PUSH_LOG_FILE" ]]; then
+    echo "Push-Log:" >&2
+    cat "$PUSH_LOG_FILE" >&2 || true
+  fi
+  exit 1
+fi
+
+echo "${IMAGE_NAME}@${DIGEST}"

--- a/scripts/ci/resolve-pushed-image-ref.test.mjs
+++ b/scripts/ci/resolve-pushed-image-ref.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const script = join(repoRoot, 'scripts/ci/resolve-pushed-image-ref.sh');
+
+function runResolve(imageName, tag, logContents) {
+  const dir = mkdtempSync(join(tmpdir(), 'arsnova-push-log-'));
+  const logPath = join(dir, 'push.log');
+  writeFileSync(logPath, logContents);
+  return spawnSync('bash', [script, imageName, tag, logPath], { encoding: 'utf8' });
+}
+
+test('resolve-pushed-image-ref reads digest from docker push log', () => {
+  const digest = `sha256:${'ab'.repeat(32)}`;
+  const result = runResolve(
+    'ghcr.io/kqc-real/arsnova.eu',
+    'ghcr.io/kqc-real/arsnova.eu:deadbeef',
+    [
+      'The push refers to repository [ghcr.io/kqc-real/arsnova.eu]',
+      'abc: Layer already exists',
+      `deadbeef: digest: ${digest} size: 1234`,
+      '',
+    ].join('\n'),
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), `ghcr.io/kqc-real/arsnova.eu@${digest}`);
+});
+
+test('resolve-pushed-image-ref rejects push log without digest', () => {
+  const result = runResolve(
+    'ghcr.io/kqc-real/arsnova.eu',
+    'ghcr.io/kqc-real/arsnova.eu:missing',
+    'The push refers to repository [ghcr.io/kqc-real/arsnova.eu]\n',
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Konnte keinen Registry-Digest/);
+});

--- a/scripts/ci/save-production-image.sh
+++ b/scripts/ci/save-production-image.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Speichert ein lokales Produktionsimage als komprimiertes CI-Artefakt inkl. Integritätsmeta.
+# Usage: save-production-image.sh <local-tag> <out-dir> <github-sha>
+set -euo pipefail
+
+LOCAL_TAG="${1:?local image tag required}"
+OUT_DIR="${2:?output directory required}"
+GITHUB_SHA="${3:?github sha required}"
+
+mkdir -p "$OUT_DIR"
+ARCHIVE_NAME='arsnova-eu-production.tar.gz'
+META_NAME='arsnova-eu-production.meta.json'
+ARCHIVE_PATH="$OUT_DIR/$ARCHIVE_NAME"
+META_PATH="$OUT_DIR/$META_NAME"
+
+if ! docker image inspect "$LOCAL_TAG" >/dev/null 2>&1; then
+  echo "Image nicht gefunden: $LOCAL_TAG" >&2
+  exit 1
+fi
+
+IMAGE_ID="$(docker image inspect --format '{{.Id}}' "$LOCAL_TAG")"
+echo "Exportiere Image $LOCAL_TAG (imageId=$IMAGE_ID) — kein zweiter Build."
+
+docker save "$LOCAL_TAG" | gzip -1 >"$ARCHIVE_PATH"
+ARCHIVE_SHA256="$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
+
+python3 - "$META_PATH" "$GITHUB_SHA" "$LOCAL_TAG" "$IMAGE_ID" "$ARCHIVE_NAME" "$ARCHIVE_SHA256" <<'PY'
+import json
+import sys
+
+meta_path, github_sha, local_tag, image_id, archive_name, archive_sha256 = sys.argv[1:]
+payload = {
+    "githubSha": github_sha,
+    "localTag": local_tag,
+    "imageId": image_id,
+    "archiveFile": archive_name,
+    "archiveSha256": archive_sha256,
+}
+with open(meta_path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+
+echo "Archiv geschrieben: $ARCHIVE_PATH"
+echo "archiveSha256=$ARCHIVE_SHA256"
+echo "imageId=$IMAGE_ID"


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** CI baute für Docker-Smokes und Trivy zwei unterschiedliche Images; ein erfolgreicher Scan belegte nicht das gescannte Artefakt für eine spätere Freigabe. Zusätzlich fehlte ein kontrollierter GHCR-Pfad für das einmal gebaute Image.
- **Lösung:** Delivery Slice **1B** von #219 mit der Aufteilung:
  1. **Docker Build** — genau einmal bauen, Runtime-Smokes, Artefakt `production-image-<github.sha>` (Image-ID + Archiv-SHA-256, Retention 1 Tag, `overwrite: true`)
  2. **Trivy Image Scan** — Artefakt laden/prüfen und scannen; **read-only** (`contents: read`), **kein** GHCR-Login/Push, **kein** Rebuild
  3. **Publish Scanned Image** — nur bei `push` auf `main` nach erfolgreichem Trivy; allein `packages: write`; Push nach `ghcr.io/kqc-real/arsnova.eu:<sha>`; Job-Output `image_ref` = `ghcr.io/kqc-real/arsnova.eu@sha256:…` (Digest aus `docker push`-Log)
- **Bewusste Nicht-Ziele:** Kein Deploy-/Compose-/`deploy.sh`-Umbau (Slice 1C), keine Umbenennung der Required Checks `Docker Build` / `Trivy Image Scan` (#221), kein Issue-Close von #219.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [x] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

- Issue #219 Delivery Slice 1B; Parent #217; Architekturentscheidungen (eine Image-Quelle in CI, kanonisch GHCR, Digest-Wahrheit, kein PR-Push, Check-Namen stabil).
- Token-Grenze: `packages: write` ausschließlich im Job `Publish Scanned Image` (`if: push && main`). PR-Checkout und Trivy-Skripte laufen ohne Schreibrecht auf GHCR.
- Für Slice 1C: `DEPLOY_IMAGE` kommt aus `needs.publish-image.outputs.image_ref` (nicht aus `Trivy Image Scan`).
- Unverändert: serverseitiger Deploy-/Compose-Vertrag (1C); Runtime-Smokes im Docker-Job.

**Betroffene externe Verträge:**

- GitHub Actions Artifacts; GHCR (`ghcr.io/kqc-real/arsnova.eu`); Docker image save/load/push.

## Implementierung

- `.github/workflows/ci.yml`:
  - `docker`: Build → Smokes → Artefakt-Export
  - `trivy-image`: Artefakt laden/scannen, read-only
  - `publish-image`: main-only GHCR-Push + Output `image_ref`
  - `deploy-freshness` wartet zusätzlich auf `publish-image`
- `scripts/ci/save-production-image.sh` / `load-production-image.sh`: Export/Import inkl. Integritätschecks
- `scripts/ci/resolve-pushed-image-ref.sh`: Digest aus Push-Log (Fallback `RepoDigests`)
- Tests: `scripts/ci/*.test.mjs` (fehlendes/manipuliertes Artefakt, Push-Log-Digest)
- `docs/CI-WORKFLOW.md`: Ablauf, Jobs und Artefakttabelle an 1B angepasst

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [ ] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [x] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

Begründung: doppelter Build strukturell verhindert; fehlendes/manipuliertes Artefakt → Fail; fehlgeschlagener Trivy überspringt Publish (kein `always()`); Job-Rerun mit `overwrite: true`.

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| Pre-Commit `npm run typecheck` / `npm test` | PASS |
| `bash -n scripts/ci/*.sh` | PASS |
| `node --test scripts/ci/*.test.mjs` | PASS (6 Tests) |
| `npx prettier --check` auf geänderte Docs/Tests | PASS |
| CI Changed Files Format / Workflow Lint / Security Audit | PASS auf Head `1266a8e4` |
| CI Docker Build → Artefakt → Trivy | läuft / erwartet auf diesem Head |
| GHCR-Push auf PR | strukturell inaktiv (`publish-image` nur `push`/`main`) |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

Hinweis: Sicherheitsgrenze CI→Registry. PR ohne `packages: write`; Trivy fail → kein Publish; Deploy-Skript unverändert.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Nach Merge auf `main` erscheint bei erfolgreichem Scan ein GHCR-Image inkl. Commit-Tag und Digest-Output `image_ref`. Der Server-Deploy nutzt dieses Image in 1B **noch nicht**.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Owner nach erstem erfolgreichen Main-Push: GHCR-Paket öffentlich pullbar schalten **oder** private Alternative dokumentieren (#219 1B). Kein `GITHUB_TOKEN` auf den Server kopieren.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Docker-Job loggt `imageId`; Trivy loggt Load ohne Rebuild; Publish loggt `image_ref=ghcr.io/…@sha256:…`.
- **Rollback:** Workflow-Revert; ggf. GHCR-Tag ignorieren. Kein Server-Deploy-Vertragswechsel in diesem PR.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Aktueller Head: `1266a8e4e3d08b6858a1e0fda715d08cf7e9eacd`
- Review-Fixes: Isolate Publish-Job, Digest aus Push-Log, Artifact-Overwrite, Prettier
- Negativtests: `scripts/ci/*.test.mjs`
- Stopp nach Review: kein Slice 1C in diesem PR.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffend:** App-/UI-/i18n-/Migrations-Tests; Live-GHCR-Push (Post-Merge-/Owner-Nachweis).
- **Verbleibende Risiken:** Erster Main-Push braucht Owner-Bestätigung zur Paket-Sichtbarkeit. Artifact-Größe kann CI-Zeit/Storage belasten (Retention 1 Tag). Deploy bleibt bis 1C auf Server-Build. Vor 1C Issue #219 bzgl. `DEPLOY_IMAGE` ← `publish-image.outputs.image_ref` anpassen.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft