### PR TITLE
Host-Aktionsleiste und mobilen Reflow korrigieren

### DIFF
--- a/apps/frontend/src/app/features/home/home.component.scss
+++ b/apps/frontend/src/app/features/home/home.component.scss
@@ -214,6 +214,7 @@
 
 .home-hero-preset-toggle {
   display: flex;
+  flex-wrap: wrap;
   width: 100%;
   max-width: 20rem;
   border: 1px solid var(--mat-sys-outline-variant);
@@ -222,7 +223,7 @@
 }
 
 .home-hero-preset-toggle__btn {
-  flex: 1;
+  flex: 1 0 max-content;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -259,22 +260,6 @@
   align-items: center;
   gap: 0.5rem;
   white-space: nowrap;
-}
-
-@media (max-width: 359px) {
-  .home-hero-preset-toggle {
-    flex-direction: column;
-  }
-
-  .home-hero-preset-toggle__btn {
-    flex: 0 0 auto;
-    width: 100%;
-  }
-
-  .home-hero-preset-toggle__btn + .home-hero-preset-toggle__btn {
-    border-top: 1px solid var(--mat-sys-outline-variant);
-    border-left: 0;
-  }
 }
 
 /* Hero + USP + Preset (mobil): eine Grid-Zeile, damit Layout und Preset-Bühne steuerbar bleiben */

--- a/apps/frontend/src/app/features/home/home.component.scss
+++ b/apps/frontend/src/app/features/home/home.component.scss
@@ -261,6 +261,22 @@
   white-space: nowrap;
 }
 
