### PR TITLE
fix(frontend): Preview-Änderungen zuverlässig speichern

### DIFF
--- a/apps/frontend/src/app/features/quiz/quiz-edit/quiz-edit.component.spec.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-edit/quiz-edit.component.spec.ts
@@ -46,7 +46,7 @@ describe('QuizEditComponent', { timeout: 30_000 }, () => {
 
   const matDialogMock = {
     open: vi.fn(() => ({
-      afterClosed: () => of(true),
+      afterClosed: () => of<boolean | 'save'>(true),
     })),
   };
   const snackBarMock = {
@@ -93,7 +93,7 @@ describe('QuizEditComponent', { timeout: 30_000 }, () => {
     mockStore.getQuizById.mockImplementation((id: string) => (id === QUIZ_ID ? quiz : null));
     matDialogMock.open.mockReset();
     matDialogMock.open.mockImplementation(() => ({
-      afterClosed: () => of(true),
+      afterClosed: () => of<boolean | 'save'>(true),
     }));
     snackBarMock.open.mockReset();
     TestBed.configureTestingModule({
@@ -484,6 +484,48 @@ describe('QuizEditComponent', { timeout: 30_000 }, () => {
     component.metadataForm.markAsDirty();
 
     await expect(component.canDeactivate()).resolves.toBe(false);
+  });
+
+  it('speichert alle Editor-Aenderungen aus dem Leave-Dialog vor der Navigation', async () => {
+    matDialogMock.open.mockImplementation(() => ({
+      afterClosed: () => of<boolean | 'save'>('save'),
+    }));
+    mockStore.updateQuizMetadata.mockImplementation((_id, metadata) => {
+      Object.assign(quiz, metadata);
+      return quiz;
+    });
+    const fixture = TestBed.createComponent(QuizEditComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.metadataForm.controls.name.setValue('Gespeicherter Titel');
+
+    await expect(component.canDeactivate()).resolves.toBe(true);
+
+    expect(matDialogMock.open.mock.calls[0]?.[1]?.data.saveLabel).toBe('Alle Änderungen speichern');
+    expect(mockStore.updateQuizMetadata).toHaveBeenCalledWith(QUIZ_ID, {
+      name: 'Gespeicherter Titel',
+      description: 'Beschreibung',
+      motifImageUrl: null,
+    });
+    expect(component.hasPendingChanges()).toBe(false);
+  });
+
+  it('blockiert die Navigation wenn Speichern im Leave-Dialog an Validierung scheitert', async () => {
+    matDialogMock.open.mockImplementation(() => ({
+      afterClosed: () => of<boolean | 'save'>('save'),
+    }));
+    const fixture = TestBed.createComponent(QuizEditComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.metadataForm.controls.name.setValue('');
+
+    await expect(component.canDeactivate()).resolves.toBe(false);
+
+    expect(mockStore.updateQuizMetadata).not.toHaveBeenCalled();
+    expect(component.metadataForm.controls.name.touched).toBe(true);
+    expect(component.hasPendingChanges()).toBe(true);
   });
 
   it('erkennt Metadatenänderungen auch ohne Angular-dirty-Status', () => {

--- a/apps/frontend/src/app/features/quiz/quiz-edit/quiz-edit.component.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-edit/quiz-edit.component.ts
@@ -2554,7 +2554,9 @@ export class QuizEditComponent implements OnDestroy {
   private async confirmDiscardPendingChangesIfNeeded(): Promise<boolean> {
     if (!this.hasPendingChanges()) return true;
     if (this.confirmDiscardInFlight) return this.confirmDiscardInFlight;
-    this.confirmDiscardInFlight = confirmDiscardUnsavedChanges(this.dialog).finally(() => {
+    this.confirmDiscardInFlight = confirmDiscardUnsavedChanges(this.dialog, () =>
+      this.saveAll(),
+    ).finally(() => {
       this.confirmDiscardInFlight = null;
     });
     return this.confirmDiscardInFlight;

--- a/apps/frontend/src/app/features/quiz/quiz-preview/quiz-preview.component.spec.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-preview/quiz-preview.component.spec.ts
@@ -7,7 +7,7 @@ import { of } from 'rxjs';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { LocaleSwitchGuardService } from '../../../core/locale-switch-guard.service';
 import { QuizPreviewComponent } from './quiz-preview.component';
-import { QuizStoreService, type QuizDocument } from '../data/quiz-store.service';
+import { QuizStoreService, type QuizDocument, type QuizQuestion } from '../data/quiz-store.service';
 
 const { quizUploadMutationMock, sessionCreateMutationMock } = vi.hoisted(() => ({
   quizUploadMutationMock: vi.fn(),
@@ -178,7 +178,7 @@ describe('QuizPreviewComponent', () => {
   };
   const matDialogMock = {
     open: vi.fn(() => ({
-      afterClosed: () => of(true),
+      afterClosed: () => of<boolean | 'save'>(true),
     })),
   };
 
@@ -187,7 +187,7 @@ describe('QuizPreviewComponent', () => {
     quizUploadMutationMock.mockResolvedValue({ quizId: 'server-quiz-id' });
     matDialogMock.open.mockReset();
     matDialogMock.open.mockImplementation(() => ({
-      afterClosed: () => of(true),
+      afterClosed: () => of<boolean | 'save'>(true),
     }));
     TestBed.configureTestingModule({
       imports: [QuizPreviewComponent],
@@ -357,6 +357,225 @@ describe('QuizPreviewComponent', () => {
     );
   });
 
+  it('speichert per Klick auf die Preview-Actionbar ohne unpassende Rating-Felder', () => {
+    const fixture = TestBed.createComponent(QuizPreviewComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.currentIndex.set(1);
+    component.enterInlineEditMode();
+    component.onQuestionDraftChanged('Per Actionbar gespeichert');
+    fixture.detectChanges();
+
+    const saveButton = Array.from<HTMLButtonElement>(
+      fixture.nativeElement.querySelectorAll('.quiz-preview-editor__actions button'),
+    ).find((button) => button.textContent?.includes('Speichern'));
+    expect(saveButton?.disabled).toBe(false);
+
+    saveButton?.click();
+
+    expect(mockStore.updateQuestion).toHaveBeenCalledWith(
+      QUIZ_ID,
+      'ef2d6b11-6389-4f2d-b9d7-9a6ad86ee91f',
+      expect.objectContaining({
+        text: 'Per Actionbar gespeichert',
+        type: 'SINGLE_CHOICE',
+      }),
+    );
+    const savedInput = mockStore.updateQuestion.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(savedInput).not.toHaveProperty('ratingMin');
+    expect(savedInput).not.toHaveProperty('ratingMax');
+    expect(component.inlineEditMode()).toBe(false);
+  });
+
+  it('bewahrt beim Preview-Speichern alle typabhaengigen Fragenfelder', () => {
+    const originalQuestion = quiz.questions[0]!;
+    const baseQuestion = (overrides: Partial<QuizQuestion>): QuizQuestion => ({
+      id: 'special-question',
+      text: 'Spezialfrage',
+      type: 'ORDERING',
+      difficulty: 'MEDIUM',
+      order: 0,
+      enabled: true,
+      timer: null,
+      answers: [],
+      ratingMin: null,
+      ratingMax: null,
+      ratingLabelMin: null,
+      ratingLabelMax: null,
+      ...overrides,
+    });
+    const cases: Array<{ question: QuizQuestion; expected: Record<string, unknown> }> = [
+      {
+        question: baseQuestion({
+          type: 'ORDERING',
+          orderingItems: [
+            { id: 'o1', text: 'Erstens' },
+            { id: 'o2', text: 'Zweitens' },
+            { id: 'o3', text: 'Drittens' },
+          ],
+        }),
+        expected: {
+          orderingItems: [
+            { id: 'o1', text: 'Erstens' },
+            { id: 'o2', text: 'Zweitens' },
+            { id: 'o3', text: 'Drittens' },
+          ],
+        },
+      },
+      {
+        question: baseQuestion({
+          type: 'MATCHING',
+          matchingPairs: [
+            { leftId: 'l1', left: 'A', rightId: 'r1', right: '1' },
+            { leftId: 'l2', left: 'B', rightId: 'r2', right: '2' },
+          ],
+          matchingShuffleRight: false,
+        }),
+        expected: {
+          matchingPairs: [
+            { leftId: 'l1', left: 'A', rightId: 'r1', right: '1' },
+            { leftId: 'l2', left: 'B', rightId: 'r2', right: '2' },
+          ],
+          matchingShuffleRight: false,
+        },
+      },
+      {
+        question: baseQuestion({
+          type: 'CATEGORIZATION',
+          categories: [
+            { id: 'c1', name: 'Links' },
+            { id: 'c2', name: 'Rechts' },
+          ],
+          categorizationItems: [
+            { id: 'i1', text: 'A', correctCategoryId: 'c1' },
+            { id: 'i2', text: 'B', correctCategoryId: 'c1' },
+            { id: 'i3', text: 'C', correctCategoryId: 'c2' },
+            { id: 'i4', text: 'D', correctCategoryId: 'c2' },
+          ],
+          categorizationShuffleItems: false,
+        }),
+        expected: {
+          categories: [
+            { id: 'c1', name: 'Links' },
+            { id: 'c2', name: 'Rechts' },
+          ],
+          categorizationItems: [
+            { id: 'i1', text: 'A', correctCategoryId: 'c1' },
+            { id: 'i2', text: 'B', correctCategoryId: 'c1' },
+            { id: 'i3', text: 'C', correctCategoryId: 'c2' },
+            { id: 'i4', text: 'D', correctCategoryId: 'c2' },
+          ],
+          categorizationShuffleItems: false,
+        },
+      },
+      {
+        question: baseQuestion({
+          type: 'SHORT_TEXT',
+          answers: [{ id: 'solution', text: '42 kg', isCorrect: true }],
+          shortTextEvaluationKind: 'numeric_unit',
+          shortTextMaxLength: 80,
+          numericInputKind: 'decimal',
+          numericToleranceMode: 'absolute',
+          numericAbsoluteTolerance: 0.5,
+          numericUnitFamily: 'mass',
+          numericRequireUnit: true,
+          numericAcceptEquivalentUnits: true,
+        }),
+        expected: {
+          shortTextEvaluationKind: 'numeric_unit',
+          shortTextMaxLength: 80,
+          numericInputKind: 'decimal',
+          numericToleranceMode: 'absolute',
+          numericAbsoluteTolerance: 0.5,
+          numericUnitFamily: 'mass',
+          numericRequireUnit: true,
+          numericAcceptEquivalentUnits: true,
+        },
+      },
+      {
+        question: baseQuestion({
+          type: 'NUMERIC_ESTIMATE',
+          numericToleranceMode: 'ABSOLUTE_INTERVAL',
+          numericReferenceValue: 42,
+          numericIntervalLeft: 40,
+          numericIntervalRight: 44,
+          numericInputType: 'DECIMAL',
+          numericDecimalPlaces: 1,
+          numericMin: 0,
+          numericMax: 100,
+          numericTwoRounds: true,
+          confidenceEnabled: true,
+          confidenceLabelLow: 'Unsicher',
+          confidenceLabelHigh: 'Sicher',
+        }),
+        expected: {
+          numericToleranceMode: 'ABSOLUTE_INTERVAL',
+          numericReferenceValue: 42,
+          numericIntervalLeft: 40,
+          numericIntervalRight: 44,
+          numericInputType: 'DECIMAL',
+          numericDecimalPlaces: 1,
+          numericMin: 0,
+          numericMax: 100,
+          numericTwoRounds: true,
+          confidenceEnabled: true,
+          confidenceLabelLow: 'Unsicher',
+          confidenceLabelHigh: 'Sicher',
+        },
+      },
+    ];
+
+    try {
+      for (const testCase of cases) {
+        quiz.questions[0] = testCase.question;
+        mockStore.updateQuestion.mockClear();
+        const fixture = TestBed.createComponent(QuizPreviewComponent);
+        const component = fixture.componentInstance;
+        fixture.detectChanges();
+
+        component.enterInlineEditMode();
+        component.onInlineQuestionTimerSecondsChange(90);
+        fixture.detectChanges();
+        const saveButton = Array.from<HTMLButtonElement>(
+          fixture.nativeElement.querySelectorAll('.quiz-preview-editor__actions button'),
+        ).find((button) => button.textContent?.includes('Speichern'));
+        saveButton?.click();
+
+        expect(mockStore.updateQuestion).toHaveBeenCalledWith(
+          QUIZ_ID,
+          'special-question',
+          expect.objectContaining({ timer: 90, ...testCase.expected }),
+        );
+        expect(component.inlineEditMode()).toBe(false);
+        fixture.destroy();
+      }
+    } finally {
+      quiz.questions[0] = originalQuestion;
+    }
+  });
+
+  it('bleibt bei einem Preview-Speicherfehler im Editor und meldet den Fehler', () => {
+    mockStore.updateQuestion.mockImplementationOnce(() => {
+      throw new Error('Speichern abgelehnt.');
+    });
+    const fixture = TestBed.createComponent(QuizPreviewComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.enterInlineEditMode();
+    component.onQuestionDraftChanged('Noch nicht gespeichert');
+
+    expect(component.finishInlineEditMode()).toBe(false);
+    expect(component.inlineEditMode()).toBe(true);
+    expect(component.inlineEditHasChanges()).toBe(true);
+    expect(snackBarMock.open).toHaveBeenCalledWith(
+      'Speichern abgelehnt.',
+      '',
+      expect.objectContaining({ duration: 8000 }),
+    );
+  });
+
   it('verwirft Inline-Aenderungen ohne Persistieren', () => {
     const fixture = TestBed.createComponent(QuizPreviewComponent);
     const component = fixture.componentInstance;
@@ -508,6 +727,31 @@ describe('QuizPreviewComponent', () => {
     expect(component.inlineEditMode()).toBe(true);
     expect(component.inlineEditHasChanges()).toBe(true);
     expect(component.questionDraftText()).toBe('Neue Frage');
+  });
+
+  it('speichert alle Inline-Aenderungen aus dem Leave-Dialog vor der Navigation', async () => {
+    matDialogMock.open.mockImplementation(() => ({
+      afterClosed: () => of<boolean | 'save'>('save'),
+    }));
+    const fixture = TestBed.createComponent(QuizPreviewComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.enterInlineEditMode();
+    component.onQuestionDraftChanged('Gespeicherte Frage');
+    component.onInlineGlobalTimerEnabledChange(true);
+
+    await expect(component.canDeactivate()).resolves.toBe(true);
+
+    expect(matDialogMock.open.mock.calls[0]?.[1]?.data.saveLabel).toBe('Alle Änderungen speichern');
+    expect(mockStore.updateQuizSettings).toHaveBeenCalledWith(QUIZ_ID, { defaultTimer: 60 });
+    expect(mockStore.updateQuestion).toHaveBeenCalledWith(
+      QUIZ_ID,
+      'f8be4e5d-2c03-4f9b-8d63-b9668212f3ea',
+      expect.objectContaining({ text: 'Gespeicherte Frage' }),
+    );
+    expect(component.inlineEditMode()).toBe(false);
+    expect(component.inlineEditHasChanges()).toBe(false);
   });
 
   it('unterdrueckt beforeunload nach bestaetigtem Locale-Unload', () => {

--- a/apps/frontend/src/app/features/quiz/quiz-preview/quiz-preview.component.ts
+++ b/apps/frontend/src/app/features/quiz/quiz-preview/quiz-preview.component.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_TIMER_SECONDS,
   SHORT_TEXT_DEFAULT_EVALUATION_MODE,
   SHORT_TEXT_DEFAULT_TOLERANCE_LEVEL,
+  questionSupportsConfidence,
   resolveShortTextMaxLength,
   resolveEffectiveQuestionTimer,
   type CreateSessionOutput,
@@ -491,9 +492,12 @@ export class QuizPreviewComponent implements OnDestroy {
     this.focusEditActionAfterInlineClose();
   }
 
-  finishInlineEditMode(): void {
-    this.commitInlineEdits();
-    this.focusEditActionAfterInlineClose();
+  finishInlineEditMode(): boolean {
+    const saved = this.commitInlineEdits();
+    if (saved) {
+      this.focusEditActionAfterInlineClose();
+    }
+    return saved;
   }
 
   /**
@@ -503,14 +507,18 @@ export class QuizPreviewComponent implements OnDestroy {
   private async prepareLeaveInlineEdit(): Promise<boolean> {
     if (!this.inlineEditMode()) return true;
     if (!(await this.confirmDiscardUnsavedIfNeeded())) return false;
-    this.cancelInlineEditMode();
+    if (this.inlineEditMode()) {
+      this.cancelInlineEditMode();
+    }
     return true;
   }
 
   private async confirmDiscardUnsavedIfNeeded(): Promise<boolean> {
     if (!this.inlineEditHasChanges()) return true;
     if (this.confirmDiscardInFlight) return this.confirmDiscardInFlight;
-    this.confirmDiscardInFlight = confirmDiscardUnsavedChanges(this.dialog).finally(() => {
+    this.confirmDiscardInFlight = confirmDiscardUnsavedChanges(this.dialog, () =>
+      this.finishInlineEditMode(),
+    ).finally(() => {
       this.confirmDiscardInFlight = null;
     });
     return this.confirmDiscardInFlight;
@@ -864,29 +872,41 @@ export class QuizPreviewComponent implements OnDestroy {
     }));
 
     this.quizStore.updateQuestion(this.id, question.id, {
+      ...this.toQuestionInput(question),
       text: this.questionDraftText(),
-      type: question.type,
-      difficulty: question.difficulty,
       timer: this.inlineQuestionTimerDraft(),
       answers,
       skipReadingPhase: this.inlineSkipReadingPhaseDraft(),
-      ratingMin: question.ratingMin,
-      ratingMax: question.ratingMax,
-      ratingLabelMin: question.ratingLabelMin,
-      ratingLabelMax: question.ratingLabelMax,
     });
   }
 
-  private commitInlineEdits(): void {
-    if (!this.inlineEditMode()) return;
+  private commitInlineEdits(): boolean {
+    if (!this.inlineEditMode()) return true;
     const shouldShowSaveConfirmation = this.inlineEditHasChanges();
     if (shouldShowSaveConfirmation) {
-      this.persistInlineEditsNow();
+      try {
+        this.persistInlineEditsNow();
+      } catch (error) {
+        this.snackBar.open(
+          localizeKnownServerError(
+            error,
+            $localize`:@@quizPreview.saveError:Änderungen konnten nicht gespeichert werden.`,
+          ),
+          '',
+          {
+            duration: 8000,
+            horizontalPosition: 'center',
+            verticalPosition: 'top',
+          },
+        );
+        return false;
+      }
     }
     this.resetInlineEditState();
     if (shouldShowSaveConfirmation) {
       this.showSaveConfirmation();
     }
+    return true;
   }
 
   private showSaveConfirmation(): void {
@@ -974,11 +994,73 @@ export class QuizPreviewComponent implements OnDestroy {
         text: answer.text,
         isCorrect: answer.isCorrect,
       })),
-      skipReadingPhase: question.skipReadingPhase,
-      ratingMin: question.ratingMin,
-      ratingMax: question.ratingMax,
-      ratingLabelMin: question.ratingLabelMin,
-      ratingLabelMax: question.ratingLabelMax,
+      skipReadingPhase: question.skipReadingPhase ?? false,
+      ...(question.type === 'RATING'
+        ? {
+            ratingMin: question.ratingMin ?? 1,
+            ratingMax: question.ratingMax ?? 5,
+            ratingLabelMin: question.ratingLabelMin ?? '',
+            ratingLabelMax: question.ratingLabelMax ?? '',
+          }
+        : {}),
+      ...(question.type === 'SHORT_TEXT'
+        ? {
+            shortTextEvaluationKind: question.shortTextEvaluationKind,
+            shortTextMaxLength: question.shortTextMaxLength,
+            shortTextCaseSensitive: question.shortTextCaseSensitive,
+            shortTextEvaluationMode: question.shortTextEvaluationMode,
+            shortTextToleranceLevel: question.shortTextToleranceLevel,
+            shortTextAllowPartialCredit: question.shortTextAllowPartialCredit,
+            shortTextTrimWhitespace: question.shortTextTrimWhitespace,
+            shortTextNormalizeWhitespace: question.shortTextNormalizeWhitespace,
+            numericInputKind: question.numericInputKind,
+            numericToleranceMode: question.numericToleranceMode,
+            numericAbsoluteTolerance: question.numericAbsoluteTolerance,
+            numericRelativeTolerancePercent: question.numericRelativeTolerancePercent,
+            numericUnitFamily: question.numericUnitFamily,
+            numericRequireUnit: question.numericRequireUnit,
+            numericAcceptEquivalentUnits: question.numericAcceptEquivalentUnits,
+          }
+        : {}),
+      ...(question.type === 'NUMERIC_ESTIMATE'
+        ? {
+            numericToleranceMode: question.numericToleranceMode,
+            numericReferenceValue: question.numericReferenceValue,
+            numericTolerancePercent: question.numericTolerancePercent,
+            numericIntervalLeft: question.numericIntervalLeft,
+            numericIntervalRight: question.numericIntervalRight,
+            numericInputType: question.numericInputType,
+            numericDecimalPlaces: question.numericDecimalPlaces,
+            numericMin: question.numericMin,
+            numericMax: question.numericMax,
+            numericTwoRounds: question.numericTwoRounds,
+          }
+        : {}),
+      ...(question.type === 'MATCHING'
+        ? {
+            matchingPairs: question.matchingPairs?.map((pair) => ({ ...pair })) ?? [],
+            matchingShuffleRight: question.matchingShuffleRight ?? true,
+          }
+        : {}),
+      ...(question.type === 'ORDERING'
+        ? {
+            orderingItems: question.orderingItems?.map((item) => ({ ...item })) ?? [],
+          }
+        : {}),
+      ...(question.type === 'CATEGORIZATION'
+        ? {
+            categories: question.categories?.map((category) => ({ ...category })) ?? [],
+            categorizationItems: question.categorizationItems?.map((item) => ({ ...item })) ?? [],
+            categorizationShuffleItems: question.categorizationShuffleItems ?? true,
+          }
+        : {}),
+      ...(questionSupportsConfidence(question.type)
+        ? {
+            confidenceEnabled: question.confidenceEnabled ?? false,
+            confidenceLabelLow: question.confidenceLabelLow ?? null,
+            confidenceLabelHigh: question.confidenceLabelHigh ?? null,
+          }
+        : {}),
     };
   }
 

--- a/apps/frontend/src/app/shared/confirm-leave-dialog/confirm-leave-dialog.component.scss
+++ b/apps/frontend/src/app/shared/confirm-leave-dialog/confirm-leave-dialog.component.scss
@@ -12,6 +12,18 @@
   line-height: 1.7;
 }
 
+.confirm-leave__actions--with-save {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+  padding-inline: 1rem;
+  padding-bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+
+  .mat-mdc-button-base {
+    width: 100%;
+  }
+}
+
 @media (max-width: 28rem) {
   mat-dialog-actions {
     flex-direction: column-reverse;

--- a/apps/frontend/src/app/shared/confirm-leave-dialog/confirm-leave-dialog.component.ts
+++ b/apps/frontend/src/app/shared/confirm-leave-dialog/confirm-leave-dialog.component.ts
@@ -16,6 +16,8 @@ export interface ConfirmLeaveDialogData {
   consequences: string[];
   confirmLabel: string;
   cancelLabel: string;
+  /** Optionale, nicht-destruktive Aktion, bevor die auslösende Navigation fortgesetzt wird. */
+  saveLabel?: string;
   /**
    * Synchron im Cancel-Klick (User-Geste), z. B. Vollbild wiederherstellen,
    * bevor der Dialog schließt (afterClosed wäre oft zu spät für die Fullscreen-API).
@@ -47,17 +49,28 @@ export interface ConfirmLeaveDialogData {
         </ul>
       }
     </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button type="button" (click)="onCancel()">{{ data.cancelLabel }}</button>
-      <button mat-flat-button type="button" color="warn" [mat-dialog-close]="true">
-        {{ data.confirmLabel }}
-      </button>
+    <mat-dialog-actions align="end" [class.confirm-leave__actions--with-save]="data.saveLabel">
+      @if (data.saveLabel) {
+        <button mat-flat-button type="button" [mat-dialog-close]="'save'">
+          <mat-icon>save</mat-icon>
+          {{ data.saveLabel }}
+        </button>
+        <button mat-button type="button" color="warn" [mat-dialog-close]="true">
+          {{ data.confirmLabel }}
+        </button>
+        <button mat-button type="button" (click)="onCancel()">{{ data.cancelLabel }}</button>
+      } @else {
+        <button mat-button type="button" (click)="onCancel()">{{ data.cancelLabel }}</button>
+        <button mat-flat-button type="button" color="warn" [mat-dialog-close]="true">
+          {{ data.confirmLabel }}
+        </button>
+      }
     </mat-dialog-actions>
   `,
 })
 export class ConfirmLeaveDialogComponent {
   readonly data = inject<ConfirmLeaveDialogData>(MAT_DIALOG_DATA);
-  private readonly dialogRef = inject(MatDialogRef<ConfirmLeaveDialogComponent, boolean>);
+  private readonly dialogRef = inject(MatDialogRef<ConfirmLeaveDialogComponent, boolean | 'save'>);
 
   onCancel(): void {
     this.data.onCancelUserGesture?.();

--- a/apps/frontend/src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts
+++ b/apps/frontend/src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts
@@ -8,8 +8,13 @@ import {
 /**
  * Bestätigungsdialog für ungespeicherte Quiz-Änderungen (Edit, New, Preview-Inline).
  * Abbrechen = false (sicherer Default); Trotzdem fortfahren = true.
+ * Wenn `saveChanges` gesetzt ist, bietet der Dialog zusätzlich „Alle Änderungen speichern“ an
+ * und lässt die Navigation nur nach einem erfolgreichen Save weiterlaufen.
  */
-export async function confirmDiscardUnsavedChanges(dialog: MatDialog): Promise<boolean> {
+export async function confirmDiscardUnsavedChanges(
+  dialog: MatDialog,
+  saveChanges?: () => boolean | Promise<boolean>,
+): Promise<boolean> {
   const data: ConfirmLeaveDialogData = {
     title: $localize`:@@quiz.unsavedChanges.title:Ungespeicherte Änderungen?`,
     message: $localize`:@@quiz.unsavedChanges.message:Wenn du fortfährst, gehen ungespeicherte Änderungen verloren.`,
@@ -18,6 +23,11 @@ export async function confirmDiscardUnsavedChanges(dialog: MatDialog): Promise<b
     ],
     confirmLabel: $localize`:@@quiz.unsavedChanges.confirm:Trotzdem fortfahren`,
     cancelLabel: $localize`:@@quiz.unsavedChanges.cancel:Abbrechen`,
+    ...(saveChanges
+      ? {
+          saveLabel: $localize`:@@quiz.unsavedChanges.saveAll:Alle Änderungen speichern`,
+        }
+      : {}),
   };
 
   const dialogRef = dialog.open(ConfirmLeaveDialogComponent, {
@@ -27,5 +37,9 @@ export async function confirmDiscardUnsavedChanges(dialog: MatDialog): Promise<b
     autoFocus: 'dialog',
   });
 
-  return (await firstValueFrom(dialogRef.afterClosed())) === true;
+  const result = await firstValueFrom(dialogRef.afterClosed());
+  if (result === 'save') {
+    return (await saveChanges?.()) === true;
+  }
+  return result === true;
 }

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -13386,6 +13386,14 @@
           <context context-type="linenumber">783</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizPreview.saveError" datatype="html">
+        <source>Änderungen konnten nicht gespeichert werden.</source>
+        <target>Changes could not be saved.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
+          <context context-type="linenumber">893</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="quizPreview.saveConfirmation" datatype="html">
         <source>Gespeichert. Deine Änderungen sind jetzt in der Vorschau und im Live-Quiz übernommen.</source>
         <target>Saved. Your changes are now applied in the preview and live quiz.</target>
@@ -21192,6 +21200,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
           <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quiz.unsavedChanges.saveAll" datatype="html">
+        <source>Alle Änderungen speichern</source>
+        <target>Save all changes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="connectionBanner.reconnecting" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -13331,6 +13331,14 @@
           <context context-type="linenumber">783</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizPreview.saveError" datatype="html">
+        <source>Änderungen konnten nicht gespeichert werden.</source>
+        <target>No se pudieron guardar los cambios.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
+          <context context-type="linenumber">893</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="quizPreview.saveConfirmation" datatype="html">
         <source>Gespeichert. Deine Änderungen sind jetzt in der Vorschau und im Live-Quiz übernommen.</source>
         <target>Guardado. Tus cambios ya se aplican en la vista previa y en el cuestionario en directo.</target>
@@ -21135,6 +21143,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
           <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quiz.unsavedChanges.saveAll" datatype="html">
+        <source>Alle Änderungen speichern</source>
+        <target>Guardar todos los cambios</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="connectionBanner.reconnecting" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -13331,6 +13331,14 @@
           <context context-type="linenumber">783</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizPreview.saveError" datatype="html">
+        <source>Änderungen konnten nicht gespeichert werden.</source>
+        <target>Les modifications n&apos;ont pas pu être enregistrées.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
+          <context context-type="linenumber">893</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="quizPreview.saveConfirmation" datatype="html">
         <source>Gespeichert. Deine Änderungen sind jetzt in der Vorschau und im Live-Quiz übernommen.</source>
         <target>Enregistré. Vos modifications sont maintenant prises en compte dans l&apos;aperçu et le quiz en direct.</target>
@@ -21135,6 +21143,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
           <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quiz.unsavedChanges.saveAll" datatype="html">
+        <source>Alle Änderungen speichern</source>
+        <target>Enregistrer toutes les modifications</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="connectionBanner.reconnecting" datatype="html">

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -13331,6 +13331,14 @@
           <context context-type="linenumber">783</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizPreview.saveError" datatype="html">
+        <source>Änderungen konnten nicht gespeichert werden.</source>
+        <target>Non è stato possibile salvare le modifiche.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
+          <context context-type="linenumber">893</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="quizPreview.saveConfirmation" datatype="html">
         <source>Gespeichert. Deine Änderungen sind jetzt in der Vorschau und im Live-Quiz übernommen.</source>
         <target>Salvato. Le tue modifiche sono ora applicate nell&apos;anteprima e nel quiz live.</target>
@@ -21135,6 +21143,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
           <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quiz.unsavedChanges.saveAll" datatype="html">
+        <source>Alle Änderungen speichern</source>
+        <target>Salva tutte le modifiche</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="connectionBanner.reconnecting" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -11842,6 +11842,13 @@
           <context context-type="linenumber">783</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="quizPreview.saveError" datatype="html">
+        <source>Änderungen konnten nicht gespeichert werden.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.ts</context>
+          <context context-type="linenumber">893</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="quizPreview.saveConfirmation" datatype="html">
         <source>Gespeichert. Deine Änderungen sind jetzt in der Vorschau und im Live-Quiz übernommen.</source>
         <context-group purpose="location">
@@ -18709,6 +18716,13 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
           <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="quiz.unsavedChanges.saveAll" datatype="html">
+        <source>Alle Änderungen speichern</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/confirm-leave-dialog/confirm-unsaved-changes.ts</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="connectionBanner.reconnecting" datatype="html">


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** In der Quiz-Vorschau erzeugte der Inline-Speicherpfad ein unvollständiges Fragen-Payload. Bei strukturierten Fragetypen fehlten typabhängige Felder wie `orderingItems`; zugleich wurden Rating-Felder auch für andere Typen gesetzt. Die Store-Validierung lehnte dadurch unter anderem Änderungen am Zeitlimit einer ORDERING-Frage ab. Der Dialog für ungespeicherte Änderungen bot außerdem nur Abbrechen oder Verwerfen.
- **Lösung:** Preview-Updates bewahren sämtliche typabhängigen Fragenfelder und überschreiben nur die tatsächlich bearbeiteten Werte. Preview und Editor können über den Leave-Dialog nun „Alle Änderungen speichern“; die Navigation wird nur nach erfolgreichem Speichern fortgesetzt.
- **Bewusste Nicht-Ziele:** Keine Änderungen an Shared Schemas, Backend-APIs, Persistenzformaten oder dem Ablauf zum Anlegen eines neuen Quiz.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

`AddQuizQuestionInput` und die Validierung in `QuizStoreService.updateQuestion` sind maßgeblich. Beim Inline-Edit müssen alle nicht bearbeiteten typabhängigen Felder unverändert erhalten bleiben. Navigation darf nach „Alle Änderungen speichern“ nur bei einem erfolgreichen Save fortgesetzt werden; Abbrechen und bewusstes Verwerfen behalten ihre bisherige Semantik.

**Betroffene externe Verträge:**

Keine.

## Implementierung

- Preview-Save erzeugt typkorrekte Payloads für RATING, SHORT_TEXT, NUMERIC_ESTIMATE, MATCHING, ORDERING und CATEGORIZATION und bewahrt Confidence-Einstellungen.
- Das konkrete Fragen-Zeitlimit und der Quiz-Standardtimer werden weiterhin als Inline-Drafts geführt und gemeinsam atomar über den bestehenden Store-Pfad übernommen.
- Der gemeinsame Leave-Dialog unterstützt eine optionale Save-Aktion mit eindeutigem Ergebniswert; Preview und Editor hängen ihre zentralen Save-Funktionen ein.
- Bei einem Preview-Speicherfehler bleibt der Editor offen und eine Snackbar meldet den Fehler.
- Drei Dialogaktionen werden in logischer DOM-/Fokusreihenfolge untereinander dargestellt; Texte sind in de, en, fr, es und it synchronisiert.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

Der Dialog wartet auf `afterClosed`. Save-Erfolg, Validierungsablehnung, Store-Fehler, Abbrechen und bewusstes Verwerfen sind abgedeckt. Der Save selbst ist synchron; Timeout und Retry sind daher nicht anwendbar.

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` | Erfolgreich |
| `npm test` | Erfolgreich, vollständige Monorepo-Suite im Commit-Hook |
| `npm run lint` | Erfolgreich, einschließlich Script-Lint-Gate |
| `npm run test -w @arsnova/frontend -- --run src/app/features/quiz/quiz-preview/quiz-preview.component.spec.ts src/app/features/quiz/quiz-edit/quiz-edit.component.spec.ts src/app/core/locale-switch-guard.service.spec.ts` | 124/124 Tests erfolgreich |
| `npm run check:i18n -w @arsnova/frontend` | 2610/2610 Einheiten je Locale erfolgreich |
| `npm run build:prod` | Erfolgreich, lokalisierter Browser-/SSR-Build und MOTD-Asset-Check für 5 Locales |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [ ] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Preview- und Editor-Entwürfe können vor Navigation zuverlässig gespeichert werden; strukturierte Fragen verlieren dabei keine Konfiguration.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Speicherfehler werden im bestehenden UI als Snackbar sichtbar; keine neuen Logs oder Metriken.
- **Rollback:** Commit revertieren; keine Datenmigration oder Konfigurationsänderung erforderlich.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Regressionstest klickt den echten Save-Button der Preview-Actionbar und prüft das konkrete Fragen-Zeitlimit.
- Payload-Abdeckung für ORDERING, MATCHING, CATEGORIZATION, SHORT_TEXT und NUMERIC_ESTIMATE.
- Save-Erfolg und Save-/Validierungsfehler im Leave-Dialog sind getestet.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Reload, Reconnect, Migration, Parallelität, Tokens und Last sind nicht betroffen, da ausschließlich lokaler Quiz-Entwurfszustand und Dialognavigation geändert werden.
- **Verbleibende Risiken:** Kein separater manueller Screenshot-Test für Zoom/Reflow. Der Drei-Aktionen-Dialog nutzt Standard-Material-Buttons, eine gestapelte Darstellung und M3-Farbtokens; Produktionsbuild und DOM-Tests sind erfolgreich.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
