### PR TITLE
fix(admin): Markdown-Bilder im Session-Detail wieder sichtbar machen

### DIFF
--- a/apps/frontend/src/app/features/admin/admin-motd-template-dialog.component.spec.ts
+++ b/apps/frontend/src/app/features/admin/admin-motd-template-dialog.component.spec.ts
@@ -20,4 +20,45 @@ describe('AdminMotdTemplateDialogComponent', () => {
     expect(fixture.componentInstance.loading()).toBe(false);
     expect(fixture.componentInstance.isEdit()).toBe(false);
   });
+
+  it('absolutisiert Root-Asset-Bilder in der Template-Vorschau', () => {
+    const previousBaseHref = document.querySelector('base')?.getAttribute('href') ?? null;
+    let baseEl = document.querySelector('base');
+    if (!baseEl) {
+      baseEl = document.createElement('base');
+      document.head.appendChild(baseEl);
+    }
+    baseEl.setAttribute('href', '/de/');
+
+    try {
+      TestBed.configureTestingModule({
+        imports: [AdminMotdTemplateDialogComponent],
+        providers: [
+          { provide: MAT_DIALOG_DATA, useValue: { templateId: null } },
+          { provide: MatDialogRef, useValue: { close: vi.fn() } },
+        ],
+      });
+
+      const fixture = TestBed.createComponent(AdminMotdTemplateDialogComponent);
+      fixture.componentInstance.tplMdDe.set('![Banner](/assets/images/AI-REVOLUTION.png)');
+      fixture.detectChanges();
+
+      const html = String(
+        (
+          fixture.componentInstance.previewHtml() as unknown as {
+            changingThisBreaksApplicationSecurity?: string;
+          }
+        ).changingThisBreaksApplicationSecurity ?? '',
+      );
+
+      expect(html).toContain('/de/assets/images/AI-REVOLUTION.png');
+      expect(html).toMatch(/data-markdown-image-lightbox="true"/);
+    } finally {
+      if (previousBaseHref === null) {
+        baseEl.removeAttribute('href');
+      } else {
+        baseEl.setAttribute('href', previousBaseHref);
+      }
+    }
+  });
 });

--- a/apps/frontend/src/app/features/admin/admin-motd-template-dialog.component.ts
+++ b/apps/frontend/src/app/features/admin/admin-motd-template-dialog.component.ts
@@ -14,7 +14,11 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { trpc } from '../../core/trpc.client';
 import { localizeKnownServerError } from '../../core/localize-known-server-message';
-import { renderMarkdownWithoutKatex } from '../../shared/markdown-katex.util';
+import { resolveMotdAssetOrigin } from '../../core/motd-asset-origin';
+import {
+  absolutizeMarkdownHtmlRootAssetImgSrc,
+  renderMarkdownWithoutKatex,
+} from '../../shared/markdown-katex.util';
 import { MarkdownImageLightboxDirective } from '../../shared/markdown-image-lightbox/markdown-image-lightbox.directive';
 
 export type AdminMotdTemplateDialogData = { templateId: string | null };
@@ -60,7 +64,10 @@ export class AdminMotdTemplateDialogComponent implements OnInit {
   /** Live aus DE (Fallback EN); `innerHTML` liegt außerhalb des Encapsulation-Scopes → Typo in `styles.scss`. */
   readonly previewHtml = computed<SafeHtml>(() => {
     const raw = this.tplMdDe().trim() || this.tplMdEn().trim() || '…';
-    const html = renderMarkdownWithoutKatex(raw);
+    const html = absolutizeMarkdownHtmlRootAssetImgSrc(
+      renderMarkdownWithoutKatex(raw),
+      resolveMotdAssetOrigin(),
+    );
     return this.sanitizer.bypassSecurityTrustHtml(html);
   });
 

--- a/apps/frontend/src/app/features/admin/admin.component.html
+++ b/apps/frontend/src/app/features/admin/admin.component.html
@@ -352,7 +352,7 @@
                                     }
                                   </section>
                                   @if (detail.questions?.length) {
-                                    <div class="admin-questions">
+                                    <div class="admin-questions" appMarkdownImageLightbox>
                                       @for (question of detail.questions!; track question.id) {
                                         <article class="admin-question">
                                           <p

--- a/apps/frontend/src/app/features/admin/admin.component.spec.ts
+++ b/apps/frontend/src/app/features/admin/admin.component.spec.ts
@@ -48,4 +48,25 @@ describe('AdminComponent', () => {
       }
     }
   });