+@media (max-width: 359px) {
+  .home-hero-preset-toggle {
+    flex-direction: column;
+  }
+
+  .home-hero-preset-toggle__btn {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+
+  .home-hero-preset-toggle__btn + .home-hero-preset-toggle__btn {
+    border-top: 1px solid var(--mat-sys-outline-variant);
+    border-left: 0;
+  }
+}
+
 /* Hero + USP + Preset (mobil): eine Grid-Zeile, damit Layout und Preset-Bühne steuerbar bleiben */
 .home-hero-band {
   display: flex;

--- a/apps/frontend/src/app/features/home/home.component.spec.ts
+++ b/apps/frontend/src/app/features/home/home.component.spec.ts
@@ -371,7 +371,7 @@ describe('HomeComponent', () => {
       expect(scss).not.toContain('mat-button-toggle:focus-within');
     });
 
-    it('stapelt die Preset-Buttons bei 320 px, ohne ihre Labels umzubrechen', async () => {
+    it('lässt die Preset-Buttons abhängig von ihrer Inhaltsbreite umbrechen', async () => {
       const { readFileSync } = await import('node:fs');
       const { fileURLToPath } = await import('node:url');
       const { dirname, join } = await import('node:path');
@@ -379,12 +379,9 @@ describe('HomeComponent', () => {
       const scss = readFileSync(scssPath, 'utf8');
 
       expect(scss).toMatch(/home-preset-option\s*\{[\s\S]*?white-space:\s*nowrap/);
-      expect(scss).toMatch(
-        /@media \(max-width: 359px\)\s*\{[\s\S]*?home-hero-preset-toggle\s*\{\s*flex-direction:\s*column/,
-      );
-      expect(scss).toMatch(
-        /home-hero-preset-toggle__btn \+ \.home-hero-preset-toggle__btn\s*\{[\s\S]*?border-top:[\s\S]*?border-left:\s*0/,
-      );
+      expect(scss).toMatch(/\.home-hero-preset-toggle\s*\{[^}]*flex-wrap:\s*wrap/);
+      expect(scss).toMatch(/\.home-hero-preset-toggle__btn\s*\{[^}]*flex:\s*1 0 max-content/);
+      expect(scss).not.toContain('@media (max-width: 359px)');
     });
   });
 

--- a/apps/frontend/src/app/features/home/home.component.spec.ts
+++ b/apps/frontend/src/app/features/home/home.component.spec.ts
@@ -370,6 +370,22 @@ describe('HomeComponent', () => {
       expect(scss).not.toContain('mat-button-toggle-button:focus-visible');
       expect(scss).not.toContain('mat-button-toggle:focus-within');
     });
+
+    it('stapelt die Preset-Buttons bei 320 px, ohne ihre Labels umzubrechen', async () => {
+      const { readFileSync } = await import('node:fs');
+      const { fileURLToPath } = await import('node:url');
+      const { dirname, join } = await import('node:path');
+      const scssPath = join(dirname(fileURLToPath(import.meta.url)), 'home.component.scss');
+      const scss = readFileSync(scssPath, 'utf8');
+
+      expect(scss).toMatch(/home-preset-option\s*\{[\s\S]*?white-space:\s*nowrap/);
+      expect(scss).toMatch(
+        /@media \(max-width: 359px\)\s*\{[\s\S]*?home-hero-preset-toggle\s*\{\s*flex-direction:\s*column/,
+      );
+      expect(scss).toMatch(
+        /home-hero-preset-toggle__btn \+ \.home-hero-preset-toggle__btn\s*\{[\s\S]*?border-top:[\s\S]*?border-left:\s*0/,
+      );
+    });
   });
 
   describe('isValidSessionCode', () => {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -4060,11 +4060,20 @@
             mat-flat-button
             color="primary"
             type="button"
-            class="session-host__exit-anchor-button session-host__exit-anchor-button--primary"
+            class="session-host__exit-anchor-button session-host__exit-anchor-button--primary session-host__exit-anchor-button--reveal-options"
             [disabled]="controlPending()"
             (click)="revealAnswers()"
           >
-            <span i18n="@@sessionHost.revealAnswerOptions">Antwortoptionen freigeben</span>
+            <span
+              class="session-host__exit-anchor-label session-host__exit-anchor-label--reveal-options-full"
+              i18n="@@sessionHost.revealAnswerOptions"
+              >Antwortoptionen freigeben</span
+            >
+            <span
+              class="session-host__exit-anchor-label session-host__exit-anchor-label--reveal-options-compact"
+              i18n="@@sessionHost.revealAnswerOptionsCompact"
+              >Antwortoptionen</span
+            >
           </button>
         }
         @if (
@@ -4087,46 +4096,50 @@
             </p>
           }
           @if (shouldOfferDiscussionPhase(displayedCurrentQuestionForHost())) {
-            <button
-              mat-flat-button
-              color="primary"
-              type="button"
-              class="session-host__exit-anchor-button session-host__exit-anchor-button--primary"
-              [disabled]="controlPending() || personalTimerBlocksReveal()"
-              [attr.aria-describedby]="
-                pendingTimerAccommodationCount() > 0
-                  ? 'session-host-timer-accommodation-status'
-                  : null
-              "
-              (click)="startDiscussion()"
-              i18n-aria-label="@@sessionHost.startDiscussionPhaseAria"
-              aria-label="Diskussionsphase starten – Austausch vor zweiter Abstimmung"
-            >
-              <mat-icon aria-hidden="true">groups</mat-icon>
-              <span i18n="@@sessionHost.discussionPhaseButton">Diskussionsphase</span>
-            </button>
-            <button
-              matButton="tonal"
-              type="button"
-              class="session-host__exit-anchor-button"
-              [disabled]="controlPending() || personalTimerBlocksReveal()"
-              [attr.aria-describedby]="
-                pendingTimerAccommodationCount() > 0
-                  ? 'session-host-timer-accommodation-status'
-                  : null
-              "
-              (click)="revealResults()"
-            >
-              @if (canForceClosePersonalTimers()) {
-                <span i18n="@@sessionHost.revealResultsForceClose">Trotzdem freigeben</span>
-              } @else if (shouldShowPeerInstructionSuggestion(displayedCurrentQuestionForHost())) {
-                <span i18n="@@sessionHost.revealResultsDespiteSuggestion"
-                  >Ergebnis trotzdem zeigen</span
-                >
-              } @else {
-                <span i18n="@@sessionHost.revealResults">Ergebnis zeigen</span>
-              }
-            </button>
+            <div class="session-host__exit-anchor-action-pair">
+              <button
+                matButton="tonal"
+                type="button"
+                class="session-host__exit-anchor-button"
+                [disabled]="controlPending() || personalTimerBlocksReveal()"
+                [attr.aria-describedby]="
+                  pendingTimerAccommodationCount() > 0
+                    ? 'session-host-timer-accommodation-status'
+                    : null
+                "
+                (click)="revealResults()"
+              >
+                @if (canForceClosePersonalTimers()) {
+                  <span i18n="@@sessionHost.revealResultsForceClose">Trotzdem freigeben</span>
+                } @else if (
+                  shouldShowPeerInstructionSuggestion(displayedCurrentQuestionForHost())
+                ) {
+                  <span i18n="@@sessionHost.revealResultsDespiteSuggestion"
+                    >Ergebnis trotzdem zeigen</span
+                  >
+                } @else {
+                  <span i18n="@@sessionHost.revealResults">Ergebnis zeigen</span>
+                }
+              </button>
+              <button
+                mat-flat-button
+                color="primary"
+                type="button"
+                class="session-host__exit-anchor-button session-host__exit-anchor-button--primary"
+                [disabled]="controlPending() || personalTimerBlocksReveal()"
+                [attr.aria-describedby]="
+                  pendingTimerAccommodationCount() > 0
+                    ? 'session-host-timer-accommodation-status'
+                    : null
+                "
+                (click)="startDiscussion()"
+                i18n-aria-label="@@sessionHost.startDiscussionPhaseAria"
+                aria-label="Diskussionsphase starten – Austausch vor zweiter Abstimmung"
+              >
+                <mat-icon aria-hidden="true">groups</mat-icon>
+                <span i18n="@@sessionHost.discussionPhaseButton">Diskussionsphase</span>
+              </button>
+            </div>
           } @else {
             <button
               mat-flat-button
@@ -4165,30 +4178,32 @@
           </button>
         }
         @if (effectiveStatus() === 'DISCUSSION') {
-          <button
-            mat-flat-button
-            color="primary"
-            type="button"
-            class="session-host__exit-anchor-button session-host__exit-anchor-button--primary"
-            [disabled]="controlPending()"
-            (click)="startSecondRound()"
-          >
-            <mat-icon aria-hidden="true">replay</mat-icon>
-            <span i18n>Zweite Abstimmung</span>
-          </button>
-          <button
-            matButton="tonal"
-            type="button"
-            class="session-host__exit-anchor-button"
-            [disabled]="controlPending()"
-            (click)="nextQuestion()"
-            i18n-aria-label="@@sessionHost.skipDiscussionNextQuestionAria"
-            aria-label="Zur nächsten Frage ohne zweite Abstimmung"
-          >
-            <span i18n="@@sessionHost.skipDiscussionNextQuestion"
-              >Zur nächsten Frage ohne zweite Abstimmung</span
+          <div class="session-host__exit-anchor-action-pair">
+            <button
+              matButton="tonal"
+              type="button"
+              class="session-host__exit-anchor-button"
+              [disabled]="controlPending()"
+              (click)="nextQuestion()"
+              i18n-aria-label="@@sessionHost.skipDiscussionNextQuestionAria"
+              aria-label="Zur nächsten Frage ohne zweite Abstimmung"
             >
-          </button>
+              <span i18n="@@sessionHost.skipDiscussionNextQuestion"
+                >Zur nächsten Frage ohne zweite Abstimmung</span
+              >
+            </button>
+            <button
+              mat-flat-button
+              color="primary"
+              type="button"
+              class="session-host__exit-anchor-button session-host__exit-anchor-button--primary"
+              [disabled]="controlPending()"
+              (click)="startSecondRound()"
+            >
+              <mat-icon aria-hidden="true">replay</mat-icon>
+              <span i18n>Zweite Abstimmung</span>
+            </button>
+          </div>
         }
       </div>
     }

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -4063,6 +4063,8 @@
             class="session-host__exit-anchor-button session-host__exit-anchor-button--primary session-host__exit-anchor-button--reveal-options"
             [disabled]="controlPending()"
             (click)="revealAnswers()"
+            i18n-aria-label="@@sessionHost.revealAnswerOptionsAria"
+            aria-label="Antwortoptionen freigeben"
           >
             <span
               class="session-host__exit-anchor-label session-host__exit-anchor-label--reveal-options-full"
@@ -4098,9 +4100,27 @@
           @if (shouldOfferDiscussionPhase(displayedCurrentQuestionForHost())) {
             <div class="session-host__exit-anchor-action-pair">
               <button
+                mat-flat-button
+                color="primary"
+                type="button"
+                class="session-host__exit-anchor-button session-host__exit-anchor-button--primary"
+                [disabled]="controlPending() || personalTimerBlocksReveal()"
+                [attr.aria-describedby]="
+                  pendingTimerAccommodationCount() > 0
+                    ? 'session-host-timer-accommodation-status'
+                    : null
+                "
+                (click)="startDiscussion()"
+                i18n-aria-label="@@sessionHost.startDiscussionPhaseAria"
+                aria-label="Diskussionsphase starten – Austausch vor zweiter Abstimmung"
+              >
+                <mat-icon aria-hidden="true">groups</mat-icon>
+                <span i18n="@@sessionHost.discussionPhaseButton">Diskussionsphase</span>
+              </button>
+              <button
                 matButton="tonal"
                 type="button"
-                class="session-host__exit-anchor-button"
+                class="session-host__exit-anchor-button session-host__exit-anchor-button--paired-secondary"
                 [disabled]="controlPending() || personalTimerBlocksReveal()"
                 [attr.aria-describedby]="
                   pendingTimerAccommodationCount() > 0
@@ -4120,24 +4140,6 @@
                 } @else {
                   <span i18n="@@sessionHost.revealResults">Ergebnis zeigen</span>
                 }
-              </button>
-              <button
-                mat-flat-button
-                color="primary"
-                type="button"
-                class="session-host__exit-anchor-button session-host__exit-anchor-button--primary"
-                [disabled]="controlPending() || personalTimerBlocksReveal()"
-                [attr.aria-describedby]="
-                  pendingTimerAccommodationCount() > 0
-                    ? 'session-host-timer-accommodation-status'
-                    : null
-                "
-                (click)="startDiscussion()"
-                i18n-aria-label="@@sessionHost.startDiscussionPhaseAria"
-                aria-label="Diskussionsphase starten – Austausch vor zweiter Abstimmung"
-              >
-                <mat-icon aria-hidden="true">groups</mat-icon>
-                <span i18n="@@sessionHost.discussionPhaseButton">Diskussionsphase</span>
               </button>
             </div>
           } @else {
@@ -4180,19 +4182,6 @@
         @if (effectiveStatus() === 'DISCUSSION') {
           <div class="session-host__exit-anchor-action-pair">
             <button
-              matButton="tonal"
-              type="button"
-              class="session-host__exit-anchor-button"
-              [disabled]="controlPending()"
-              (click)="nextQuestion()"
-              i18n-aria-label="@@sessionHost.skipDiscussionNextQuestionAria"
-              aria-label="Zur nächsten Frage ohne zweite Abstimmung"
-            >
-              <span i18n="@@sessionHost.skipDiscussionNextQuestion"
-                >Zur nächsten Frage ohne zweite Abstimmung</span
-              >
-            </button>
-            <button
               mat-flat-button
               color="primary"
               type="button"
@@ -4202,6 +4191,19 @@
             >
               <mat-icon aria-hidden="true">replay</mat-icon>
               <span i18n>Zweite Abstimmung</span>
+            </button>
+            <button
+              matButton="tonal"
+              type="button"
+              class="session-host__exit-anchor-button session-host__exit-anchor-button--paired-secondary"
+              [disabled]="controlPending()"
+              (click)="nextQuestion()"
+              i18n-aria-label="@@sessionHost.skipDiscussionNextQuestionAria"
+              aria-label="Zur nächsten Frage ohne zweite Abstimmung"
+            >
+              <span i18n="@@sessionHost.skipDiscussionNextQuestion"
+                >Zur nächsten Frage ohne zweite Abstimmung</span
+              >
             </button>
           </div>
         }

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.scss
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.scss
@@ -213,6 +213,10 @@
   box-shadow: var(--mat-sys-level2);
 }
 
+.session-host__exit-anchor-action-pair {
+  display: contents;
+}
+
 .session-host__exit-anchor-button--end {
   margin-inline-end: auto;
   border: 1px solid color-mix(in srgb, var(--mat-sys-error) 42%, var(--mat-sys-outline-variant));
@@ -229,7 +233,8 @@
   margin-inline-end: auto;
 }
 
-.session-host__exit-anchor-label--previous-compact {
+.session-host__exit-anchor-label--previous-compact,
+.session-host__exit-anchor-label--reveal-options-compact {
   display: none;
 }
 
@@ -298,6 +303,13 @@
     grid-column: 2;
   }
 
+  .session-host__exit-anchor-action-pair {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
   .session-host__exit-anchor-button--end,
   .session-host__exit-anchor-button--previous {
     margin-inline-end: 0;
@@ -305,12 +317,20 @@
 }
 
 @media (max-width: 599px) and (orientation: portrait) {
-  .session-host__exit-anchor-label--previous-full {
+  .session-host__exit-anchor-button--previous,
+  .session-host__exit-anchor-button--reveal-options {
+    padding-inline: 0.5rem;
+  }
+
+  .session-host__exit-anchor-label--previous-full,
+  .session-host__exit-anchor-label--reveal-options-full {
     display: none;
   }
 
-  .session-host__exit-anchor-label--previous-compact {
+  .session-host__exit-anchor-label--previous-compact,
+  .session-host__exit-anchor-label--reveal-options-compact {
     display: inline;
+    white-space: nowrap;
   }
 }
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.scss
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.scss
@@ -310,6 +310,16 @@
     gap: 0.75rem;
   }
 
+  .session-host__exit-anchor-action-pair > .session-host__exit-anchor-button--paired-secondary {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .session-host__exit-anchor-action-pair > .session-host__exit-anchor-button--primary {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
   .session-host__exit-anchor-button--end,
   .session-host__exit-anchor-button--previous {
     margin-inline-end: 0;
@@ -330,7 +340,9 @@
   .session-host__exit-anchor-label--previous-compact,
   .session-host__exit-anchor-label--reveal-options-compact {
     display: inline;
-    white-space: nowrap;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    hyphens: auto;
   }
 }
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -3366,11 +3366,16 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     expect(buttonTexts).toEqual([
       'Session beenden',
       'skip_nextFrage auslassen',
-      'Ergebnis trotzdem zeigen',
       'Diskussionsphase',
+      'Ergebnis trotzdem zeigen',
     ]);
-    const buttons = Array.from(exitAnchor.querySelectorAll('button'));
-    expect(buttons.at(-1)?.className).toContain('session-host__exit-anchor-button--primary');
+    const actionPairButtons = Array.from(
+      exitAnchor.querySelectorAll('.session-host__exit-anchor-action-pair button'),
+    );
+    expect(actionPairButtons[0]?.className).toContain('session-host__exit-anchor-button--primary');
+    expect(actionPairButtons[1]?.className).toContain(
+      'session-host__exit-anchor-button--paired-secondary',
+    );
     fixture.destroy();
   });
 
@@ -3718,6 +3723,11 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
       exitAnchor.querySelector('.session-host__exit-anchor-label--reveal-options-compact')
         ?.textContent,
     ).toBe('Antwortoptionen');
+    expect(
+      exitAnchor
+        .querySelector('.session-host__exit-anchor-button--reveal-options')
+        ?.getAttribute('aria-label'),
+    ).toBe('Antwortoptionen freigeben');
     expect(el.querySelector('.session-host__answers')).toBeNull();
     fixture.destroy();
   });
@@ -6295,17 +6305,17 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     fixture.destroy();
   });
 
-  it('hält die kompakten Portrait-Labels in allen Übersetzungen kurz und einzeilig', async () => {
+  it('hält die kompakten Portrait-Labels kurz, semantisch und bei Vergrößerung umbrechbar', async () => {
     const { readFileSync } = await import('node:fs');
     const { fileURLToPath } = await import('node:url');
     const { dirname, join } = await import('node:path');
     const componentDir = dirname(fileURLToPath(import.meta.url));
     const styles = readFileSync(join(componentDir, 'session-host.component.scss'), 'utf8');
     const translations = new Map([
-      ['messages.en.xlf', 'Last result'],
-      ['messages.fr.xlf', 'Résultat'],
-      ['messages.es.xlf', 'Resultado'],
-      ['messages.it.xlf', 'Risultato'],
+      ['messages.en.xlf', 'Previous'],
+      ['messages.fr.xlf', 'Précédent'],
+      ['messages.es.xlf', 'Anterior'],
+      ['messages.it.xlf', 'Precedente'],
     ]);
     const revealTranslations = new Map([
       ['messages.en.xlf', 'Options'],
@@ -6313,9 +6323,21 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
       ['messages.es.xlf', 'Opciones'],
       ['messages.it.xlf', 'Opzioni'],
     ]);
+    const revealAriaTranslations = new Map([
+      ['messages.en.xlf', 'Reveal answer options'],
+      ['messages.fr.xlf', 'Afficher les options de réponse'],
+      ['messages.es.xlf', 'Mostrar opciones de respuesta'],
+      ['messages.it.xlf', 'Mostra opzioni di risposta'],
+    ]);
 
     expect(styles).toMatch(
-      /session-host__exit-anchor-label--previous-compact,\s*\.session-host__exit-anchor-label--reveal-options-compact\s*\{[\s\S]*?white-space:\s*nowrap/,
+      /@media \(max-width: 599px\) and \(orientation: portrait\)[\s\S]*?session-host__exit-anchor-label--previous-compact,\s*\.session-host__exit-anchor-label--reveal-options-compact\s*\{[^}]*white-space:\s*normal[^}]*overflow-wrap:\s*anywhere[^}]*hyphens:\s*auto/,
+    );
+    expect(styles).toMatch(
+      /session-host__exit-anchor-action-pair\s*>\s*\.session-host__exit-anchor-button--paired-secondary\s*\{[^}]*grid-column:\s*1[^}]*grid-row:\s*1/,
+    );
+    expect(styles).toMatch(
+      /session-host__exit-anchor-action-pair\s*>\s*\.session-host__exit-anchor-button--primary\s*\{[^}]*grid-column:\s*2[^}]*grid-row:\s*1/,
     );
 
     for (const [fileName, expectedLabel] of translations) {
@@ -6338,6 +6360,16 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
       expect(unitStart).toBeGreaterThanOrEqual(0);
       expect(unit).toContain(`<target>${expectedLabel}</target>`);
       expect(expectedLabel.length).toBeLessThanOrEqual(8);
+    }
+
+    for (const [fileName, expectedLabel] of revealAriaTranslations) {
+      const catalog = readFileSync(join(componentDir, '../../../../locale', fileName), 'utf8');
+      const unitStart = catalog.indexOf('<trans-unit id="sessionHost.revealAnswerOptionsAria"');
+      const unitEnd = catalog.indexOf('</trans-unit>', unitStart);
+      const unit = catalog.slice(unitStart, unitEnd);
+
+      expect(unitStart).toBeGreaterThanOrEqual(0);
+      expect(unit).toContain(`<target>${expectedLabel}</target>`);
     }
   });
 
@@ -6451,11 +6483,16 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     expect(exitAnchor.className).toContain('session-host__exit-anchor--with-primary');
     expect(buttonTexts).toEqual([
       'Session beenden',
-      'Zur nächsten Frage ohne zweite Abstimmung',
       'Zweite Abstimmung',
+      'Zur nächsten Frage ohne zweite Abstimmung',
     ]);
-    const buttons = Array.from(exitAnchor.querySelectorAll('button'));
-    expect(buttons.at(-1)?.className).toContain('session-host__exit-anchor-button--primary');
+    const actionPairButtons = Array.from(
+      exitAnchor.querySelectorAll('.session-host__exit-anchor-action-pair button'),
+    );
+    expect(actionPairButtons[0]?.className).toContain('session-host__exit-anchor-button--primary');
+    expect(actionPairButtons[1]?.className).toContain(
+      'session-host__exit-anchor-button--paired-secondary',
+    );
     fixture.destroy();
   });
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -3366,9 +3366,11 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     expect(buttonTexts).toEqual([
       'Session beenden',
       'skip_nextFrage auslassen',
-      'Diskussionsphase',
       'Ergebnis trotzdem zeigen',
+      'Diskussionsphase',
     ]);
+    const buttons = Array.from(exitAnchor.querySelectorAll('button'));
+    expect(buttons.at(-1)?.className).toContain('session-host__exit-anchor-button--primary');
     fixture.destroy();
   });
 
@@ -3710,8 +3712,12 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     expect(buttonTexts).toEqual([
       'Session beenden',
       'skip_nextFrage auslassen',
-      'Antwortoptionen freigeben',
+      'Antwortoptionen freigebenAntwortoptionen',
     ]);
+    expect(
+      exitAnchor.querySelector('.session-host__exit-anchor-label--reveal-options-compact')
+        ?.textContent,
+    ).toBe('Antwortoptionen');
     expect(el.querySelector('.session-host__answers')).toBeNull();
     fixture.destroy();
   });
