### PR TITLE
fix(frontend): prevent structured select touch freeze

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1085,6 +1085,7 @@ jobs:
           npm run smoke:host-music -w @arsnova/frontend
           npm run smoke:short-text -w @arsnova/frontend
           npm run smoke:numeric-estimate -w @arsnova/frontend
+          npm run smoke:structured-question-types -w @arsnova/frontend
           npm run smoke:quiz-sync -w @arsnova/frontend
           npm run smoke:session-question-progress -w @arsnova/frontend
           npm run smoke:unified-session -w @arsnova/frontend

--- a/apps/frontend/scripts/check-structured-question-types-flow.mjs
+++ b/apps/frontend/scripts/check-structured-question-types-flow.mjs
@@ -1019,9 +1019,8 @@ async function selectMatOption(
   nextFormFieldLocator = null,
   selectionAlreadyOpen = false,
 ) {
-  const select = formFieldLocator.locator('mat-select');
   if (!selectionAlreadyOpen) {
-    await select.click();
+    await formFieldLocator.tap();
   }
   const needle = String(optionText || '').trim();
   const option = page
@@ -1033,13 +1032,12 @@ async function selectMatOption(
     })
     .first();
   await option.waitFor({ state: 'visible', timeout: 8_000 });
-  await option.click();
+  await option.tap();
   await page.locator('.mat-mdc-select-panel').waitFor({ state: 'hidden', timeout: 8_000 });
   await page.locator('.cdk-overlay-backdrop').waitFor({ state: 'hidden', timeout: 8_000 });
 
   if (nextFormFieldLocator) {
-    const nextSelect = nextFormFieldLocator.locator('mat-select');
-    await nextSelect.click({ timeout: 2_000 });
+    await nextFormFieldLocator.tap({ timeout: 2_000 });
     await page.locator('.mat-mdc-select-panel').waitFor({ state: 'visible', timeout: 2_000 });
   }
 }
@@ -1510,7 +1508,11 @@ async function main() {
       { sessionCode: code, token: hostToken, prefix: HOST_TOKEN_STORAGE_PREFIX },
     );
 
-    const participantContext = await browser.newContext({ viewport: MOBILE });
+    const participantContext = await browser.newContext({
+      viewport: MOBILE,
+      hasTouch: true,
+      isMobile: true,
+    });
     const host = await hostContext.newPage();
     const participant = await participantContext.newPage();
 

--- a/apps/frontend/scripts/check-structured-question-types-flow.mjs
+++ b/apps/frontend/scripts/check-structured-question-types-flow.mjs
@@ -1018,7 +1018,9 @@ async function selectMatOption(
   optionText,
   nextFormFieldLocator = null,
   selectionAlreadyOpen = false,
+  exerciseSameRowReopenRace = false,
 ) {
+  const select = formFieldLocator.locator('mat-select');
   if (!selectionAlreadyOpen) {
     await formFieldLocator.tap();
   }
@@ -1033,6 +1035,11 @@ async function selectMatOption(
     .first();
   await option.waitFor({ state: 'visible', timeout: 8_000 });
   await option.tap();
+  if (exerciseSameRowReopenRace) {
+    // Reproduce the delayed synthetic click that touch browsers can deliver to the
+    // original control while Material is still detaching its overlay.
+    await select.dispatchEvent('click');
+  }
   await page.locator('.mat-mdc-select-panel').waitFor({ state: 'hidden', timeout: 8_000 });
   await page.locator('.cdk-overlay-backdrop').waitFor({ state: 'hidden', timeout: 8_000 });
 
@@ -1103,6 +1110,7 @@ async function runMatchingFlow(
       rightLabels[wrongPairs[index].rightId],
       index === 0 ? fields.nth(1) : null,
       index === 1,
+      index === 0,
     );
   }
 
@@ -1261,6 +1269,7 @@ async function runCategorizationFlow(
       categories[wrongSelections[index].categoryId],
       index === 0 ? fields.nth(1) : null,
       index === 1,
+      index === 0,
     );
   }
 

--- a/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.html
+++ b/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.html
@@ -12,6 +12,7 @@
       [aria-label]="selectAriaLabel"
       [disabled]="disabled"
       (selectionChange)="confirmSelection($event.value, selectionControl)"
