### PR TITLE
[codex] tRPC DoD Slice 2D: admin.motd evidence

### DIFF
--- a/.github/trpc-dod-baseline.json
+++ b/.github/trpc-dod-baseline.json
@@ -55,57 +55,57 @@
     "admin.motd.motdCreate": {
       "kind": "mutation",
       "fingerprint": "sha256:d8110dd83e1cd65638ba72c4e24e7e43528f53fa8e3d84194f4af6818f4691b9",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.motdDelete": {
       "kind": "mutation",
       "fingerprint": "sha256:831bb0819a111bf00f0da8e352a88f0d6c04becb50ed033f267954741cd37ddf",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.motdGet": {
       "kind": "query",
       "fingerprint": "sha256:d4f1b4e3359f8320a0d8d39f6dfb25c13b29b99b30034425b6473bc186f36afa",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.motdList": {
       "kind": "query",
       "fingerprint": "sha256:b665b591bd6edc9470d76f078df3136a7bd65d0c0f92f7bd70f01a4dfebd5c65",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.motdResetInteractionStats": {
       "kind": "mutation",
       "fingerprint": "sha256:07989ab8b31f50cb0df05a9553fdabeb24547e9b09a36d7863cb907d9d21624a",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.motdUpdate": {
       "kind": "mutation",
       "fingerprint": "sha256:04f281ee4ad8f3c7b7299594823eaa117c2fc6266b029c0497032802375f8f48",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.templateCreate": {
       "kind": "mutation",
       "fingerprint": "sha256:0c1cf443c0a5375fc68a9f8926be5e3b4bc96188567757b29101c00b929a9136",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.templateDelete": {
       "kind": "mutation",
       "fingerprint": "sha256:387d6ffd10504c16a78a2341c009d34a0e0c758a93ce97aa85cc383827fd2bed",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.templateGet": {
       "kind": "query",
       "fingerprint": "sha256:e4787abdcad710c3f69b9d299b8cb4c9a7b2a688ae38e24686f1d2a49eb06a2a",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.templateList": {
       "kind": "query",
       "fingerprint": "sha256:8975352e435fb3b870f3fcddae2a7215c46a76ca19c7324d638f53e617f12d3b",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.motd.templateUpdate": {
       "kind": "mutation",
       "fingerprint": "sha256:72c643ae1aa7e6e0b84b8f17dd8bd7ba1f718776deb9d36f9c0010321c2c4252",
-      "missing": ["happy", "error"]
+      "missing": []
     },
     "admin.resetMaxParticipantsRecord": {
       "kind": "mutation",

--- a/apps/backend/src/__tests__/adminMotd.test.ts
+++ b/apps/backend/src/__tests__/adminMotd.test.ts
@@ -450,6 +450,8 @@ describe('adminMotdRouter', () => {
         data: expect.objectContaining({
           status: 'DRAFT',
           priority: 0,
+          startsAt: STARTS_AT,
+          endsAt: ENDS_AT,
           contentVersion: 1,
           templateId: null,
         }),

--- a/apps/backend/src/__tests__/adminMotd.test.ts
+++ b/apps/backend/src/__tests__/adminMotd.test.ts
@@ -1,10 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { trpcDodIt } from './test-utils/trpc-dod-evidence';
 
 const { prismaMock, extractAdminTokenMock, isAdminSessionTokenValidMock } = vi.hoisted(() => ({
   prismaMock: {
+    motdTemplate: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
     motd: {
+      findMany: vi.fn(),
       findUnique: vi.fn(),
       findUniqueOrThrow: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
     },
     motdInteractionCounter: {
       findUnique: vi.fn(),
@@ -16,6 +28,8 @@ const { prismaMock, extractAdminTokenMock, isAdminSessionTokenValidMock } = vi.h
     },
     motdLocale: {
       findMany: vi.fn(),
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
     },
   },
   extractAdminTokenMock: vi.fn(),
@@ -35,66 +49,615 @@ vi.mock('../lib/adminAuth', () => ({
 import { adminMotdRouter } from '../routers/adminMotd';
 
 const MID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const TID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const STARTS_AT = new Date('2026-01-01T00:00:00.000Z');
+const ENDS_AT = new Date('2026-12-31T23:59:59.999Z');
+const CREATED_AT = new Date('2025-12-31T00:00:00.000Z');
+const UPDATED_AT = new Date('2026-01-02T00:00:00.000Z');
+
+function template(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TID,
+    name: 'Standard',
+    description: 'Standardvorlage',
+    markdownDe: 'Hallo',
+    markdownEn: 'Hello',
+    markdownFr: '',
+    markdownEs: '',
+    markdownIt: '',
+    createdAt: CREATED_AT,
+    updatedAt: UPDATED_AT,
+    ...overrides,
+  };
+}
+
+function motd(overrides: Record<string, unknown> = {}) {
+  return {
+    id: MID,
+    status: 'DRAFT',
+    priority: 0,
+    startsAt: STARTS_AT,
+    endsAt: ENDS_AT,
+    visibleInArchive: false,
+    contentVersion: 1,
+    templateId: null,
+    createdAt: CREATED_AT,
+    updatedAt: UPDATED_AT,
+    locales: [
+      { locale: 'de', markdown: 'Hallo' },
+      { locale: 'en', markdown: 'Hello' },
+    ],
+    ...overrides,
+  };
+}
+
+function interaction(overrides: Record<string, unknown> = {}) {
+  return {
+    motdId: MID,
+    contentVersion: 1,
+    ackCount: 2,
+    thumbUp: 3,
+    thumbDown: 1,
+    dismissClose: 4,
+    dismissSwipe: 5,
+    ...overrides,
+  };
+}
+
+async function expectTrpcCode(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toMatchObject({ code });
+}
 
 describe('adminMotdRouter', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     extractAdminTokenMock.mockReturnValue('admin-session');
     isAdminSessionTokenValidMock.mockResolvedValue(true);
   });
 
-  it('motdResetInteractionStats löscht Zählerzeile und liefert Detail mit Nullen', async () => {
-    prismaMock.motd.findUnique.mockResolvedValue({
-      id: MID,
-      status: 'PUBLISHED',
-      priority: 0,
-      startsAt: new Date('2026-01-01T00:00:00.000Z'),
-      endsAt: new Date('2026-12-31T23:59:59.999Z'),
-      visibleInArchive: true,
-      contentVersion: 3,
-      templateId: null,
-    });
-    prismaMock.motdInteractionCounter.deleteMany.mockResolvedValue({ count: 1 });
-    prismaMock.motdInteractionCounter.findUnique.mockResolvedValue(null);
-    prismaMock.motdAuditLog.create.mockResolvedValue({});
-    prismaMock.motd.findUniqueOrThrow.mockResolvedValue({
-      id: MID,
-      status: 'PUBLISHED',
-      priority: 0,
-      startsAt: new Date('2026-01-01T00:00:00.000Z'),
-      endsAt: new Date('2026-12-31T23:59:59.999Z'),
-      visibleInArchive: true,
-      contentVersion: 3,
-      templateId: null,
-      createdAt: new Date('2026-01-01T00:00:00.000Z'),
-      updatedAt: new Date('2026-01-02T00:00:00.000Z'),
-      locales: [
-        { locale: 'de', markdown: 'Hallo' },
-        { locale: 'en', markdown: 'Hi' },
-      ],
-    });
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateList',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.templateList liefert Template-Zusammenfassungen',
+    },
+    async () => {
+      prismaMock.motdTemplate.findMany.mockResolvedValue([template()]);
 
-    const caller = adminMotdRouter.createCaller({ req: {} as never });
-    const out = await caller.motdResetInteractionStats({ id: MID });
+      const out = await adminMotdRouter.createCaller({ req: {} as never }).templateList();
 
-    expect(prismaMock.motdInteractionCounter.deleteMany).toHaveBeenCalledWith({
-      where: { motdId: MID, contentVersion: 3 },
-    });
-    expect(prismaMock.motdAuditLog.create).toHaveBeenCalledWith(
-      expect.objectContaining({
+      expect(prismaMock.motdTemplate.findMany).toHaveBeenCalledWith({
+        orderBy: { updatedAt: 'desc' },
+      });
+      expect(out).toEqual([
+        {
+          id: TID,
+          name: 'Standard',
+          description: 'Standardvorlage',
+          updatedAt: UPDATED_AT.toISOString(),
+        },
+      ]);
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateList',
+      case: 'error',
+      mode: 'direct',
+      contract: 'UNAUTHORIZED',
+      title: 'admin.motd.templateList weist fehlende und ungültige Admin-Sitzungen ab',
+    },
+    async () => {
+      extractAdminTokenMock.mockReturnValue(undefined);
+
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).templateList(),
+        'UNAUTHORIZED',
+      );
+
+      extractAdminTokenMock.mockReturnValue('expired-admin-session');
+      isAdminSessionTokenValidMock.mockResolvedValue(false);
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).templateList(),
+        'UNAUTHORIZED',
+      );
+      expect(isAdminSessionTokenValidMock).toHaveBeenCalledWith('expired-admin-session');
+      expect(prismaMock.motdTemplate.findMany).not.toHaveBeenCalled();
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateGet',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.templateGet liefert die angeforderte Vorlage',
+    },
+    async () => {
+      prismaMock.motdTemplate.findUnique.mockResolvedValue(template());
+
+      const out = await adminMotdRouter.createCaller({ req: {} as never }).templateGet({ id: TID });
+
+      expect(prismaMock.motdTemplate.findUnique).toHaveBeenCalledWith({ where: { id: TID } });
+      expect(out).toMatchObject({ id: TID, markdownDe: 'Hallo', markdownEn: 'Hello' });
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateGet',
+      case: 'error',
+      mode: 'direct',
+      contract: 'NOT_FOUND',
+      title: 'admin.motd.templateGet meldet eine unbekannte Vorlage als NOT_FOUND',
+    },
+    async () => {
+      prismaMock.motdTemplate.findUnique.mockResolvedValue(null);
+
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).templateGet({ id: TID }),
+        'NOT_FOUND',
+      );
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateCreate',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.templateCreate speichert lokalisierte Vorlage und Audit-Eintrag',
+    },
+    async () => {
+      prismaMock.motdTemplate.create.mockResolvedValue(template());
+      prismaMock.motdAuditLog.create.mockResolvedValue({});
+
+      const out = await adminMotdRouter.createCaller({ req: {} as never }).templateCreate({
+        name: 'Standard',
+        description: 'Standardvorlage',
+        markdownDe: 'Hallo',
+        markdownEn: 'Hello',
+      });
+
+      expect(prismaMock.motdTemplate.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
-          action: 'MOTD_RESET_INTERACTION_STATS',
-          motdId: MID,
+          name: 'Standard',
+          description: 'Standardvorlage',
+          markdownDe: 'Hallo',
+          markdownEn: 'Hello',
         }),
-      }),
-    );
-    expect(out.interaction).toEqual({
-      ackCount: 0,
-      thumbUp: 0,
-      thumbDown: 0,
-      dismissClose: 0,
-      dismissSwipe: 0,
-    });
-    expect(out.contentVersion).toBe(3);
-  });
+      });
+      expect(prismaMock.motdAuditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ action: 'MOTD_TEMPLATE_CREATE', motdId: TID }),
+        }),
+      );
+      expect(out.id).toBe(TID);
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateCreate',
+      case: 'error',
+      mode: 'direct',
+      contract: 'VALIDATION',
+      title: 'admin.motd.templateCreate lehnt eine leere Template-Bezeichnung ab',
+    },
+    async () => {
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).templateCreate({ name: '' }),
+        'BAD_REQUEST',
+      );
+      expect(prismaMock.motdTemplate.create).not.toHaveBeenCalled();
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateUpdate',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.templateUpdate übernimmt gezielte Vorlagenänderungen',
+    },
+    async () => {
+      prismaMock.motdTemplate.findUnique.mockResolvedValue(template());
+      prismaMock.motdTemplate.update.mockResolvedValue(template({ name: 'Überarbeitet' }));
+      prismaMock.motdAuditLog.create.mockResolvedValue({});
+
+      const out = await adminMotdRouter
+        .createCaller({ req: {} as never })
+        .templateUpdate({ id: TID, name: 'Überarbeitet' });
+
+      expect(prismaMock.motdTemplate.update).toHaveBeenCalledWith({
+        where: { id: TID },
+        data: { name: 'Überarbeitet' },
+      });
+      expect(out.name).toBe('Überarbeitet');
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateUpdate',
+      case: 'error',
+      mode: 'direct',
+      contract: 'NOT_FOUND',
+      title: 'admin.motd.templateUpdate meldet unbekannte Vorlagen als NOT_FOUND',
+    },
+    async () => {
+      prismaMock.motdTemplate.findUnique.mockResolvedValue(null);
+
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).templateUpdate({ id: TID }),
+        'NOT_FOUND',
+      );
+      expect(prismaMock.motdTemplate.update).not.toHaveBeenCalled();
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateDelete',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.templateDelete entfernt eine vorhandene Vorlage',
+    },
+    async () => {
+      prismaMock.motdTemplate.findUnique.mockResolvedValue(template());
+      prismaMock.motdTemplate.delete.mockResolvedValue(template());
+      prismaMock.motdAuditLog.create.mockResolvedValue({});
+
+      await expect(
+        adminMotdRouter.createCaller({ req: {} as never }).templateDelete({ id: TID }),
+      ).resolves.toBeUndefined();
+
+      expect(prismaMock.motdTemplate.delete).toHaveBeenCalledWith({ where: { id: TID } });
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.templateDelete',
+      case: 'error',
+      mode: 'direct',
+      contract: 'NOT_FOUND',
+      title: 'admin.motd.templateDelete meldet unbekannte Vorlagen als NOT_FOUND',
+    },
+    async () => {
+      prismaMock.motdTemplate.findUnique.mockResolvedValue(null);
+
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).templateDelete({ id: TID }),
+        'NOT_FOUND',
+      );
+      expect(prismaMock.motdTemplate.delete).not.toHaveBeenCalled();
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdList',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.motdList verbindet MOTDs mit der aktuellen Interaktionsstatistik',
+    },
+    async () => {
+      prismaMock.motd.findMany.mockResolvedValue([motd()]);
+      prismaMock.motdInteractionCounter.findMany.mockResolvedValue([interaction()]);
+
+      const out = await adminMotdRouter.createCaller({ req: {} as never }).motdList();
+
+      expect(prismaMock.motdInteractionCounter.findMany).toHaveBeenCalledWith({
+        where: { OR: [{ motdId: MID, contentVersion: 1 }] },
+      });
+      expect(out[0]?.interaction).toEqual({
+        ackCount: 2,
+        thumbUp: 3,
+        thumbDown: 1,
+        dismissClose: 4,
+        dismissSwipe: 5,
+      });
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdList',
+      case: 'error',
+      mode: 'direct',
+      contract: 'UNAUTHORIZED',
+      title: 'admin.motd.motdList weist Aufrufe ohne Admin-Token ab',
+    },
+    async () => {
+      extractAdminTokenMock.mockReturnValue(undefined);
+
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).motdList(),
+        'UNAUTHORIZED',
+      );
+      expect(prismaMock.motd.findMany).not.toHaveBeenCalled();
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdGet',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.motdGet liefert lokalisierte Inhalte und Interaktionen',
+    },
+    async () => {
+      prismaMock.motd.findUnique.mockResolvedValue(motd());
+      prismaMock.motdInteractionCounter.findUnique.mockResolvedValue(interaction());
+
+      const out = await adminMotdRouter.createCaller({ req: {} as never }).motdGet({ id: MID });
+
+      expect(prismaMock.motd.findUnique).toHaveBeenCalledWith({
+        where: { id: MID },
+        include: { locales: true },
+      });
+      expect(out).toMatchObject({
+        id: MID,
+        locales: { de: 'Hallo', en: 'Hello', fr: '', es: '', it: '' },
+        interaction: { ackCount: 2, thumbUp: 3 },
+      });
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdGet',
+      case: 'error',
+      mode: 'direct',
+      contract: 'NOT_FOUND',
+      title: 'admin.motd.motdGet meldet unbekannte MOTDs als NOT_FOUND',
+    },
+    async () => {
+      prismaMock.motd.findUnique.mockResolvedValue(null);
+
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).motdGet({ id: MID }),
+        'NOT_FOUND',
+      );
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdCreate',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.motdCreate speichert Zeitfenster, Lokalisierungen und Audit-Eintrag',
+    },
+    async () => {
+      prismaMock.motd.create.mockResolvedValue(motd());
+      prismaMock.motdLocale.deleteMany.mockResolvedValue({ count: 0 });
+      prismaMock.motdLocale.createMany.mockResolvedValue({ count: 2 });
+      prismaMock.motdAuditLog.create.mockResolvedValue({});
+      prismaMock.motd.findUniqueOrThrow.mockResolvedValue(motd());
+      prismaMock.motdInteractionCounter.findUnique.mockResolvedValue(null);
+
+      const out = await adminMotdRouter.createCaller({ req: {} as never }).motdCreate({
+        startsAt: STARTS_AT.toISOString(),
+        endsAt: ENDS_AT.toISOString(),
+        locales: { de: 'Hallo', en: 'Hello' },
+      });
+
+      expect(prismaMock.motd.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          status: 'DRAFT',
+          priority: 0,
+          contentVersion: 1,
+          templateId: null,
+        }),
+      });
+      expect(prismaMock.motdLocale.createMany).toHaveBeenCalledWith({
+        data: [
+          { motdId: MID, locale: 'de', markdown: 'Hallo' },
+          { motdId: MID, locale: 'en', markdown: 'Hello' },
+        ],
+      });
+      expect(out.locales).toMatchObject({ de: 'Hallo', en: 'Hello' });
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdCreate',
+      case: 'error',
+      mode: 'direct',
+      contract: 'BAD_REQUEST',
+      title: 'admin.motd.motdCreate lehnt umgekehrte und leere Zeitfenster ab',
+    },
+    async () => {
+      for (const [startsAt, endsAt] of [
+        [ENDS_AT, STARTS_AT],
+        [STARTS_AT, STARTS_AT],
+      ]) {
+        await expectTrpcCode(
+          adminMotdRouter.createCaller({ req: {} as never }).motdCreate({
+            startsAt: startsAt.toISOString(),
+            endsAt: endsAt.toISOString(),
+            locales: {},
+          }),
+          'BAD_REQUEST',
+        );
+      }
+      expect(prismaMock.motd.create).not.toHaveBeenCalled();
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdUpdate',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.motdUpdate erhöht die Inhaltsversion bei Prioritätsänderung',
+    },
+    async () => {
+      prismaMock.motd.findUnique.mockResolvedValue(motd());
+      prismaMock.motd.update.mockResolvedValue(motd({ contentVersion: 2, priority: 1 }));
+      prismaMock.motdAuditLog.create.mockResolvedValue({});
+      prismaMock.motd.findUniqueOrThrow.mockResolvedValue(motd({ contentVersion: 2, priority: 1 }));
+      prismaMock.motdInteractionCounter.findUnique.mockResolvedValue(null);
+
+      const out = await adminMotdRouter
+        .createCaller({ req: {} as never })
+        .motdUpdate({ id: MID, priority: 1 });
+
+      expect(prismaMock.motd.update).toHaveBeenCalledWith({
+        where: { id: MID },
+        data: expect.objectContaining({ priority: 1, contentVersion: 2 }),
+      });
+      expect(out).toMatchObject({ id: MID, priority: 1, contentVersion: 2 });
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdUpdate',
+      case: 'error',
+      mode: 'direct',
+      contract: 'NOT_FOUND',
+      title: 'admin.motd.motdUpdate meldet unbekannte MOTDs als NOT_FOUND',
+    },
+    async () => {
+      prismaMock.motd.findUnique.mockResolvedValue(null);
+
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).motdUpdate({ id: MID }),
+        'NOT_FOUND',
+      );
+      expect(prismaMock.motd.update).not.toHaveBeenCalled();
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdDelete',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.motdDelete löscht vorhandene MOTDs und protokolliert dies',
+    },
+    async () => {
+      prismaMock.motd.findUnique.mockResolvedValue(motd());
+      prismaMock.motd.delete.mockResolvedValue(motd());
+      prismaMock.motdAuditLog.create.mockResolvedValue({});
+
+      await expect(
+        adminMotdRouter.createCaller({ req: {} as never }).motdDelete({ id: MID }),
+      ).resolves.toBeUndefined();
+
+      expect(prismaMock.motd.delete).toHaveBeenCalledWith({ where: { id: MID } });
+      expect(prismaMock.motdAuditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ action: 'MOTD_DELETE', motdId: MID }),
+        }),
+      );
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdDelete',
+      case: 'error',
+      mode: 'direct',
+      contract: 'NOT_FOUND',
+      title: 'admin.motd.motdDelete meldet unbekannte MOTDs als NOT_FOUND',
+    },
+    async () => {
+      prismaMock.motd.findUnique.mockResolvedValue(null);
+
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).motdDelete({ id: MID }),
+        'NOT_FOUND',
+      );
+      expect(prismaMock.motd.delete).not.toHaveBeenCalled();
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdResetInteractionStats',
+      case: 'happy',
+      mode: 'direct',
+      title: 'admin.motd.motdResetInteractionStats löscht Zählerzeile und liefert Nullen',
+    },
+    async () => {
+      prismaMock.motd.findUnique.mockResolvedValue({
+        id: MID,
+        status: 'PUBLISHED',
+        priority: 0,
+        startsAt: STARTS_AT,
+        endsAt: ENDS_AT,
+        visibleInArchive: true,
+        contentVersion: 3,
+        templateId: null,
+      });
+      prismaMock.motdInteractionCounter.deleteMany.mockResolvedValue({ count: 1 });
+      prismaMock.motdInteractionCounter.findUnique.mockResolvedValue(null);
+      prismaMock.motdAuditLog.create.mockResolvedValue({});
+      prismaMock.motd.findUniqueOrThrow.mockResolvedValue({
+        id: MID,
+        status: 'PUBLISHED',
+        priority: 0,
+        startsAt: STARTS_AT,
+        endsAt: ENDS_AT,
+        visibleInArchive: true,
+        contentVersion: 3,
+        templateId: null,
+        createdAt: CREATED_AT,
+        updatedAt: UPDATED_AT,
+        locales: [
+          { locale: 'de', markdown: 'Hallo' },
+          { locale: 'en', markdown: 'Hi' },
+        ],
+      });
+
+      const caller = adminMotdRouter.createCaller({ req: {} as never });
+      const out = await caller.motdResetInteractionStats({ id: MID });
+
+      expect(prismaMock.motdInteractionCounter.deleteMany).toHaveBeenCalledWith({
+        where: { motdId: MID, contentVersion: 3 },
+      });
+      expect(prismaMock.motdAuditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'MOTD_RESET_INTERACTION_STATS',
+            motdId: MID,
+          }),
+        }),
+      );
+      expect(out.interaction).toEqual({
+        ackCount: 0,
+        thumbUp: 0,
+        thumbDown: 0,
+        dismissClose: 0,
+        dismissSwipe: 0,
+      });
+      expect(out.contentVersion).toBe(3);
+    },
+  );
+
+  trpcDodIt(
+    {
+      procedure: 'admin.motd.motdResetInteractionStats',
+      case: 'error',
+      mode: 'direct',
+      contract: 'NOT_FOUND',
+      title: 'admin.motd.motdResetInteractionStats meldet unbekannte MOTDs als NOT_FOUND',
+    },
+    async () => {
+      prismaMock.motd.findUnique.mockResolvedValue(null);
+
+      await expectTrpcCode(
+        adminMotdRouter.createCaller({ req: {} as never }).motdResetInteractionStats({ id: MID }),
+        'NOT_FOUND',
+      );
+      expect(prismaMock.motdInteractionCounter.deleteMany).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/docs/architecture/decisions/0034-trpc-dod-evidence-helper-and-fingerprint.md
+++ b/docs/architecture/decisions/0034-trpc-dod-evidence-helper-and-fingerprint.md
@@ -267,3 +267,17 @@ Vor Slice 2D ausdrücklich im PR-Review bestätigen:
 4. Rename, Löschung und Subscriptions folgen den dokumentierten Regeln.
 5. CI nennt Prozedur, Änderung und fehlende Evidenz und veröffentlicht weiterhin
    JSON, Markdown, Job Summary und Artefakt.
+
+## Slice-2D-Fortschritt
+
+Die Bestandsbereinigung erfolgt ausschließlich in kleinen Routergruppen und
+aktiviert noch kein 100-%-Gate. Die erste Gruppe `admin.motd` ist vollständig
+migriert: Alle elf Queries und Mutations haben je einen direkten Happy Path und
+einen fachlich relevanten Fehlervertrag. Für die lesenden Listenpfade ist dies
+die Admin-Authentifizierungsgrenze; für Detail- und Änderungsoperationen sind es
+`NOT_FOUND`, Zeitfenster- oder Eingabevalidierungsfehler. Damit sinkt die
+verbleibende Legacy-Schuld auf 102 Prozeduren beziehungsweise 204 Dimensionen.
+
+Die weitere Reihenfolge bleibt `admin`, `quizSync`, anschließend Session, Q&A
+und Quick Feedback. Erst nach vollständiger realer Bestandsbereinigung darf das
+Gate auf 100 % umgestellt werden.

--- a/scripts/audit/trpc-dod.test.mjs
+++ b/scripts/audit/trpc-dod.test.mjs
@@ -1352,7 +1352,7 @@ test('changed incomplete procedure is an actionable Slice 2C gate violation', as
   }
 });
 
