### PR TITLE
Standalone-Blitzlicht an MD3-Aktionsleiste angleichen

### DIFF
--- a/apps/frontend/src/app/features/feedback/feedback-host.component.html
+++ b/apps/frontend/src/app/features/feedback/feedback-host.component.html
@@ -831,9 +831,16 @@
       </section>
     </div>
     @if (showStandaloneBottomActionBar()) {
-      <div class="feedback-host__bottom-actions">
+      <div
+        class="feedback-host__bottom-actions"
+        (wheel)="onBottomActionsWheel($event)"
+        (touchstart)="onBottomActionsTouchStart($event)"
+        (touchmove)="onBottomActionsTouchMove($event)"
+        (touchend)="onBottomActionsTouchEnd()"
+        (touchcancel)="onBottomActionsTouchEnd()"
+      >
         <button
-          mat-button
+          matButton="tonal"
           type="button"
           class="feedback-host__bottom-action-secondary"
           (click)="endSession()"

--- a/apps/frontend/src/app/features/feedback/feedback-host.component.scss
+++ b/apps/frontend/src/app/features/feedback/feedback-host.component.scss
@@ -1072,42 +1072,46 @@
 .feedback-host__bottom-actions {
   position: fixed;
   left: 50%;
-  bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem);
-  transform: translateX(-50%);
-  z-index: 30;
-  width: min(36rem, calc(100vw - (var(--app-live-channel-inline) * 2)));
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.65rem;
-  padding: 0.75rem 0.85rem 0.7rem;
-  border: 1px solid color-mix(in srgb, var(--mat-sys-outline-variant) 90%, transparent);
-  border-radius: var(--mat-sys-corner-large);
-  background: color-mix(
-    in srgb,
-    var(--mat-sys-surface-container-highest) 92%,
-    var(--mat-sys-surface)
+  bottom: calc(
+    max(0.75rem, calc(env(safe-area-inset-bottom, 0px) + 0.5rem)) +
+      var(--app-footer-visible-offset, 0px)
   );
-  box-shadow:
-    var(--mat-sys-level1),
-    inset 0 1px 0 color-mix(in srgb, var(--mat-sys-on-surface) 4%, transparent);
+  transform: translateX(-50%);
+  z-index: 40;
+  width: min(var(--app-toolbar-max-width), calc(100vw - (var(--app-live-channel-inline) * 2)));
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  pointer-events: none;
   box-sizing: border-box;
 }
 
+.feedback-host__bottom-action-secondary,
 .feedback-host__bottom-action-primary {
-  flex: 1 1 auto;
-  min-height: 3rem;
-  padding-inline: 1.5rem;
+  flex: 0 0 auto;
+  max-width: 100%;
+  font-weight: 600;
+  pointer-events: auto;
+  touch-action: pinch-zoom;
+  box-shadow: var(--mat-sys-level2);
 }
 
-.feedback-host__bottom-actions .mat-mdc-button-base {
-  white-space: nowrap;
+.feedback-host__bottom-action-secondary {
+  margin-inline-end: auto;
 }
 
-@supports (backdrop-filter: blur(10px)) {
-  .feedback-host__bottom-actions {
-    backdrop-filter: blur(8px);
-  }
+.feedback-host__bottom-action-secondary.mat-tonal-button:not(:disabled) {
+  border: 1px solid color-mix(in srgb, var(--mat-sys-error) 42%, var(--mat-sys-outline-variant));
+  background: color-mix(in srgb, var(--mat-sys-error-container) 72%, var(--mat-sys-surface));
+  color: var(--mat-sys-on-error-container);
+}
+
+.feedback-host__bottom-actions .mdc-button__label {
+  white-space: normal;
+  text-align: center;
+  line-height: 1.2;
 }
 
 @media (min-width: 960px) {
@@ -1303,17 +1307,33 @@
   .feedback-host__tempo-view-toggle {
     width: 100%;
   }
+}
 
+@media (max-width: 599px) {
   .feedback-host__bottom-actions {
-    left: 1rem;
-    right: 1rem;
+    left: var(--host-mobile-inline);
+    right: var(--host-mobile-inline);
+    bottom: calc(
+      max(0.5rem, calc(var(--host-mobile-safe-bottom) + 0.25rem)) +
+        var(--app-footer-visible-offset, 0px)
+    );
     width: auto;
     transform: none;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .feedback-host__bottom-action-secondary,
+  .feedback-host__bottom-action-primary {
+    width: 100%;
+  }
+
+  .feedback-host__bottom-action-secondary {
+    margin-inline-end: 0;
   }
 
   .feedback-host__bottom-action-primary {
-    width: 100%;
+    grid-column: 2;
   }
 }
 

--- a/apps/frontend/src/app/features/feedback/feedback-host.component.spec.ts
+++ b/apps/frontend/src/app/features/feedback/feedback-host.component.spec.ts
@@ -423,6 +423,72 @@ describe('FeedbackHostComponent', () => {
     expect(bottomActions?.textContent).toContain('Session beenden');
   });
 
+  it('leitet Wheel- und Touch-Scrollen über den Standalone-Aktionen an den Hauptinhalt weiter', () => {
+    const fixture = TestBed.createComponent(FeedbackHostComponent);
+    const main = document.createElement('main');
+    main.id = 'main-content';
+    main.scrollTop = 100;
+    document.body.append(main);
+
+    const wheelPreventDefault = vi.fn();
+    const zoomPreventDefault = vi.fn();
+    const shortTouchPreventDefault = vi.fn();
+    const scrollTouchPreventDefault = vi.fn();
+
+    try {
+      fixture.componentInstance.onBottomActionsWheel({
+        deltaY: 2,
+        deltaMode: 1,
+        cancelable: true,
+        preventDefault: wheelPreventDefault,
+      } as unknown as WheelEvent);
+
+      fixture.componentInstance.onBottomActionsWheel({
+        ctrlKey: true,
+        deltaY: 100,
+        deltaMode: 0,
+        cancelable: true,
+        preventDefault: zoomPreventDefault,
+      } as unknown as WheelEvent);
+
+      fixture.componentInstance.onBottomActionsTouchStart({
+        touches: [{ clientY: 300 }],
+      } as unknown as TouchEvent);
+      fixture.componentInstance.onBottomActionsTouchMove({
+        touches: [{ clientY: 296 }],
+        cancelable: true,
+        preventDefault: shortTouchPreventDefault,
+      } as unknown as TouchEvent);
+      fixture.componentInstance.onBottomActionsTouchMove({
+        touches: [{ clientY: 280 }],
+        cancelable: true,
+        preventDefault: scrollTouchPreventDefault,
+      } as unknown as TouchEvent);
+      fixture.componentInstance.onBottomActionsTouchEnd();
+
+      expect(main.scrollTop).toBe(152);
+      expect(wheelPreventDefault).toHaveBeenCalledOnce();
+      expect(zoomPreventDefault).not.toHaveBeenCalled();
+      expect(shortTouchPreventDefault).not.toHaveBeenCalled();
+      expect(scrollTouchPreventDefault).toHaveBeenCalledOnce();
+    } finally {
+      main.remove();
+      fixture.destroy();
+    }
+  });
+
+  it('priorisiert die destruktiven MD3-Farben vor nachgeladenen Tonal-Button-Stilen', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, join } = await import('node:path');
+    const componentDir = dirname(fileURLToPath(import.meta.url));
+    const styles = readFileSync(join(componentDir, 'feedback-host.component.scss'), 'utf8');
+
+    expect(styles).toMatch(
+      /\.feedback-host__bottom-action-secondary\.mat-tonal-button:not\(:disabled\)\s*\{[^}]*background:[^}]*--mat-sys-error-container[^}]*color:\s*var\(--mat-sys-on-error-container\)/,
+    );
+  });
+
   it('rendert im eingebetteten Session-Host keine eigene Bottom-Leiste mit "Session beenden"', () => {
     window.history.replaceState({}, '', '/session/ABC123/host');
     const fixture = TestBed.createComponent(FeedbackHostComponent);

--- a/apps/frontend/src/app/features/feedback/feedback-host.component.ts
+++ b/apps/frontend/src/app/features/feedback/feedback-host.component.ts
@@ -49,6 +49,7 @@ import type { Unsubscribable } from '@trpc/server/observable';
 
 type StarAverageIcon = 'star' | 'star_half' | 'star_border';
 type TempoViewMode = 'details' | 'trend';
+const BOTTOM_ACTIONS_TOUCH_SCROLL_THRESHOLD_PX = 6;
 
 interface StarAverageSummary {
   scoreLabel: string;
@@ -105,6 +106,9 @@ export class FeedbackHostComponent implements OnInit, OnDestroy {
   readonly feedbackJoinPopoverOpen = signal(false);
   private feedbackJoinFocusReturn: HTMLElement | null = null;
   private tempoHelpFocusReturn: HTMLElement | null = null;
+  private bottomActionsTouchStartY: number | null = null;
+  private bottomActionsTouchLastY: number | null = null;
+  private bottomActionsTouchScrolling = false;
   readonly showEmbeddedEmptyState = computed(
     () => this.embeddedInSession() && this.result() === null,
   );
@@ -447,6 +451,73 @@ export class FeedbackHostComponent implements OnInit, OnDestroy {
       default:
         return this.locked() ? 'play_arrow' : 'stop';
     }
+  }
+
+  onBottomActionsWheel(event: WheelEvent): void {
+    if (event.ctrlKey) {
+      return;
+    }
+
+    const scrollContainer = this.document.getElementById('main-content');
+    if (!scrollContainer || event.deltaY === 0) {
+      return;
+    }
+    const deltaScale =
+      event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? scrollContainer.clientHeight : 1;
+    scrollContainer.scrollTop += event.deltaY * deltaScale;
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+  }
+
+  onBottomActionsTouchStart(event: TouchEvent): void {
+    const touch = event.touches[0];
+    if (event.touches.length !== 1 || !touch) {
+      this.resetBottomActionsTouchScroll();
+      return;
+    }
+    this.bottomActionsTouchStartY = touch.clientY;
+    this.bottomActionsTouchLastY = touch.clientY;
+    this.bottomActionsTouchScrolling = false;
+  }
+
+  onBottomActionsTouchMove(event: TouchEvent): void {
+    const touch = event.touches[0];
+    const scrollContainer = this.document.getElementById('main-content');
+    if (
+      event.touches.length !== 1 ||
+      !touch ||
+      !scrollContainer ||
+      this.bottomActionsTouchStartY === null ||
+      this.bottomActionsTouchLastY === null
+    ) {
+      return;
+    }
+
+    if (
+      !this.bottomActionsTouchScrolling &&
+      Math.abs(touch.clientY - this.bottomActionsTouchStartY) <
+        BOTTOM_ACTIONS_TOUCH_SCROLL_THRESHOLD_PX
+    ) {
+      return;
+    }
+
+    this.bottomActionsTouchScrolling = true;
+    scrollContainer.scrollTop += this.bottomActionsTouchLastY - touch.clientY;
+    this.bottomActionsTouchLastY = touch.clientY;
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+  }
+
+  onBottomActionsTouchEnd(): void {
+    this.resetBottomActionsTouchScroll();
+  }
+
+  private resetBottomActionsTouchScroll(): void {
+    this.bottomActionsTouchStartY = null;
+    this.bottomActionsTouchLastY = null;
+    this.bottomActionsTouchScrolling = false;
   }
 
   async runStandalonePrimaryAction(): Promise<void> {


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Das Standalone-Blitzlicht verwendete noch die alte, eingefasste Aktionsleiste. Sie wich in Breite, Hierarchie, Mobile-Reflow, Scrollverhalten und destruktiver Farbgebung vom Livekanal ab.
- **Lösung:** Die Leiste übernimmt das bestehende MD3-Muster des Session-Hosts: sichtbarer Exit links, primärer CTA rechts, zweispaltiger Portrait-Reflow und Scroll-Weiterleitung über Buttons. Eine spezifische Tonal-Button-Regel hält die Exit-Farben auch bei der Lazy-Load-Cascade identisch zum Livekanal.
- **Bewusste Nicht-Ziele:** Keine Änderung der Aktionen selbst, der eingebetteten Blitzlicht-Ansicht, von Texten/Übersetzungen, APIs oder Backend-Verhalten.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Maßgeblich ist die bestehende `session-host__exit-anchor`-Implementierung. „Session beenden“ bleibt auf Desktop und Mobile sichtbar, der primäre CTA liegt am rechten Rand, Gesten über der fixierten Leiste scrollen weiterhin `#main-content`, und Pinch-Zoom beziehungsweise Ctrl-Wheel bleiben erhalten.

**Betroffene externe Verträge:**

Keine Netzwerk- oder Datenverträge. Verwendet werden bestehende Browser-`WheelEvent`-/`TouchEvent`-Semantiken und Angular-Material-Buttonklassen.

## Implementierung

- Alte 36-rem-Panel-Leiste durch eine transparente, 56-rem-breite MD3-Aktionsanordnung analog zum Session-Host ersetzt.
- Desktop: Exit links, intrinsisch breiter Filled-CTA rechts; Mobile Portrait: zwei gleich breite Spalten mit CTA in der rechten Spalte.
- Freien Leistenraum per `pointer-events: none` durchlässig gemacht und Wheel-/Touch-Gesten auf Buttons an `#main-content` weitergeleitet.
- Destruktive Tonal-Farben mit ausreichend spezifischem Selektor gegen nachgeladene Material-Stile abgesichert.
- Regressionstests für Scroll-Weiterleitung, Zoom-/Touch-Schwellenwert und die Lazy-Load-Farbkaskade ergänzt.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [x] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run lint` | Erfolgreich, einschließlich Script-Lint-Gate |
| `npm run typecheck` | Erfolgreich im Commit-Hook für Shared Types, Report, Backend und Frontend |
| `npm test` | Erfolgreich im Commit-Hook |
| `npm run test -w @arsnova/frontend` | 85 Testdateien, 1.232 Tests erfolgreich |
| `npm run test -w @arsnova/frontend -- --run src/app/features/feedback/feedback-host.component.spec.ts` | 20 Tests erfolgreich |
| `npm run typecheck -w @arsnova/frontend` | Erfolgreich |
| `npm run build:prod` | Erfolgreich für Shared Types, Backend und lokalisiertes Frontend |
| `npm run build:prod -w @arsnova/frontend` | Erfolgreich; fünf Locales und MOTD-Asset-Check |
| Manueller Browsercheck, 1280×720 und 390×844 | Desktop-/Portrait-Reflow, Scroll-over auf CTA und freiem Leistenraum erfolgreich; keine Console-Warnungen/-Fehler |
| MD3-Farbvergleich, Dark und Light | Berechnete Hintergrund-, Text- und Rahmenfarben des Exit-Buttons in Standalone und Livekanal exakt identisch |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Rein visuelle und interaktive Änderung der fixierten Standalone-Blitzlicht-Aktionsleiste.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Logs oder Metriken; Browser-Konsole im manuellen Test ohne Warnungen/Fehler.
- **Rollback:** Commit `5870aab8` revertieren.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Gezielter Regressionstest und vollständige Frontend-Suite lokal erfolgreich.
- Browsermessung: Desktop-Leiste 896 px breit; Mobile Portrait zwei Spalten à 177 px, CTA rechts.
- Scrollmessung: Scrollen über CTA und freien Leistenraum verändert `#main-content`; Ctrl-Wheel wird nicht abgefangen.
- Computed-Style-Vergleich: Exit-Button in Dark und Light jeweils identisch zum Livekanal.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Reconnect, Migration, Parallelität, Backend-/Realtime-Ausfälle und asynchrone Pending-/Fehlerzustände sind nicht betroffen. Es werden keine Elemente ersetzt und keine Fokusziele programmgesteuert verschoben.
- **Verbleibende Risiken:** Das reale Touch-Scrollgefühl wurde nicht auf physischer iOS-Hardware geprüft; der Touchpfad ist durch Unit-Tests abgedeckt und folgt der bereits produktiv verwendeten Session-Host-Implementierung.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft