### PR TITLE
fix(frontend): close structured selection menus on touch devices

### DIFF
--- a/apps/frontend/scripts/check-structured-question-types-flow.mjs
+++ b/apps/frontend/scripts/check-structured-question-types-flow.mjs
@@ -1012,8 +1012,17 @@ async function runOrderingFlow(
   }
 }
 
-async function selectMatOption(page, formFieldLocator, optionText) {
-  await formFieldLocator.locator('mat-select').click();
+async function selectMatOption(
+  page,
+  formFieldLocator,
+  optionText,
+  nextFormFieldLocator = null,
+  selectionAlreadyOpen = false,
+) {
+  const select = formFieldLocator.locator('mat-select');
+  if (!selectionAlreadyOpen) {
+    await select.click();
+  }
   const needle = String(optionText || '').trim();
   const option = page
     .getByRole('option', {
@@ -1026,6 +1035,13 @@ async function selectMatOption(page, formFieldLocator, optionText) {
   await option.waitFor({ state: 'visible', timeout: 8_000 });
   await option.click();
   await page.locator('.mat-mdc-select-panel').waitFor({ state: 'hidden', timeout: 8_000 });
+  await page.locator('.cdk-overlay-backdrop').waitFor({ state: 'hidden', timeout: 8_000 });
+
+  if (nextFormFieldLocator) {
+    const nextSelect = nextFormFieldLocator.locator('mat-select');
+    await nextSelect.click({ timeout: 2_000 });
+    await page.locator('.mat-mdc-select-panel').waitFor({ state: 'visible', timeout: 2_000 });
+  }
 }
 
 async function runMatchingFlow(
@@ -1083,7 +1099,13 @@ async function runMatchingFlow(
     '.vote-matching__list app-item-selection-row .item-selection-row__field',
   );
   for (let index = 0; index < wrongPairs.length; index += 1) {
-    await selectMatOption(participant, fields.nth(index), rightLabels[wrongPairs[index].rightId]);
+    await selectMatOption(
+      participant,
+      fields.nth(index),
+      rightLabels[wrongPairs[index].rightId],
+      index === 0 ? fields.nth(1) : null,
+      index === 1,
+    );
   }
 
   const progressDone = await waitForText(
@@ -1239,6 +1261,8 @@ async function runCategorizationFlow(
       participant,
       fields.nth(index),
       categories[wrongSelections[index].categoryId],
+      index === 0 ? fields.nth(1) : null,
+      index === 1,
     );
   }
 

--- a/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.html
+++ b/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.html
@@ -11,7 +11,7 @@
       [value]="selectedId"
       [aria-label]="selectAriaLabel"
       [disabled]="disabled"
-      (selectionChange)="selectedIdChange.emit($event.value)"
+      (selectionChange)="confirmSelection($event.value, selectionControl)"
     >
       <mat-select-trigger>
         <span class="markdown-body" [innerHTML]="renderMarkdown(selectedText())"></span>

--- a/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.spec.ts
+++ b/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.spec.ts
@@ -1,8 +1,41 @@
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MatSelect } from '@angular/material/select';
 import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, expect, it, vi } from 'vitest';
 import { ItemSelectionRowComponent } from './item-selection-row.component';
+
+@Component({
+  standalone: true,
+  imports: [ItemSelectionRowComponent],
+  template: `
+    <app-item-selection-row
+      itemText="Erstes Element"
+      [options]="options"
+      [selectedId]="firstSelectedId"
+      selectLabel="Erste Auswahl"
+      selectAriaLabel="Auswahl für das erste Element"
+      (selectedIdChange)="firstSelectedId = $event"
+    />
+    <app-item-selection-row
+      itemText="Zweites Element"
+      [options]="options"
+      [selectedId]="secondSelectedId"
+      selectLabel="Zweite Auswahl"
+      selectAriaLabel="Auswahl für das zweite Element"
+      (selectedIdChange)="secondSelectedId = $event"
+    />
+  `,
+})
+class ItemSelectionRowTestHostComponent {
+  readonly options = [
+    { id: 'stable-option-id', text: 'Sichtbarer Text' },
+    { id: 'other-option-id', text: 'Andere Option' },
+  ];
+  firstSelectedId = '';
+  secondSelectedId = '';
+}
 
 describe('ItemSelectionRowComponent', () => {
   it('rendert Markdown und KaTeX in Element, Auswahl und Optionen', () => {
@@ -42,29 +75,35 @@ describe('ItemSelectionRowComponent', () => {
     expect(listener).not.toHaveBeenCalledWith('Sichtbarer Text');
   });
 
-  it('schließt das Auswahlmenü nach einer bestätigten Auswahl explizit', async () => {
-    const fixture = TestBed.createComponent(ItemSelectionRowComponent);
-    fixture.componentRef.setInput('itemText', 'Element');
-    fixture.componentRef.setInput('options', [{ id: 'stable-option-id', text: 'Sichtbarer Text' }]);
-    fixture.componentRef.setInput('selectedId', '');
-    fixture.componentRef.setInput('selectLabel', 'Auswahl');
-    fixture.componentRef.setInput('selectAriaLabel', 'Auswahl für Element');
+  it('schließt das echte Overlay und öffnet die nächste Auswahl mit der ersten Interaktion', async () => {
+    TestBed.configureTestingModule({ imports: [NoopAnimationsModule] });
+    const fixture = TestBed.createComponent(ItemSelectionRowTestHostComponent);
     fixture.detectChanges();
 
-    const select = fixture.debugElement.query(By.directive(MatSelect))
-      .componentInstance as MatSelect;
-    const closeSpy = vi.spyOn(select, 'close').mockImplementation(() => undefined);
-    const listener = vi.fn();
-    fixture.componentInstance.selectedIdChange.subscribe(listener);
+    const selects = fixture.debugElement
+      .queryAll(By.directive(MatSelect))
+      .map((element) => element.componentInstance as MatSelect);
+    const selectElements = (fixture.nativeElement as HTMLElement).querySelectorAll('mat-select');
 
-    fixture.componentInstance.confirmSelection('stable-option-id', select);
+    (selectElements[0] as HTMLElement).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(selects[0].panelOpen).toBe(true);
+    expect(document.querySelector('.cdk-overlay-backdrop')).toBeTruthy();
 
-    expect(listener).toHaveBeenCalledWith('stable-option-id');
-    expect(closeSpy).not.toHaveBeenCalled();
+    (document.querySelector('mat-option') as HTMLElement).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
 
-    await Promise.resolve();
+    expect(fixture.componentInstance.firstSelectedId).toBe('stable-option-id');
+    expect(selects[0].panelOpen).toBe(false);
+    expect(document.querySelector('.cdk-overlay-backdrop')).toBeNull();
 
-    expect(closeSpy).toHaveBeenCalledTimes(1);
+    (selectElements[1] as HTMLElement).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(selects[1].panelOpen).toBe(true);
   });
 
   it('öffnet die Auswahl mit dem ersten Klick auf den sichtbaren Formularrahmen', () => {

--- a/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.spec.ts
+++ b/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.spec.ts
@@ -42,6 +42,31 @@ describe('ItemSelectionRowComponent', () => {
     expect(listener).not.toHaveBeenCalledWith('Sichtbarer Text');
   });
 
+  it('schließt das Auswahlmenü nach einer bestätigten Auswahl explizit', async () => {
+    const fixture = TestBed.createComponent(ItemSelectionRowComponent);
+    fixture.componentRef.setInput('itemText', 'Element');
+    fixture.componentRef.setInput('options', [{ id: 'stable-option-id', text: 'Sichtbarer Text' }]);
+    fixture.componentRef.setInput('selectedId', '');
+    fixture.componentRef.setInput('selectLabel', 'Auswahl');
+    fixture.componentRef.setInput('selectAriaLabel', 'Auswahl für Element');
+    fixture.detectChanges();
+
+    const select = fixture.debugElement.query(By.directive(MatSelect))
+      .componentInstance as MatSelect;
+    const closeSpy = vi.spyOn(select, 'close').mockImplementation(() => undefined);
+    const listener = vi.fn();
+    fixture.componentInstance.selectedIdChange.subscribe(listener);
+
+    fixture.componentInstance.confirmSelection('stable-option-id', select);
+
+    expect(listener).toHaveBeenCalledWith('stable-option-id');
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('öffnet die Auswahl mit dem ersten Klick auf den sichtbaren Formularrahmen', () => {
     const fixture = TestBed.createComponent(ItemSelectionRowComponent);
     fixture.componentRef.setInput('itemText', 'Element');

--- a/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.ts
+++ b/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.ts
@@ -37,6 +37,14 @@ export class ItemSelectionRowComponent {
     );
   }
 
+  confirmSelection(selectedId: string, select: MatSelect): void {
+    this.selectedIdChange.emit(selectedId);
+
+    // Run after Material's option handlers and the parent input update. This keeps the
+    // single-select overlay closed on touch devices even if that update reopens the panel.
+    queueMicrotask(() => select.close());
+  }
+
   openSelectionFromField(event: MouseEvent, select: MatSelect): void {
     const target = event.target;
     if (this.disabled || (target instanceof Element && target.closest('mat-select') !== null)) {


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Auf Touch-Geräten blieb das Kategorien-Auswahlmenü nach einer bestätigten Auswahl sichtbar. Der transparente Overlay-Backdrop blockierte dadurch den Wechsel zum nächsten Kategorienmenü.
- **Lösung:** Der gemeinsame Auswahlbaustein schließt das `MatSelect`-Panel nach der Ausgabe der stabilen Options-ID am Ende desselben Ereigniszyklus nochmals explizit. Ein Regressionstest sichert Reihenfolge und Schließen ab.
- **Bewusste Nicht-Ziele:** Keine Änderungen an Frageschemata, Bewertung, Persistenz, Darstellung oder Übersetzungen.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Das bestehende Single-Select-Verhalten des gemeinsam von Matching und Kategorisierung verwendeten `ItemSelectionRowComponent`: Eine bestätigte Auswahl gibt ausschließlich die stabile ID aus, schließt das Panel und lässt danach unmittelbar die nächste Auswahl zu. Die nativen Angular-Material-Combobox- und Tastatursemantiken bleiben erhalten.

**Betroffene externe Verträge:**

Keine. Es werden weder API- noch Datenverträge geändert.

## Implementierung

- Die bisher direkte `selectedIdChange`-Ausgabe läuft über `confirmSelection`.
- Nach der Ausgabe wird `MatSelect.close()` per Microtask idempotent nach den Material- und Parent-Update-Handlern ausgeführt.
- Ein echter DOM-/Material-Overlay-Regressionstest öffnet zwei gerenderte Zeilen, wählt eine Option, prüft das entfernte Backdrop und öffnet die nächste Auswahl mit der ersten Interaktion.
- Der mobile Structured-Question-Types-Playwright-Smoke prüft denselben Wechsel für Matching und Kategorisierung einschließlich vollständig entferntem Overlay.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [x] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run test -w @arsnova/frontend -- src/app/shared/item-selection-row/item-selection-row.component.spec.ts` | 5/5 bestanden |
| `npm run test -w @arsnova/frontend` | 1.216/1.216 bestanden |
| `npm run typecheck` | bestanden |
| `npm run lint` | bestanden, einschließlich Script-Lint ohne Fehler und Warnungen |
| `npm run build:localize -w @arsnova/frontend` | bestanden; 5 Locales, 40 prerenderte Routen, 5 × 14 MOTD-Assets |
| `npm test` | 2.210 bestanden, 11 planmäßig übersprungen |
| Commit-Hook: Typecheck und `npm test` | bestanden |
| Mobiler Live-Browsertest bei 432 × 900 px | Auswahl geschlossen (`expanded=false`), nächstes Menü mit einem Klick geöffnet (`expanded=true`), keine Browserfehler |
| `A11Y_SCAN=0 BASE_URL=http://127.0.0.1:4200/de TRPC_URL=http://127.0.0.1:3000/trpc npm run smoke:structured-question-types -w @arsnova/frontend` | bestanden; Matching und Kategorisierung schließen Panel und Backdrop, das nächste Menü öffnet mit dem ersten Klick |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Auswahl-Overlays für Matching und Kategorisierung schließen auf Touch-Geräten zuverlässig nach der Auswahl.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Logs oder Metriken; Fehler war rein clientseitig und visuell.
- **Rollback:** Revert des Pull Requests.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Manueller mobiler Live-Test des Demo-Quiz auf Frage 12 bei 432 × 900 px.
- Echter Overlay-Regressionstest in `item-selection-row.component.spec.ts`.
- Mobiler Playwright-Regressionstest für Matching und Kategorisierung in `check-structured-question-types-flow.mjs`.
- Folge-Fix zu dem in PR #249 gemergten strukturierten Fragen-Feature.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Kein eigener `npm run build:prod`-Lauf, da der vollständig lokalisierte Frontend-Produktionsbuild direkt mit `npm run build:localize -w @arsnova/frontend` ausgeführt wurde. Keine Fehler-/Retry-Zustände, Realtime-, Datenbank-, Security-, Last- oder Deploymentpfade sind betroffen. Der Microtask besitzt keinen fachlichen Ablehnungs- oder Timeoutzustand. Es werden keine DOM-Elemente ersetzt und kein Fokus programmgesteuert verschoben.
- **Verbleibende Risiken:** Herstellerspezifische Touch-Ereignisdetails können zwischen Browsern variieren; das abschließende, idempotente `close()` entkoppelt das Ergebnis von dieser Reihenfolge.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
