### PR TITLE
[codex] Phase 3A: Script-Lint-Inventur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,6 +540,10 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: npm run lint
 
+      - name: Report script ESLint inventory
+        if: needs.changes.outputs.docs_only != 'true'
+        run: npm run lint:scripts:test && npm run lint:scripts
+
       - name: Check i18n locale consistency
         if: needs.changes.outputs.docs_only != 'true'
         run: npm run check:i18n -w @arsnova/frontend

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,19 +10,21 @@
 
 ## NPM-Skripte (Root)
 
-| Befehl                                        | Bedeutung                                                                                                   |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `npm run build`                               | `shared-types` → Backend `tsc` → Frontend `ng build`                                                        |
-| `npm run typecheck`                           | `shared-types` bauen (`dist`), dann Backend + Frontend `tsc --noEmit`                                       |
-| `npm run lint`                                | ESLint über `libs/` und `apps/`                                                                             |
-| `npm test`                                    | **Shared Contracts**, **Session-Export-Report**, **Backend** und **Frontend** mit Vitest (sequentiell)      |
-| `npm run format:check`                        | Prettier (ohne Schreiben)                                                                                   |
-| `npm run validate:pdfua`                      | Fünf PDF/UA-1-Locale-Demos mit veraPDF validieren                                                           |
-| `npm run verify:production-serving`           | HTTP-Smoke gegen einen laufenden Production-Serve (`/`, `/de/`, Compression, `health.stats`)                |
-| `npm run audit:trpc-dod`                      | Blockierendes Non-Regression-Gate für AppRouter und alle Backend-`src/**/*.test.ts`; Legacy bleibt zulässig |
-| `npm run audit:trpc-dod -- --update-baseline` | Vollständigen/verbesserten Zustand atomar und monoton in die Git-verankerte Baseline übernehmen             |
-| `npm run audit:trpc-dod:poc`                  | Isolierter Fixture-Audit der in Slice 2A eingeführten Evidenzkonvention                                     |
-| `npm run audit:trpc-dod:test`                 | Negativ- und Determinismus-Tests für `scripts/audit-trpc-dod.mjs` (nach `npm ci`, nicht im Workflow-Lint)   |
+| Befehl                                        | Bedeutung                                                                                                                                             |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm run build`                               | `shared-types` → Backend `tsc` → Frontend `ng build`                                                                                                  |
+| `npm run typecheck`                           | `shared-types` bauen (`dist`), dann Backend + Frontend `tsc --noEmit`                                                                                 |
+| `npm run lint`                                | ESLint über `libs/` und `apps/`                                                                                                                       |
+| `npm run lint:scripts`                        | Reportende ESLint-Inventur für operative JS-/TS-Skripte; unbekannte Skriptpfade scheitern, bekannte Altbefunde werden nach Laufzeitprofil ausgewiesen |
+| `npm run lint:scripts:test`                   | Negativtests für Skriptinventur und minimale Laufzeit-Globals                                                                                         |
+| `npm test`                                    | **Shared Contracts**, **Session-Export-Report**, **Backend** und **Frontend** mit Vitest (sequentiell)                                                |
+| `npm run format:check`                        | Prettier (ohne Schreiben)                                                                                                                             |
+| `npm run validate:pdfua`                      | Fünf PDF/UA-1-Locale-Demos mit veraPDF validieren                                                                                                     |
+| `npm run verify:production-serving`           | HTTP-Smoke gegen einen laufenden Production-Serve (`/`, `/de/`, Compression, `health.stats`)                                                          |
+| `npm run audit:trpc-dod`                      | Blockierendes Non-Regression-Gate für AppRouter und alle Backend-`src/**/*.test.ts`; Legacy bleibt zulässig                                           |
+| `npm run audit:trpc-dod -- --update-baseline` | Vollständigen/verbesserten Zustand atomar und monoton in die Git-verankerte Baseline übernehmen                                                       |
+| `npm run audit:trpc-dod:poc`                  | Isolierter Fixture-Audit der in Slice 2A eingeführten Evidenzkonvention                                                                               |
+| `npm run audit:trpc-dod:test`                 | Negativ- und Determinismus-Tests für `scripts/audit-trpc-dod.mjs` (nach `npm ci`, nicht im Workflow-Lint)                                             |
 
 Workspace-spezifisch:
 
@@ -137,7 +139,7 @@ Auslöser: **Push** und **Pull Request** auf `main`.
 | **landing-build**                      | Produktionsbuild der Astro-Landingpage plus axe-Gate für Start, Impressum und Datenschutz                                                                                                                                        |
 | **build** (Node 22 & 24)               | `npm ci` → `prisma validate` → `prisma generate` → `tsc -b apps/backend` → Frontend `tsc --noEmit` → `build:localize` (Frontend, **alle** konfigurierten Locales `de/en/fr/it/es`)                                               |
 | **typecheck** (Node 22 & 24, parallel) | `npm ci` → `prisma validate` → `prisma generate` → `npm run typecheck` (inkl. `build` für `shared-types`, dann `--noEmit`)                                                                                                       |
-| **lint**                               | `npm run lint` (nach build), einschließlich Angular-Template-A11y-Regeln                                                                                                                                                         |
+| **lint**                               | `npm run lint` (nach build), einschließlich Angular-Template-A11y-Regeln; zusätzlich reportende Skriptinventur mit `npm run lint:scripts:test && npm run lint:scripts` (Slice 3A, noch kein vollständiges Gate)                  |
 | **audit**                              | `npm audit --audit-level=high --omit=dev`, CycloneDX-SBOM als Artefakt (**blockierend ab High für Produktionsabhängigkeiten**)                                                                                                   |
 | **test**                               | `npm run test:coverage` (nach build, inkl. Coverage-Thresholds)                                                                                                                                                                  |
 | **pdfua**                              | veraPDF-1.30.2-Gate für die PDF/UA-1-Demoexporte aller fünf Locales                                                                                                                                                              |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,11 +14,17 @@ const forbidBrowserGlobalsInNodeScripts = [
   })),
 ];
 const browserCallbackMethods = new Set([
+  'addInitScript',
   'evaluate',
   'evaluateAll',
   'evaluateHandle',
   'waitForFunction',
 ]);
+const playwrightScriptFiles = [
+  'apps/frontend/scripts/**/*.{js,mjs,cjs,ts,mts}',
+  'apps/landing/scripts/**/*.{js,mjs,cjs,ts,mts}',
+  'scripts/verify-csp-browser.mjs',
+];
 
 const runtimeProfilePlugin = {
   rules: {
@@ -41,16 +47,36 @@ const runtimeProfilePlugin = {
         },
       },
       create(context) {
+        const sourceCode = context.sourceCode;
+        const namedBrowserCallbacks = new Set();
         const allowPlaywrightCallbacks = context.options[0]?.allowPlaywrightCallbacks === true;
         const checkBareBrowserGlobals = context.options[0]?.checkBareBrowserGlobals === true;
+        const isGlobalReference = (node) => {
+          for (let scope = sourceCode.getScope(node); scope; scope = scope.upper) {
+            const reference = scope.references.find((candidate) => candidate.identifier === node);
+            if (reference) {
+              return reference.resolved === null || reference.resolved.scope.type === 'global';
+            }
+          }
+          return false;
+        };
         const isMemberProperty = (node) =>
           node.parent?.type === 'MemberExpression' &&
           node.parent.property === node &&
           !node.parent.computed;
+        const isObjectPropertyKey = (node) =>
+          node.parent?.type === 'Property' && node.parent.key === node && !node.parent.computed;
         const isBrowserCallback = (node) => {
           for (let current = node; current; current = current.parent) {
             if (
-              !['ArrowFunctionExpression', 'FunctionExpression'].includes(current.type) ||
+              !['ArrowFunctionExpression', 'FunctionExpression', 'FunctionDeclaration'].includes(
+                current.type,
+              )
+            ) {
+              continue;
+            }
+            if (namedBrowserCallbacks.has(current)) return true;
+            if (
               current.parent?.type !== 'CallExpression' ||
               !current.parent.arguments.includes(current)
             ) {
@@ -67,11 +93,56 @@ const runtimeProfilePlugin = {
           return false;
         };
         return {
+          Program(node) {
+            const pending = [node];
+            while (pending.length > 0) {
+              const current = pending.pop();
+              if (
+                current.type === 'CallExpression' &&
+                current.callee.type === 'MemberExpression' &&
+                current.callee.property.type === 'Identifier' &&
+                browserCallbackMethods.has(current.callee.property.name)
+              ) {
+                for (const argument of current.arguments) {
+                  if (argument.type !== 'Identifier') continue;
+                  for (let scope = sourceCode.getScope(argument); scope; scope = scope.upper) {
+                    const reference = scope.references.find(
+                      (candidate) => candidate.identifier === argument,
+                    );
+                    if (!reference?.resolved) continue;
+                    for (const definition of reference.resolved.defs) {
+                      if (definition.node.type === 'FunctionDeclaration') {
+                        namedBrowserCallbacks.add(definition.node);
+                      } else if (
+                        definition.node.type === 'VariableDeclarator' &&
+                        ['ArrowFunctionExpression', 'FunctionExpression'].includes(
+                          definition.node.init?.type,
+                        )
+                      ) {
+                        namedBrowserCallbacks.add(definition.node.init);
+                      }
+                    }
+                    break;
+                  }
+                }
+              }
+              for (const [key, value] of Object.entries(current)) {
+                if (key === 'parent') continue;
+                if (Array.isArray(value)) {
+                  pending.push(...value.filter((item) => item?.type));
+                } else if (value?.type) {
+                  pending.push(value);
+                }
+              }
+            }
+          },
           Identifier(node) {
             if (
               !checkBareBrowserGlobals ||
               !browserOnlyGlobalNames.includes(node.name) ||
+              !isGlobalReference(node) ||
               isMemberProperty(node) ||
+              isObjectPropertyKey(node) ||
               (allowPlaywrightCallbacks && isBrowserCallback(node))
             ) {
               return;
@@ -134,7 +205,7 @@ export default tseslint.config(
       'libs/**/scripts/**/*.{js,mjs,cjs,ts,mts}',
       '.github/scripts/**/*.{js,mjs,cjs,ts,mts}',
     ],
-    ignores: ['scripts/load/k6-*.js'],
+    ignores: ['scripts/load/k6-*.js', ...playwrightScriptFiles],
     languageOptions: { globals: globals.node },
   },
   {
@@ -145,7 +216,7 @@ export default tseslint.config(
       'libs/**/scripts/**/*.{js,mjs,cjs,ts,mts}',
       '.github/scripts/**/*.{js,mjs,cjs,ts,mts}',
     ],
-    ignores: ['scripts/load/k6-*.js'],
+    ignores: ['scripts/load/k6-*.js', ...playwrightScriptFiles],
     plugins: { 'runtime-profile': runtimeProfilePlugin },
     rules: {
       'runtime-profile/no-browser-global-outside-playwright-callback': [
@@ -155,7 +226,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['apps/frontend/scripts/**/*.{js,mjs,cjs,ts,mts}'],
+    files: playwrightScriptFiles,
     // Playwright startet unter Node, evaluiert ausgewählte Callbacks aber im
     // Browser. Die Regel unten begrenzt Browser-Globals auf genau diese APIs.
     languageOptions: { globals: { ...globals.node, ...globals.browser } },
@@ -166,14 +237,14 @@ export default tseslint.config(
     files: [
       'scripts/**/*.{ts,mts}',
       'apps/backend/scripts/**/*.{ts,mts}',
-      'apps/landing/scripts/**/*.{ts,mts}',
       'libs/**/scripts/**/*.{ts,mts}',
       '.github/scripts/**/*.{ts,mts}',
     ],
+    ignores: playwrightScriptFiles,
     rules: { 'no-restricted-globals': forbidBrowserGlobalsInNodeScripts },
   },
   {
-    files: ['apps/frontend/scripts/**/*.{js,mjs,cjs,ts,mts}'],
+    files: playwrightScriptFiles,
     plugins: { 'runtime-profile': runtimeProfilePlugin },
     rules: {
       'runtime-profile/no-browser-global-outside-playwright-callback': [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,12 +8,6 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   {
     files: ['**/*.ts', '**/*.mts'],
-    languageOptions: {
-      globals: {
-        ...globals.node,
-        ...globals.browser,
-      },
-    },
     rules: {
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': [
@@ -29,7 +23,45 @@ export default tseslint.config(
   },
   {
     files: ['apps/frontend/src/**/*.ts'],
+    languageOptions: { globals: globals.browser },
     processor: angular.processInlineTemplates,
+  },
+  {
+    files: ['apps/backend/**/*.{ts,mts}', 'libs/**/*.{ts,mts}'],
+    languageOptions: { globals: globals.node },
+  },
+  // Laufzeitprofile für operative Skripte. Die vollständige Zuordnung wird
+  // durch scripts/script-lint-inventory.json und dessen Validator erzwungen.
+  {
+    files: [
+      'scripts/**/*.{js,mjs,cjs,ts,mts}',
+      'apps/backend/scripts/**/*.{js,mjs,cjs,ts,mts}',
+      'apps/landing/scripts/**/*.{js,mjs,cjs,ts,mts}',
+      'libs/**/scripts/**/*.{js,mjs,cjs,ts,mts}',
+    ],
+    ignores: ['scripts/load/k6-*.js'],
+    languageOptions: { globals: globals.node },
+  },
+  {
+    files: ['apps/frontend/scripts/**/*.{js,mjs,cjs,ts,mts}'],
+    // Playwright startet hier unter Node. Browser-Code läuft ausschließlich
+    // innerhalb der vom Browser evaluierten Callbacks und erhält keine
+    // Browser-Globals im Node-Prozess.
+    languageOptions: { globals: globals.node },
+  },
+  {
+    files: ['.github/scripts/**/*.{js,mjs,cjs,ts,mts}'],
+    languageOptions: { globals: globals.node },
+  },
+  {
+    files: ['scripts/load/k6-*.js'],
+    languageOptions: {
+      globals: {
+        __ENV: 'readonly',
+        __ITER: 'readonly',
+        __VU: 'readonly',
+      },
+    },
   },
   {
     files: ['apps/frontend/src/**/*.html'],
@@ -47,6 +79,8 @@ export default tseslint.config(
       '**/.astro/**',
       '**/coverage/**',
       '**/tmp/**',
+      // Das reguläre Anwendungs-Lint bleibt in Slice 3A unverändert. Das
+      // spezialisierte Skript-Lint deaktiviert diese Ignore-Regel gezielt.
       '**/scripts/**',
       '**/*.config.mjs',
     ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,14 +3,78 @@ import tseslint from 'typescript-eslint';
 import globals from 'globals';
 import angular from 'angular-eslint';
 
-const browserGlobalNames = Object.keys(globals.browser);
+const browserOnlyGlobalNames = Object.keys(globals.browser).filter(
+  (name) => !Object.hasOwn(globals.node, name),
+);
 const forbidBrowserGlobalsInNodeScripts = [
   'error',
-  ...browserGlobalNames.map((name) => ({
+  ...browserOnlyGlobalNames.map((name) => ({
     name,
     message: 'Browser-Global ist in diesem Node-Laufzeitprofil nicht verfügbar.',
   })),
 ];
+const browserCallbackMethods = new Set([
+  'evaluate',
+  'evaluateAll',
+  'evaluateHandle',
+  'waitForFunction',
+]);
+
+const runtimeProfilePlugin = {
+  rules: {
+    'no-browser-global-outside-playwright-callback': {
+      meta: {
+        type: 'problem',
+        schema: [],
+        messages: {
+          browserGlobal:
+            'Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.',
+        },
+      },
+      create(context) {
+        const sourceCode = context.sourceCode;
+        const isGlobalReference = (node) => {
+          let scope = sourceCode.getScope(node);
+          while (scope) {
+            const reference = scope.references.find((candidate) => candidate.identifier === node);
+            if (reference) return reference.resolved === null;
+            scope = scope.upper;
+          }
+          return false;
+        };
+        const isBrowserCallback = (node) => {
+          for (let current = node; current; current = current.parent) {
+            if (
+              !['ArrowFunctionExpression', 'FunctionExpression'].includes(current.type) ||
+              current.parent?.type !== 'CallExpression' ||
+              !current.parent.arguments.includes(current)
+            ) {
+              continue;
+            }
+            const property =
+              current.parent.callee.type === 'MemberExpression'
+                ? current.parent.callee.property
+                : null;
+            return property?.type === 'Identifier' && browserCallbackMethods.has(property.name);
+          }
+          return false;
+        };
+        return {
+          Identifier(node) {
+            if (
+              !browserOnlyGlobalNames.includes(node.name) ||
+              !isGlobalReference(node) ||
+              isBrowserCallback(node)
+            ) {
+              return;
+            }
+            context.report({ node, messageId: 'browserGlobal' });
+          },
+        };
+      },
+    },
+  },
+};
 
 export default tseslint.config(
   eslint.configs.recommended,
@@ -68,12 +132,18 @@ export default tseslint.config(
     files: [
       'scripts/**/*.{ts,mts}',
       'apps/backend/scripts/**/*.{ts,mts}',
-      'apps/frontend/scripts/**/*.{ts,mts}',
       'apps/landing/scripts/**/*.{ts,mts}',
       'libs/**/scripts/**/*.{ts,mts}',
       '.github/scripts/**/*.{ts,mts}',
     ],
     rules: { 'no-restricted-globals': forbidBrowserGlobalsInNodeScripts },
+  },
+  {
+    files: ['apps/frontend/scripts/**/*.{ts,mts}'],
+    plugins: { 'runtime-profile': runtimeProfilePlugin },
+    rules: {
+      'runtime-profile/no-browser-global-outside-playwright-callback': 'error',
+    },
   },
   {
     files: ['scripts/load/k6-*.js'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,15 @@ import tseslint from 'typescript-eslint';
 import globals from 'globals';
 import angular from 'angular-eslint';
 
+const browserGlobalNames = Object.keys(globals.browser);
+const forbidBrowserGlobalsInNodeScripts = [
+  'error',
+  ...browserGlobalNames.map((name) => ({
+    name,
+    message: 'Browser-Global ist in diesem Node-Laufzeitprofil nicht verfügbar.',
+  })),
+];
+
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
@@ -52,6 +61,19 @@ export default tseslint.config(
   {
     files: ['.github/scripts/**/*.{js,mjs,cjs,ts,mts}'],
     languageOptions: { globals: globals.node },
+  },
+  // typescript-eslint deaktiviert no-undef für TS-Dateien. Diese explizite
+  // Regel hält den Laufzeitvertrag auch für .ts/.mts durchsetzbar.
+  {
+    files: [
+      'scripts/**/*.{ts,mts}',
+      'apps/backend/scripts/**/*.{ts,mts}',
+      'apps/frontend/scripts/**/*.{ts,mts}',
+      'apps/landing/scripts/**/*.{ts,mts}',
+      'libs/**/scripts/**/*.{ts,mts}',
+      '.github/scripts/**/*.{ts,mts}',
+    ],
+    rules: { 'no-restricted-globals': forbidBrowserGlobalsInNodeScripts },
   },
   {
     files: ['scripts/load/k6-*.js'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,27 @@ const browserCallbackMethods = new Set([
   'evaluateHandle',
   'waitForFunction',
 ]);
+const playwrightReceiverFactoryMethods = new Set([
+  'contentFrame',
+  'filter',
+  'first',
+  'frame',
+  'frameLocator',
+  'getByAltText',
+  'getByLabel',
+  'getByPlaceholder',
+  'getByRole',
+  'getByTestId',
+  'getByText',
+  'getByTitle',
+  'last',
+  'launch',
+  'locator',
+  'newContext',
+  'newPage',
+  'nth',
+  'owner',
+]);
 const playwrightScriptFiles = [
   'apps/frontend/scripts/**/*.{js,mjs,cjs,ts,mts}',
   'apps/landing/scripts/**/*.{js,mjs,cjs,ts,mts}',
@@ -49,6 +70,10 @@ const runtimeProfilePlugin = {
       create(context) {
         const sourceCode = context.sourceCode;
         const namedBrowserCallbacks = new Set();
+        const playwrightReceiverVariables = new Set();
+        const untrustedPlaywrightReceiverVariables = new Set();
+        const playwrightReceiverFactories = new Set();
+        const playwrightReceiverFactoryProperties = new Map();
         const allowPlaywrightCallbacks = context.options[0]?.allowPlaywrightCallbacks === true;
         const checkBareBrowserGlobals = context.options[0]?.checkBareBrowserGlobals === true;
         const isGlobalReference = (node) => {
@@ -66,6 +91,104 @@ const runtimeProfilePlugin = {
           !node.parent.computed;
         const isObjectPropertyKey = (node) =>
           node.parent?.type === 'Property' && node.parent.key === node && !node.parent.computed;
+        const unwrapExpression = (node) => {
+          let current = node;
+          while (current) {
+            if (current.type === 'AwaitExpression') {
+              current = current.argument;
+              continue;
+            }
+            if (['ChainExpression', 'TSAsExpression', 'TSNonNullExpression'].includes(current.type)) {
+              current = current.expression;
+              continue;
+            }
+            break;
+          }
+          return current;
+        };
+        const resolveVariable = (node) => {
+          for (let scope = sourceCode.getScope(node); scope; scope = scope.upper) {
+            const reference = scope.references.find((candidate) => candidate.identifier === node);
+            if (reference) return reference.resolved;
+            const declared = scope.variables.find((variable) =>
+              variable.identifiers.includes(node),
+            );
+            if (declared) return declared;
+          }
+          return null;
+        };
+        const resolvesToPlaywrightImport = (node) => {
+          const variable = resolveVariable(node);
+          return variable?.defs.some(
+            (definition) =>
+              definition.type === 'ImportBinding' &&
+              definition.node.type === 'ImportSpecifier' &&
+              definition.node.imported.type === 'Identifier' &&
+              ['chromium', 'firefox', 'webkit'].includes(definition.node.imported.name) &&
+              ['playwright', '@playwright/test'].includes(
+                definition.parent?.source?.value ?? definition.node.parent?.source?.value,
+              ),
+          );
+        };
+        const resolvesToFactory = (node) => {
+          const variable = resolveVariable(node);
+          return variable?.defs.some((definition) => {
+            const factory =
+              definition.node.type === 'FunctionDeclaration'
+                ? definition.node
+                : definition.node.type === 'VariableDeclarator'
+                  ? definition.node.init
+                  : null;
+            return playwrightReceiverFactories.has(factory);
+          });
+        };
+        const resolvedFunctions = (node) => {
+          const variable = resolveVariable(node);
+          const functions = [];
+          for (const definition of variable?.defs ?? []) {
+            const fn =
+              definition.node.type === 'FunctionDeclaration'
+                ? definition.node
+                : definition.node.type === 'VariableDeclarator'
+                  ? definition.node.init
+                  : null;
+            if (fn && 'params' in fn) functions.push(fn);
+          }
+          return functions;
+        };
+        const isPlaywrightReceiver = (node, seen = new Set()) => {
+          const current = unwrapExpression(node);
+          if (!current || seen.has(current)) return false;
+          seen.add(current);
+          if (current.type === 'Identifier') {
+            const variable = resolveVariable(current);
+            return (
+              resolvesToPlaywrightImport(current) ||
+              (variable !== null &&
+                playwrightReceiverVariables.has(variable) &&
+                !untrustedPlaywrightReceiverVariables.has(variable))
+            );
+          }
+          if (current.type !== 'CallExpression') return false;
+          if (current.callee.type === 'Identifier') return resolvesToFactory(current.callee);
+          if (
+            current.callee.type !== 'MemberExpression' ||
+            current.callee.computed ||
+            current.callee.property.type !== 'Identifier' ||
+            !playwrightReceiverFactoryMethods.has(current.callee.property.name)
+          ) {
+            return false;
+          }
+          return isPlaywrightReceiver(current.callee.object, seen);
+        };
+        const isSupportedBrowserCallbackCall = (call, callback) =>
+          call?.type === 'CallExpression' &&
+          call.arguments[0] === callback &&
+          call.callee.type === 'MemberExpression' &&
+          !call.callee.computed &&
+          call.callee.property.type === 'Identifier' &&
+          browserCallbackMethods.has(call.callee.property.name) &&
+          isPlaywrightReceiver(call.callee.object);
         const isBrowserCallback = (node) => {
           for (let current = node; current; current = current.parent) {
             if (
@@ -76,62 +199,197 @@ const runtimeProfilePlugin = {
               continue;
             }
             if (namedBrowserCallbacks.has(current)) return true;
-            if (
-              current.parent?.type !== 'CallExpression' ||
-              !current.parent.arguments.includes(current)
-            ) {
-              continue;
-            }
-            const property =
-              current.parent.callee.type === 'MemberExpression'
-                ? current.parent.callee.property
-                : null;
-            if (property?.type === 'Identifier' && browserCallbackMethods.has(property.name)) {
-              return true;
-            }
+            if (isSupportedBrowserCallbackCall(current.parent, current)) return true;
           }
           return false;
         };
         return {
           Program(node) {
             const pending = [node];
+            const nodes = [];
             while (pending.length > 0) {
               const current = pending.pop();
-              if (
-                current.type === 'CallExpression' &&
-                current.callee.type === 'MemberExpression' &&
-                current.callee.property.type === 'Identifier' &&
-                browserCallbackMethods.has(current.callee.property.name)
-              ) {
-                for (const argument of current.arguments) {
-                  if (argument.type !== 'Identifier') continue;
-                  for (let scope = sourceCode.getScope(argument); scope; scope = scope.upper) {
-                    const reference = scope.references.find(
-                      (candidate) => candidate.identifier === argument,
-                    );
-                    if (!reference?.resolved) continue;
-                    for (const definition of reference.resolved.defs) {
-                      if (definition.node.type === 'FunctionDeclaration') {
-                        namedBrowserCallbacks.add(definition.node);
-                      } else if (
-                        definition.node.type === 'VariableDeclarator' &&
-                        ['ArrowFunctionExpression', 'FunctionExpression'].includes(
-                          definition.node.init?.type,
-                        )
-                      ) {
-                        namedBrowserCallbacks.add(definition.node.init);
-                      }
-                    }
-                    break;
-                  }
-                }
-              }
+              nodes.push(current);
               for (const [key, value] of Object.entries(current)) {
                 if (key === 'parent') continue;
                 if (Array.isArray(value)) {
                   pending.push(...value.filter((item) => item?.type));
                 } else if (value?.type) {
                   pending.push(value);
+                }
+              }
+            }
+
+            let changed = true;
+            while (changed) {
+              changed = false;
+              for (const current of nodes) {
+                if (
+                  current.type === 'VariableDeclarator' &&
+                  current.id.type === 'Identifier' &&
+                  isPlaywrightReceiver(current.init)
+                ) {
+                  const variable = resolveVariable(current.id);
+                  if (variable && !playwrightReceiverVariables.has(variable)) {
+                    playwrightReceiverVariables.add(variable);
+                    changed = true;
+                  }
+                }
+                if (
+                  current.type === 'VariableDeclarator' &&
+                  current.id.type === 'ObjectPattern'
+                ) {
+                  const initializer = unwrapExpression(current.init);
+                  if (
+                    initializer?.type === 'CallExpression' &&
+                    initializer.callee.type === 'Identifier'
+                  ) {
+                    const returnedProperties = new Set(
+                      resolvedFunctions(initializer.callee).flatMap((fn) => [
+                        ...(playwrightReceiverFactoryProperties.get(fn) ?? []),
+                      ]),
+                    );
+                    for (const property of current.id.properties) {
+                      if (
+                        property.type !== 'Property' ||
+                        property.key.type !== 'Identifier' ||
+                        property.value.type !== 'Identifier' ||
+                        !returnedProperties.has(property.key.name)
+                      ) {
+                        continue;
+                      }
+                      const variable = resolveVariable(property.value);
+                      if (variable && !playwrightReceiverVariables.has(variable)) {
+                        playwrightReceiverVariables.add(variable);
+                        changed = true;
+                      }
+                    }
+                  }
+                }
+                if (
+                  current.type === 'AssignmentExpression' &&
+                  current.left.type === 'Identifier' &&
+                  isPlaywrightReceiver(current.right)
+                ) {
+                  const variable = resolveVariable(current.left);
+                  if (variable && !playwrightReceiverVariables.has(variable)) {
+                    playwrightReceiverVariables.add(variable);
+                    changed = true;
+                  }
+                }
+                if (current.type === 'ReturnStatement') {
+                  let owner = current.parent;
+                  while (
+                    owner &&
+                    !['ArrowFunctionExpression', 'FunctionExpression', 'FunctionDeclaration'].includes(
+                      owner.type,
+                    )
+                  ) {
+                    owner = owner.parent;
+                  }
+                  if (
+                    owner &&
+                    isPlaywrightReceiver(current.argument) &&
+                    !playwrightReceiverFactories.has(owner)
+                  ) {
+                    playwrightReceiverFactories.add(owner);
+                    changed = true;
+                  }
+                  const returned = unwrapExpression(current.argument);
+                  if (owner && returned?.type === 'ObjectExpression') {
+                    const properties = playwrightReceiverFactoryProperties.get(owner) ?? new Set();
+                    for (const property of returned.properties) {
+                      if (
+                        property.type !== 'Property' ||
+                        property.key.type !== 'Identifier' ||
+                        !isPlaywrightReceiver(property.value) ||
+                        properties.has(property.key.name)
+                      ) {
+                        continue;
+                      }
+                      properties.add(property.key.name);
+                      changed = true;
+                    }
+                    playwrightReceiverFactoryProperties.set(owner, properties);
+                  }
+                }
+                if (current.type === 'CallExpression' && current.callee.type === 'Identifier') {
+                  for (const fn of resolvedFunctions(current.callee)) {
+                    current.arguments.forEach((argument, index) => {
+                      const parameter = fn.params[index];
+                      if (
+                        parameter?.type !== 'Identifier' ||
+                        !isPlaywrightReceiver(argument)
+                      ) {
+                        return;
+                      }
+                      const variable = resolveVariable(parameter);
+                      if (variable && !playwrightReceiverVariables.has(variable)) {
+                        playwrightReceiverVariables.add(variable);
+                        changed = true;
+                      }
+                    });
+                  }
+                }
+              }
+            }
+
+            let trustChanged = true;
+            while (trustChanged) {
+              trustChanged = false;
+              for (const current of nodes) {
+                if (
+                  current.type === 'AssignmentExpression' &&
+                  current.left.type === 'Identifier'
+                ) {
+                  const variable = resolveVariable(current.left);
+                  if (
+                    variable &&
+                    playwrightReceiverVariables.has(variable) &&
+                    !untrustedPlaywrightReceiverVariables.has(variable) &&
+                    !isPlaywrightReceiver(current.right)
+                  ) {
+                    untrustedPlaywrightReceiverVariables.add(variable);
+                    trustChanged = true;
+                  }
+                }
+                if (current.type !== 'CallExpression' || current.callee.type !== 'Identifier') {
+                  continue;
+                }
+                for (const fn of resolvedFunctions(current.callee)) {
+                  current.arguments.forEach((argument, index) => {
+                    const parameter = fn.params[index];
+                    if (parameter?.type !== 'Identifier') return;
+                    const variable = resolveVariable(parameter);
+                    if (
+                      variable &&
+                      playwrightReceiverVariables.has(variable) &&
+                      !untrustedPlaywrightReceiverVariables.has(variable) &&
+                      !isPlaywrightReceiver(argument)
+                    ) {
+                      untrustedPlaywrightReceiverVariables.add(variable);
+                      trustChanged = true;
+                    }
+                  });
+                }
+              }
+            }
+
+            for (const current of nodes) {
+              const callback = current.type === 'CallExpression' ? current.arguments[0] : null;
+              if (!callback || !isSupportedBrowserCallbackCall(current, callback)) continue;
+              if (callback.type !== 'Identifier') continue;
+              const variable = resolveVariable(callback);
+              for (const definition of variable?.defs ?? []) {
+                if (definition.node.type === 'FunctionDeclaration') {
+                  namedBrowserCallbacks.add(definition.node);
+                } else if (
+                  definition.node.type === 'VariableDeclarator' &&
+                  ['ArrowFunctionExpression', 'FunctionExpression'].includes(
+                    definition.node.init?.type,
+                  )
+                ) {
+                  namedBrowserCallbacks.add(definition.node.init);
                 }
               }
             }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,23 +25,28 @@ const runtimeProfilePlugin = {
     'no-browser-global-outside-playwright-callback': {
       meta: {
         type: 'problem',
-        schema: [],
+        schema: [
+          {
+            type: 'object',
+            properties: {
+              allowPlaywrightCallbacks: { type: 'boolean' },
+              checkBareBrowserGlobals: { type: 'boolean' },
+            },
+            additionalProperties: false,
+          },
+        ],
         messages: {
           browserGlobal:
             'Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.',
         },
       },
       create(context) {
-        const sourceCode = context.sourceCode;
-        const isGlobalReference = (node) => {
-          let scope = sourceCode.getScope(node);
-          while (scope) {
-            const reference = scope.references.find((candidate) => candidate.identifier === node);
-            if (reference) return reference.resolved === null;
-            scope = scope.upper;
-          }
-          return false;
-        };
+        const allowPlaywrightCallbacks = context.options[0]?.allowPlaywrightCallbacks === true;
+        const checkBareBrowserGlobals = context.options[0]?.checkBareBrowserGlobals === true;
+        const isMemberProperty = (node) =>
+          node.parent?.type === 'MemberExpression' &&
+          node.parent.property === node &&
+          !node.parent.computed;
         const isBrowserCallback = (node) => {
           for (let current = node; current; current = current.parent) {
             if (
@@ -55,20 +60,36 @@ const runtimeProfilePlugin = {
               current.parent.callee.type === 'MemberExpression'
                 ? current.parent.callee.property
                 : null;
-            return property?.type === 'Identifier' && browserCallbackMethods.has(property.name);
+            if (property?.type === 'Identifier' && browserCallbackMethods.has(property.name)) {
+              return true;
+            }
           }
           return false;
         };
         return {
           Identifier(node) {
             if (
+              !checkBareBrowserGlobals ||
               !browserOnlyGlobalNames.includes(node.name) ||
-              !isGlobalReference(node) ||
-              isBrowserCallback(node)
+              isMemberProperty(node) ||
+              (allowPlaywrightCallbacks && isBrowserCallback(node))
             ) {
               return;
             }
             context.report({ node, messageId: 'browserGlobal' });
+          },
+          MemberExpression(node) {
+            if (
+              node.object.type !== 'Identifier' ||
+              node.object.name !== 'globalThis' ||
+              node.computed ||
+              node.property.type !== 'Identifier' ||
+              !browserOnlyGlobalNames.includes(node.property.name) ||
+              (allowPlaywrightCallbacks && isBrowserCallback(node))
+            ) {
+              return;
+            }
+            context.report({ node: node.property, messageId: 'browserGlobal' });
           },
         };
       },
@@ -111,20 +132,33 @@ export default tseslint.config(
       'apps/backend/scripts/**/*.{js,mjs,cjs,ts,mts}',
       'apps/landing/scripts/**/*.{js,mjs,cjs,ts,mts}',
       'libs/**/scripts/**/*.{js,mjs,cjs,ts,mts}',
+      '.github/scripts/**/*.{js,mjs,cjs,ts,mts}',
     ],
     ignores: ['scripts/load/k6-*.js'],
     languageOptions: { globals: globals.node },
   },
   {
-    files: ['apps/frontend/scripts/**/*.{js,mjs,cjs,ts,mts}'],
-    // Playwright startet hier unter Node. Browser-Code läuft ausschließlich
-    // innerhalb der vom Browser evaluierten Callbacks und erhält keine
-    // Browser-Globals im Node-Prozess.
-    languageOptions: { globals: globals.node },
+    files: [
+      'scripts/**/*.{js,mjs,cjs,ts,mts}',
+      'apps/backend/scripts/**/*.{js,mjs,cjs,ts,mts}',
+      'apps/landing/scripts/**/*.{js,mjs,cjs,ts,mts}',
+      'libs/**/scripts/**/*.{js,mjs,cjs,ts,mts}',
+      '.github/scripts/**/*.{js,mjs,cjs,ts,mts}',
+    ],
+    ignores: ['scripts/load/k6-*.js'],
+    plugins: { 'runtime-profile': runtimeProfilePlugin },
+    rules: {
+      'runtime-profile/no-browser-global-outside-playwright-callback': [
+        'error',
+        { allowPlaywrightCallbacks: false, checkBareBrowserGlobals: false },
+      ],
+    },
   },
   {
-    files: ['.github/scripts/**/*.{js,mjs,cjs,ts,mts}'],
-    languageOptions: { globals: globals.node },
+    files: ['apps/frontend/scripts/**/*.{js,mjs,cjs,ts,mts}'],
+    // Playwright startet unter Node, evaluiert ausgewählte Callbacks aber im
+    // Browser. Die Regel unten begrenzt Browser-Globals auf genau diese APIs.
+    languageOptions: { globals: { ...globals.node, ...globals.browser } },
   },
   // typescript-eslint deaktiviert no-undef für TS-Dateien. Diese explizite
   // Regel hält den Laufzeitvertrag auch für .ts/.mts durchsetzbar.
@@ -139,10 +173,13 @@ export default tseslint.config(
     rules: { 'no-restricted-globals': forbidBrowserGlobalsInNodeScripts },
   },
   {
-    files: ['apps/frontend/scripts/**/*.{ts,mts}'],
+    files: ['apps/frontend/scripts/**/*.{js,mjs,cjs,ts,mts}'],
     plugins: { 'runtime-profile': runtimeProfilePlugin },
     rules: {
-      'runtime-profile/no-browser-global-outside-playwright-callback': 'error',
+      'runtime-profile/no-browser-global-outside-playwright-callback': [
+        'error',
+        { allowPlaywrightCallbacks: true, checkBareBrowserGlobals: true },
+      ],
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,6 +73,7 @@ const runtimeProfilePlugin = {
         const playwrightReceiverVariables = new Set();
         const untrustedPlaywrightReceiverVariables = new Set();
         const playwrightReceiverFactories = new Set();
+        const untrustedPlaywrightReceiverFactories = new Set();
         const playwrightReceiverFactoryProperties = new Map();
         const allowPlaywrightCallbacks = context.options[0]?.allowPlaywrightCallbacks === true;
         const checkBareBrowserGlobals = context.options[0]?.checkBareBrowserGlobals === true;
@@ -98,7 +99,9 @@ const runtimeProfilePlugin = {
               current = current.argument;
               continue;
             }
-            if (['ChainExpression', 'TSAsExpression', 'TSNonNullExpression'].includes(current.type)) {
+            if (
+              ['ChainExpression', 'TSAsExpression', 'TSNonNullExpression'].includes(current.type)
+            ) {
               current = current.expression;
               continue;
             }
@@ -139,7 +142,10 @@ const runtimeProfilePlugin = {
                 : definition.node.type === 'VariableDeclarator'
                   ? definition.node.init
                   : null;
-            return playwrightReceiverFactories.has(factory);
+            return (
+              playwrightReceiverFactories.has(factory) &&
+              !untrustedPlaywrightReceiverFactories.has(factory)
+            );
           });
         };
         const resolvedFunctions = (node) => {
@@ -169,6 +175,12 @@ const runtimeProfilePlugin = {
                 !untrustedPlaywrightReceiverVariables.has(variable))
             );
           }
+          if (current.type === 'ConditionalExpression') {
+            return (
+              isPlaywrightReceiver(current.consequent, seen) &&
+              isPlaywrightReceiver(current.alternate, seen)
+            );
+          }
           if (current.type !== 'CallExpression') return false;
           if (current.callee.type === 'Identifier') return resolvesToFactory(current.callee);
           if (
@@ -180,6 +192,99 @@ const runtimeProfilePlugin = {
             return false;
           }
           return isPlaywrightReceiver(current.callee.object, seen);
+        };
+        const combineBranches = (...branches) => ({
+          returns: branches.flatMap((branch) => branch.returns),
+          canContinue: branches.some((branch) => branch.canContinue),
+          unknown: branches.some((branch) => branch.unknown),
+        });
+        const analyzeStatements = (statements) => {
+          const result = { returns: [], canContinue: true, unknown: false };
+          for (const statement of statements) {
+            if (!result.canContinue) break;
+            const outcome = analyzeStatement(statement);
+            result.returns.push(...outcome.returns);
+            result.canContinue = outcome.canContinue;
+            result.unknown ||= outcome.unknown;
+          }
+          return result;
+        };
+        const analyzeStatement = (statement) => {
+          switch (statement.type) {
+            case 'ReturnStatement':
+              return statement.argument
+                ? { returns: [statement.argument], canContinue: false, unknown: false }
+                : { returns: [], canContinue: false, unknown: true };
+            case 'ThrowStatement':
+              return { returns: [], canContinue: false, unknown: false };
+            case 'BlockStatement':
+              return analyzeStatements(statement.body);
+            case 'IfStatement':
+              return combineBranches(
+                analyzeStatement(statement.consequent),
+                statement.alternate
+                  ? analyzeStatement(statement.alternate)
+                  : { returns: [], canContinue: true, unknown: false },
+              );
+            case 'TryStatement': {
+              if (statement.finalizer?.body.length) {
+                return { returns: [], canContinue: true, unknown: true };
+              }
+              const body = analyzeStatement(statement.block);
+              return statement.handler
+                ? combineBranches(body, analyzeStatement(statement.handler.body))
+                : body;
+            }
+            case 'LabeledStatement':
+              return analyzeStatement(statement.body);
+            case 'ForStatement':
+            case 'ForInStatement':
+            case 'ForOfStatement':
+            case 'WhileStatement': {
+              const body = analyzeStatement(statement.body);
+              return { ...body, canContinue: true };
+            }
+            case 'DoWhileStatement':
+              return analyzeStatement(statement.body);
+            case 'BreakStatement':
+            case 'ContinueStatement':
+            case 'SwitchStatement':
+            case 'WithStatement':
+              return { returns: [], canContinue: true, unknown: true };
+            default:
+              return { returns: [], canContinue: true, unknown: false };
+          }
+        };
+        const analyzeFunctionReturns = (fn) => {
+          if (fn.type === 'ArrowFunctionExpression' && fn.expression) {
+            return { returns: [fn.body], canContinue: false, unknown: false };
+          }
+          return analyzeStatement(fn.body);
+        };
+        const receiverPropertiesReturnedBy = (summary) => {
+          if (summary.unknown || summary.canContinue || summary.returns.length === 0) return [];
+          const returnedObjects = summary.returns.map(unwrapExpression);
+          if (returnedObjects.some((returned) => returned?.type !== 'ObjectExpression')) return [];
+          const [first, ...rest] = returnedObjects;
+          return first.properties
+            .filter(
+              (property) =>
+                property.type === 'Property' &&
+                property.key.type === 'Identifier' &&
+                isPlaywrightReceiver(property.value),
+            )
+            .map((property) => property.key.name)
+            .filter((name) =>
+              rest.every((returned) =>
+                returned.properties.some(
+                  (property) =>
+                    property.type === 'Property' &&
+                    property.key.type === 'Identifier' &&
+                    property.key.name === name &&
+                    isPlaywrightReceiver(property.value),
+                ),
+              ),
+            );
         };
         const isSupportedBrowserCallbackCall = (call, callback) =>
           call?.type === 'CallExpression' &&
@@ -223,6 +328,32 @@ const runtimeProfilePlugin = {
             let changed = true;
             while (changed) {
               changed = false;
+              for (const fn of nodes.filter((current) =>
+                ['ArrowFunctionExpression', 'FunctionExpression', 'FunctionDeclaration'].includes(
+                  current.type,
+                ),
+              )) {
+                const summary = analyzeFunctionReturns(fn);
+                if (
+                  !summary.unknown &&
+                  !summary.canContinue &&
+                  summary.returns.length > 0 &&
+                  summary.returns.every((returned) => isPlaywrightReceiver(returned)) &&
+                  !playwrightReceiverFactories.has(fn)
+                ) {
+                  playwrightReceiverFactories.add(fn);
+                  changed = true;
+                }
+                const properties = receiverPropertiesReturnedBy(summary);
+                const knownProperties = playwrightReceiverFactoryProperties.get(fn) ?? new Set();
+                for (const property of properties) {
+                  if (!knownProperties.has(property)) {
+                    knownProperties.add(property);
+                    changed = true;
+                  }
+                }
+                playwrightReceiverFactoryProperties.set(fn, knownProperties);
+              }
               for (const current of nodes) {
                 if (
                   current.type === 'VariableDeclarator' &&
@@ -235,10 +366,7 @@ const runtimeProfilePlugin = {
                     changed = true;
                   }
                 }
-                if (
-                  current.type === 'VariableDeclarator' &&
-                  current.id.type === 'ObjectPattern'
-                ) {
+                if (current.type === 'VariableDeclarator' && current.id.type === 'ObjectPattern') {
                   const initializer = unwrapExpression(current.init);
                   if (
                     initializer?.type === 'CallExpression' &&
@@ -277,50 +405,11 @@ const runtimeProfilePlugin = {
                     changed = true;
                   }
                 }
-                if (current.type === 'ReturnStatement') {
-                  let owner = current.parent;
-                  while (
-                    owner &&
-                    !['ArrowFunctionExpression', 'FunctionExpression', 'FunctionDeclaration'].includes(
-                      owner.type,
-                    )
-                  ) {
-                    owner = owner.parent;
-                  }
-                  if (
-                    owner &&
-                    isPlaywrightReceiver(current.argument) &&
-                    !playwrightReceiverFactories.has(owner)
-                  ) {
-                    playwrightReceiverFactories.add(owner);
-                    changed = true;
-                  }
-                  const returned = unwrapExpression(current.argument);
-                  if (owner && returned?.type === 'ObjectExpression') {
-                    const properties = playwrightReceiverFactoryProperties.get(owner) ?? new Set();
-                    for (const property of returned.properties) {
-                      if (
-                        property.type !== 'Property' ||
-                        property.key.type !== 'Identifier' ||
-                        !isPlaywrightReceiver(property.value) ||
-                        properties.has(property.key.name)
-                      ) {
-                        continue;
-                      }
-                      properties.add(property.key.name);
-                      changed = true;
-                    }
-                    playwrightReceiverFactoryProperties.set(owner, properties);
-                  }
-                }
                 if (current.type === 'CallExpression' && current.callee.type === 'Identifier') {
                   for (const fn of resolvedFunctions(current.callee)) {
                     current.arguments.forEach((argument, index) => {
                       const parameter = fn.params[index];
-                      if (
-                        parameter?.type !== 'Identifier' ||
-                        !isPlaywrightReceiver(argument)
-                      ) {
+                      if (parameter?.type !== 'Identifier' || !isPlaywrightReceiver(argument)) {
                         return;
                       }
                       const variable = resolveVariable(parameter);
@@ -337,11 +426,71 @@ const runtimeProfilePlugin = {
             let trustChanged = true;
             while (trustChanged) {
               trustChanged = false;
+              for (const factory of playwrightReceiverFactories) {
+                const summary = analyzeFunctionReturns(factory);
+                if (
+                  !untrustedPlaywrightReceiverFactories.has(factory) &&
+                  (summary.unknown ||
+                    summary.canContinue ||
+                    summary.returns.length === 0 ||
+                    !summary.returns.every((returned) => isPlaywrightReceiver(returned)))
+                ) {
+                  untrustedPlaywrightReceiverFactories.add(factory);
+                  trustChanged = true;
+                }
+              }
               for (const current of nodes) {
                 if (
-                  current.type === 'AssignmentExpression' &&
-                  current.left.type === 'Identifier'
+                  current.type === 'VariableDeclarator' &&
+                  current.id.type === 'Identifier' &&
+                  current.init !== null
                 ) {
+                  const variable = resolveVariable(current.id);
+                  if (
+                    variable &&
+                    playwrightReceiverVariables.has(variable) &&
+                    !untrustedPlaywrightReceiverVariables.has(variable) &&
+                    !isPlaywrightReceiver(current.init)
+                  ) {
+                    untrustedPlaywrightReceiverVariables.add(variable);
+                    trustChanged = true;
+                  }
+                }
+                if (current.type === 'VariableDeclarator' && current.id.type === 'ObjectPattern') {
+                  const initializer = unwrapExpression(current.init);
+                  const factories =
+                    initializer?.type === 'CallExpression' &&
+                    initializer.callee.type === 'Identifier'
+                      ? resolvedFunctions(initializer.callee)
+                      : [];
+                  for (const property of current.id.properties) {
+                    if (
+                      property.type !== 'Property' ||
+                      property.key.type !== 'Identifier' ||
+                      property.value.type !== 'Identifier'
+                    ) {
+                      continue;
+                    }
+                    const variable = resolveVariable(property.value);
+                    const isProvenProperty =
+                      factories.length > 0 &&
+                      factories.every((factory) =>
+                        receiverPropertiesReturnedBy(analyzeFunctionReturns(factory)).includes(
+                          property.key.name,
+                        ),
+                      );
+                    if (
+                      variable &&
+                      playwrightReceiverVariables.has(variable) &&
+                      !untrustedPlaywrightReceiverVariables.has(variable) &&
+                      !isProvenProperty
+                    ) {
+                      untrustedPlaywrightReceiverVariables.add(variable);
+                      trustChanged = true;
+                    }
+                  }
+                }
+                if (current.type === 'AssignmentExpression' && current.left.type === 'Identifier') {
                   const variable = resolveVariable(current.left);
                   if (
                     variable &&

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "test:coverage": "npm run build:libs && npm run test:coverage -w @arsnova/shared-types && npm run test -w @arsnova/session-export-report && npm run test:coverage -w @arsnova/backend && npm run test:coverage -w @arsnova/frontend",
     "clean:generated": "node scripts/clean-generated.mjs",
     "lint": "eslint libs/ apps/ --no-warn-ignored",
+    "lint:scripts": "node scripts/lint-scripts.mjs",
+    "lint:scripts:test": "node --test scripts/validate-script-lint-inventory.test.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,html,css,scss,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,html,css,scss,md}\"",
     "format:check:changed": "node scripts/check-changed-format.mjs",

--- a/scripts/lint-scripts.mjs
+++ b/scripts/lint-scripts.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { ESLint } from 'eslint';
+import { appendFileSync } from 'node:fs';
+import { relative, sep } from 'node:path';
+import {
+  listTrackedFiles,
+  loadInventory,
+  validateInventory,
+} from './validate-script-lint-inventory.mjs';
+
+function formatProfileReport(profile, result) {
+  return `- ${profile}: ${result.files} Datei(en), ${result.errors} Fehler, ${result.warnings} Warnungen`;
+}
+
+function writeSummary(lines) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) appendFileSync(summaryPath, `${lines.join('\n')}\n`);
+}
+
+async function main() {
+  const inventory = loadInventory();
+  const { errors: inventoryErrors, rows } = validateInventory(inventory, listTrackedFiles());
+  if (inventoryErrors.length > 0) {
+    process.stderr.write(`Script lint inventory failed:\n${inventoryErrors.join('\n')}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const eslint = new ESLint({ ignore: false });
+  const results = await eslint.lintFiles(rows.map(({ file }) => file));
+  const report = new Map(
+    inventory.profiles.map((profile) => [profile.name, { files: 0, errors: 0, warnings: 0 }]),
+  );
+  for (const result of results) {
+    const file = relative(process.cwd(), result.filePath).split(sep).join('/');
+    const row = rows.find((entry) => entry.file === file);
+    if (!row) throw new Error(`Lint result without inventory entry: ${result.filePath}`);
+    const entry = report.get(row.profile);
+    entry.files += 1;
+    entry.errors += result.errorCount;
+    entry.warnings += result.warningCount;
+  }
+
+  const lines = [
+    '## Script lint inventory (report-only)',
+    '',
+    ...inventory.profiles.map((profile) =>
+      formatProfileReport(profile.name, report.get(profile.name)),
+    ),
+    '',
+    'Bekannte Bestandsbefunde sind in Slice 3A reportend. Neue oder nicht zugeordnete Skriptpfade bleiben fehlerhaft.',
+    'Lokal: `npm run lint:scripts`',
+  ];
+  process.stdout.write(`${lines.join('\n')}\n`);
+  writeSummary(lines);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/script-lint-inventory.json
+++ b/scripts/script-lint-inventory.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "extensions": [".js", ".mjs", ".cjs", ".ts", ".mts"],
+  "scope": ["scripts/**", "apps/**/scripts/**", "libs/**/scripts/**", ".github/scripts/**"],
+  "profiles": [
+    {
+      "name": "k6",
+      "runtime": "k6 virtual-user runtime",
+      "include": ["scripts/load/k6-*.js"],
+      "exclude": [],
+      "globals": ["__ENV", "__ITER", "__VU"]
+    },
+    {
+      "name": "playwright-node",
+      "runtime": "Node.js process controlling Playwright browsers",
+      "include": ["apps/frontend/scripts/**"],
+      "exclude": [],
+      "globals": ["Node.js"]
+    },
+    {
+      "name": "github-actions-node",
+      "runtime": "Node.js helper invoked by GitHub Actions",
+      "include": [".github/scripts/**"],
+      "exclude": [],
+      "globals": ["Node.js"]
+    },
+    {
+      "name": "node",
+      "runtime": "Node.js CLI, test, build or operations process",
+      "include": [
+        "scripts/**",
+        "apps/backend/scripts/**",
+        "apps/landing/scripts/**",
+        "libs/**/scripts/**"
+      ],
+      "exclude": ["scripts/load/k6-*.js"],
+      "globals": ["Node.js"]
+    }
+  ],
+  "exceptions": [
+    {
+      "glob": "scripts/load/artillery/reports/**",
+      "reason": "Artillery reports are generated runtime output and are excluded by the existing tmp/report handling."
+    }
+  ]
+}

