### PR TITLE
fix: serialize session finalization

### DIFF
--- a/.github/trpc-dod-baseline.json
+++ b/.github/trpc-dod-baseline.json
@@ -504,7 +504,7 @@
     },
     "session.nextQuestion": {
       "kind": "mutation",
-      "fingerprint": "sha256:c8005da5ca9ea577e4a275f76e110b8f5a9a8782a1c45c78fb442222728f9656",
+      "fingerprint": "sha256:8106b7bb5bc134975f9c1d85d05281f5ca91e1ee543407c3b2bfb33734137716",
       "missing": []
     },
     "session.onCurrentQuestionForHostChanged": {
@@ -529,7 +529,7 @@
     },
     "session.prevQuestion": {
       "kind": "mutation",
-      "fingerprint": "sha256:c6c648a48b8d589c4b660e4565fdb94323dba089ec2ccea78267800b320e4c88",
+      "fingerprint": "sha256:9de46f82f3f5a5415e4c48ebc11e7e2095405bcfc8ed14915a7fce569b7fc9c3",
       "missing": []
     },
     "session.react": {
@@ -554,7 +554,7 @@
     },
     "session.revealResults": {
       "kind": "mutation",
-      "fingerprint": "sha256:e15d54872f8389ef4df2b4085444870c8c79a48da3859b97ded1de0ac93f934a",
+      "fingerprint": "sha256:c2a68916a817426a071405c577705a2cff2f32a99373539af44c63aac3ce808c",
       "missing": []
     },
     "session.setPreferredLiveChannel": {
@@ -574,17 +574,17 @@
     },
     "session.startDiscussion": {
       "kind": "mutation",
-      "fingerprint": "sha256:e09a36f14b1639a53e45a9b2de02dbfb65e79a9827b3c5d51fdd4b117c5886d5",
+      "fingerprint": "sha256:a6e5f669840716b3237a8dd058b815fdd7219bc959228f4353954c466571b1b4",
       "missing": []
     },
     "session.startQa": {
       "kind": "mutation",
-      "fingerprint": "sha256:dec102a3c5390c9e6d89ae30779fe149e9d8f59d2d38480dc6e770057771a833",
+      "fingerprint": "sha256:ac5b6888463ab9b9c70fc6aa6d49d62cc16f295e86cf200cf35c46f476a17ec8",
       "missing": []
     },
     "session.startSecondRound": {
       "kind": "mutation",
-      "fingerprint": "sha256:cddd94b32c860b99f7b7803005d9f6f3d892435e487f0318daa9ac4edfb524db",
+      "fingerprint": "sha256:dae929c1658060a33029ebd51ceb3545cb5a06e55e4ae501156b38b945725b25",
       "missing": []
     },
     "session.submitSessionFeedback": {

--- a/.github/trpc-dod-baseline.json
+++ b/.github/trpc-dod-baseline.json
@@ -349,7 +349,7 @@
     },
     "session.end": {
       "kind": "mutation",
-      "fingerprint": "sha256:c07473e727fb4173a138e13b7745ce1194da1f7adc9f59ff30f26e4432636c9f",
+      "fingerprint": "sha256:18018bdd76b2477bcc5061f3d2ea1f8a14c376e49e8582f94fff0d5690f5dbb9",
       "missing": []
     },
     "session.getActiveQuizIds": {
@@ -504,7 +504,7 @@
     },
     "session.nextQuestion": {
       "kind": "mutation",
-      "fingerprint": "sha256:a0d52e868bb65a173d9931288481e96a0dafe71c0fc8453b775331f406a04462",
+      "fingerprint": "sha256:c8005da5ca9ea577e4a275f76e110b8f5a9a8782a1c45c78fb442222728f9656",
       "missing": []
     },
     "session.onCurrentQuestionForHostChanged": {
@@ -569,7 +569,7 @@
     },
     "session.skipQuestion": {
       "kind": "mutation",
-      "fingerprint": "sha256:b59b3ba5cde0151acffca45f6c70869c6603c92d58d82eecd18711e6f877893c",
+      "fingerprint": "sha256:786c1da9f7b142caaf6ba873b5a0acfca2e4d4abf0cb49673e7fa2b1d96ce3a6",
       "missing": []
     },
     "session.startDiscussion": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,13 @@ jobs:
           RUN_PG_CLEANUP_TESTS: '1'
         run: npx vitest run src/__tests__/sessionCleanup.orphan-scope.pg.test.ts
 
+      - name: Session finalization PostgreSQL race regression
+        if: needs.changes.outputs.docs_only != 'true'
+        working-directory: apps/backend
+        env:
+          RUN_PG_SESSION_RACE_TESTS: '1'
+        run: npx vitest run src/__tests__/session.finalization-race.pg.test.ts
+
   # ─── Build & Validate ────────────────────────────────────────────────────────
   build:
     name: Build & Validate (Node ${{ matrix.node-version }})

--- a/apps/backend/src/__tests__/session.end.test.ts
+++ b/apps/backend/src/__tests__/session.end.test.ts
@@ -13,6 +13,8 @@ const { prismaMock, hostAuthMocks, loadSignalMocks, platformStatisticMocks } = v
     bonusToken: {
       createMany: vi.fn(),
     },
+    $executeRaw: vi.fn(),
+    $transaction: vi.fn(),
   },
   hostAuthMocks: {
     extractHostTokenMock: vi.fn(),
@@ -62,6 +64,10 @@ describe('session.end', () => {
     hostAuthMocks.extractHostTokenMock.mockReturnValue('host-token-123');
     hostAuthMocks.extractHostTokenFromConnectionParamsMock.mockReturnValue(null);
     hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
+    prismaMock.$executeRaw.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
     prismaMock.session.update.mockResolvedValue({
       id: 'sess-1',
       status: 'FINISHED',
@@ -89,6 +95,14 @@ describe('session.end', () => {
 
     expect(platformStatisticMocks.incrementCompletedSessionsTotal).toHaveBeenCalledWith();
     expect(prismaMock.bonusToken.createMany).not.toHaveBeenCalled();
+    expect(prismaMock.session.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          lastSkippedQuestionId: null,
+          lastQuestionSkippedAt: null,
+        }),
+      }),
+    );
   });
 
   trpcDodIt(
@@ -136,8 +150,36 @@ describe('session.end', () => {
           ],
         }),
       );
+      expect(prismaMock.bonusToken.createMany.mock.invocationCallOrder[0]).toBeLessThan(
+        platformStatisticMocks.incrementCompletedSessionsTotal.mock.invocationCallOrder[0]!,
+      );
     },
   );