+      (openedChange)="handleSelectionOpenedChange($event, selectionControl)"
     >
       <mat-select-trigger>
         <span class="markdown-body" [innerHTML]="renderMarkdown(selectedText())"></span>

--- a/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.spec.ts
+++ b/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.spec.ts
@@ -2,7 +2,10 @@ import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MatSelect } from '@angular/material/select';
 import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import {
+  BrowserAnimationsModule,
+  NoopAnimationsModule,
+} from '@angular/platform-browser/animations';
 import { describe, expect, it, vi } from 'vitest';
 import { ItemSelectionRowComponent } from './item-selection-row.component';
 
@@ -107,7 +110,7 @@ describe('ItemSelectionRowComponent', () => {
   });
 
   it('schließt dieselbe Auswahl erneut, wenn ein Folgeklick die Ausblendphase unterbricht', async () => {
-    TestBed.configureTestingModule({ imports: [NoopAnimationsModule] });
+    TestBed.configureTestingModule({ imports: [BrowserAnimationsModule] });
     const fixture = TestBed.createComponent(ItemSelectionRowTestHostComponent);
     fixture.detectChanges();
 
@@ -126,15 +129,21 @@ describe('ItemSelectionRowComponent', () => {
     fixture.detectChanges();
     await Promise.resolve();
     expect(select.panelOpen).toBe(false);
+    expect(document.querySelector('.cdk-overlay-backdrop')).toBeTruthy();
 
     selectElement.click();
     fixture.detectChanges();
     await Promise.resolve();
     await Promise.resolve();
     fixture.detectChanges();
-
     expect(select.panelOpen).toBe(false);
-    expect(document.querySelector('.cdk-overlay-backdrop')).toBeNull();
+    await vi.waitFor(
+      () => {
+        fixture.detectChanges();
+        expect(document.querySelector('.cdk-overlay-backdrop')).toBeNull();
+      },
+      { timeout: 1_000 },
+    );
   });
 
   it('öffnet die Auswahl mit dem ersten Klick auf den sichtbaren Formularrahmen', () => {

--- a/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.spec.ts
+++ b/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.spec.ts
@@ -106,6 +106,37 @@ describe('ItemSelectionRowComponent', () => {
     expect(selects[1].panelOpen).toBe(true);
   });
 
+  it('schließt dieselbe Auswahl erneut, wenn ein Folgeklick die Ausblendphase unterbricht', async () => {
+    TestBed.configureTestingModule({ imports: [NoopAnimationsModule] });
+    const fixture = TestBed.createComponent(ItemSelectionRowTestHostComponent);
+    fixture.detectChanges();
+
+    const select = fixture.debugElement.query(By.directive(MatSelect))
+      .componentInstance as MatSelect;
+    const selectElement = (fixture.nativeElement as HTMLElement).querySelector(
+      'mat-select',
+    ) as HTMLElement;
+
+    selectElement.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(select.panelOpen).toBe(true);
+
+    (document.querySelector('mat-option') as HTMLElement).click();
+    fixture.detectChanges();
+    await Promise.resolve();
+    expect(select.panelOpen).toBe(false);
+
+    selectElement.click();
+    fixture.detectChanges();
+    await Promise.resolve();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(select.panelOpen).toBe(false);
+    expect(document.querySelector('.cdk-overlay-backdrop')).toBeNull();
+  });
+
   it('öffnet die Auswahl mit dem ersten Klick auf den sichtbaren Formularrahmen', () => {
     const fixture = TestBed.createComponent(ItemSelectionRowComponent);
     fixture.componentRef.setInput('itemText', 'Element');

--- a/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.ts
+++ b/apps/frontend/src/app/shared/item-selection-row/item-selection-row.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Input, Output, inject } from '@angular/core';
 import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelect, MatSelectModule } from '@angular/material/select';
@@ -9,6 +9,8 @@ export interface ItemSelectionOption {
   text: string;
 }
 
+const SELECT_CLOSE_GUARD_MS = 250;
+
 @Component({
   selector: 'app-item-selection-row',
   standalone: true,
@@ -18,6 +20,9 @@ export interface ItemSelectionOption {
 })
 export class ItemSelectionRowComponent {
   private readonly sanitizer = inject(DomSanitizer);
+  private readonly destroyRef = inject(DestroyRef);
+  private selectionCloseGuardActive = false;
+  private selectionCloseGuardTimer: ReturnType<typeof setTimeout> | null = null;
 
   @Input({ required: true }) itemText = '';
   @Input({ required: true }) options: ItemSelectionOption[] = [];
@@ -26,6 +31,14 @@ export class ItemSelectionRowComponent {
   @Input({ required: true }) selectAriaLabel = '';
   @Input() disabled = false;
   @Output() readonly selectedIdChange = new EventEmitter<string>();
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      if (this.selectionCloseGuardTimer) {
+        clearTimeout(this.selectionCloseGuardTimer);
+      }
+    });
+  }
 
   selectedText(): string {
     return this.options.find((option) => option.id === this.selectedId)?.text ?? '';
@@ -39,17 +52,40 @@ export class ItemSelectionRowComponent {
 
   confirmSelection(selectedId: string, select: MatSelect): void {
     this.selectedIdChange.emit(selectedId);
+    this.closeSelectionWithReopenGuard(select);
+  }
 
-    // Run after Material's option handlers and the parent input update. This keeps the
-    // single-select overlay closed on touch devices even if that update reopens the panel.
-    queueMicrotask(() => select.close());
+  handleSelectionOpenedChange(opened: boolean, select: MatSelect): void {
+    if (opened && this.selectionCloseGuardActive) {
+      this.closeSelectionWithReopenGuard(select);
+    }
   }
 
   openSelectionFromField(event: MouseEvent, select: MatSelect): void {
     const target = event.target;
-    if (this.disabled || (target instanceof Element && target.closest('mat-select') !== null)) {
+    if (
+      this.disabled ||
+      this.selectionCloseGuardActive ||
+      (target instanceof Element && target.closest('mat-select') !== null)
+    ) {
       return;
     }
     select.open();
+  }
+
+  private closeSelectionWithReopenGuard(select: MatSelect): void {
+    this.selectionCloseGuardActive = true;
+    if (this.selectionCloseGuardTimer) {
+      clearTimeout(this.selectionCloseGuardTimer);
+    }
+
+    // Material detaches a closing select overlay asynchronously. A second touch-generated
+    // click during that window can reopen the same overlay and cancel its detach fallback.
+    // Keep closing only this row until the overlay's fallback window has elapsed.
+    queueMicrotask(() => select.close());
+    this.selectionCloseGuardTimer = setTimeout(() => {
+      this.selectionCloseGuardActive = false;
+      this.selectionCloseGuardTimer = null;
+    }, SELECT_CLOSE_GUARD_MS);
   }
 }


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Bei Matching und Kategorisierung konnte ein zusätzlicher Touch-/synthetischer Klick während der asynchronen Schließphase denselben `mat-select` erneut öffnen. Dadurch wurde das laufende Overlay-Detach abgebrochen; ein transparenter Backdrop konnte anschließend die gesamte Touch-Oberfläche blockieren, bis die Seite neu geladen wurde.
- **Lösung:** Der gemeinsame Auswahlbaustein schützt nur die gerade bestätigte Zeile für das Material-Detach-Fenster, schließt ein in dieser Phase erneut geöffnetes Overlay automatisch und räumt den Timer beim Komponentenabbau auf. Unit- und mobiler Playwright-Test reproduzieren Auswahl → sofortiger Folgeklick derselben Zeile während des animierten Detach → vollständiges Entfernen von Panel/Backdrop → erster Tap auf die nächste Zeile. Der Structured-Smoke ist im verpflichtenden CI-E2E-Job verankert.
- **Bewusste Nicht-Ziele:** Keine Änderung an Frageformaten, Antworten, Scoring, Backend/API, Texten oder Gestaltung.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Der gemeinsame `ItemSelectionRowComponent` bleibt die maßgebliche Implementierung für Matching und Kategorisierung. Nach einer Einzelauswahl muss das Material-Overlay vollständig schließen; die nächste Zeile muss sofort mit der ersten Interaktion bedienbar bleiben; ein Wiederöffnen während der Detach-Phase darf keinen Backdrop zurücklassen.

**Betroffene externe Verträge:**

Angular Material 21 `MatSelect` mit dem öffentlichen `openedChange`- und `close()`-Verhalten; durch animierten DOM-Overlay-Regressionstest und mobilen Playwright-Touch-Smoke abgedeckt.

## Implementierung

- Komponentenlokale Schließsperre für die gerade bestätigte Auswahl ergänzt und beim Destroy bereinigt.
- Erneutes `openedChange(true)` innerhalb des Detach-Fensters führt zu einem erneuten, idempotenten Schließen.
- Direkte Rahmenöffnung respektiert dieselbe Sperre; andere Zeilen bleiben unbeeinträchtigt.
- Regressionstest läuft mit echten Browseranimationen und prüft das unterbrochene Ausblenden bis zur vollständigen Backdrop-Entfernung.
- Mobiler Touch-Smoke reproduziert das Race für Matching und Kategorisierung und prüft anschließend die nächste Zeile mit dem ersten Tap.
- `smoke:structured-question-types` ist im CI-Job `Playwright Smoke E2E` verankert.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [x] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [x] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` | erfolgreich |
| `npm test` | erfolgreich: Shared Types 47, Report 81, Backend 879 (11 übersprungen), Frontend 1219 |
| `npm run lint` | erfolgreich, einschließlich Skript-Gate |
| `npm run build:localize -w @arsnova/frontend` | erfolgreich: Production-Browser/SSR, Prerendering und Assets für de/en/fr/es/it |
| `npm run test -w @arsnova/frontend -- --run src/app/shared/item-selection-row/item-selection-row.component.spec.ts` | erfolgreich: 6 Tests, Regression mit Browseranimationen |
| `A11Y_SCAN=0 BASE_URL=http://localhost:4200 TRPC_URL=http://localhost:3000/trpc npm run smoke:structured-question-types -w @arsnova/frontend` | erfolgreich: mobiler Touch-Kontext, animiertes Same-Row-Race, je 6 Matching-/Kategorisierungszeilen, zwei Runden und Nachbesprechungsplan |
| `npx prettier --check ...` und `git diff --check` | erfolgreich |
| GitHub `Playwright Smoke E2E` am Head `57d4acb9` | erfolgreich in 8:33 Minuten, einschließlich CI-verankertem Structured-Smoke |

Der lokalisierte Build führt intern die Production-Browser- und Server-Builds aus; der abweichend benannte Root-Befehl `npm run build:prod` wurde deshalb nicht zusätzlich ausgeführt.

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Matching- und Kategorisierungs-Auswahlmenüs hinterlassen bei Touch-Wiederholungen keinen blockierenden Overlay-Backdrop mehr.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Logs; Regression wird durch Unit- und verpflichtenden mobilen E2E-Smoke erkannt.
- **Rollback:** Den produktionswirksamen Commit `7722764e` und den Test-/CI-Commit `57d4acb9` revertieren.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Der Unit-Test prüft mit echten Browseranimationen: Auswahl → asynchrones Schließen mit noch vorhandenem Backdrop → sofortiger Folgeklick derselben Zeile → Panel geschlossen → Backdrop vollständig entfernt.
- Der mobile Playwright-Smoke läuft mit `hasTouch: true`, `isMobile: true`, echten `tap()`-Interaktionen und einem gezielten synthetischen Folgeereignis während des Material-Detach-Fensters.
- Die jeweils nächste Matching- und Kategorisierungszeile wird anschließend mit dem ersten Tap geöffnet.
- Der Structured-Smoke ist im verpflichtenden CI-E2E-Job verankert und auf dem finalen Head erfolgreich.
- Vollständiger lokalisierter Production-/SSR-/Prerender-Build für fünf Sprachen erfolgreich.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Backend-Ablehnungen, Reconnect, Token-Rotation, Migrationen und Lasttests sind nicht betroffen, da ausschließlich der lokale Lebenszyklus eines bestehenden Frontend-Overlays geändert wird. Separate Übersetzungen entfallen, da kein Text geändert wurde.
- **Verbleibende Risiken:** Eine absichtliche erneute Auswahl derselben Zeile innerhalb des 250-ms-Detach-Fensters wird einmalig geschlossen; die nächste Zeile ist unmittelbar bedienbar und dieselbe Zeile danach wieder regulär.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