@@ -6289,6 +6295,52 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     fixture.destroy();
   });
 
+  it('hält die kompakten Portrait-Labels in allen Übersetzungen kurz und einzeilig', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, join } = await import('node:path');
+    const componentDir = dirname(fileURLToPath(import.meta.url));
+    const styles = readFileSync(join(componentDir, 'session-host.component.scss'), 'utf8');
+    const translations = new Map([
+      ['messages.en.xlf', 'Last result'],
+      ['messages.fr.xlf', 'Résultat'],
+      ['messages.es.xlf', 'Resultado'],
+      ['messages.it.xlf', 'Risultato'],
+    ]);
+    const revealTranslations = new Map([
+      ['messages.en.xlf', 'Options'],
+      ['messages.fr.xlf', 'Réponses'],
+      ['messages.es.xlf', 'Opciones'],
+      ['messages.it.xlf', 'Opzioni'],
+    ]);
+
+    expect(styles).toMatch(
+      /session-host__exit-anchor-label--previous-compact,\s*\.session-host__exit-anchor-label--reveal-options-compact\s*\{[\s\S]*?white-space:\s*nowrap/,
+    );
+
+    for (const [fileName, expectedLabel] of translations) {
+      const catalog = readFileSync(join(componentDir, '../../../../locale', fileName), 'utf8');
+      const unitStart = catalog.indexOf('<trans-unit id="sessionHost.prevQuestionAnchorCompact"');
+      const unitEnd = catalog.indexOf('</trans-unit>', unitStart);
+      const unit = catalog.slice(unitStart, unitEnd);
+
+      expect(unitStart).toBeGreaterThanOrEqual(0);
+      expect(unit).toContain(`<target>${expectedLabel}</target>`);
+      expect(expectedLabel.length).toBeLessThanOrEqual(11);
+    }
+
+    for (const [fileName, expectedLabel] of revealTranslations) {
+      const catalog = readFileSync(join(componentDir, '../../../../locale', fileName), 'utf8');
+      const unitStart = catalog.indexOf('<trans-unit id="sessionHost.revealAnswerOptionsCompact"');
+      const unitEnd = catalog.indexOf('</trans-unit>', unitStart);
+      const unit = catalog.slice(unitStart, unitEnd);
+
+      expect(unitStart).toBeGreaterThanOrEqual(0);
+      expect(unit).toContain(`<target>${expectedLabel}</target>`);
+      expect(expectedLabel.length).toBeLessThanOrEqual(8);
+    }
+  });
+
   it('leitet Wheel- und Touch-Scrollen über den Exit-Buttons an den Hauptinhalt weiter', () => {
     const fixture = setup();
     const main = document.createElement('main');
@@ -6297,6 +6349,7 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     document.body.append(main);
 
     const wheelPreventDefault = vi.fn();
+    const zoomPreventDefault = vi.fn();
     const shortTouchPreventDefault = vi.fn();
     const scrollTouchPreventDefault = vi.fn();
 
@@ -6306,6 +6359,14 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
         deltaMode: 1,
         cancelable: true,
         preventDefault: wheelPreventDefault,
+      } as unknown as WheelEvent);
+
+      fixture.componentInstance.onExitAnchorWheel({
+        ctrlKey: true,
+        deltaY: 100,
+        deltaMode: 0,
+        cancelable: true,
+        preventDefault: zoomPreventDefault,
       } as unknown as WheelEvent);
 
       fixture.componentInstance.onExitAnchorTouchStart({
@@ -6325,6 +6386,7 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
 
       expect(main.scrollTop).toBe(152);
       expect(wheelPreventDefault).toHaveBeenCalledOnce();
+      expect(zoomPreventDefault).not.toHaveBeenCalled();
       expect(shortTouchPreventDefault).not.toHaveBeenCalled();
       expect(scrollTouchPreventDefault).toHaveBeenCalledOnce();
     } finally {
@@ -6389,9 +6451,11 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     expect(exitAnchor.className).toContain('session-host__exit-anchor--with-primary');
     expect(buttonTexts).toEqual([
       'Session beenden',
-      'Zweite Abstimmung',
       'Zur nächsten Frage ohne zweite Abstimmung',
+      'Zweite Abstimmung',
     ]);
+    const buttons = Array.from(exitAnchor.querySelectorAll('button'));
+    expect(buttons.at(-1)?.className).toContain('session-host__exit-anchor-button--primary');
     fixture.destroy();
   });
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -2675,6 +2675,10 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   }
 
   onExitAnchorWheel(event: WheelEvent): void {
+    if (event.ctrlKey) {
+      return;
+    }
+
     const scrollContainer = this.document.getElementById('main-content');
     if (!scrollContainer || event.deltaY === 0) {
       return;

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -15180,6 +15180,14 @@
           <context context-type="linenumber">3998</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsAria" datatype="html">
+        <source>Antwortoptionen freigeben</source>
+        <target>Reveal answer options</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4067</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
         <source>Antwortoptionen</source>
         <target>Options</target>
@@ -15282,7 +15290,7 @@
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchorCompact" datatype="html">
         <source>Letztes Ergebnis</source>
-        <target>Last result</target>
+        <target>Previous</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4018</context>

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -15180,6 +15180,14 @@
           <context context-type="linenumber">3998</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
+        <source>Antwortoptionen</source>
+        <target>Options</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4075</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
         <source>Diskussionsphase starten – Austausch vor zweiter Abstimmung</source>
         <target>Start discussion phase—talk it over before round 2</target>
@@ -15274,7 +15282,7 @@
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchorCompact" datatype="html">
         <source>Letztes Ergebnis</source>
-        <target>Previous result</target>
+        <target>Last result</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4018</context>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -15123,6 +15123,14 @@
           <context context-type="linenumber">3998</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsAria" datatype="html">
+        <source>Antwortoptionen freigeben</source>
+        <target>Mostrar opciones de respuesta</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4067</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
         <source>Antwortoptionen</source>
         <target>Opciones</target>
@@ -15225,7 +15233,7 @@
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchorCompact" datatype="html">
         <source>Letztes Ergebnis</source>
-        <target>Resultado</target>
+        <target>Anterior</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4018</context>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -15123,6 +15123,14 @@
           <context context-type="linenumber">3998</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
+        <source>Antwortoptionen</source>
+        <target>Opciones</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4075</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
         <source>Diskussionsphase starten – Austausch vor zweiter Abstimmung</source>
         <target>Iniciar fase de discusión: intercambio antes de la segunda votación</target>
@@ -15217,7 +15225,7 @@
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchorCompact" datatype="html">
         <source>Letztes Ergebnis</source>
-        <target>Resultado anterior</target>
+        <target>Resultado</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4018</context>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -15123,6 +15123,14 @@
           <context context-type="linenumber">3998</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsAria" datatype="html">
+        <source>Antwortoptionen freigeben</source>
+        <target>Afficher les options de réponse</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4067</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
         <source>Antwortoptionen</source>
         <target>Réponses</target>
@@ -15225,7 +15233,7 @@
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchorCompact" datatype="html">
         <source>Letztes Ergebnis</source>
-        <target>Résultat</target>
+        <target>Précédent</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4018</context>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -15123,6 +15123,14 @@
           <context context-type="linenumber">3998</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
+        <source>Antwortoptionen</source>
+        <target>Réponses</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4075</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
         <source>Diskussionsphase starten – Austausch vor zweiter Abstimmung</source>
         <target>Démarrer la phase de discussion – échanger avant le deuxième vote</target>
@@ -15217,7 +15225,7 @@
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchorCompact" datatype="html">
         <source>Letztes Ergebnis</source>
-        <target>Résultat précédent</target>
+        <target>Résultat</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4018</context>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -15123,6 +15123,14 @@
           <context context-type="linenumber">3998</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
+        <source>Antwortoptionen</source>
+        <target>Opzioni</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4075</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
         <source>Diskussionsphase starten – Austausch vor zweiter Abstimmung</source>
         <target>Avvia la fase di discussione – confronto prima della seconda votazione</target>
@@ -15217,7 +15225,7 @@
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchorCompact" datatype="html">
         <source>Letztes Ergebnis</source>
-        <target>Risultato precedente</target>
+        <target>Risultato</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4018</context>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -15123,6 +15123,14 @@
           <context context-type="linenumber">3998</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsAria" datatype="html">
+        <source>Antwortoptionen freigeben</source>
+        <target>Mostra opzioni di risposta</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4067</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
         <source>Antwortoptionen</source>
         <target>Opzioni</target>
@@ -15225,7 +15233,7 @@
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionAnchorCompact" datatype="html">
         <source>Letztes Ergebnis</source>
-        <target>Risultato</target>
+        <target>Precedente</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4018</context>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -13437,6 +13437,13 @@
           <context context-type="linenumber">4025</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsAria" datatype="html">
+        <source>Antwortoptionen freigeben</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4067</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
         <source>Antwortoptionen</source>
         <context-group purpose="location">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -13437,6 +13437,13 @@
           <context context-type="linenumber">4025</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.revealAnswerOptionsCompact" datatype="html">
+        <source>Antwortoptionen</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4075</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.startDiscussionPhaseAria" datatype="html">
         <source>Diskussionsphase starten – Austausch vor zweiter Abstimmung</source>
         <context-group purpose="location">


### PR DESCRIPTION
## Zusammenfassung

Follow-up zu #260 und den dortigen Post-Merge-Review-Hinweisen.

- **Problem:** Modifier-gestütztes Wheel-Zoomen wurde im Host-Footer unterdrückt, gekoppelte mobile Aktionen belegten unnötige Grid-Zeilen, kompakte Portrait-Labels konnten bei Textvergrößerung abgeschnitten werden und der Startseiten-Preset-Schalter reagierte nur auf eine feste Viewport-Grenze statt auf seine tatsächliche Inhaltsbreite. Außerdem verloren verkürzte Ergebnis-Übersetzungen teilweise die Bedeutung „vorheriges“ und das kurze Antwortoptions-Label benannte für Screenreader keine Aktion.
- **Lösung:** Ctrl-Wheel bleibt beim Browser, gekoppelte Host-Aktionen erhalten mobil eine gemeinsame Grid-Zeile mit CTA rechts und behalten im Desktop ihre ursprüngliche DOM-/Tastaturreihenfolge. Portrait-Labels bleiben bei normaler Breite kompakt, dürfen bei Textvergrößerung umbrechen und erhalten vollständige lokalisierte Accessibility-Namen. Der Preset-Schalter bricht anhand intrinsischer Inhaltsbreiten um.
- **Bewusste Nicht-Ziele:** Keine Änderung an Session-Statuslogik, Berechtigungen, APIs, Desktop-Wording oder der sichtbaren Desktop-Anordnung.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Die bestehende Host-Gestaltung, Material-3-Aktionshierarchie und WCAG-2.2-AA-Anforderungen bleiben maßgeblich. „Session beenden“ bleibt sichtbar, der CTA steht mobil rechts, normales Scrollen funktioniert über der Action-Bar, Browser-Zoom wird nicht abgefangen und vergrößerter Text darf weder abgeschnitten werden noch benachbarte Aktionen überlagern. Desktop-Reihenfolge und Tastaturabfolge bleiben unverändert. Die Session-Zustands- und Berechtigungslogik bleibt unangetastet.

**Betroffene externe Verträge:**

Browser-`WheelEvent` (`ctrlKey` bei Modifier-gestützten Zoom-Gesten) sowie CSS-Intrinsic-Sizing und Reflow; keine Netzwerk- oder API-Verträge.

## Implementierung

- Ctrl-Wheel kehrt vor Scroll-Weiterleitung und `preventDefault()` zurück.
- Peer-Instruction- und Diskussionsaktionen werden als sekundär/primär-Paar gruppiert. Im Desktop bleiben primäre und sekundäre Aktion in der ursprünglichen DOM-Reihenfolge; nur das mobile Grid platziert die sekundäre Aktion links und den CTA rechts.
- Die kompakten Ergebnis- und Antwortoptions-Labels bleiben auf Portrait-Mobilgeräten kurz, dürfen bei Textvergrößerung aber umbrechen beziehungsweise getrennt werden, statt zu clippen oder zu überlappen.
- „Antwortoptionen“ erhält einen vollständigen, in `de`, `en`, `fr`, `es` und `it` lokalisierten Accessibility-Namen. Die kompakten Ergebnis-Übersetzungen behalten jeweils die Bedeutung „vorheriges“.
- Der mobile Startseiten-Preset-Schalter verwendet `flex-wrap` mit intrinsischer Mindestbreite; die Labels selbst bleiben ungebrochen, während bei Platzmangel der vollständige Button in die nächste Zeile wechselt.
- Regressionstests decken Zoom-Weiterleitung, Desktop-DOM-Reihenfolge, mobile Grid-Platzierung, Accessibility-Namen, Übersetzungen und inhaltsabhängigen Reflow ab.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [ ] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [x] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` (Commit-Hook) | Erfolgreich: Shared Types, Export-Report, Backend und Frontend |
| `npm test` (Commit-Hook) | Erfolgreich: Shared Types 47, Export-Report 81, Backend 886 und Frontend 1.230 Tests bestanden; 13 bestehende Backend-Skips |
| `npm run test -w @arsnova/frontend -- src/app/features/home/home.component.spec.ts src/app/features/session/session-host/session-host.component.spec.ts` | Erfolgreich: 256 Tests |
| `npm run check:i18n -w @arsnova/frontend` | Erfolgreich: 2.613/2.613 Einheiten je Locale |
| `npm run lint` | Erfolgreich: ESLint und Script-Lint ohne Fehler oder Warnungen |
| `npm run build:prod` | Erfolgreich: Shared Types, Backend, lokalisierter Browser-Build, SSR, Prerendering und MOTD-Asset-Prüfung für fünf Locales |
| `npm run check:viewport -w @arsnova/frontend` | Erfolgreich: 49 responsive Zustände, Desktop-Join und Footer-Breakpoints; Reflow, Fokus und 24-px-Ziele |
| `npm run format:check:changed`; `git diff --check` | Erfolgreich |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Ausschließlich responsive Host- und Startseiten-Darstellung, Scroll-/Zoom-Interaktion sowie Portrait-Kurztexte und Accessibility-Namen; keine Daten- oder Protokolländerung.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine; regulärer Frontend-Deploy genügt.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Logs oder Metriken erforderlich; das Verhalten ist direkt im gerenderten DOM messbar.
- **Rollback:** Die Commits `cc17d3c4` und `6f09f0a4` revertieren und regulär deployen.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Reale Browsermessung bei 320 × 800 px: Der deutsche Preset-Schalter bleibt bei normaler Schrift einzeilig und ungeclippt (`scrollWidth <= clientWidth`). Bei testweise verdoppelter Schrift wechseln beide vollständigen Buttons in getrennte Zeilen; ihre Labels bleiben weiterhin ungeclippt. Die temporäre Prüfregel wurde entfernt und der finale Normalzustand erneut gemessen.
- Der projektinterne Viewport-Check bestätigt Reflow, sichtbaren Tastaturfokus und Mindestzielgrößen in 49 Zuständen über alle fünf Locales sowie bei Footer-Breakpoints von 320 bis 1.280 px.
- Unit-Regressionen prüfen Ctrl-Wheel ohne `preventDefault()`, die Desktop-DOM-Reihenfolge, die mobile CTA-Platzierung, den vollständigen Accessibility-Namen und semantisch korrekte kompakte Labels in allen fünf Locales.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Ablehnungs-/Fehlerpfade, Retry, Reconnect, Migration, Parallelität, Realtime, Datenbank, Last und Sicherheitsgrenzen sind nicht betroffen, weil ausschließlich vorhandene synchrone UI-Aktionen, Styles und Übersetzungen angepasst werden.
- **Verbleibende Risiken:** Bei ungewöhnlichen Schriftmetriken kann ein kompaktes Label früher als in den geprüften Browser-/Viewport-Kombinationen umbrechen. Dieser Umbruch ist nun ausdrücklich zulässig und vergrößert den Button, statt Text zu clippen oder andere Aktionen zu überlagern.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