+
+  it('führt nach verlorenem End-/Skip-Race keine Abschluss-Nebenwirkungen erneut aus', async () => {
+    prismaMock.session.findUnique.mockResolvedValueOnce({ id: 'sess-1' }).mockResolvedValueOnce({
+      id: 'sess-1',
+      status: 'FINISHED',
+      currentQuestion: null,
+      quiz: null,
+      participants: [],
+      bonusTokens: [],
+    });
+
+    await expect(caller.end({ code: 'ABC123' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Session ist bereits beendet.',
+    });
+
+    expect(prismaMock.$executeRaw).toHaveBeenCalledOnce();
+    expect(prismaMock.$executeRaw.mock.invocationCallOrder[0]!).toBeLessThan(
+      prismaMock.session.findUnique.mock.invocationCallOrder[1]!,
+    );
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+    expect(prismaMock.bonusToken.createMany).not.toHaveBeenCalled();
+    expect(platformStatisticMocks.incrementCompletedSessionsTotal).not.toHaveBeenCalled();
+    expect(loadSignalMocks.recordSessionTransitionActivity).not.toHaveBeenCalled();
+  });
 });
 
 trpcDodIt(

--- a/apps/backend/src/__tests__/session.finalization-race.pg.test.ts
+++ b/apps/backend/src/__tests__/session.finalization-race.pg.test.ts
@@ -1,0 +1,271 @@
+/**
+ * PostgreSQL-Regression für konkurrierende Host-Steuerung und Sessionabschluss.
+ *
+ * Ein externer Row-Lock reiht `session.end` kontrolliert vor `nextQuestion`
+ * beziehungsweise `prevQuestion` ein. Nach dem End-Commit muss der zweite
+ * Übergang den gesperrt neu gelesenen FINISHED-Zustand ablehnen.
+ */
+import { randomUUID } from 'node:crypto';
+import { Client } from 'pg';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { hostAuthMocks } = vi.hoisted(() => ({
+  hostAuthMocks: {
+    extractHostTokenMock: vi.fn(),
+    extractHostTokenFromConnectionParamsMock: vi.fn(() => null as string | null),
+    isHostSessionTokenValidMock: vi.fn(),
+  },
+}));
+
+vi.mock('../lib/hostAuth', async () => {
+  const { buildHostAuthTestMock } = await import('./lib/hostAuth-vitest-mock');
+  return buildHostAuthTestMock({
+    extractHostToken: hostAuthMocks.extractHostTokenMock,
+    extractHostTokenFromConnectionParams: hostAuthMocks.extractHostTokenFromConnectionParamsMock,
+    isHostSessionTokenValid: hostAuthMocks.isHostSessionTokenValidMock,
+  });
+});
+
+import { prisma } from '../db';
+import { PLATFORM_STATISTIC_ID } from '../lib/platformStatistic';
+import { sessionRouter } from '../routers/session';
+
+const RUN_PG = process.env['RUN_PG_SESSION_RACE_TESTS'] === '1';
+const DATABASE_URL =
+  process.env['DATABASE_URL'] ??
+  'postgresql://arsnova_user:secretpassword@localhost:5432/arsnova_v3_dev?schema=public';
+const caller = sessionRouter.createCaller({ req: {} as never });
+
+function uniqueSessionCode(): string {
+  return `R${randomUUID().replaceAll('-', '').slice(0, 5).toUpperCase()}`;
+}
+
+async function waitForBlockedSessionLocks(
+  monitor: Client,
+  expectedCount: number,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await monitor.query<{ count: string }>(`
+      SELECT COUNT(*)::text AS count
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND wait_event_type = 'Lock'
+        AND query LIKE '%FROM "Session"%FOR UPDATE%'
+    `);
+    if (Number(result.rows[0]?.count ?? 0) >= expectedCount) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`${expectedCount} wartende Session-Row-Locks wurden nicht beobachtet.`);
+}
+
+async function completedSessionsTotal(): Promise<number> {
+  const statistic = await prisma.platformStatistic.upsert({
+    where: { id: PLATFORM_STATISTIC_ID },
+    create: { id: PLATFORM_STATISTIC_ID },
+    update: {},
+    select: { completedSessionsTotal: true },
+  });
+  return statistic.completedSessionsTotal;
+}
+
+describe.skipIf(!RUN_PG)('session finalization races (PostgreSQL)', () => {
+  const createdQuizIds: string[] = [];
+  const createdSessionIds: string[] = [];
+  let dbReady = false;
+
+  beforeAll(async () => {
+    await prisma.$queryRaw`SELECT 1`;
+    dbReady = true;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hostAuthMocks.extractHostTokenMock.mockReturnValue('host-token');
+    hostAuthMocks.extractHostTokenFromConnectionParamsMock.mockReturnValue(null);
+    hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
+  });
+
+  afterAll(async () => {
+    if (!dbReady) return;
+    if (createdSessionIds.length > 0) {
+      await prisma.session.deleteMany({ where: { id: { in: createdSessionIds } } });
+    }
+    if (createdQuizIds.length > 0) {
+      await prisma.quiz.deleteMany({ where: { id: { in: createdQuizIds } } });
+    }
+  });
+
+  it('lässt nextQuestion eine zuerst beendete Session nicht wieder öffnen', async () => {
+    const quiz = await prisma.quiz.create({
+      data: {
+        name: `next-end-race-${randomUUID()}`,
+        readingPhaseEnabled: false,
+        questions: {
+          create: [
+            { text: 'Frage 1', type: 'SINGLE_CHOICE', order: 0 },
+            { text: 'Frage 2', type: 'SINGLE_CHOICE', order: 1 },
+          ],
+        },
+      },
+      include: { questions: { orderBy: { order: 'asc' } } },
+    });
+    createdQuizIds.push(quiz.id);
+    const session = await prisma.session.create({
+      data: {
+        code: uniqueSessionCode(),
+        quizId: quiz.id,
+        status: 'RESULTS',
+        currentQuestion: 0,
+        quizStarted: true,
+        questionProgressComplete: true,
+        questionProgress: {
+          [quiz.questions[0]!.id]: {
+            state: 'OPENED',
+            openedAt: new Date().toISOString(),
+          },
+        },
+      },
+    });
+    createdSessionIds.push(session.id);
+    const metricBefore = await completedSessionsTotal();
+
+    const blocker = new Client({ connectionString: DATABASE_URL });
+    const monitor = new Client({ connectionString: DATABASE_URL });
+    await Promise.all([blocker.connect(), monitor.connect()]);
+    let blockerTransactionOpen = false;
+    try {
+      await blocker.query('BEGIN');
+      blockerTransactionOpen = true;
+      await blocker.query('SELECT 1 FROM "Session" WHERE id = $1 FOR UPDATE', [session.id]);
+
+      const ending = caller.end({ code: session.code });
+      await waitForBlockedSessionLocks(monitor, 1);
+      const navigating = caller.nextQuestion({ code: session.code });
+      await waitForBlockedSessionLocks(monitor, 2);
+      await blocker.query('COMMIT');
+      blockerTransactionOpen = false;
+
+      const [endResult, nextResult] = await Promise.allSettled([ending, navigating]);
+      expect(endResult).toMatchObject({
+        status: 'fulfilled',
+        value: { status: 'FINISHED' },
+      });
+      expect(nextResult).toMatchObject({
+        status: 'rejected',
+        reason: { code: 'BAD_REQUEST' },
+      });
+    } finally {
+      if (blockerTransactionOpen) {
+        await blocker.query('ROLLBACK').catch(() => undefined);
+      }
+      await Promise.all([blocker.end(), monitor.end()]);
+    }
+
+    await expect(
+      prisma.session.findUnique({
+        where: { id: session.id },
+        select: { status: true, currentQuestion: true, endedAt: true },
+      }),
+    ).resolves.toMatchObject({
+      status: 'FINISHED',
+      currentQuestion: null,
+      endedAt: expect.any(Date),
+    });
+    await expect(completedSessionsTotal()).resolves.toBe(metricBefore + 1);
+    await expect(prisma.bonusToken.count({ where: { sessionId: session.id } })).resolves.toBe(0);
+  });
+
+  it('lässt prevQuestion eine zuerst beendete Session nicht öffnen und erzeugt Bonus nur einmal', async () => {
+    const quiz = await prisma.quiz.create({
+      data: {
+        name: `prev-end-race-${randomUUID()}`,
+        bonusTokenCount: 1,
+        questions: {
+          create: [
+            { text: 'Frage 1', type: 'SINGLE_CHOICE', order: 0 },
+            { text: 'Frage 2', type: 'SINGLE_CHOICE', order: 1 },
+          ],
+        },
+      },
+      include: { questions: { orderBy: { order: 'asc' } } },
+    });
+    createdQuizIds.push(quiz.id);
+    const now = new Date().toISOString();
+    const session = await prisma.session.create({
+      data: {
+        code: uniqueSessionCode(),
+        quizId: quiz.id,
+        status: 'RESULTS',
+        currentQuestion: 1,
+        quizStarted: true,
+        questionProgressComplete: true,
+        questionProgress: {
+          [quiz.questions[0]!.id]: { state: 'COMPLETED', openedAt: now, completedAt: now },
+          [quiz.questions[1]!.id]: { state: 'OPENED', openedAt: now },
+        },
+        participants: { create: { nickname: `Ada-${randomUUID().slice(0, 8)}` } },
+      },
+      include: { participants: true },
+    });
+    createdSessionIds.push(session.id);
+    await prisma.vote.create({
+      data: {
+        sessionId: session.id,
+        participantId: session.participants[0]!.id,
+        questionId: quiz.questions[1]!.id,
+        round: 1,
+        score: 2_000,
+        responseTimeMs: 900,
+        isCorrect: true,
+      },
+    });
+    const metricBefore = await completedSessionsTotal();
+
+    const blocker = new Client({ connectionString: DATABASE_URL });
+    const monitor = new Client({ connectionString: DATABASE_URL });
+    await Promise.all([blocker.connect(), monitor.connect()]);
+    let blockerTransactionOpen = false;
+    try {
+      await blocker.query('BEGIN');
+      blockerTransactionOpen = true;
+      await blocker.query('SELECT 1 FROM "Session" WHERE id = $1 FOR UPDATE', [session.id]);
+
+      const ending = caller.end({ code: session.code });
+      await waitForBlockedSessionLocks(monitor, 1);
+      const navigating = caller.prevQuestion({ code: session.code });
+      await waitForBlockedSessionLocks(monitor, 2);
+      await blocker.query('COMMIT');
+      blockerTransactionOpen = false;
+
+      const [endResult, prevResult] = await Promise.allSettled([ending, navigating]);
+      expect(endResult).toMatchObject({
+        status: 'fulfilled',
+        value: { status: 'FINISHED' },
+      });
+      expect(prevResult).toMatchObject({
+        status: 'rejected',
+        reason: { code: 'BAD_REQUEST' },
+      });
+    } finally {
+      if (blockerTransactionOpen) {
+        await blocker.query('ROLLBACK').catch(() => undefined);
+      }
+      await Promise.all([blocker.end(), monitor.end()]);
+    }
+
+    await expect(
+      prisma.session.findUnique({
+        where: { id: session.id },
+        select: { status: true, currentQuestion: true, endedAt: true },
+      }),
+    ).resolves.toMatchObject({
+      status: 'FINISHED',
+      currentQuestion: null,
+      endedAt: expect.any(Date),
+    });
+    await expect(completedSessionsTotal()).resolves.toBe(metricBefore + 1);
+    await expect(prisma.bonusToken.count({ where: { sessionId: session.id } })).resolves.toBe(1);
+  });
+});