--- a/scripts/script-lint-inventory.json
+++ b/scripts/script-lint-inventory.json
@@ -13,7 +13,11 @@
     {
       "name": "playwright-node",
       "runtime": "Node.js process controlling Playwright browsers",
-      "include": ["apps/frontend/scripts/**"],
+      "include": [
+        "apps/frontend/scripts/**",
+        "apps/landing/scripts/**",
+        "scripts/verify-csp-browser.mjs"
+      ],
       "exclude": [],
       "globals": ["Node.js"]
     },
@@ -33,7 +37,12 @@
         "apps/landing/scripts/**",
         "libs/**/scripts/**"
       ],
-      "exclude": ["scripts/load/k6-*.js"],
+      "exclude": [
+        "scripts/load/k6-*.js",
+        "apps/frontend/scripts/**",
+        "apps/landing/scripts/**",
+        "scripts/verify-csp-browser.mjs"
+      ],
       "globals": ["Node.js"]
     }
   ],

--- a/scripts/validate-script-lint-inventory.mjs
+++ b/scripts/validate-script-lint-inventory.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const INVENTORY_PATH = new URL('./script-lint-inventory.json', import.meta.url);
+
+function escapeRegex(character) {
+  return /[|\\{}()[\]^$+?.]/.test(character) ? `\\${character}` : character;
+}
+
+export function globMatches(path, glob) {
+  let pattern = '^';
+  for (let index = 0; index < glob.length; index += 1) {
+    const character = glob[index];
+    if (character === '*') {
+      if (glob[index + 1] === '*') {
+        index += 1;
+        if (glob[index + 1] === '/') {
+          index += 1;
+          pattern += '(?:.*/)?';
+        } else {
+          pattern += '.*';
+        }
+      } else {
+        pattern += '[^/]*';
+      }
+    } else {
+      pattern += escapeRegex(character);
+    }
+  }
+  return new RegExp(`${pattern}$`).test(path);
+}
+
+export function classifyFile(path, inventory) {
+  const matchingProfiles = inventory.profiles.filter(
+    (profile) =>
+      profile.include.some((glob) => globMatches(path, glob)) &&
+      !profile.exclude.some((glob) => globMatches(path, glob)),
+  );
+  return matchingProfiles.map((profile) => profile.name);
+}
+
+export function isRelevantScript(path, inventory) {
+  return inventory.extensions.some((extension) => path.endsWith(extension));
+}
+
+export function isDocumentedException(path, inventory) {
+  return inventory.exceptions.some((exception) => globMatches(path, exception.glob));
+}
+
+export function listTrackedFiles() {
+  return execFileSync('git', ['ls-files', '--cached', '--others', '--exclude-standard', '-z'], {
+    encoding: 'utf8',
+  })
+    .split('\0')
+    .filter(Boolean);
+}
+
+export function validateInventory(inventory, files) {
+  const relevantFiles = files.filter((path) => isRelevantScript(path, inventory));
+  const errors = [];
+  const rows = [];
+  const scopedFiles = relevantFiles.filter(
+    (path) =>
+      inventory.scope.some((glob) => globMatches(path, glob)) &&
+      !isDocumentedException(path, inventory),
+  );
+  for (const path of scopedFiles) {
+    const profiles = classifyFile(path, inventory);
+    if (profiles.length === 0) {
+      errors.push(`${path}: script path is in scope but has no profile`);
+      continue;
+    }
+    if (profiles.length !== 1) {
+      errors.push(`${path}: expected exactly one profile, found ${profiles.join(', ')}`);
+      continue;
+    }
+    rows.push({ file: path, profile: profiles[0] });
+  }
+
+  return { errors, rows };
+}
+
+export function loadInventory() {
+  return JSON.parse(readFileSync(INVENTORY_PATH, 'utf8'));
+}
+
+function main() {
+  const { errors, rows } = validateInventory(loadInventory(), listTrackedFiles());
+  if (errors.length > 0) {
+    process.stderr.write(`Script lint inventory failed:\n${errors.join('\n')}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(
+    `Script lint inventory: ${rows.length} tracked files assigned exactly once.\n`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/validate-script-lint-inventory.test.mjs
+++ b/scripts/validate-script-lint-inventory.test.mjs
@@ -87,19 +87,18 @@ test('runtime profiles expose only their declared globals', async () => {
   );
 });
 
-test('Node and Playwright-Node TypeScript profiles reject browser globals', async () => {
+test('Node TypeScript profiles reject browser-only globals while keeping Node Web APIs', async () => {
   const eslint = new ESLint({ ignore: false });
-  for (const filePath of [
-    'scripts/check-runtime.ts',
-    'scripts/check-runtime.mts',
-    'apps/frontend/scripts/check-runtime.mts',
-  ]) {
+  for (const filePath of ['scripts/check-runtime.ts', 'scripts/check-runtime.mts']) {
     const config = await eslint.calculateConfigForFile(filePath);
     assert.equal(Object.hasOwn(config.languageOptions.globals, 'process'), true);
     assert.equal('window' in config.languageOptions.globals, false);
-    const result = await eslint.lintText('process.stdout.write("ok"); window.alert("no");', {
-      filePath,
-    });
+    const result = await eslint.lintText(
+      'console.log(new URL("https://example.org")); window.alert("no");',
+      {
+        filePath,
+      },
+    );
     const restrictedMessages = result[0].messages.filter(
       (message) => message.ruleId === 'no-restricted-globals',
     );
@@ -109,4 +108,31 @@ test('Node and Playwright-Node TypeScript profiles reject browser globals', asyn
       /Browser-Global ist in diesem Node-Laufzeitprofil nicht verfügbar\./,
     );
   }
+});
+
+test('Playwright TypeScript profiles allow browser callbacks but reject browser-only globals elsewhere', async () => {
+  const eslint = new ESLint({ ignore: false });
+  const outsideCallback = await eslint.lintText('window.location.href;', {
+    filePath: 'apps/frontend/scripts/check-runtime.mts',
+  });
+  assert.deepEqual(
+    outsideCallback[0].messages
+      .filter(
+        (message) =>
+          message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+      )
+      .map((message) => message.message),
+    ['Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.'],
+  );
+
+  const browserCallback = await eslint.lintText('page.evaluate(() => window.location.href);', {
+    filePath: 'apps/frontend/scripts/check-runtime.mts',
+  });
+  assert.equal(
+    browserCallback[0].messages.some(
+      (message) =>
+        message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+    ),
+    false,
+  );
 });

--- a/scripts/validate-script-lint-inventory.test.mjs
+++ b/scripts/validate-script-lint-inventory.test.mjs
@@ -61,9 +61,12 @@ test('runtime profiles expose only their declared globals', async () => {
   );
   assert.deepEqual(
     playwrightResult[0].messages
-      .filter((message) => message.ruleId === 'no-undef')
+      .filter(
+        (message) =>
+          message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+      )
       .map((message) => message.message),
-    ["'window' is not defined."],
+    ['Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.'],
   );
 
   const githubResult = await eslint.lintText('process.stdout.write("ok"); window.alert("no");', {
@@ -134,5 +137,51 @@ test('Playwright TypeScript profiles allow browser callbacks but reject browser-
         message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
     ),
     false,
+  );
+
+  const nestedBrowserCallback = await eslint.lintText(
+    'page.evaluate(() => [1].map(() => window.location.href));',
+    { filePath: 'apps/frontend/scripts/check-runtime.mts' },
+  );
+  assert.equal(
+    nestedBrowserCallback[0].messages.some(
+      (message) =>
+        message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+    ),
+    false,
+  );
+
+  const browserJavaScriptCallback = await eslint.lintText(
+    'page.evaluate(() => window.location.href);',
+    { filePath: 'apps/frontend/scripts/check-runtime.mjs' },
+  );
+  assert.equal(
+    browserJavaScriptCallback[0].messages.some(
+      (message) =>
+        message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+    ),
+    false,
+  );
+});
+
+test('Node scripts reject explicit globalThis browser-only access', async () => {
+  const eslint = new ESLint({ ignore: false });
+  const result = await eslint.lintText(
+    'globalThis.window.alert("no"); globalThis.document.title;',
+    {
+      filePath: 'scripts/check-runtime.mts',
+    },
+  );
+  assert.deepEqual(
+    result[0].messages
+      .filter(
+        (message) =>
+          message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+      )
+      .map((message) => message.message),
+    [
+      'Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.',
+      'Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.',
+    ],
   );
 });

--- a/scripts/validate-script-lint-inventory.test.mjs
+++ b/scripts/validate-script-lint-inventory.test.mjs
@@ -31,6 +31,14 @@ const inventory = {
   ],
 };
 
+const withPlaywrightPage = (source) => `
+  import { chromium } from 'playwright';
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  ${source}
+`;
+
 test('classifies k6 and Node scripts without overlapping globals', () => {
   assert.deepEqual(classifyFile('scripts/load/k6-health.js', inventory), ['k6']);
   assert.deepEqual(classifyFile('scripts/load/run-k6.mjs', inventory), ['node']);
@@ -143,9 +151,10 @@ test('Playwright TypeScript profiles allow browser callbacks but reject browser-
     ['Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.'],
   );
 
-  const browserCallback = await eslint.lintText('page.evaluate(() => window.location.href);', {
-    filePath: 'apps/frontend/scripts/check-runtime.mts',
-  });
+  const browserCallback = await eslint.lintText(
+    withPlaywrightPage('page.evaluate(() => window.location.href);'),
+    { filePath: 'apps/frontend/scripts/check-runtime.mts' },
+  );
   assert.equal(
     browserCallback[0].messages.some(
       (message) =>
@@ -155,7 +164,7 @@ test('Playwright TypeScript profiles allow browser callbacks but reject browser-
   );
 
   const nestedBrowserCallback = await eslint.lintText(
-    'page.evaluate(() => [1].map(() => window.location.href));',
+    withPlaywrightPage('page.evaluate(() => [1].map(() => window.location.href));'),
     { filePath: 'apps/frontend/scripts/check-runtime.mts' },
   );
   assert.equal(
@@ -167,7 +176,7 @@ test('Playwright TypeScript profiles allow browser callbacks but reject browser-
   );
 
   const browserJavaScriptCallback = await eslint.lintText(
-    'page.evaluate(() => window.location.href);',
+    withPlaywrightPage('page.evaluate(() => window.location.href);'),
     { filePath: 'apps/frontend/scripts/check-runtime.mjs' },
   );
   assert.equal(
@@ -179,7 +188,9 @@ test('Playwright TypeScript profiles allow browser callbacks but reject browser-
   );
 
   const namedBrowserCallback = await eslint.lintText(
-    'const readLocation = () => window.location.href; page.waitForFunction(readLocation);',
+    withPlaywrightPage(
+      'const readLocation = () => window.location.href; page.waitForFunction(readLocation);',
+    ),
     { filePath: 'apps/frontend/scripts/check-runtime.mjs' },
   );
   assert.equal(
@@ -191,7 +202,9 @@ test('Playwright TypeScript profiles allow browser callbacks but reject browser-
   );
 
   const shadowedCallbackName = await eslint.lintText(
-    'const readLocation = () => "ok"; { const readLocation = () => window.location.href; } page.waitForFunction(readLocation);',
+    withPlaywrightPage(
+      'const readLocation = () => "ok"; { const readLocation = () => window.location.href; } page.waitForFunction(readLocation);',
+    ),
     { filePath: 'apps/frontend/scripts/check-runtime.mjs' },
   );
   assert.equal(
@@ -230,11 +243,13 @@ test('Playwright callbacks outside frontend scripts include addInitScript', asyn
   for (const [filePath, source] of [
     [
       'apps/landing/scripts/check-runtime.mjs',
-      'page.addInitScript(() => localStorage.setItem("theme", "dark"));',
+      withPlaywrightPage('page.addInitScript(() => localStorage.setItem("theme", "dark"));'),
     ],
     [
       'scripts/verify-csp-browser.mjs',
-      'context.addInitScript(() => document.documentElement.dataset.test = "ok");',
+      withPlaywrightPage(
+        'context.addInitScript(() => document.documentElement.dataset.test = "ok");',
+      ),
     ],
   ]) {
     const result = await eslint.lintText(source, { filePath });
@@ -259,4 +274,32 @@ test('Playwright callbacks outside frontend scripts include addInitScript', asyn
       .map((message) => message.message),
     ['Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.'],
   );
+});
+
+test('Playwright callback exemptions require a proven receiver and argument zero', async () => {
+  const eslint = new ESLint({ ignore: false });
+  for (const source of [
+    'const helper = { evaluate(callback) { return callback(); } }; helper.evaluate(() => window.location.href);',
+    withPlaywrightPage(
+      'page.evaluate(() => "ok", () => window.location.href);',
+    ),
+    'import { devices } from "playwright"; devices.launch().evaluate(() => window.location.href);',
+    withPlaywrightPage(
+      'const helper = { evaluate(callback) { return callback(); } }; page = helper; page.evaluate(() => window.location.href);',
+    ),
+    withPlaywrightPage(
+      'const helper = { evaluate(callback) { return callback(); } }; function read(target) { target.evaluate(() => window.location.href); } read(page); read(helper);',
+    ),
+  ]) {
+    const result = await eslint.lintText(source, {
+      filePath: 'apps/frontend/scripts/check-runtime.mjs',
+    });
+    assert.equal(
+      result[0].messages.filter(
+        (message) =>
+          message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+      ).length,
+      1,
+    );
+  }
 });

--- a/scripts/validate-script-lint-inventory.test.mjs
+++ b/scripts/validate-script-lint-inventory.test.mjs
@@ -86,3 +86,27 @@ test('runtime profiles expose only their declared globals', async () => {
     ["'process' is not defined."],
   );
 });
+
+test('Node and Playwright-Node TypeScript profiles reject browser globals', async () => {
+  const eslint = new ESLint({ ignore: false });
+  for (const filePath of [
+    'scripts/check-runtime.ts',
+    'scripts/check-runtime.mts',
+    'apps/frontend/scripts/check-runtime.mts',
+  ]) {
+    const config = await eslint.calculateConfigForFile(filePath);
+    assert.equal(Object.hasOwn(config.languageOptions.globals, 'process'), true);
+    assert.equal('window' in config.languageOptions.globals, false);
+    const result = await eslint.lintText('process.stdout.write("ok"); window.alert("no");', {
+      filePath,
+    });
+    const restrictedMessages = result[0].messages.filter(
+      (message) => message.ruleId === 'no-restricted-globals',
+    );
+    assert.equal(restrictedMessages.length, 1);
+    assert.match(
+      restrictedMessages[0].message,
+      /Browser-Global ist in diesem Node-Laufzeitprofil nicht verfügbar\./,
+    );
+  }
+});

--- a/scripts/validate-script-lint-inventory.test.mjs
+++ b/scripts/validate-script-lint-inventory.test.mjs
@@ -39,6 +39,17 @@ const withPlaywrightPage = (source) => `
   ${source}
 `;
 
+const runtimeProfileErrors = async (
+  source,
+  filePath = 'apps/frontend/scripts/check-runtime.mjs',
+) => {
+  const eslint = new ESLint({ ignore: false });
+  const result = await eslint.lintText(source, { filePath });
+  return result[0].messages.filter(
+    (message) => message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+  );
+};
+
 test('classifies k6 and Node scripts without overlapping globals', () => {
   assert.deepEqual(classifyFile('scripts/load/k6-health.js', inventory), ['k6']);
   assert.deepEqual(classifyFile('scripts/load/run-k6.mjs', inventory), ['node']);
@@ -277,12 +288,9 @@ test('Playwright callbacks outside frontend scripts include addInitScript', asyn
 });
 
 test('Playwright callback exemptions require a proven receiver and argument zero', async () => {
-  const eslint = new ESLint({ ignore: false });
   for (const source of [
     'const helper = { evaluate(callback) { return callback(); } }; helper.evaluate(() => window.location.href);',
-    withPlaywrightPage(
-      'page.evaluate(() => "ok", () => window.location.href);',
-    ),
+    withPlaywrightPage('page.evaluate(() => "ok", () => window.location.href);'),
     'import { devices } from "playwright"; devices.launch().evaluate(() => window.location.href);',
     withPlaywrightPage(
       'const helper = { evaluate(callback) { return callback(); } }; page = helper; page.evaluate(() => window.location.href);',
@@ -291,15 +299,111 @@ test('Playwright callback exemptions require a proven receiver and argument zero
       'const helper = { evaluate(callback) { return callback(); } }; function read(target) { target.evaluate(() => window.location.href); } read(page); read(helper);',
     ),
   ]) {
-    const result = await eslint.lintText(source, {
-      filePath: 'apps/frontend/scripts/check-runtime.mjs',
-    });
-    assert.equal(
-      result[0].messages.filter(
-        (message) =>
-          message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
-      ).length,
-      1,
-    );
+    assert.equal((await runtimeProfileErrors(source)).length, 1);
   }
+});
+
+test('mixed factory returns cannot authorize a foreign receiver', async () => {
+  const allowed = await runtimeProfileErrors(
+    withPlaywrightPage('page.evaluate(() => document.title);'),
+  );
+  const rejected = await runtimeProfileErrors(
+    withPlaywrightPage(`
+      const helper = { evaluate(callback) { return callback(); } };
+      function makeTarget(usePage) {
+        if (usePage) return page;
+        return helper;
+      }
+      makeTarget(false).evaluate(() => window.location.href);
+    `),
+  );
+  assert.equal(allowed.length, 0);
+  assert.equal(rejected.length, 1);
+  assert.match(rejected[0].message, /außerhalb eines Playwright-Browsercallbacks/);
+});
+
+test('expression-bodied factories require every conditional result to be Playwright', async () => {
+  const allowed = await runtimeProfileErrors(
+    withPlaywrightPage(`
+      const makeTarget = (usePage) => usePage ? page : page.locator('body');
+      makeTarget(false).evaluate(() => document.title);
+    `),
+  );
+  const rejected = await runtimeProfileErrors(
+    withPlaywrightPage(`
+      const helper = { evaluate(callback) { return callback(); } };
+      const makeHelper = () => helper;
+      makeHelper().evaluate(() => window.location.href);
+    `),
+  );
+  assert.equal(allowed.length, 0);
+  assert.equal(rejected.length, 1);
+  assert.match(rejected[0].message, /außerhalb eines Playwright-Browsercallbacks/);
+});
+
+test('block factories allow callbacks only when every value return is Playwright', async () => {
+  const allowed = await runtimeProfileErrors(
+    withPlaywrightPage(`
+      function makeTarget(usePage) {
+        if (usePage) return page;
+        return page.locator('body');
+      }
+      makeTarget(false).evaluate(() => document.title);
+    `),
+  );
+  const rejected = await runtimeProfileErrors(
+    withPlaywrightPage(`
+      const helper = { evaluate(callback) { return callback(); } };
+      helper.evaluate(() => window.location.href);
+    `),
+  );
+  assert.equal(allowed.length, 0);
+  assert.equal(rejected.length, 1);
+  assert.match(rejected[0].message, /außerhalb eines Playwright-Browsercallbacks/);
+});
+
+test('unknown and valueless factory paths are rejected conservatively', async () => {
+  const allowed = await runtimeProfileErrors(
+    withPlaywrightPage(`
+      function makeKnownTarget(usePage) {
+        if (usePage) return page;
+        throw new Error('unavailable');
+      }
+      makeKnownTarget(true).evaluate(() => document.title);
+    `),
+  );
+  const rejected = await runtimeProfileErrors(
+    withPlaywrightPage(`
+      function makeTarget(usePage) {
+        if (usePage) return page;
+        return;
+      }
+      makeTarget(false).evaluate(() => window.location.href);
+    `),
+  );
+  assert.equal(allowed.length, 0);
+  assert.equal(rejected.length, 1);
+  assert.match(rejected[0].message, /außerhalb eines Playwright-Browsercallbacks/);
+});
+
+test('object factory properties remain trusted only across proven call sites', async () => {
+  const allowed = await runtimeProfileErrors(
+    withPlaywrightPage(`
+      function wrap(target) { return { target }; }
+      const { target } = wrap(page);
+      target.evaluate(() => document.title);
+    `),
+  );
+  const rejected = await runtimeProfileErrors(
+    withPlaywrightPage(`
+      const helper = { evaluate(callback) { return callback(); } };
+      function wrap(target) { return { target }; }
+      wrap(page);
+      const { target } = wrap(helper);
+      target.evaluate(() => window.location.href);
+    `),
+  );
+  assert.equal(allowed.length, 0);
+  assert.equal(rejected.length, 1);
+  assert.match(rejected[0].message, /außerhalb eines Playwright-Browsercallbacks/);
 });

--- a/scripts/validate-script-lint-inventory.test.mjs
+++ b/scripts/validate-script-lint-inventory.test.mjs
@@ -14,14 +14,29 @@ const inventory = {
   exceptions: [{ glob: 'scripts/generated/**', reason: 'generated fixture output' }],
   profiles: [
     { name: 'k6', include: ['scripts/load/k6-*.js'], exclude: [] },
-    { name: 'node', include: ['scripts/**'], exclude: ['scripts/load/k6-*.js'] },
-    { name: 'playwright-node', include: ['apps/frontend/scripts/**'], exclude: [] },
+    {
+      name: 'node',
+      include: ['scripts/**'],
+      exclude: ['scripts/load/k6-*.js', 'scripts/verify-csp-browser.mjs'],
+    },
+    {
+      name: 'playwright-node',
+      include: [
+        'apps/frontend/scripts/**',
+        'apps/landing/scripts/**',
+        'scripts/verify-csp-browser.mjs',
+      ],
+      exclude: [],
+    },
   ],
 };
 
 test('classifies k6 and Node scripts without overlapping globals', () => {
   assert.deepEqual(classifyFile('scripts/load/k6-health.js', inventory), ['k6']);
   assert.deepEqual(classifyFile('scripts/load/run-k6.mjs', inventory), ['node']);
+  assert.deepEqual(classifyFile('apps/landing/scripts/check-theme.mjs', inventory), [
+    'playwright-node',
+  ]);
 });
 
 test('recognizes a new script path without silently assigning a profile', () => {
@@ -162,6 +177,30 @@ test('Playwright TypeScript profiles allow browser callbacks but reject browser-
     ),
     false,
   );
+
+  const namedBrowserCallback = await eslint.lintText(
+    'const readLocation = () => window.location.href; page.waitForFunction(readLocation);',
+    { filePath: 'apps/frontend/scripts/check-runtime.mjs' },
+  );
+  assert.equal(
+    namedBrowserCallback[0].messages.some(
+      (message) =>
+        message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+    ),
+    false,
+  );
+
+  const shadowedCallbackName = await eslint.lintText(
+    'const readLocation = () => "ok"; { const readLocation = () => window.location.href; } page.waitForFunction(readLocation);',
+    { filePath: 'apps/frontend/scripts/check-runtime.mjs' },
+  );
+  assert.equal(
+    shadowedCallbackName[0].messages.filter(
+      (message) =>
+        message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+    ).length,
+    1,
+  );
 });
 
 test('Node scripts reject explicit globalThis browser-only access', async () => {
@@ -183,5 +222,41 @@ test('Node scripts reject explicit globalThis browser-only access', async () => 
       'Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.',
       'Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.',
     ],
+  );
+});
+
+test('Playwright callbacks outside frontend scripts include addInitScript', async () => {
+  const eslint = new ESLint({ ignore: false });
+  for (const [filePath, source] of [
+    [
+      'apps/landing/scripts/check-runtime.mjs',
+      'page.addInitScript(() => localStorage.setItem("theme", "dark"));',
+    ],
+    [
+      'scripts/verify-csp-browser.mjs',
+      'context.addInitScript(() => document.documentElement.dataset.test = "ok");',
+    ],
+  ]) {
+    const result = await eslint.lintText(source, { filePath });
+    assert.equal(
+      result[0].messages.some(
+        (message) =>
+          message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+      ),
+      false,
+    );
+  }
+
+  const outsideCallback = await eslint.lintText('document.title = "no";', {
+    filePath: 'apps/landing/scripts/check-runtime.mjs',
+  });
+  assert.deepEqual(
+    outsideCallback[0].messages
+      .filter(
+        (message) =>
+          message.ruleId === 'runtime-profile/no-browser-global-outside-playwright-callback',
+      )
+      .map((message) => message.message),
+    ['Browser-Global ist außerhalb eines Playwright-Browsercallbacks nicht verfügbar.'],
   );
 });

--- a/scripts/validate-script-lint-inventory.test.mjs
+++ b/scripts/validate-script-lint-inventory.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ESLint } from 'eslint';
+import {
+  classifyFile,
+  globMatches,
+  isDocumentedException,
+  validateInventory,
+} from './validate-script-lint-inventory.mjs';
+
+const inventory = {
+  extensions: ['.js', '.mjs', '.cjs', '.ts', '.mts'],
+  scope: ['scripts/**', 'apps/**/scripts/**'],
+  exceptions: [{ glob: 'scripts/generated/**', reason: 'generated fixture output' }],
+  profiles: [
+    { name: 'k6', include: ['scripts/load/k6-*.js'], exclude: [] },
+    { name: 'node', include: ['scripts/**'], exclude: ['scripts/load/k6-*.js'] },
+    { name: 'playwright-node', include: ['apps/frontend/scripts/**'], exclude: [] },
+  ],
+};
+
+test('classifies k6 and Node scripts without overlapping globals', () => {
+  assert.deepEqual(classifyFile('scripts/load/k6-health.js', inventory), ['k6']);
+  assert.deepEqual(classifyFile('scripts/load/run-k6.mjs', inventory), ['node']);
+});
+
+test('recognizes a new script path without silently assigning a profile', () => {
+  const result = validateInventory(inventory, ['apps/unknown/scripts/new-check.mjs']);
+  assert.equal(result.rows.length, 0);
+  assert.deepEqual(result.errors, [
+    'apps/unknown/scripts/new-check.mjs: script path is in scope but has no profile',
+  ]);
+  assert.equal(globMatches('apps/unknown/scripts/new-check.mjs', 'apps/**/scripts/**'), true);
+});
+
+test('does not require a runtime profile for a documented generated exception', () => {
+  assert.equal(isDocumentedException('scripts/generated/report.mjs', inventory), true);
+  assert.deepEqual(validateInventory(inventory, ['scripts/generated/report.mjs']), {
+    errors: [],
+    rows: [],
+  });
+});
+
+test('runtime profiles expose only their declared globals', async () => {
+  const eslint = new ESLint({ ignore: false });
+  const nodeResult = await eslint.lintText('process.stdout.write("ok"); window.alert("no");', {
+    filePath: 'scripts/check-runtime.mjs',
+  });
+  assert.deepEqual(
+    nodeResult[0].messages
+      .filter((message) => message.ruleId === 'no-undef')
+      .map((message) => message.message),
+    ["'window' is not defined."],
+  );
+
+  const playwrightResult = await eslint.lintText(
+    'process.stdout.write("ok"); window.alert("no");',
+    {
+      filePath: 'apps/frontend/scripts/check-runtime.mjs',
+    },
+  );
+  assert.deepEqual(
+    playwrightResult[0].messages
+      .filter((message) => message.ruleId === 'no-undef')
+      .map((message) => message.message),
+    ["'window' is not defined."],
+  );
+
+  const githubResult = await eslint.lintText('process.stdout.write("ok"); window.alert("no");', {
+    filePath: '.github/scripts/check-runtime.mjs',
+  });
+  assert.deepEqual(
+    githubResult[0].messages
+      .filter((message) => message.ruleId === 'no-undef')
+      .map((message) => message.message),
+    ["'window' is not defined."],
+  );
+
+  const k6Result = await eslint.lintText('__ENV.TARGET; process.stdout.write("no");', {
+    filePath: 'scripts/load/k6-runtime.js',
+  });
+  assert.deepEqual(
+    k6Result[0].messages
+      .filter((message) => message.ruleId === 'no-undef')
+      .map((message) => message.message),
+    ["'process' is not defined."],
+  );
+});


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Operative JS-/TS-Skripte waren über `**/scripts/**` aus ESLint ausgenommen. Damit fehlten nachvollziehbare Laufzeitprofile und neue Skriptpfade konnten unbemerkt bleiben.
- **Lösung:** Slice 3A inventarisiert alle relevanten Skriptpfade, ordnet sie genau einem Node-, Playwright-Node-, k6- oder GitHub-Actions-Node-Profil zu und ergänzt im bestehenden `lint`-Job einen reportenden Lauf.
- **Bewusste Nicht-Ziele:** Kein blockierendes Changed-File-Gate (Slice 3B), keine Bereinigung der 40 Bestandsfehler/25 Bestandswarnungen (Slice 3C), keine Änderung der bestehenden Required-Check-Namen.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:** Issue #218, Slice 3A. `npm run lint` bleibt semantisch unverändert. Jede relevante Datei in `scripts/`, `apps/**/scripts/`, `libs/**/scripts/` und `.github/scripts/` besitzt genau ein Profil oder eine begründete Ausnahme. Der neue Bericht bleibt reportend; unbekannte Skriptpfade sind hingegen fehlerhaft.

**Betroffene externe Verträge:** ESLint Flat Config, Node.js- und k6-Laufzeitglobals sowie GitHub-Actions-Step-Summary.

## Implementierung

- `scripts/script-lint-inventory.json` beschreibt Scope, 125 aktuelle Skripte, Profile und die enge Ausnahme für generierte Artillery-Reports.
- `npm run lint:scripts` validiert die Inventur, lintet mit deaktivierter globaler Script-Ignore-Regel und schreibt die Fehler/Warnungen je Profil in Konsole und CI-Summary.
- Die vorhandene `lint`-CI-Stufe ruft zusätzlich die Inventurtests und den reportenden Bericht auf; ihr Check-Name bleibt unverändert.
- `docs/TESTING.md` dokumentiert die lokalen Reproduktionsbefehle und den reportenden Charakter.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [x] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run lint:scripts:test` | 14/14 Negativ-, Provenienz-, Factory- und Inventurtests grün |
| `npm run lint:scripts` | Inventur vollständig; k6 0/0, Playwright-Node 12/2, GitHub-Actions-Node 0/0, Node 28/23 (Fehler/Warnungen, bewusst reportend) |
| `npm run lint` | grün; bestehender Scope unverändert |
| `npm run typecheck` | grün |
| `npm test` | grün: 38 Shared-Types-, 70 Export-Report-, 766 Backend- und 1.142 Frontend-Tests |
| `npm run build:prod` | grün; alle fünf Locales und MOTD-Assets geprüft |
| `npx prettier --check …` und `git diff --check` | grün |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`) synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Keine Anwendungsänderung; CI veröffentlicht im vorhandenen `lint`-Kontext zusätzlich eine reportende Summary.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** GitHub-Step-Summary zeigt Datei-, Fehler- und Warnungszahlen je Laufzeitprofil.
- **Rollback:** `git revert 8d07ab99 bfbe856a 210acf55 d8dcafad 1f8239f4 0f5d2ffa d7d649bd` entfernt Laufzeitprofile, Inventur, Bericht und CI-Aufruf vollständig.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Adversariales Selbstreview: Ein neuer `apps/unknown/scripts/…`-Pfad ohne Profil wird als Inventurfehler geprüft; ein dokumentierter generierter Pfad wird ausschließlich über seine begründete Ausnahme übersprungen.
- Adversariales Selbstreview: Für Node, Playwright-Node und GitHub-Actions-Node wird konkret `window` als undefiniert erwartet, für k6 konkret `process`; zugleich sind `process` bzw. `__ENV` in ihrem eigenen Profil erlaubt. Damit können eine gemeinsame Browser-/Node-Globalmenge oder ein versehentliches k6-Global nicht grün werden.
- Review-Fix: Da `typescript-eslint` Core-`no-undef` für `.ts`/`.mts` deaktiviert, sperrt `no-restricted-globals` in Node-Skriptprofilen ausschließlich browserexklusive Globals. Eine kontextabhängige Regel gilt einheitlich für `.js`, `.mjs`, `.cjs`, `.ts` und `.mts`; sie erlaubt Browser-Globals nur innerhalb des ersten Callback-Arguments von `addInitScript`, `evaluate`, `evaluateAll`, `evaluateHandle` und `waitForFunction`.
- Mutationstests prüfen `.ts` und `.mts` mit erlaubtem `console`/`URL` sowie verbotenem `window`, einen erlaubten `.mjs`-Callback, einen verschachtelten `.mts`-Callback und verbotene `globalThis.window`-/`globalThis.document`-Zugriffe. Damit können weder überlappende Node-Web-APIs noch legitime Browsercallbacks die spätere Changed-File-Prüfung verfälschen.
- Review-Fix: Das Playwright-Profil umfasst alle bestehenden Frontend- und Landing-Skripte sowie `scripts/verify-csp-browser.mjs`. `addInitScript`, benannte Callback-Helfer und deren lexikalische Bindung werden berücksichtigt; ein gleichnamiger Schatten-Callback erhält keine Ausnahme.
- Review-Fix: Die Callback-Ausnahme folgt der im Skript nachgewiesenen Playwright-Herkunft von `chromium`/`firefox`/`webkit` über Browser, Context, Page und Locator sowie lokale Parameter- und Rückgabepfade. Gleichnamige Methoden fremder Objekte und Funktionsargumente ab Position 1 erhalten keine Ausnahme.
- Adversariale Gegenproben blockieren zusätzlich einen fremden `helper.evaluate`, ein zweites `page.evaluate`-Funktionsargument, einen ungeeigneten Playwright-Import, einen nachträglich durch einen Helper ersetzten Page-Receiver und einen Parameter mit gemischten echten/falschen Aufrufern. Die reale 125-Dateien-Inventur behält dabei unverändert ihre bereinigte Baseline.
- Abschluss-Fix: Lokale Factories gelten nur bei vollständiger Rückgabeabdeckung und ausschließlich nachgewiesenen Playwright-Werten als Receiver-Herkunft. Expression-Bodies, bedingte Ausdrücke, mehrere und verschachtelte Rückgaben sowie `try`/`catch` werden ausgewertet; Fall-through, wertlose, fremde und nicht beweisbare Pfade werden konservativ abgelehnt.
- Eigenständige Mutationstests trennen Positiv- und Negativquelle für gemischte Factory-Rückgaben, Expression-Factories, vollständige Block-Factories und wertlose/unklare Pfade. Eine zusätzliche Gegenprobe entwertet gemeinsam manipulierte Objekt-Fixtures und gemischte Call-Sites, damit ein einzelner echter Aufruf keinen fremden Receiver legitimiert.
- CI bleibt absichtlich reportend: Die bereinigte sichtbare Baseline beträgt 40 echte Fehler und 25 Warnungen. Erst Slice 3B blockiert neue/geänderte Skripte; Slice 3C reduziert Bestandsbefunde.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Keine UI-, API-, Datenbank-, Realtime-, Berechtigungs- oder Produktionsdeploy-Änderung.
- **Verbleibende Risiken:** Bestehende Skriptbefunde blockieren noch nicht. Das ist der dokumentierte Stop-Punkt von Slice 3A und wird erst in den folgenden Slices verschärft.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