-test('real Slice 2C report is deterministic and unchanged legacy debt is non-blocking', () => {
+test('real gate report is deterministic and unchanged legacy debt is non-blocking', () => {
   const dir = mkdtempSync(join(tmpdir(), 'trpc-dod-'));
   try {
     const baseline = join(repoRoot, '.github/trpc-dod-baseline.json');
@@ -1368,12 +1368,24 @@ test('real Slice 2C report is deterministic and unchanged legacy debt is non-blo
     assert.equal(readFileSync(outputs[0], 'utf8'), readFileSync(outputs[1], 'utf8'));
     const report = JSON.parse(readFileSync(outputs[0], 'utf8'));
     assert.equal(report.summary.queriesMutations, 113);
-    assert.equal(report.summary.legacyMissingDimensions, 226);
+    assert.equal(report.summary.complete, 11);
+    assert.equal(report.summary.untested, 102);
+    assert.equal(report.summary.legacyProcedures, 102);
+    assert.equal(report.summary.legacyMissingDimensions, 204);
     assert.equal(report.summary.newSinceBaseline, 0);
     assert.equal(report.summary.gateViolations, 0);
     assert.equal(report.summary.baselineChanges, 0);
     assert.equal(report.summary.structuralErrors, 0);
     assert.equal('integrity' in report.baseline, false);
+    const migrated = report.procedures.filter((procedure) =>
+      procedure.id.startsWith('admin.motd.'),
+    );
+    assert.equal(migrated.length, 11);
+    assert.ok(
+      migrated.every(
+        (procedure) => procedure.status === 'complete' && procedure.baseline?.legacyDebt === false,
+      ),
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Nach Slice 2C fehlte für alle elf Prozeduren der Routergruppe `admin.motd` noch die direkte Happy- und Fehler-Evidenz im tRPC-DoD-Audit.
- **Lösung:** Die Routergruppe ist mit 22 direkt ausgeführten `trpcDodIt`-Tests (je Happy Path und fachlich relevanter Fehlerpfad) abgedeckt. Die Baseline und der reale Audit-Bericht führen die elf Prozeduren nun als vollständig; die verbleibende Legacy-Schuld sinkt von 226 auf 204 Dimensionen.
- **Bewusste Nicht-Ziele:** Keine Änderung an Laufzeitcode, Schemas, Datenbank oder Frontend; keine vorgezogene 100-%-Gate-Aktivierung. Weitere Gruppen folgen gemäß Issue #222 separat (`admin`, `quizSync`, Session/Q&A/Quick Feedback).

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:** Issue #222, ADR 0034, `.github/trpc-dod-baseline.json` und der reale Audit. Für jede in Slice 2D migrierte Prozedur muss die kanonische Evidenzhilfe genau einen direkten Happy Path und genau einen direkten Fehlervertrag ausweisen; außerhalb der migrierten Gruppe bleibt die bestehende Legacy-Schuld unverändert und nicht blockierend.

**Betroffene externe Verträge:** Keine. Der interne Vertrag zwischen `trpcDodIt`-Metadaten, Baseline und Audit wird durch die Audit-Suite geprüft.

## Implementierung

- Alle elf `admin.motd`-Prozeduren in `adminMotd.test.ts` mit direkter Happy- und Fehler-Evidenz ergänzt.
- Relevante Negativverträge decken ungültige Admin-Sitzungen, `NOT_FOUND`, Eingabevalidierung und nicht positive Zeitfenster ab.
- Erfolgsfälle prüfen unter anderem die exakte Persistenz von `startsAt` und `endsAt`, Lokalisierungen, Audit-Einträge, Interaktionsrücksetzung und die Inkrementierung der Inhaltsversion.
- Baseline, deterministischer realer Audit-Test und ADR-Fortschritt auf 11 vollständige sowie 102 verbleibende Prozeduren aktualisiert.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [x] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` | Erfolgreich (Commit-Hook; Shared Types, Export-Report, Backend und Frontend) |
| `npm test` | Erfolgreich (Commit-Hook; Shared Types 38, Export-Report 70, Backend 766/11 skipped, Frontend 1.142) |
| `npm run lint` | Erfolgreich |
| `npm run test -w @arsnova/backend -- --run src/__tests__/adminMotd.test.ts` | Erfolgreich: 22/22 |
| `npm run audit:trpc-dod:test` | Erfolgreich: 32/32 |
| `npm run audit:trpc-dod -- --json-out /tmp/trpc-2d-admin-motd-final.json --md-out /tmp/trpc-2d-admin-motd-final.md` | Erfolgreich: 113 Queries/Mutations, 8 Subscriptions, 11 vollständig, 102 Legacy-Prozeduren, 204 fehlende Dimensionen, 0 Gate-Verstöße |
| `npx prettier --check apps/backend/src/__tests__/adminMotd.test.ts scripts/audit/trpc-dod.test.mjs docs/architecture/decisions/0034-trpc-dod-evidence-helper-and-fingerprint.md` und `git diff --check` | Erfolgreich |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Keine Laufzeitänderung. CI weist nach Merge die reduzierte Legacy-Schuld aus.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Der tRPC-DoD-JSON-/Markdown-Bericht meldet 11 vollständige und 102 verbleibende Legacy-Prozeduren.
- **Rollback:** Die PR-Commits `6be8f919` und `5386a6b4` in umgekehrter Reihenfolge zurücknehmen; dadurch kehren die elf Baseline-Einträge und der Audit-Bericht zu ihrer vorherigen Legacy-Klassifikation zurück.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Adversariales Selbstreview mit frischem Kontext: Jede absichtlich fehlerhafte Implementierung ließ den zugehörigen Test fehlschlagen und wurde danach zurückgenommen.
  - Die Admin-Guard-Prüfung wurde umgangen; der Test für fehlende beziehungsweise abgelaufene Sitzungen erwartete `UNAUTHORIZED` und schlug fehl.
  - Die Zeitfensterprüfung wurde von `endsAt <= startsAt` auf `<` gelockert; der Gleichheitsfall (`startsAt === endsAt`) schlug fehl.
  - Die Erhöhung von `contentVersion` wurde unterdrückt; der Update-Test erwartete weiterhin Version 2 und schlug fehl.
  - Die Persistenz wurde so verfälscht, dass nur `de` gespeichert würde; der Create-Test forderte weiterhin exakt `de` und `en` und schlug fehl.
  - Nach dem P2-Review-Finding wurden `startsAt` und `endsAt` im Prisma-Create-Aufruf explizit geprüft. Eine absichtliche Vertauschung beider Werte ließ den Happy-Path-Test erwartungsgemäß fehlschlagen.
- Der reale Audit prüft zusätzlich, dass alle elf `admin.motd`-Einträge vollständig und nicht mehr als Baseline-Legacy markiert sind.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Produktions-Build, UI-, Accessibility-, Realtime-, Migrations-, Last- und Lokalisierungsprüfungen sind nicht betroffen, weil ausschließlich Backend-Tests, Audit-Baseline, Audit-Test und Architektur-Dokumentation geändert wurden.
- **Verbleibende Risiken:** Die restlichen 102 Prozeduren sind bewusst weiterhin Legacy-Schuld; das 100-%-Gate bleibt bis zu ihrer separat überprüften Migration deaktiviert. Der PR bleibt Draft, bis der End-to-End-CI-Lauf erfolgreich ist.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