+
+  it('liefert für denselben Text und Heading-Level dieselbe SafeHtml-Referenz', () => {
+    TestBed.configureTestingModule({
+      imports: [AdminComponent],
+    });
+
+    const fixture = TestBed.createComponent(AdminComponent);
+    const first = fixture.componentInstance.renderQuizRichText(
+      '![Demo](https://example.org/a.png)',
+    );
+    const second = fixture.componentInstance.renderQuizRichText(
+      '![Demo](https://example.org/a.png)',
+    );
+    const differentLevel = fixture.componentInstance.renderQuizRichText(
+      '![Demo](https://example.org/a.png)',
+      4,
+    );
+
+    expect(second).toBe(first);
+    expect(differentLevel).not.toBe(first);
+  });
 });

--- a/apps/frontend/src/app/features/admin/admin.component.spec.ts
+++ b/apps/frontend/src/app/features/admin/admin.component.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, vi } from 'vitest';
+import { AdminComponent } from './admin.component';
+
+vi.mock('../../core/trpc.client', () => ({
+  getAdminToken: vi.fn().mockReturnValue(null),
+  setAdminToken: vi.fn(),
+  trpc: {
+    admin: {
+      whoami: { query: vi.fn().mockRejectedValue(new Error('unauthorized')) },
+      listSessions: { query: vi.fn().mockResolvedValue({ sessions: [], total: 0 }) },
+    },
+  },
+}));
+
+describe('AdminComponent', () => {
+  it('rendert Quiz-Markdown mit Lightbox-Attributen und absolutisierten Asset-URLs', () => {
+    const previousBaseHref = document.querySelector('base')?.getAttribute('href') ?? null;
+    let baseEl = document.querySelector('base');
+    if (!baseEl) {
+      baseEl = document.createElement('base');
+      document.head.appendChild(baseEl);
+    }
+    baseEl.setAttribute('href', '/de/');
+
+    try {
+      TestBed.configureTestingModule({
+        imports: [AdminComponent],
+      });
+
+      const fixture = TestBed.createComponent(AdminComponent);
+      const html = String(
+        (
+          fixture.componentInstance.renderQuizRichText(
+            '![Demo](/assets/demo/example.png)',
+          ) as unknown as { changingThisBreaksApplicationSecurity?: string }
+        ).changingThisBreaksApplicationSecurity ?? '',
+      );
+
+      expect(html).toMatch(/data-markdown-image-lightbox="true"/);
+      expect(html).toMatch(/data-markdown-image-state="loading"/);
+      expect(html).toContain('/de/assets/demo/example.png');
+    } finally {
+      if (previousBaseHref === null) {
+        baseEl.removeAttribute('href');
+      } else {
+        baseEl.setAttribute('href', previousBaseHref);
+      }
+    }
+  });
+});