--- a/apps/backend/src/__tests__/session.start-qa.test.ts
+++ b/apps/backend/src/__tests__/session.start-qa.test.ts
@@ -3,6 +3,8 @@ import { trpcDodIt } from './test-utils/trpc-dod-evidence';
 
 const { prismaMock, hostAuthMocks } = vi.hoisted(() => ({
   prismaMock: {
+    $executeRaw: vi.fn(),
+    $transaction: vi.fn(),
     session: {
       findUnique: vi.fn(),
       update: vi.fn(),
@@ -43,6 +45,10 @@ describe('session.startQa (Story 8.1)', () => {
     hostAuthMocks.extractHostTokenMock.mockReturnValue('host-token-123');
     hostAuthMocks.extractHostTokenFromConnectionParamsMock.mockReturnValue(null);
     hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
+    prismaMock.$executeRaw.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
     prismaMock.session.update.mockResolvedValue({
       id: SESSION_ID,
       status: 'ACTIVE',
@@ -72,9 +78,20 @@ describe('session.startQa (Story 8.1)', () => {
       expect(result.currentQuestion).toBeNull();
       expect(result.currentRound).toBe(1);
       expect(result.activeAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-      expect(prismaMock.session.findUnique).toHaveBeenCalledWith({
+      expect(prismaMock.session.findUnique).toHaveBeenNthCalledWith(1, {
         where: { code: 'ABC123' },
-        select: { id: true, status: true, type: true, quizId: true, qaEnabled: true, qaOpen: true },
+        select: { id: true },
+      });
+      expect(prismaMock.session.findUnique).toHaveBeenNthCalledWith(2, {
+        where: { id: SESSION_ID },
+        select: {
+          id: true,
+          status: true,
+          type: true,
+          quizId: true,
+          qaEnabled: true,
+          qaOpen: true,
+        },
       });
       expect(prismaMock.session.update).toHaveBeenCalledWith({
         where: { id: SESSION_ID },
@@ -148,4 +165,22 @@ describe('session.startQa (Story 8.1)', () => {
       expect(prismaMock.session.update).not.toHaveBeenCalled();
     },
   );
+
+  it('öffnet eine unter der Sperre bereits beendete Q&A-Session nicht erneut', async () => {
+    prismaMock.session.findUnique.mockResolvedValueOnce({ id: SESSION_ID }).mockResolvedValueOnce({
+      id: SESSION_ID,
+      type: 'Q_AND_A',
+      quizId: null,
+      status: 'FINISHED',
+      qaEnabled: true,
+      qaOpen: true,
+    });
+
+    await expect(caller.startQa({ code: 'ABC123' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Q&A-Session kann nur aus Status LOBBY gestartet werden. Aktuell: FINISHED.',
+    });
+    expect(prismaMock.$executeRaw).toHaveBeenCalledOnce();
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+  });
 });

--- a/apps/backend/src/__tests__/session.steering.test.ts
+++ b/apps/backend/src/__tests__/session.steering.test.ts
@@ -382,6 +382,25 @@ describe('session.nextQuestion (Story 2.3)', () => {
       message: 'skipCurrentResultQuestion ist nur aus Status RESULTS oder DISCUSSION erlaubt.',
     });
   });
+
+  it('öffnet eine unter der Sperre bereits beendete Session nicht mit der nächsten Frage erneut', async () => {
+    prismaMock.session.findUnique.mockResolvedValueOnce({ id: SESSION_ID }).mockResolvedValueOnce({
+      id: SESSION_ID,
+      status: 'FINISHED',
+      currentQuestion: null,
+      quiz: { readingPhaseEnabled: false, questions: [{ id: 'q1' }] },
+      participants: [],
+      bonusTokens: [],
+    });
+
+    await expect(caller.nextQuestion({ code: CODE })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: /Nächste Frage nur aus Status/,
+    });
+    expect(prismaMock.$executeRaw).toHaveBeenCalledOnce();
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+    expect(platformStatisticMocks.incrementCompletedSessionsTotal).not.toHaveBeenCalled();
+  });
 });
 
 describe('session.skipQuestion', () => {
@@ -859,6 +878,27 @@ describe('session.revealResults (Story 2.3)', () => {
     );
   });
 
+  it('öffnet eine fragefreie Session nach parallelem Abschluss nicht als RESULTS erneut', async () => {
+    prismaMock.session.findUnique
+      .mockResolvedValueOnce({
+        id: SESSION_ID,
+        status: 'ACTIVE',
+        currentQuestion: null,
+        currentRound: 1,
+        activeQuestionStartedAt: null,
+        questionProgress: null,
+        quiz: null,
+      })
+      .mockResolvedValueOnce({ status: 'FINISHED', currentQuestion: null });
+
+    await expect(caller.revealResults({ code: CODE })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Ergebnis anzeigen nur im Status ACTIVE.',
+    });
+    expect(prismaMock.$executeRaw).toHaveBeenCalledOnce();
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+  });
+
   trpcDodIt(
     {
       procedure: 'session.revealResults',
@@ -890,6 +930,10 @@ describe('session.prevQuestion', () => {
     hostAuthMocks.extractHostTokenFromConnectionParamsMock.mockReturnValue(null);
     hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
     prismaMock.vote.findMany.mockResolvedValue([]);
+    prismaMock.$executeRaw.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
   });
 
   trpcDodIt(
@@ -961,6 +1005,29 @@ describe('session.prevQuestion', () => {
       message: 'Bereits bei der ersten Frage – Rückwärtsnavigation nicht möglich.',
     });
   });
+
+  it('öffnet eine unter der Sperre bereits beendete Session nicht rückwärts erneut', async () => {
+    prismaMock.session.findUnique.mockResolvedValueOnce({ id: SESSION_ID }).mockResolvedValueOnce({
+      id: SESSION_ID,
+      status: 'FINISHED',
+      currentQuestion: null,
+      questionProgress: null,
+      questionProgressComplete: true,
+      quiz: {
+        questions: [
+          { id: 'q1', order: 0 },
+          { id: 'q2', order: 1 },
+        ],
+      },
+    });
+
+    await expect(caller.prevQuestion({ code: CODE })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Zurück nur aus Status RESULTS oder DISCUSSION möglich.',
+    });
+    expect(prismaMock.$executeRaw).toHaveBeenCalledOnce();
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+  });
 });
 
 describe('session peer-instruction steering gates', () => {
@@ -970,6 +1037,10 @@ describe('session peer-instruction steering gates', () => {
     hostAuthMocks.extractHostTokenFromConnectionParamsMock.mockReturnValue(null);
     hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
     prismaMock.vote.findMany.mockResolvedValue([]);
+    prismaMock.$executeRaw.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
   });
 
   it.each(['MATCHING', 'ORDERING', 'CATEGORIZATION'] as const)(
@@ -999,6 +1070,12 @@ describe('session peer-instruction steering gates', () => {
           status: 'ACTIVE',
           currentQuestion: 0,
           currentRound: 1,
+        })
+        .mockResolvedValueOnce({
+          id: SESSION_ID,
+          status: 'DISCUSSION',
+          currentQuestion: 0,
+          quiz: { questions: [{ type }] },
         })
         .mockResolvedValueOnce({
           id: SESSION_ID,
@@ -1200,6 +1277,22 @@ describe('session peer-instruction steering gates', () => {
       expect(loadSignalMocks.markCountdownSessionActive).toHaveBeenCalledWith(SESSION_ID);
     },
   );
+
+  it('öffnet eine unter der Sperre bereits beendete Session nicht für Runde 2 erneut', async () => {
+    prismaMock.session.findUnique.mockResolvedValueOnce({ id: SESSION_ID }).mockResolvedValueOnce({
+      id: SESSION_ID,
+      status: 'FINISHED',
+      currentQuestion: null,
+      quiz: { questions: [{ type: 'SINGLE_CHOICE', numericTwoRounds: false }] },
+    });
+
+    await expect(caller.startSecondRound({ code: CODE })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Zweite Runde nur aus Status DISCUSSION.',
+    });
+    expect(prismaMock.$executeRaw).toHaveBeenCalledOnce();
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+  });
 
   trpcDodIt(
     {

--- a/apps/backend/src/__tests__/session.steering.test.ts
+++ b/apps/backend/src/__tests__/session.steering.test.ts
@@ -15,6 +15,9 @@ const { prismaMock, hostAuthMocks, readingReadyMocks, platformStatisticMocks, lo
       vote: {
         findMany: vi.fn(),
       },
+      bonusToken: {
+        createMany: vi.fn(),
+      },
       $executeRaw: vi.fn(),
       $transaction: vi.fn(),
     },
@@ -76,6 +79,10 @@ describe('session.nextQuestion (Story 2.3)', () => {
     hostAuthMocks.extractHostTokenFromConnectionParamsMock.mockReturnValue(null);
     hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
     prismaMock.vote.findMany.mockResolvedValue([]);
+    prismaMock.$executeRaw.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
   });
 
   trpcDodIt(
@@ -199,20 +206,42 @@ describe('session.nextQuestion (Story 2.3)', () => {
   });
 
   it('setzt FINISHED wenn nach letzter Frage', async () => {
+    const questionId = '33333333-3333-4333-8333-333333333333';
     prismaMock.session.findUnique.mockResolvedValue({
       id: SESSION_ID,
       status: 'RESULTS',
       currentQuestion: 0,
-      quiz: {
-        readingPhaseEnabled: true,
-        questions: [{ id: 'q1' }],
+      questionProgress: {
+        [questionId]: {
+          state: 'OPENED',
+          openedAt: '2026-08-10T12:00:00.000Z',
+        },
       },
+      questionProgressComplete: true,
+      quiz: {
+        name: 'Testquiz',
+        readingPhaseEnabled: true,
+        bonusTokenCount: 1,
+        questions: [{ id: questionId, order: 0, type: 'SINGLE_CHOICE' }],
+      },
+      participants: [{ id: 'p1', nickname: 'Ada' }],
+      bonusTokens: [],
     });
     prismaMock.session.update.mockResolvedValue({
       id: SESSION_ID,
       status: 'FINISHED',
       currentQuestion: null,
     });
+    prismaMock.vote.findMany.mockResolvedValue([
+      {
+        participantId: 'p1',
+        questionId,
+        round: 1,
+        score: 2000,
+        responseTimeMs: 900,
+      },
+    ]);
+    prismaMock.bonusToken.createMany.mockResolvedValue({ count: 1 });
 
     const result = await caller.nextQuestion({ code: CODE });
 
@@ -225,6 +254,15 @@ describe('session.nextQuestion (Story 2.3)', () => {
       }),
     );
     expect(platformStatisticMocks.incrementCompletedSessionsTotal).toHaveBeenCalledWith();
+    expect(prismaMock.$executeRaw).toHaveBeenCalledOnce();
+    expect(prismaMock.bonusToken.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [expect.objectContaining({ participantId: 'p1', totalScore: 2000, rank: 1 })],
+      }),
+    );
+    expect(prismaMock.bonusToken.createMany.mock.invocationCallOrder[0]).toBeLessThan(
+      platformStatisticMocks.incrementCompletedSessionsTotal.mock.invocationCallOrder[0]!,
+    );
   });
 
   trpcDodIt(
@@ -472,6 +510,81 @@ describe('session.skipQuestion', () => {
       skippedQuestionId: QUESTION_ID_2,
     });
     expect(platformStatisticMocks.incrementCompletedSessionsTotal).toHaveBeenCalledOnce();
+  });
+
+  it('erzeugt Bonus-Tokens beim letzten Skip vor den Abschluss-Nebenwirkungen', async () => {
+    const completedAt = '2026-08-10T11:01:00.000Z';
+    const openedAt = '2026-08-10T12:00:00.000Z';
+    const session = activeSession({
+      currentQuestion: 1,
+      questionProgress: {
+        [QUESTION_ID_1]: {
+          state: 'COMPLETED',
+          openedAt: '2026-08-10T11:00:00.000Z',
+          completedAt,
+        },
+        [QUESTION_ID_2]: { state: 'OPENED', openedAt },
+      },
+      quiz: {
+        ...activeSession().quiz,
+        bonusTokenCount: 1,
+      },
+      participants: [{ id: 'p1', nickname: 'Ada' }],
+    });
+    prismaMock.session.findUnique
+      .mockResolvedValueOnce({ id: SESSION_ID })
+      .mockResolvedValueOnce(session)
+      .mockResolvedValueOnce({
+        questionProgress: {
+          [QUESTION_ID_1]: {
+            state: 'COMPLETED',
+            openedAt: '2026-08-10T11:00:00.000Z',
+            completedAt,
+          },
+          [QUESTION_ID_2]: {
+            state: 'SKIPPED',
+            openedAt,
+            skippedAt: '2026-08-10T12:01:00.000Z',
+          },
+        },
+        questionProgressComplete: true,
+        quiz: {
+          questions: [
+            { id: QUESTION_ID_1, order: 0 },
+            { id: QUESTION_ID_2, order: 1 },
+          ],
+        },
+      });
+    prismaMock.vote.findMany.mockResolvedValue([
+      {
+        participantId: 'p1',
+        questionId: QUESTION_ID_1,
+        round: 1,
+        score: 2000,
+        responseTimeMs: 900,
+      },
+    ]);
+    prismaMock.bonusToken.createMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      caller.skipQuestion({ code: CODE, questionId: QUESTION_ID_2 }),
+    ).resolves.toMatchObject({ status: 'FINISHED' });
+
+    expect(prismaMock.bonusToken.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [
+          expect.objectContaining({
+            sessionId: SESSION_ID,
+            participantId: 'p1',
+            totalScore: 2000,
+            rank: 1,
+          }),
+        ],
+      }),
+    );
+    expect(prismaMock.bonusToken.createMany.mock.invocationCallOrder[0]).toBeLessThan(
+      platformStatisticMocks.incrementCompletedSessionsTotal.mock.invocationCallOrder[0]!,
+    );
   });
 
   it('behandelt eine Wiederholung desselben Skip-Requests idempotent', async () => {

--- a/apps/backend/src/routers/session.ts
+++ b/apps/backend/src/routers/session.ts
@@ -4621,50 +4621,77 @@ export const sessionRouter = router({
     .output(SessionStatusUpdateSchema)
     .mutation(async ({ input }) => {
       const code = input.code.toUpperCase();
-      const session = await prisma.session.findUnique({
+      const identity = await prisma.session.findUnique({
         where: { code },
-        select: { id: true, status: true, type: true, quizId: true, qaEnabled: true, qaOpen: true },
+        select: { id: true },
       });
-      if (!session) {
+      if (!identity) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Session nicht gefunden.' });
       }
-      if (session.type !== 'Q_AND_A' && session.qaEnabled !== true) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Q&A-Start ist nur für Sessions mit aktiviertem Fragen-Kanal verfügbar.',
-        });
-      }
-      if (session.status !== 'LOBBY') {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: `Q&A-Session kann nur aus Status LOBBY gestartet werden. Aktuell: ${session.status}.`,
-        });
-      }
 
-      const isQuizWithQaChannel =
-        session.type === 'QUIZ' && session.qaEnabled === true && !!session.quizId;
-      if (isQuizWithQaChannel) {
+      const outcome = await prisma.$transaction(async (tx) => {
+        await lockSessionRow(tx, identity.id);
+        const session = await tx.session.findUnique({
+          where: { id: identity.id },
+          select: {
+            id: true,
+            status: true,
+            type: true,
+            quizId: true,
+            qaEnabled: true,
+            qaOpen: true,
+          },
+        });
+        if (!session) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Session nicht gefunden.' });
+        }
+        if (session.type !== 'Q_AND_A' && session.qaEnabled !== true) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Q&A-Start ist nur für Sessions mit aktiviertem Fragen-Kanal verfügbar.',
+          });
+        }
+        if (session.status !== 'LOBBY') {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: `Q&A-Session kann nur aus Status LOBBY gestartet werden. Aktuell: ${session.status}.`,
+          });
+        }
+
+        const isQuizWithQaChannel =
+          session.type === 'QUIZ' && session.qaEnabled === true && !!session.quizId;
+        if (isQuizWithQaChannel) {
+          return {
+            transitioned: false as const,
+            update: {
+              status: 'LOBBY' as const,
+              currentQuestion: null,
+              currentRound: 1,
+            },
+          };
+        }
+
+        const now = new Date();
+        await tx.session.update({
+          where: { id: session.id },
+          data: { status: 'ACTIVE', statusChangedAt: now },
+        });
         return {
-          status: 'LOBBY' as const,
-          currentQuestion: null,
-          currentRound: 1,
+          transitioned: true as const,
+          update: {
+            status: 'ACTIVE' as const,
+            currentQuestion: null,
+            currentRound: 1,
+            activeAt: now.toISOString(),
+          },
         };
-      }
-
-      const now = new Date();
-      await prisma.session.update({
-        where: { id: session.id },
-        data: { status: 'ACTIVE', statusChangedAt: now },
       });
-      invalidateSessionStatusCachesForCode(code);
-      void recordSessionTransitionActivity();
 
-      return {
-        status: 'ACTIVE' as const,
-        currentQuestion: null,
-        currentRound: 1,
-        activeAt: now.toISOString(),
-      };
+      if (outcome.transitioned) {
+        invalidateSessionStatusCachesForCode(code);
+        void recordSessionTransitionActivity();
+      }
+      return outcome.update;
     }),
 
   enableQaChannel: hostProcedure
@@ -5571,152 +5598,89 @@ export const sessionRouter = router({
     .mutation(async ({ input }) => {
       const code = input.code.toUpperCase();
       const skipCurrentResultQuestion = input.skipCurrentResultQuestion === true;
-      const session = await prisma.session.findUnique({
+      const identity = await prisma.session.findUnique({
         where: { code },
-        include: {
-          quiz: {
-            select: {
-              name: true,
-              readingPhaseEnabled: true,
-              defaultTimer: true,
-              timerScaleByDifficulty: true,
-              bonusTokenCount: true,
-              questions: {
-                orderBy: { order: 'asc' },
-                select: {
-                  id: true,
-                  type: true,
-                  skipReadingPhase: true,
-                  timer: true,
-                  difficulty: true,
-                  answers: { select: { id: true } },
-                },
-              },
-            },
-          },
-          participants: { select: { id: true, nickname: true } },
-          bonusTokens: { select: { id: true }, take: 1 },
-        },
+        select: { id: true },
       });
-      if (!session?.quiz) {
+      if (!identity) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Session oder Quiz nicht gefunden.' });
       }
-      const questionCount = session.quiz.questions.length;
-      if (questionCount === 0) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Quiz hat keine Fragen.' });
-      }
-      const allowedFrom = ['LOBBY', 'PAUSED', 'RESULTS', 'DISCUSSION'];
-      const awaitingFirstQuizQuestion =
-        session.status === 'ACTIVE' && session.currentQuestion === null;
-      if (!allowedFrom.includes(session.status) && !awaitingFirstQuizQuestion) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: `Nächste Frage nur aus Status LOBBY, PAUSED, RESULTS oder DISCUSSION — oder ACTIVE ohne laufende Frage. Aktuell: ${session.status}.`,
-        });
-      }
 
-      if (skipCurrentResultQuestion && !['RESULTS', 'DISCUSSION'].includes(session.status)) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'skipCurrentResultQuestion ist nur aus Status RESULTS oder DISCUSSION erlaubt.',
-        });
-      }
-
-      const currentIdx = session.currentQuestion ?? -1;
-      const progress = parseSessionQuestionProgress(session.questionProgress);
-      const legacyNavigationStart =
-        skipCurrentResultQuestion && !session.questionProgressComplete
-          ? currentIdx + 1
-          : currentIdx;
-      const nextIdx = findNextUnskippedQuestionIndex(
-        session.quiz.questions.map((question, order) => ({ id: question.id, order })),
-        progress,
-        legacyNavigationStart,
-        skipCurrentResultQuestion && session.questionProgressComplete ? 1 : 0,
-      );
-      const currentQuestionId =
-        currentIdx >= 0 ? (session.quiz.questions[currentIdx]?.id ?? null) : null;
-      const progressAfterCurrent =
-        currentQuestionId && ['RESULTS', 'DISCUSSION'].includes(session.status)
-          ? markSessionQuestionCompleted(progress, currentQuestionId, new Date())
-          : progress;
-
-      if (nextIdx === null) {
-        const completedQuestionId = await prisma.$transaction(async (tx) => {
-          await lockSessionRow(tx, session.id);
-          const lockedSession = await tx.session.findUnique({
-            where: { id: session.id },
-            include: {
-              quiz: {
-                select: {
-                  name: true,
-                  readingPhaseEnabled: true,
-                  defaultTimer: true,
-                  timerScaleByDifficulty: true,
-                  bonusTokenCount: true,
-                  questions: {
-                    orderBy: { order: 'asc' },
-                    select: {
-                      id: true,
-                      type: true,
-                      skipReadingPhase: true,
-                      timer: true,
-                      difficulty: true,
-                      answers: { select: { id: true } },
-                    },
+      const outcome = await prisma.$transaction(async (tx) => {
+        await lockSessionRow(tx, identity.id);
+        const session = await tx.session.findUnique({
+          where: { id: identity.id },
+          include: {
+            quiz: {
+              select: {
+                name: true,
+                readingPhaseEnabled: true,
+                defaultTimer: true,
+                timerScaleByDifficulty: true,
+                bonusTokenCount: true,
+                questions: {
+                  orderBy: { order: 'asc' },
+                  select: {
+                    id: true,
+                    type: true,
+                    skipReadingPhase: true,
+                    timer: true,
+                    difficulty: true,
+                    answers: { select: { id: true } },
                   },
                 },
               },
-              participants: { select: { id: true, nickname: true } },
-              bonusTokens: { select: { id: true }, take: 1 },
             },
+            participants: { select: { id: true, nickname: true } },
+            bonusTokens: { select: { id: true }, take: 1 },
+          },
+        });
+        if (!session?.quiz) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Session oder Quiz nicht gefunden.' });
+        }
+        if (session.quiz.questions.length === 0) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: 'Quiz hat keine Fragen.' });
+        }
+        const allowedFrom = ['LOBBY', 'PAUSED', 'RESULTS', 'DISCUSSION'];
+        const awaitingFirstQuizQuestion =
+          session.status === 'ACTIVE' && session.currentQuestion === null;
+        if (!allowedFrom.includes(session.status) && !awaitingFirstQuizQuestion) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: `Nächste Frage nur aus Status LOBBY, PAUSED, RESULTS oder DISCUSSION — oder ACTIVE ohne laufende Frage. Aktuell: ${session.status}.`,
           });
-          if (!lockedSession?.quiz) {
-            throw new TRPCError({
-              code: 'NOT_FOUND',
-              message: 'Session oder Quiz nicht gefunden.',
-            });
-          }
-          if (
-            lockedSession.status !== session.status ||
-            lockedSession.currentQuestion !== session.currentQuestion
-          ) {
-            throw new TRPCError({
-              code: 'CONFLICT',
-              message: 'Die erwartete Frage ist nicht mehr aktuell.',
-            });
-          }
+        }
+        if (skipCurrentResultQuestion && !['RESULTS', 'DISCUSSION'].includes(session.status)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message:
+              'skipCurrentResultQuestion ist nur aus Status RESULTS oder DISCUSSION erlaubt.',
+          });
+        }
 
-          const lockedCurrentIdx = lockedSession.currentQuestion ?? -1;
-          const lockedProgress = parseSessionQuestionProgress(lockedSession.questionProgress);
-          const lockedNavigationStart =
-            skipCurrentResultQuestion && !lockedSession.questionProgressComplete
-              ? lockedCurrentIdx + 1
-              : lockedCurrentIdx;
-          const lockedNextIdx = findNextUnskippedQuestionIndex(
-            lockedSession.quiz.questions.map((question, order) => ({ id: question.id, order })),
-            lockedProgress,
-            lockedNavigationStart,
-            skipCurrentResultQuestion && lockedSession.questionProgressComplete ? 1 : 0,
-          );
-          if (lockedNextIdx !== null) {
-            throw new TRPCError({
-              code: 'CONFLICT',
-              message: 'Die erwartete Frage ist nicht mehr aktuell.',
-            });
-          }
+        const currentIdx = session.currentQuestion ?? -1;
+        const progress = parseSessionQuestionProgress(session.questionProgress);
+        const legacyNavigationStart =
+          skipCurrentResultQuestion && !session.questionProgressComplete
+            ? currentIdx + 1
+            : currentIdx;
+        const nextIdx = findNextUnskippedQuestionIndex(
+          session.quiz.questions.map((question, order) => ({ id: question.id, order })),
+          progress,
+          legacyNavigationStart,
+          skipCurrentResultQuestion && session.questionProgressComplete ? 1 : 0,
+        );
+        const currentQuestionId =
+          currentIdx >= 0 ? (session.quiz.questions[currentIdx]?.id ?? null) : null;
+        const now = new Date();
+        const progressAfterCurrent =
+          currentQuestionId && ['RESULTS', 'DISCUSSION'].includes(session.status)
+            ? markSessionQuestionCompleted(progress, currentQuestionId, now)
+            : progress;
 
-          const lockedCurrentQuestionId =
-            lockedCurrentIdx >= 0
-              ? (lockedSession.quiz.questions[lockedCurrentIdx]?.id ?? null)
-              : null;
-          const lockedProgressAfterCurrent =
-            lockedCurrentQuestionId && ['RESULTS', 'DISCUSSION'].includes(lockedSession.status)
-              ? markSessionQuestionCompleted(lockedProgress, lockedCurrentQuestionId, new Date())
-              : lockedProgress;
-          const now = new Date();
+        if (nextIdx === null) {
           await tx.session.update({
-            where: { id: lockedSession.id },
+            where: { id: session.id },
             data: {
               status: 'FINISHED',
               currentQuestion: null,
@@ -5724,81 +5688,88 @@ export const sessionRouter = router({
               activeQuestionStartedAt: null,
               statusChangedAt: now,
               endedAt: now,
-              questionProgress: serializeSessionQuestionProgress(lockedProgressAfterCurrent),
+              questionProgress: serializeSessionQuestionProgress(progressAfterCurrent),
               lastSkippedQuestionId: null,
               lastQuestionSkippedAt: null,
             },
           });
-          await generateBonusTokens(lockedSession, tx);
-          return lockedCurrentQuestionId;
+          await generateBonusTokens(session, tx);
+          return {
+            finished: true as const,
+            sessionId: session.id,
+            currentQuestionIdToClear: currentQuestionId,
+            update: { status: 'FINISHED' as const, currentQuestion: null, currentRound: 1 },
+          };
+        }
+
+        const nextQuestion = session.quiz.questions[nextIdx];
+        const skipReadingPhaseForType =
+          nextQuestion?.type === 'SURVEY' || nextQuestion?.type === 'RATING';
+        const readingPhase =
+          session.quiz.readingPhaseEnabled &&
+          !skipReadingPhaseForType &&
+          nextQuestion?.skipReadingPhase !== true;
+        const newStatus = readingPhase ? ('QUESTION_OPEN' as const) : ('ACTIVE' as const);
+        const effectiveTimer =
+          newStatus === 'ACTIVE'
+            ? resolveEffectiveQuestionTimer(
+                nextQuestion?.timer,
+                session.quiz.defaultTimer,
+                nextQuestion?.difficulty ?? 'MEDIUM',
+                session.quiz.timerScaleByDifficulty ?? true,
+              )
+            : null;
+
+        let answerDisplayOrderPayload:
+          ReturnType<typeof buildAnswerDisplayOrderForQuiz> | undefined;
+        if ((session.answerDisplayOrder ?? null) === null) {
+          const built = buildAnswerDisplayOrderForQuiz(session.quiz.questions);
+          if (Object.keys(built).length > 0) answerDisplayOrderPayload = built;
+        }
+
+        const nextProgress = markSessionQuestionOpened(progressAfterCurrent, nextQuestion.id, now);
+        await tx.session.update({
+          where: { id: session.id },
+          data: {
+            status: newStatus,
+            currentQuestion: nextIdx,
+            currentRound: 1,
+            quizStarted: true,
+            statusChangedAt: now,
+            activeQuestionStartedAt: newStatus === 'ACTIVE' ? now : null,
+            questionProgress: serializeSessionQuestionProgress(nextProgress),
+            lastSkippedQuestionId: null,
+            lastQuestionSkippedAt: null,
+            ...(answerDisplayOrderPayload && { answerDisplayOrder: answerDisplayOrderPayload }),
+          },
         });
-        if (completedQuestionId) {
-          await clearReadingReady(session.id, completedQuestionId);
-        }
-        await incrementCompletedSessionsTotal();
-        invalidateSessionStatusCachesForCode(code);
-        void recordSessionTransitionActivity();
-        return { status: 'FINISHED' as const, currentQuestion: null, currentRound: 1 };
-      }
-
-      const nextQuestion = session.quiz.questions[nextIdx];
-      const skipReadingPhaseForType =
-        nextQuestion?.type === 'SURVEY' || nextQuestion?.type === 'RATING';
-      const readingPhase =
-        session.quiz.readingPhaseEnabled &&
-        !skipReadingPhaseForType &&
-        nextQuestion?.skipReadingPhase !== true;
-      const newStatus = readingPhase ? ('QUESTION_OPEN' as const) : ('ACTIVE' as const);
-      const effectiveTimer =
-        newStatus === 'ACTIVE'
-          ? resolveEffectiveQuestionTimer(
-              nextQuestion?.timer,
-              session.quiz.defaultTimer,
-              nextQuestion?.difficulty ?? 'MEDIUM',
-              session.quiz.timerScaleByDifficulty ?? true,
-            )
-          : null;
-
-      let answerDisplayOrderPayload: ReturnType<typeof buildAnswerDisplayOrderForQuiz> | undefined;
-      if ((session.answerDisplayOrder ?? null) === null) {
-        const built = buildAnswerDisplayOrderForQuiz(session.quiz.questions);
-        if (Object.keys(built).length > 0) {
-          answerDisplayOrderPayload = built;
-        }
-      }
-
-      const now = new Date();
-      const nextProgress = markSessionQuestionOpened(progressAfterCurrent, nextQuestion.id, now);
-      await prisma.session.update({
-        where: { id: session.id },
-        data: {
-          status: newStatus,
-          currentQuestion: nextIdx,
-          currentRound: 1,
-          quizStarted: true,
-          statusChangedAt: now,
-          activeQuestionStartedAt: newStatus === 'ACTIVE' ? now : null,
-          questionProgress: serializeSessionQuestionProgress(nextProgress),
-          lastSkippedQuestionId: null,
-          lastQuestionSkippedAt: null,
-          ...(answerDisplayOrderPayload && { answerDisplayOrder: answerDisplayOrderPayload }),
-        },
+        return {
+          finished: false as const,
+          sessionId: session.id,
+          currentQuestionIdToClear: currentQuestionId,
+          update: {
+            status: newStatus,
+            currentQuestion: nextIdx,
+            currentRound: 1,
+            ...(newStatus === 'ACTIVE' && {
+              activeAt: now.toISOString(),
+              timer: effectiveTimer,
+            }),
+          },
+        };
       });
-      if (currentQuestionId) {
-        await clearReadingReady(session.id, currentQuestionId);
+
+      if (outcome.currentQuestionIdToClear) {
+        await clearReadingReady(outcome.sessionId, outcome.currentQuestionIdToClear);
+      }
+      if (outcome.finished) {
+        await incrementCompletedSessionsTotal();
+      } else {
+        void markCountdownSessionActive(outcome.sessionId);
       }
       invalidateSessionStatusCachesForCode(code);
       void recordSessionTransitionActivity();
-      void markCountdownSessionActive(session.id);
-      return {
-        status: newStatus,
-        currentQuestion: nextIdx,
-        currentRound: 1,
-        ...(newStatus === 'ACTIVE' && {
-          activeAt: now.toISOString(),
-          timer: effectiveTimer,
-        }),
-      };
+      return outcome.update;
     }),
 
   prevQuestion: hostProcedure
@@ -5806,57 +5777,68 @@ export const sessionRouter = router({
     .output(SessionStatusUpdateSchema)
     .mutation(async ({ input }) => {
       const code = input.code.toUpperCase();
-      const session = await prisma.session.findUnique({
+      const identity = await prisma.session.findUnique({
         where: { code },
-        select: {
-          id: true,
-          status: true,
-          currentQuestion: true,
-          questionProgress: true,
-          questionProgressComplete: true,
-          quiz: {
-            select: {
-              questions: { orderBy: { order: 'asc' }, select: { id: true, order: true } },
-            },
-          },
-        },
+        select: { id: true },
       });
-      if (!session) {
+      if (!identity) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Session nicht gefunden.' });
       }
-      const allowedFrom = ['RESULTS', 'DISCUSSION'];
-      if (!allowedFrom.includes(session.status)) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Zurück nur aus Status RESULTS oder DISCUSSION möglich.',
+
+      const prevIdx = await prisma.$transaction(async (tx) => {
+        await lockSessionRow(tx, identity.id);
+        const session = await tx.session.findUnique({
+          where: { id: identity.id },
+          select: {
+            id: true,
+            status: true,
+            currentQuestion: true,
+            questionProgress: true,
+            questionProgressComplete: true,
+            quiz: {
+              select: {
+                questions: { orderBy: { order: 'asc' }, select: { id: true, order: true } },
+              },
+            },
+          },
         });
-      }
-      const progress = parseSessionQuestionProgress(session.questionProgress);
-      const prevIdx =
-        session.currentQuestion === null || !session.quiz
-          ? null
-          : findPreviousIncludedQuestionIndex(
-              session.quiz.questions,
-              progress,
-              session.questionProgressComplete,
-              session.currentQuestion,
-            );
-      if (prevIdx === null) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Bereits bei der ersten Frage – Rückwärtsnavigation nicht möglich.',
+        if (!session) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Session nicht gefunden.' });
+        }
+        if (!['RESULTS', 'DISCUSSION'].includes(session.status)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Zurück nur aus Status RESULTS oder DISCUSSION möglich.',
+          });
+        }
+        const progress = parseSessionQuestionProgress(session.questionProgress);
+        const previousIndex =
+          session.currentQuestion === null || !session.quiz
+            ? null
+            : findPreviousIncludedQuestionIndex(
+                session.quiz.questions,
+                progress,
+                session.questionProgressComplete,
+                session.currentQuestion,
+              );
+        if (previousIndex === null) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Bereits bei der ersten Frage – Rückwärtsnavigation nicht möglich.',
+          });
+        }
+        await tx.session.update({
+          where: { id: session.id },
+          data: {
+            status: 'RESULTS',
+            currentQuestion: previousIndex,
+            currentRound: 1,
+            statusChangedAt: new Date(),
+            lastSkippedQuestionId: null,
+            lastQuestionSkippedAt: null,
+          },
         });
-      }
-      await prisma.session.update({
-        where: { id: session.id },
-        data: {
-          status: 'RESULTS',
-          currentQuestion: prevIdx,
-          currentRound: 1,
-          statusChangedAt: new Date(),
-          lastSkippedQuestionId: null,
-          lastQuestionSkippedAt: null,
-        },
+        return previousIndex;
       });
       invalidateSessionStatusCachesForCode(code);
       void recordSessionTransitionActivity();
@@ -6266,14 +6248,31 @@ export const sessionRouter = router({
           });
         });
       } else {
-        await prisma.session.update({
-          where: { id: session.id },
-          data: {
-            status: 'RESULTS',
-            statusChangedAt: new Date(),
-            lastSkippedQuestionId: null,
-            lastQuestionSkippedAt: null,
-          },
+        await prisma.$transaction(async (tx) => {
+          await lockSessionRow(tx, session.id);
+          const locked = await tx.session.findUnique({
+            where: { id: session.id },
+            select: { status: true, currentQuestion: true },
+          });
+          if (
+            !locked ||
+            locked.status !== 'ACTIVE' ||
+            locked.currentQuestion !== session.currentQuestion
+          ) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Ergebnis anzeigen nur im Status ACTIVE.',
+            });
+          }
+          await tx.session.update({
+            where: { id: session.id },
+            data: {
+              status: 'RESULTS',
+              statusChangedAt: new Date(),
+              lastSkippedQuestionId: null,
+              lastQuestionSkippedAt: null,
+            },
+          });
         });
       }
       invalidateSessionStatusCachesForCode(code);
@@ -6333,88 +6332,76 @@ export const sessionRouter = router({
         session.currentQuestion !== null && session.currentQuestion !== undefined
           ? (session.quiz?.questions[session.currentQuestion] ?? null)
           : null;
-      if (!questionSupportsSecondRound(question)) {
+      if (!question || !session.quiz || !questionSupportsSecondRound(question)) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Diese Frage ist nicht für eine zweite Runde konfiguriert.',
         });
       }
-      if (question && session.quiz) {
-        const baseTimerSeconds = resolveEffectiveQuestionTimer(
-          question.timer,
-          session.quiz.defaultTimer,
-          question.difficulty as Difficulty,
-          session.quiz.timerScaleByDifficulty,
-        );
-        await prisma.$transaction(async (tx) => {
-          await lockSessionRow(tx, session.id);
-          const locked = await tx.session.findUnique({
-            where: { id: session.id },
-            select: { status: true, currentQuestion: true, currentRound: true },
+      const baseTimerSeconds = resolveEffectiveQuestionTimer(
+        question.timer,
+        session.quiz.defaultTimer,
+        question.difficulty as Difficulty,
+        session.quiz.timerScaleByDifficulty,
+      );
+      await prisma.$transaction(async (tx) => {
+        await lockSessionRow(tx, session.id);
+        const locked = await tx.session.findUnique({
+          where: { id: session.id },
+          select: { status: true, currentQuestion: true, currentRound: true },
+        });
+        if (
+          !locked ||
+          locked.status !== 'ACTIVE' ||
+          locked.currentQuestion !== session.currentQuestion ||
+          locked.currentRound !== 1
+        ) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Diskussionsphase nur aus Status ACTIVE.',
           });
-          if (
-            !locked ||
-            locked.status !== 'ACTIVE' ||
-            locked.currentQuestion !== session.currentQuestion ||
-            locked.currentRound !== 1
-          ) {
-            throw new TRPCError({
-              code: 'BAD_REQUEST',
-              message: 'Diskussionsphase nur aus Status ACTIVE.',
-            });
-          }
-          const questionType = question.type as QuestionType;
-          if (usesPeerInstructionCorrectnessWindow(questionType)) {
-            const votes = await tx.vote.findMany({
-              where: {
-                sessionId: session.id,
-                questionId: question.id,
-                round: session.currentRound,
-              },
-              select: { isCorrect: true },
-            });
-            const correctVoterCount = votes.filter((vote) => vote.isCorrect === true).length;
-            if (
-              !buildPeerInstructionSuggestion(
-                questionType,
-                session.currentRound,
-                correctVoterCount,
-                votes.length,
-              )
-            ) {
-              throw new TRPCError({
-                code: 'BAD_REQUEST',
-                message:
-                  'Diskussionsphase nur bei einem Anteil vollständig korrekter Antworten zwischen einem Drittel und zwei Dritteln.',
-              });
-            }
-          }
-          await assertPersonalTimerGate(
-            {
+        }
+        const questionType = question.type as QuestionType;
+        if (usesPeerInstructionCorrectnessWindow(questionType)) {
+          const votes = await tx.vote.findMany({
+            where: {
               sessionId: session.id,
               questionId: question.id,
               round: session.currentRound,
-              activeQuestionStartedAt: session.activeQuestionStartedAt,
-              baseTimerSeconds,
             },
-            {
-              forceClosePersonalTimers: input.forceClosePersonalTimers,
-              action: 'startDiscussion',
-            },
-            tx,
-          );
-          await tx.session.update({
-            where: { id: session.id },
-            data: {
-              status: 'DISCUSSION',
-              statusChangedAt: new Date(),
-              lastSkippedQuestionId: null,
-              lastQuestionSkippedAt: null,
-            },
+            select: { isCorrect: true },
           });
-        });
-      } else {
-        await prisma.session.update({
+          const correctVoterCount = votes.filter((vote) => vote.isCorrect === true).length;
+          if (
+            !buildPeerInstructionSuggestion(
+              questionType,
+              session.currentRound,
+              correctVoterCount,
+              votes.length,
+            )
+          ) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message:
+                'Diskussionsphase nur bei einem Anteil vollständig korrekter Antworten zwischen einem Drittel und zwei Dritteln.',
+            });
+          }
+        }
+        await assertPersonalTimerGate(
+          {
+            sessionId: session.id,
+            questionId: question.id,
+            round: session.currentRound,
+            activeQuestionStartedAt: session.activeQuestionStartedAt,
+            baseTimerSeconds,
+          },
+          {
+            forceClosePersonalTimers: input.forceClosePersonalTimers,
+            action: 'startDiscussion',
+          },
+          tx,
+        );
+        await tx.session.update({
           where: { id: session.id },
           data: {
             status: 'DISCUSSION',
@@ -6423,7 +6410,7 @@ export const sessionRouter = router({
             lastQuestionSkippedAt: null,
           },
         });
-      }
+      });
       invalidateSessionStatusCachesForCode(code);
       void recordSessionTransitionActivity();
       return {
@@ -6439,62 +6426,77 @@ export const sessionRouter = router({
     .output(SessionStatusUpdateSchema)
     .mutation(async ({ input }) => {
       const code = input.code.toUpperCase();
-      const session = await prisma.session.findUnique({
+      const identity = await prisma.session.findUnique({
         where: { code },
-        select: {
-          id: true,
-          status: true,
-          currentQuestion: true,
-          quiz: {
-            select: {
-              questions: {
-                orderBy: { order: 'asc' },
-                select: { type: true, numericTwoRounds: true },
+        select: { id: true },
+      });
+      if (!identity) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Session nicht gefunden.' });
+      }
+
+      const outcome = await prisma.$transaction(async (tx) => {
+        await lockSessionRow(tx, identity.id);
+        const session = await tx.session.findUnique({
+          where: { id: identity.id },
+          select: {
+            id: true,
+            status: true,
+            currentQuestion: true,
+            quiz: {
+              select: {
+                questions: {
+                  orderBy: { order: 'asc' },
+                  select: { type: true, numericTwoRounds: true },
+                },
               },
             },
           },
-        },
-      });
-      if (!session) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Session nicht gefunden.' });
-      }
-      if (session.status !== 'DISCUSSION') {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Zweite Runde nur aus Status DISCUSSION.',
         });
-      }
-      const question =
-        session.currentQuestion !== null && session.currentQuestion !== undefined
-          ? (session.quiz?.questions[session.currentQuestion] ?? null)
-          : null;
-      if (!questionSupportsSecondRound(question)) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Diese Frage ist nicht für eine zweite Runde konfiguriert.',
+        if (!session) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Session nicht gefunden.' });
+        }
+        if (session.status !== 'DISCUSSION') {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Zweite Runde nur aus Status DISCUSSION.',
+          });
+        }
+        const question =
+          session.currentQuestion !== null && session.currentQuestion !== undefined
+            ? (session.quiz?.questions[session.currentQuestion] ?? null)
+            : null;
+        if (!questionSupportsSecondRound(question)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Diese Frage ist nicht für eine zweite Runde konfiguriert.',
+          });
+        }
+        const now = new Date();
+        await tx.session.update({
+          where: { id: session.id },
+          data: {
+            status: 'ACTIVE',
+            currentRound: 2,
+            statusChangedAt: now,
+            activeQuestionStartedAt: now,
+            lastSkippedQuestionId: null,
+            lastQuestionSkippedAt: null,
+          },
         });
-      }
-      const now = new Date();
-      await prisma.session.update({
-        where: { id: session.id },
-        data: {
-          status: 'ACTIVE',
-          currentRound: 2,
-          statusChangedAt: now,
-          activeQuestionStartedAt: now,
-          lastSkippedQuestionId: null,
-          lastQuestionSkippedAt: null,
-        },
+        return {
+          sessionId: session.id,
+          update: {
+            status: 'ACTIVE' as const,
+            currentQuestion: session.currentQuestion,
+            currentRound: 2,
+            activeAt: now.toISOString(),
+          },
+        };
       });
       invalidateSessionStatusCachesForCode(code);
       void recordSessionTransitionActivity();
-      void markCountdownSessionActive(session.id);
-      return {
-        status: 'ACTIVE' as const,
-        currentQuestion: session.currentQuestion,
-        currentRound: 2,
-        activeAt: now.toISOString(),
-      };
+      void markCountdownSessionActive(outcome.sessionId);
+      return outcome.update;
     }),
 
   /** Aktuelle Frage für Host-Ansicht (Story 2.3): Text + Antwortoptionen inkl. isCorrect. */

--- a/apps/backend/src/routers/session.ts
+++ b/apps/backend/src/routers/session.ts
@@ -3166,13 +3166,18 @@ function generateBonusCode(): string {
  * Generiert Bonus-Tokens für die Top X Teilnehmer (Story 4.6).
  * Nur wenn bonusTokenCount konfiguriert und noch keine Tokens existieren.
  */
-async function generateBonusTokens(session: {
-  id: string;
-  currentQuestion: number | null;
-  quiz: { name: string; bonusTokenCount: number | null; questions: { type: string }[] } | null;
-  participants: { id: string; nickname: string }[];
-  bonusTokens: { id: string }[];
-}): Promise<void> {
+type BonusTokenDbClient = Pick<Prisma.TransactionClient, 'session' | 'vote' | 'bonusToken'>;
+
+async function generateBonusTokens(
+  session: {
+    id: string;
+    currentQuestion: number | null;
+    quiz: { name: string; bonusTokenCount: number | null; questions: { type: string }[] } | null;
+    participants: { id: string; nickname: string }[];
+    bonusTokens: { id: string }[];
+  },
+  db: BonusTokenDbClient = prisma,
+): Promise<void> {
   const topX = session.quiz?.bonusTokenCount;
   if (!topX || topX <= 0 || !session.quiz) return;
   if (session.bonusTokens.length > 0) return;
@@ -3185,7 +3190,7 @@ async function generateBonusTokens(session: {
     return;
   }
 
-  const progressSession = await prisma.session.findUnique({
+  const progressSession = await db.session.findUnique({
     where: { id: session.id },
     select: {
       questionProgress: true,
@@ -3207,7 +3212,7 @@ async function generateBonusTokens(session: {
 
   const votes = selectEffectiveCompetitionVotes(
     (
-      await prisma.vote.findMany({
+      await db.vote.findMany({
         where: { sessionId: session.id, round: { in: [1, 2] } },
         select: {
           participantId: true,
@@ -3251,7 +3256,7 @@ async function generateBonusTokens(session: {
     rank: i + 1,
   }));
 
-  await prisma.bonusToken.createMany({ data: tokenData });
+  await db.bonusToken.createMany({ data: tokenData });
 }
 
 type HostCurrentQuestionSession = {
@@ -5637,28 +5642,102 @@ export const sessionRouter = router({
           : progress;
 
       if (nextIdx === null) {
-        const now = new Date();
-        await prisma.session.update({
-          where: { id: session.id },
-          data: {
-            status: 'FINISHED',
-            currentQuestion: null,
-            currentRound: 1,
-            activeQuestionStartedAt: null,
-            statusChangedAt: now,
-            endedAt: now,
-            questionProgress: serializeSessionQuestionProgress(progressAfterCurrent),
-            lastSkippedQuestionId: null,
-            lastQuestionSkippedAt: null,
-          },
+        const completedQuestionId = await prisma.$transaction(async (tx) => {
+          await lockSessionRow(tx, session.id);
+          const lockedSession = await tx.session.findUnique({
+            where: { id: session.id },
+            include: {
+              quiz: {
+                select: {
+                  name: true,
+                  readingPhaseEnabled: true,
+                  defaultTimer: true,
+                  timerScaleByDifficulty: true,
+                  bonusTokenCount: true,
+                  questions: {
+                    orderBy: { order: 'asc' },
+                    select: {
+                      id: true,
+                      type: true,
+                      skipReadingPhase: true,
+                      timer: true,
+                      difficulty: true,
+                      answers: { select: { id: true } },
+                    },
+                  },
+                },
+              },
+              participants: { select: { id: true, nickname: true } },
+              bonusTokens: { select: { id: true }, take: 1 },
+            },
+          });
+          if (!lockedSession?.quiz) {
+            throw new TRPCError({
+              code: 'NOT_FOUND',
+              message: 'Session oder Quiz nicht gefunden.',
+            });
+          }
+          if (
+            lockedSession.status !== session.status ||
+            lockedSession.currentQuestion !== session.currentQuestion
+          ) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: 'Die erwartete Frage ist nicht mehr aktuell.',
+            });
+          }
+
+          const lockedCurrentIdx = lockedSession.currentQuestion ?? -1;
+          const lockedProgress = parseSessionQuestionProgress(lockedSession.questionProgress);
+          const lockedNavigationStart =
+            skipCurrentResultQuestion && !lockedSession.questionProgressComplete
+              ? lockedCurrentIdx + 1
+              : lockedCurrentIdx;
+          const lockedNextIdx = findNextUnskippedQuestionIndex(
+            lockedSession.quiz.questions.map((question, order) => ({ id: question.id, order })),
+            lockedProgress,
+            lockedNavigationStart,
+            skipCurrentResultQuestion && lockedSession.questionProgressComplete ? 1 : 0,
+          );
+          if (lockedNextIdx !== null) {
+            throw new TRPCError({
+              code: 'CONFLICT',
+              message: 'Die erwartete Frage ist nicht mehr aktuell.',
+            });
+          }
+
+          const lockedCurrentQuestionId =
+            lockedCurrentIdx >= 0
+              ? (lockedSession.quiz.questions[lockedCurrentIdx]?.id ?? null)
+              : null;
+          const lockedProgressAfterCurrent =
+            lockedCurrentQuestionId && ['RESULTS', 'DISCUSSION'].includes(lockedSession.status)
+              ? markSessionQuestionCompleted(lockedProgress, lockedCurrentQuestionId, new Date())
+              : lockedProgress;
+          const now = new Date();
+          await tx.session.update({
+            where: { id: lockedSession.id },
+            data: {
+              status: 'FINISHED',
+              currentQuestion: null,
+              currentRound: 1,
+              activeQuestionStartedAt: null,
+              statusChangedAt: now,
+              endedAt: now,
+              questionProgress: serializeSessionQuestionProgress(lockedProgressAfterCurrent),
+              lastSkippedQuestionId: null,
+              lastQuestionSkippedAt: null,
+            },
+          });
+          await generateBonusTokens(lockedSession, tx);
+          return lockedCurrentQuestionId;
         });
-        if (currentQuestionId) {
-          await clearReadingReady(session.id, currentQuestionId);
+        if (completedQuestionId) {
+          await clearReadingReady(session.id, completedQuestionId);
         }
-        invalidateSessionStatusCachesForCode(code);
         await incrementCompletedSessionsTotal();
+        invalidateSessionStatusCachesForCode(code);
         void recordSessionTransitionActivity();
-        await generateBonusTokens(session);
         return { status: 'FINISHED' as const, currentQuestion: null, currentRound: 1 };
       }
 
@@ -5952,7 +6031,6 @@ export const sessionRouter = router({
                 skippedQuestionId: input.questionId,
                 questionSkippedAt: priorSkip.skippedAt,
               },
-              bonusSession: null,
             };
           }
           throw new TRPCError({
@@ -5990,6 +6068,7 @@ export const sessionRouter = router({
               lastQuestionSkippedAt: now,
             },
           });
+          await generateBonusTokens(session, tx);
           return {
             transitioned: true as const,
             finished: true,
@@ -6004,7 +6083,6 @@ export const sessionRouter = router({
               skippedQuestionId: currentQuestion.id,
               questionSkippedAt: now.toISOString(),
             },
-            bonusSession: session,
           };
         }
 
@@ -6069,7 +6147,6 @@ export const sessionRouter = router({
               timer: effectiveTimer,
             }),
           },
-          bonusSession: null,
         };
       });
 
@@ -6077,14 +6154,13 @@ export const sessionRouter = router({
         await clearReadingReady(outcome.sessionId, outcome.currentQuestionIdToClear);
       }
       if (outcome.transitioned) {
-        invalidateSessionStatusCachesForCode(code);
-        void recordSessionTransitionActivity();
         if (outcome.finished) {
           await incrementCompletedSessionsTotal();
-          if (outcome.bonusSession) await generateBonusTokens(outcome.bonusSession);
         } else {
           void markCountdownSessionActive(outcome.sessionId);
         }
+        invalidateSessionStatusCachesForCode(code);
+        void recordSessionTransitionActivity();
       }
       return outcome.update;
     }),
@@ -7498,47 +7574,57 @@ export const sessionRouter = router({
     .output(SessionStatusUpdateSchema)
     .mutation(async ({ input }) => {
       const code = input.code.toUpperCase();
-      const session = await prisma.session.findUnique({
+      const identity = await prisma.session.findUnique({
         where: { code },
-        select: {
-          id: true,
-          status: true,
-          currentQuestion: true,
-          quizId: true,
-          quiz: {
-            select: {
-              name: true,
-              bonusTokenCount: true,
-              questions: { select: { type: true } },
-            },
-          },
-          participants: { select: { id: true, nickname: true } },
-          bonusTokens: { select: { id: true }, take: 1 },
-        },
+        select: { id: true },
       });
-      if (!session) {
+      if (!identity) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Session nicht gefunden.' });
       }
-      if (session.status === 'FINISHED') {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Session ist bereits beendet.' });
-      }
-      const now = new Date();
-      await prisma.session.update({
-        where: { id: session.id },
-        data: {
-          status: 'FINISHED',
-          currentQuestion: null,
-          currentRound: 1,
-          activeQuestionStartedAt: null,
-          statusChangedAt: now,
-          endedAt: now,
-        },
-      });
-      invalidateSessionStatusCachesForCode(code);
-      await incrementCompletedSessionsTotal();
-      void recordSessionTransitionActivity();
 
-      await generateBonusTokens(session);
+      await prisma.$transaction(async (tx) => {
+        await lockSessionRow(tx, identity.id);
+        const session = await tx.session.findUnique({
+          where: { id: identity.id },
+          include: {
+            quiz: {
+              select: {
+                name: true,
+                bonusTokenCount: true,
+                questions: { select: { type: true } },
+              },
+            },
+            participants: { select: { id: true, nickname: true } },
+            bonusTokens: { select: { id: true }, take: 1 },
+          },
+        });
+        if (!session) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Session nicht gefunden.' });
+        }
+        if (session.status === 'FINISHED') {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: 'Session ist bereits beendet.' });
+        }
+
+        const now = new Date();
+        await tx.session.update({
+          where: { id: session.id },
+          data: {
+            status: 'FINISHED',
+            currentQuestion: null,
+            currentRound: 1,
+            activeQuestionStartedAt: null,
+            statusChangedAt: now,
+            endedAt: now,
+            lastSkippedQuestionId: null,
+            lastQuestionSkippedAt: null,
+          },
+        });
+        await generateBonusTokens(session, tx);
+      });
+
+      await incrementCompletedSessionsTotal();
+      invalidateSessionStatusCachesForCode(code);
+      void recordSessionTransitionActivity();
 
       return { status: 'FINISHED' as const, currentQuestion: null, currentRound: 1 };
     }),

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -3857,6 +3857,51 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     fixture.destroy();
   });
 
+  it('stellt den laufenden Countdown nach einem fehlgeschlagenen Skip wieder her', async () => {
+    const questionId = 'bbbbbbbb-2222-4222-8222-222222222222';
+    const activeAt = new Date(Date.now() - 3000).toISOString();
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'ACTIVE' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({
+          status: 'ACTIVE',
+          currentQuestion: 0,
+          currentRound: 1,
+          activeAt,
+          timer: 30,
+        });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId,
+      order: 0,
+      totalQuestions: 2,
+      text: 'Aktuelle Frage',
+      type: 'SINGLE_CHOICE',
+      timer: 30,
+      answers: [],
+      totalVotes: 0,
+    });
+    skipQuestionMutateMock.mockRejectedValueOnce(new Error('offline'));
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+
+    const beforeSkip = fixture.componentInstance.countdownSeconds();
+    expect(beforeSkip).not.toBeNull();
+    expect(beforeSkip).toBeGreaterThan(0);
+
+    await fixture.componentInstance.skipQuestion();
+
+    expect(fixture.componentInstance.controlPending()).toBe(false);
+    expect(fixture.componentInstance.countdownSeconds()).not.toBeNull();
+    expect(fixture.componentInstance.countdownSeconds()).toBeGreaterThan(0);
+    expect(fixture.componentInstance.countdownSeconds()).toBeLessThanOrEqual(beforeSkip ?? 30);
+    fixture.destroy();
+  });
+
   it('unterscheidet in QUESTION_OPEN zwischen verbundenen und insgesamt teilnehmenden Personen', async () => {
     getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'QUESTION_OPEN' });
     getParticipantsQueryMock.mockResolvedValue({

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -5802,6 +5802,10 @@ export class SessionHostComponent implements OnInit, OnDestroy {
 
   private async executeSkipQuestion(questionId: string): Promise<void> {
     if (this.controlPending() || !this.code) return;
+    const countdownDeadline =
+      this.effectiveStatus() === 'ACTIVE' && this.countdownSeconds() !== null
+        ? Date.now() + Math.max(0, this.countdownSeconds() ?? 0) * 1000
+        : null;
     this.controlPending.set(true);
     try {
       this.clearEmojiNewBadge();
@@ -5826,12 +5830,45 @@ export class SessionHostComponent implements OnInit, OnDestroy {
         );
       }
     } catch {
+      this.restoreCountdownAfterFailedSkip(questionId, countdownDeadline);
       this.openHostSteeringCalloutForSteeringFailure(
         () => void this.executeSkipQuestion(questionId),
       );
     } finally {
       this.controlPending.set(false);
     }
+  }
+
+  private restoreCountdownAfterFailedSkip(
+    questionId: string,
+    countdownDeadline: number | null,
+  ): void {
+    if (
+      this.effectiveStatus() !== 'ACTIVE' ||
+      this.displayedCurrentQuestionForHost()?.questionId !== questionId
+    ) {
+      return;
+    }
+
+    const latestStatus = this.statusUpdate();
+    if (
+      latestStatus?.status === 'ACTIVE' &&
+      latestStatus.activeAt &&
+      latestStatus.timer !== undefined
+    ) {
+      this.syncCountdownFromStatusUpdate(latestStatus);
+      return;
+    }
+
+    if (countdownDeadline === null) return;
+    const remaining = remainingCountdownSeconds(countdownDeadline);
+    if (remaining > 0) {
+      this.startCountdown(remaining);
+      return;
+    }
+    this.stopCountdown();
+    this.countdownSeconds.set(0);
+    this.countdownEnded.set(true);
   }
 
   private focusAfterQuestionSkip(status: SessionStatus): void {


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Die nachgelieferte Copilot-Prüfung zu #255 zeigte zunächst vier konkrete Abschlussfehler. Das neue Review zu diesem PR belegte anschließend ein weiteres Interleaving: `nextQuestion` und `prevQuestion` konnten nach einem parallel erfolgreich abgeschlossenen `session.end` mit veraltetem Zustand `FINISHED` wieder in einen aktiven Status überschreiben. Analoge ungesperrte Host-Statuswechsel hatten dieselbe Fehlerklasse.
- **Lösung:** Sämtliche Host-Pfade, die den Session-Status verändern können, lesen und validieren den autoritativen Sessionzustand nach `SELECT ... FOR UPDATE` und schreiben innerhalb derselben Transaktion. Ein echter PostgreSQL-Regressionstest reiht `session.end` kontrolliert vor `nextQuestion` beziehungsweise `prevQuestion` ein und beweist, dass `FINISHED` terminal bleibt sowie Abschlussmetrik und Bonus-Token nur einmal entstehen.
- **Bewusste Nicht-Ziele:** Keine API-/Schemaänderung, keine Prisma-Migration und kein nachträgliches Bereinigen möglicher historischer Bonus-Token-Duplikate. Eine zusätzliche Unique-Constraint ist nicht nötig, weil sämtliche erzeugenden Abschlusswege und konkurrierenden Statusübergänge pro Session unter derselben Zeilensperre serialisiert sind.

Follow-up zu #255 und den danach eingegangenen Reviews.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [x] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Maßgeblich ist der in PostgreSQL persistierte Sessionzustand nach erneutem Lesen unter `SELECT ... FOR UPDATE`. `FINISHED` ist terminal und darf durch keinen konkurrierenden Host-Steuerpfad wieder geöffnet werden. Ein Session-Abschluss darf pro Zustandsübergang nur einmal Nebenwirkungen auslösen. Bonus-Tokens müssen auf den effektiven Competition-Votes und dem finalen Fragefortschritt beruhen und vor der Veröffentlichung von `FINISHED` dauerhaft geschrieben sein. Teilnehmerdaten und tRPC-Verträge bleiben unverändert.

**Betroffene externe Verträge:**

Keine. Die bestehenden tRPC-Ein-/Ausgabeschemas und Realtime-Payloads bleiben unverändert. PostgreSQL-Zeilensperren sind bereits die etablierte Serialisierungsgrenze des Backends und werden durch einen echten Datenbanktest abgesichert.

## Implementierung

- `generateBonusTokens` akzeptiert einen Prisma-Transaktionsclient und liest beziehungsweise schreibt damit vollständig innerhalb der Abschluss-Transaktion.
- Automatischer Abschluss, letzter Skip und manueller Abschluss sperren dieselbe Session-Zeile, lesen den autoritativen Zustand erneut und lassen konkurrierende Verlierer ohne Abschluss-Nebenwirkungen abbrechen.
- `nextQuestion` führt nun auch den nicht-terminalen Übergang vollständig unter der Session-Zeilensperre aus; `prevQuestion`, `startQa`, der fragefreie `revealResults`-Pfad und `startSecondRound` verwenden dieselbe Sperr-/Neuvalidierungslogik. Der fachlich unerreichbare ungesperrte `startDiscussion`-Fallback wurde entfernt.
- Bonus-Tokens werden vor Commit, Metrik, Cache-Invalidierung und Realtime-Signal erzeugt; ein Fehler rollt den gesamten Abschluss zurück.
- `session.end` löscht `lastSkippedQuestionId` und `lastQuestionSkippedAt`, damit Reconnects keinen alten Skip melden.
- Der Host merkt sich vor dem Skip die Countdown-Deadline und synchronisiert beziehungsweise rekonstruiert den Countdown nach einer Ablehnung, sofern noch dieselbe aktive Frage angezeigt wird.
- Unit-Regressionen decken alle analogen Wiederöffnungswege ab. Ein neuer opt-in PostgreSQL-Test steuert die Lock-Warteschlange für `nextQuestion`/`prevQuestion` gegen `end`; der CI-Migrationsjob führt ihn nach den Migrationen aus.
- Die tRPC-DoD-Prüfsummen wurden für alle sechs geänderten Prozeduren aktualisiert.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [x] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [x] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [x] Parallelität oder Race Conditions
- [x] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` | Erfolgreich für Shared Types, Report, Backend und Frontend |
| `npm test` | 2.233 Tests erfolgreich: Shared Types 47, Report 81, Backend 886, Frontend 1.219; 13 opt-in Backend-Tests im Standardlauf übersprungen |
| `npm run test -w @arsnova/backend` | 886/886 reguläre Backend-Tests erfolgreich; 13 opt-in Tests übersprungen |
| `RUN_PG_SESSION_RACE_TESTS=1 npx vitest run src/__tests__/session.finalization-race.pg.test.ts` | 2/2 echte PostgreSQL-Races erfolgreich; `FINISHED`, Metrikdelta 1 und Bonusanzahl 1 belegt |
| `npx vitest run src/__tests__/session.steering.test.ts src/__tests__/session.start-qa.test.ts src/__tests__/session.reading-ready.test.ts src/__tests__/session.end.test.ts` | 63/63 gezielte Unit-Regressionen erfolgreich |
| `npm run lint` | Erfolgreich einschließlich Script-Lint-Gate |
| `npm run build:prod` | Erfolgreich einschließlich SSR und Prerendering für `de`, `en`, `fr`, `es`, `it` |
| `npm run audit:trpc-dod -- --update-baseline` | 114/114 Queries/Mutations vollständig; 0 Gate-Verletzungen, 0 Strukturfehler |
| `npx prettier --check <betroffene Dateien>` | Erfolgreich |
| `git diff --check` | Erfolgreich |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Statusänderungen einer einzelnen Session werden kurz serialisiert. Ein bereits laufender Abschluss oder Statusübergang darf zuerst committen; der nachfolgende Pfad validiert den neuen Zustand und lehnt einen unzulässigen Übergang ab. Bei Bonus-Token-Fehlern bleibt die Session unverändert statt als beendet ohne Tokens zurück.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Bestehende Transaktionsfehler sowie `completed_sessions_total` und die bestehende Session-Transition-Aktivität. Die Metrik wird erst nach erfolgreichem Commit erhöht.
- **Rollback:** Commit `6bc94b12` zurückrollen; keine Schema- oder Datenmigration ist rückgängig zu machen. Damit würden allerdings die beschriebenen Race Conditions wieder möglich.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Commit `6bc94b12` mit erfolgreichen Commit-Hooks für ESLint, Prettier, Typecheck und alle 2.233 regulären Tests.
- Echter lokaler PostgreSQL-Lauf mit zwei kontrollierten Lock-Interleavings; beide Regressionen grün.
- Vollständiger lokaler Produktionsbuild und tRPC-DoD-Audit wie oben dokumentiert.
- GitHub-CI wird auf dem aktualisierten PR-Head ausgeführt; der Migrationsjob enthält den neuen PostgreSQL-Race-Test.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Keine Migration, keine Auth-/Capability-Grenze, keine neue Text-, Template-, Style- oder Semantikänderung. Daher waren eine separate frische lokale Prisma-Migrationskette, neue Mobile-/Reflow-/Screenreader-Prüfungen und Locale-Anpassungen nicht erforderlich. Das Realtime-Protokoll ist unverändert; der vollständige Backend-Testlauf umfasst die bestehenden HTTP-, WebSocket- und Yjs-Szenarien. Der PostgreSQL-Test läuft im CI-Migrationsjob nach `prisma migrate deploy` gegen eine frische Datenbank.
- **Verbleibende Risiken:** Bereits vorhandene historische Bonus-Token-Duplikate werden nicht bereinigt. Die zusätzliche Serialisierung gilt nur pro Sessionzeile; parallele Veranstaltungen blockieren einander nicht. Ein kurz vor Abschluss laufender Vote kann den Abschluss bis zum Ende seiner Transaktion verzögern; das ist beabsichtigt, damit Bonus-Tokens auf einem konsistenten effektiven Vote-Stand basieren.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