--- a/apps/frontend/src/app/features/admin/admin.component.ts
+++ b/apps/frontend/src/app/features/admin/admin.component.ts
@@ -77,6 +77,8 @@ const ADMIN_SESSION_GROUP_ORDER: readonly SessionStatus[] = [
 export class AdminComponent implements OnInit {
   private readonly locale = inject(LOCALE_ID);
   private readonly sanitizer = inject(DomSanitizer);
+  /** Stabiles SafeHtml für Change Detection — sonst reißt Lightbox-restoreFocus den Trigger ab. */
+  private readonly quizRichTextCache = new Map<string, SafeHtml>();
   readonly adminSecret = signal('');
   readonly loginLoading = signal(false);
   readonly loginError = signal<string | null>(null);
@@ -570,15 +572,25 @@ export class AdminComponent implements OnInit {
   /**
    * Session-Detail: Fragen/Antworten wie in der Live-Ansicht (Markdown + KaTeX, DOMPurify im Util).
    * Root-`/assets/…`-Bilder werden absolutisiert (lokalisierte Builds mit base href).
+   * Ergebnis wird gecacht, damit Change Detection denselben SafeHtml-Referenz behält
+   * und MatDialog-restoreFocus den Lightbox-Trigger nicht an einem detached Node sucht.
    */
   renderQuizRichText(text: string, headingStartLevel: 3 | 4 = 3): SafeHtml {
-    const { html } = renderMarkdownWithKatex(text ?? '', {
+    const source = text ?? '';
+    const cacheKey = `${headingStartLevel}\u0000${source}`;
+    const cached = this.quizRichTextCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const { html } = renderMarkdownWithKatex(source, {
       imagePolicy: 'allow-relative-and-https',
       headingStartLevel,
     });
-    return this.sanitizer.bypassSecurityTrustHtml(
+    const rendered = this.sanitizer.bypassSecurityTrustHtml(
       absolutizeMarkdownHtmlRootAssetImgSrc(html, resolveMotdAssetOrigin()),
     );
+    this.quizRichTextCache.set(cacheKey, rendered);
+    return rendered;
   }
 
   private async verifyAdminSession(): Promise<void> {

--- a/apps/frontend/src/app/features/admin/admin.component.ts
+++ b/apps/frontend/src/app/features/admin/admin.component.ts
@@ -15,7 +15,12 @@ import { MatTab, MatTabContent, MatTabGroup } from '@angular/material/tabs';
 import { formatLocaleCount } from '../../core/locale-number.util';
 import { localizeKnownServerError } from '../../core/localize-known-server-message';
 import { trpc } from '../../core/trpc.client';
-import { renderMarkdownWithKatex } from '../../shared/markdown-katex.util';
+import { resolveMotdAssetOrigin } from '../../core/motd-asset-origin';
+import {
+  absolutizeMarkdownHtmlRootAssetImgSrc,
+  renderMarkdownWithKatex,
+} from '../../shared/markdown-katex.util';
+import { MarkdownImageLightboxDirective } from '../../shared/markdown-image-lightbox/markdown-image-lightbox.directive';
 import { AdminMotdPanelComponent } from './admin-motd-panel.component';
 import { AdminMonitoringPanelComponent } from './admin-monitoring-panel.component';
 import { getAdminToken, setAdminToken } from '../../core/trpc.client';
@@ -62,6 +67,7 @@ const ADMIN_SESSION_GROUP_ORDER: readonly SessionStatus[] = [
     MatTabGroup,
     MatTab,
     MatTabContent,
+    MarkdownImageLightboxDirective,
     AdminMotdPanelComponent,
     AdminMonitoringPanelComponent,
   ],
@@ -563,13 +569,16 @@ export class AdminComponent implements OnInit {
 
   /**
    * Session-Detail: Fragen/Antworten wie in der Live-Ansicht (Markdown + KaTeX, DOMPurify im Util).
+   * Root-`/assets/…`-Bilder werden absolutisiert (lokalisierte Builds mit base href).
    */
   renderQuizRichText(text: string, headingStartLevel: 3 | 4 = 3): SafeHtml {
     const { html } = renderMarkdownWithKatex(text ?? '', {
       imagePolicy: 'allow-relative-and-https',
       headingStartLevel,
     });
-    return this.sanitizer.bypassSecurityTrustHtml(html);
+    return this.sanitizer.bypassSecurityTrustHtml(
+      absolutizeMarkdownHtmlRootAssetImgSrc(html, resolveMotdAssetOrigin()),
+    );
   }
 
   private async verifyAdminSession(): Promise<void> {

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -643,25 +643,22 @@ html {
   font: var(--mat-sys-body-small);
 }
 
-.markdown-lightbox-enabled img[data-markdown-image-lightbox='true'],
-img[data-markdown-image-lightbox='true'] {
+/* Fade-in/Zoom nur mit Lightbox-Directive — sonst bleiben Bilder bei state=loading unsichtbar. */
+.markdown-lightbox-enabled img[data-markdown-image-lightbox='true'] {
   cursor: -webkit-zoom-in !important;
   cursor: zoom-in !important;
   transition: opacity 180ms ease-out;
 }
 
 .markdown-lightbox-enabled
-  img[data-markdown-image-lightbox='true'][data-markdown-image-state='loading'],
-img[data-markdown-image-lightbox='true'][data-markdown-image-state='loading'] {
+  img[data-markdown-image-lightbox='true'][data-markdown-image-state='loading'] {
   opacity: 0;
 }
 
 .markdown-lightbox-enabled
   img[data-markdown-image-lightbox='true'][data-markdown-image-state='ready'],
 .markdown-lightbox-enabled
-  img[data-markdown-image-lightbox='true'][data-markdown-image-state='error'],
-img[data-markdown-image-lightbox='true'][data-markdown-image-state='ready'],
-img[data-markdown-image-lightbox='true'][data-markdown-image-state='error'] {
+  img[data-markdown-image-lightbox='true'][data-markdown-image-state='error'] {
   opacity: 1;
 }
 


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Im Admin-Session-Detail blieben Markdown-Bilder dauerhaft unsichtbar. Der Renderer setzt `data-markdown-image-state="loading"`, und globales CSS hielt sie bei `opacity: 0`, solange die Lightbox-Directive den State nicht auf `ready`/`error` setzt. Genau diese Directive fehlte im Fragenbereich.
- **Lösung:** `appMarkdownImageLightbox` im Admin-Session-Detail ergänzt, Root-`/assets/…`-URLs absolutisiert (lokalisierte Builds), Fade-in-CSS nur noch unter `.markdown-lightbox-enabled`, und dieselbe Asset-Absolutierung im MOTD-Template-Dialog nachgezogen.
- **Bewusste Nicht-Ziele:** Keine Änderung der Image-Policy oder der Markdown-/KaTeX-Pipeline; keine neuen Admin-Funktionen.

## Risiko und Verträge

- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Bestehendes Markdown-Bildverhalten in MOTD/Quiz/Session: Lightbox-Directive steuert Fade-in und Vollansicht; Root-Asset-URLs müssen unter lokalisiertem `base href` absolutisiert werden.

**Betroffene externe Verträge:**

Keine.

## Implementierung

- Admin-Session-Detail: `MarkdownImageLightboxDirective` importiert und am Fragencontainer gesetzt
- `renderQuizRichText`: Asset-Absolutierung analog Quiz-Liste/MOTD
- Globales CSS: Opacity-/Zoom-Regeln nur noch mit `.markdown-lightbox-enabled`
- MOTD-Template-Dialog: Asset-Absolutierung in der Live-Vorschau
- Regressionstests für Admin-Rendering und Template-Vorschau

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

Bildzustand `loading` → `ready`/`error` über die bestehende Lightbox-Directive; ohne Directive bleiben Bilder sichtbar (CSS-Scoping). Fokus/Lightbox-Dialog unverändert gegenüber bestehenden Oberflächen.

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| Pre-commit: `npm run typecheck` | bestanden |
| Pre-commit: `npm test` (shared-types, session-export-report, backend, frontend) | bestanden (u. a. frontend 1147 Tests) |
| `npm run test -w @arsnova/frontend -- --run …admin… …lightbox…` | 5/5 bestanden |
| `npm run lint` | nicht separat ausgeführt (eslint/prettier im Pre-commit auf den staged Files) |
| `npm run build:prod` / lokalisiertes Frontend-Build | nicht ausgeführt; Risiko: gering, da nur Directive/CSS/URL-Rewrite ohne Build-Config |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

Mobile Darstellung: strukturell unverändert; Sichtbarkeit der Bilder ist CSS-/Directive-Thema und durch Unit-Tests für Attribute/Absolutierung abgedeckt. Manuelle Admin-UI-Prüfung in CI/Review empfohlen.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Admin-Session-Detail und MOTD-Template-Vorschau zeigen Markdown-Bilder wieder; Fade-in nur noch mit Lightbox-Host.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Signale
- **Rollback:** Revert dieses PR

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Pre-commit Typecheck + Full Unit Suite grün
- Neue Tests: `admin.component.spec.ts`, erweitert `admin-motd-template-dialog.component.spec.ts`

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Kein Realtime/Migration/Last/i18n-Text/Security-Vertragswechsel. `build:prod` nicht lokal gelaufen; CI-Build deckt das ab.
- **Verbleibende Risiken:** Manuelle Sichtprüfung im Admin-Session-Detail (HTTPS- und `/assets/demo/…`-Bilder) empfohlen.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)