### PR TITLE
Skip-Link- und MOTD-Fokus korrekt zurückführen

### DIFF
--- a/.github/required-checks.json
+++ b/.github/required-checks.json
@@ -146,7 +146,7 @@
     {
       "context": "Playwright Smoke E2E",
       "ruleset": "CI-CD",
-      "purpose": "End-to-End-, axe-, Reflow- und Fokus-Smokes.",
+      "purpose": "Chromium-Axe-/Reflow-Smokes und WebKit-MOTD-/Fokus-Regressionen.",
       "source": {
         "type": "workflow",
         "producers": [{ "workflow": ".github/workflows/ci.yml", "job": "e2e" }]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -935,8 +935,8 @@ jobs:
           retention-days: 7
 
   # ─── End-to-End Tests (Playwright Smoke) ────────────────────────────────────
-  e2e:
-    name: Playwright Smoke E2E
+  e2e-chromium:
+    name: Chromium Smoke E2E
     runs-on: ubuntu-latest
     needs: [changes, build]
     if: github.event_name != 'schedule'
@@ -1101,6 +1101,184 @@ jobs:
             ${{ runner.temp }}/browser-smokes
           if-no-files-found: ignore
           retention-days: 7
+
+  # ─── WebKit Safari Focus Regression ───────────────────────────────────────
+  webkit-e2e:
+    name: WebKit MOTD & Tab E2E
+    runs-on: ubuntu-latest
+    needs: [changes, build]
+    if: github.event_name != 'schedule'
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: arsnova_user
+          POSTGRES_PASSWORD: secretpassword
+          POSTGRES_DB: arsnova_v3_dev
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U arsnova_user -d arsnova_v3_dev"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DB_USER: arsnova_user
+      DB_PASSWORD: secretpassword
+      DB_NAME: arsnova_v3_dev
+      REDIS_URL: redis://localhost:6379
+      JWT_SECRET: ci-jwt-secret
+      ADMIN_SECRET: ci-admin-secret
+      ADMIN_DIAGNOSTIC_SECRET: ci-diagnostic-secret-distinct-from-admin-0001
+      NODE_ENV: development
+      PORT: 3000
+      HOST: 0.0.0.0
+      WS_PORT: 3001
+      YJS_WS_PORT: 3002
+
+    steps:
+      - name: Docs-only fast pass
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Docs-only change — skipping WebKit E2E."
+
+      - name: Checkout
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+
+      - name: Setup Node.js 24
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        if: needs.changes.outputs.docs_only != 'true'
+        run: npm ci
+
+      - name: Prisma generate
+        if: needs.changes.outputs.docs_only != 'true'
+        run: npx prisma generate --schema prisma/schema.prisma
+
+      - name: Apply production migrations
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          set -euo pipefail
+          export DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@localhost:5432/${DB_NAME}?schema=public"
+          npx prisma migrate deploy --schema prisma/schema.prisma
+
+      - name: Build libs
+        if: needs.changes.outputs.docs_only != 'true'
+        run: npm run build:libs
+
+      - name: Download frontend production build
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: frontend-dist-browser
+          path: apps/frontend/dist/browser
+
+      - name: Install Playwright WebKit
+        if: needs.changes.outputs.docs_only != 'true'
+        run: node node_modules/playwright/cli.js install --with-deps webkit
+
+      - name: Run WebKit MOTD and tab focus flows
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          set -euo pipefail
+          export DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@localhost:5432/${DB_NAME}?schema=public"
+          cleanup() {
+            if [ -f "$RUNNER_TEMP/frontend.pid" ]; then
+              kill "$(cat "$RUNNER_TEMP/frontend.pid")" 2>/dev/null || true
+            fi
+            if [ -f "$RUNNER_TEMP/backend.pid" ]; then
+              kill "$(cat "$RUNNER_TEMP/backend.pid")" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
+
+          npm run dev -w @arsnova/backend > "$RUNNER_TEMP/backend.log" 2>&1 &
+          echo "$!" > "$RUNNER_TEMP/backend.pid"
+          for attempt in {1..60}; do
+            if curl -fsS http://localhost:3000/trpc/health.check >/dev/null; then
+              if kill -0 "$(cat "$RUNNER_TEMP/backend.pid")" 2>/dev/null; then
+                break
+              fi
+              echo "Backend-Prozess ist beendet."
+              cat "$RUNNER_TEMP/backend.log"
+              exit 1
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              echo "Backend-Server konnte nicht gestartet werden."
+              cat "$RUNNER_TEMP/backend.log"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          PORT=4200 BACKEND_URL=http://localhost:3000 npm run serve:localize:api -w @arsnova/frontend > "$RUNNER_TEMP/frontend.log" 2>&1 &
+          echo "$!" > "$RUNNER_TEMP/frontend.pid"
+          frontend_ready=0
+          for _ in {1..60}; do
+            if curl -fsS http://localhost:4200/de/ >/dev/null; then
+              frontend_ready=1
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$frontend_ready" -ne 1 ]; then
+            cat "$RUNNER_TEMP/frontend.log"
+            exit 1
+          fi
+
+          export BASE_URL=http://localhost:4200
+          export PLAYWRIGHT_BROWSER=webkit
+          export SMOKE_ARTIFACT_DIR="$RUNNER_TEMP/webkit-browser-smokes"
+          npm run e2e:motd-focus -w @arsnova/frontend
+
+      - name: Upload WebKit E2E logs
+        if: always() && needs.changes.outputs.docs_only != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: webkit-e2e-service-logs
+          path: |
+            ${{ runner.temp }}/backend.log
+            ${{ runner.temp }}/frontend.log
+            ${{ runner.temp }}/webkit-browser-smokes
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Der bestehende Required-Check bleibt stabil und aggregiert beide Engines.
+  e2e:
+    name: Playwright Smoke E2E
+    runs-on: ubuntu-latest
+    needs: [e2e-chromium, webkit-e2e]
+    if: always() && github.event_name != 'schedule'
+    steps:
+      - name: Verify Chromium and WebKit results
+        env:
+          CHROMIUM_RESULT: ${{ needs['e2e-chromium'].result }}
+          WEBKIT_RESULT: ${{ needs['webkit-e2e'].result }}
+        run: |
+          set -euo pipefail
+          if [ "$CHROMIUM_RESULT" != 'success' ] || [ "$WEBKIT_RESULT" != 'success' ]; then
+            echo "Browser-E2E fehlgeschlagen: chromium=$CHROMIUM_RESULT webkit=$WEBKIT_RESULT"
+            exit 1
+          fi
+          echo "Browser-E2E bestanden: chromium=$CHROMIUM_RESULT webkit=$WEBKIT_RESULT"
 
   # ─── Classroom Scenario Smokes (tRPC, Postgres + Redis, Backend only) ───────
   classroom-smokes:

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -21,6 +21,7 @@
     "smoke:numeric-estimate": "node scripts/check-numeric-estimate-flow.mjs",
     "smoke:structured-question-types": "node scripts/check-structured-question-types-flow.mjs",
     "e2e:confidence-summary-demo": "node scripts/check-confidence-summary-demo-flow.mjs",
+    "e2e:motd-focus": "node scripts/check-motd-focus-flow.mjs",
     "generate:session-pdf-demo": "npx tsx scripts/generate-session-results-pdf-demo.ts",
     "smoke:quiz-sync": "node scripts/check-quiz-sync-flow.mjs",
     "smoke:session-question-progress": "node scripts/check-session-question-progress-flow.mjs",

--- a/apps/frontend/scripts/check-motd-focus-flow.mjs
+++ b/apps/frontend/scripts/check-motd-focus-flow.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Browser-E2E für den MOTD-Fokusrücksprung auf der Desktop-Startseite.
+ * WebKit deckt die Safari-nahe Pointer-/Tab-Reihenfolge ab; zwei Szenarien
+ * bilden zusätzlich fehlendes window.TouchEvent und fehlenden Button-Fokus nach.
+ *
+ * Run: BASE_URL=http://localhost:4200 PLAYWRIGHT_BROWSER=webkit node scripts/check-motd-focus-flow.mjs
+ */
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { chromium, webkit } from 'playwright';
+
+const BASE_URL = (process.env.BASE_URL || 'http://localhost:4200').replace(/\/+$/, '');
+const BROWSER_NAME = process.env.PLAYWRIGHT_BROWSER || 'chromium';
+const ARTIFACT_DIR = process.env.SMOKE_ARTIFACT_DIR || 'tmp/motd-focus';
+const HOME_URL = `${BASE_URL}/de/`;
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function waitForServer(url, maxAttempts = 60) {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Der produktionsnahe Serve ist noch nicht bereit.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`App nicht erreichbar: ${url}`);
+}
+
+async function openHomeWithMotd(page, { focusCodeInput = false } = {}) {
+  // Die MOTD wird per Idle-Callback geöffnet. Die kurze API-Verzögerung macht
+  // den Regressionstest reproduzierbar: Das Codefeld ist vor dem Overlay aktiv.
+  await page.route(/motd\.getCurrent/, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    await route.continue();
+  });
+  await page.goto(HOME_URL, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+
+  if (focusCodeInput) {
+    const codeInput = page.locator('.home-code-segments__input');
+    await codeInput.waitFor({ state: 'visible', timeout: 5_000 });
+    await codeInput.focus();
+    assert(
+      await codeInput.evaluate((element) => element === document.activeElement),
+      'Vor Öffnen der MOTD konnte das Codefeld nicht fokussiert werden.',
+    );
+  }
+
+  const motd = page.locator('.home-motd-sheet');
+  await motd.waitFor({ state: 'visible', timeout: 10_000 });
+  return motd;
+}
+
+async function waitForPrimaryAction(page) {
+  await page.waitForFunction(
+    () => document.querySelector('.home-hero-code-enter') === document.activeElement,
+    undefined,
+    { timeout: 3_000 },
+  );
+}
+
+async function primaryFocusState(page) {
+  return page.locator('.home-hero-code-enter').evaluate((element) => {
+    const indicator = element.querySelector('.mat-focus-indicator');
+    const indicatorStyle = indicator ? getComputedStyle(indicator, '::before') : null;
+    const style = getComputedStyle(element);
+    return {
+      active: element === document.activeElement,
+      keyboard: element.classList.contains('cdk-keyboard-focused'),
+      mouse: element.classList.contains('cdk-mouse-focused'),
+      outlineStyle: style.outlineStyle,
+      outlineWidth: Number.parseFloat(style.outlineWidth),
+      indicatorDisplay: indicatorStyle?.display ?? null,
+    };
+  });
+}
+
+async function assertNextTabContinuesHeroFlow(page) {
+  const nextAction = page.locator('.home-hero-host-row > a').first();
+  await page.keyboard.press('Tab');
+  if (await nextAction.evaluate((element) => element === document.activeElement)) return;
+
+  // Safari überspringt bei deaktivierter vollständiger Tab-Navigation Links
+  // mit Tab. ⌥ Tab schaltet für diesen Tastendruck auf alle Bedienelemente.
+  // Andere Playwright-WebKit-Ports verwenden bereits Tab und kehren oben zurück.
+  const codeInputActive = await page
+    .locator('.home-code-segments__input')
+    .evaluate((element) => element === document.activeElement);
+  assert(
+    BROWSER_NAME === 'webkit' && codeInputActive,
+    'Tab nach dem MOTD-Rücksprung folgt weder der vollständigen noch der Safari-reduzierten Tab-Reihe.',
+  );
+  await page.locator('.home-hero-code-enter').focus();
+  await page.keyboard.press('Alt+Tab');
+  assert(
+    await nextAction.evaluate((element) => element === document.activeElement),
+    '⌥ Tab nach dem MOTD-Rücksprung setzt den Safari-Hero-Flow nicht bei „Quiz erstellen“ fort.',
+  );
+}
+
+async function assertKeyboardReturn(page) {
+  await waitForPrimaryAction(page);
+  const state = await primaryFocusState(page);
+  assert(
+    state.active && state.keyboard && state.outlineStyle !== 'none' && state.outlineWidth >= 3,
+    `Tastatur-Rücksprung hat keinen sichtbaren Fokusrahmen: ${JSON.stringify(state)}`,
+  );
+  await assertNextTabContinuesHeroFlow(page);
+}
+
+async function assertPointerReturn(page) {
+  await waitForPrimaryAction(page);
+  const state = await primaryFocusState(page);
+  assert(
+    state.active && state.mouse && !state.keyboard && state.indicatorDisplay === 'none',
+    `Pointer-Rücksprung zeigt den falschen Fokuszustand: ${JSON.stringify(state)}`,
+  );
+  await assertNextTabContinuesHeroFlow(page);
+}
+
+async function runScenario(
+  browser,
+  name,
+  { missingTouchEvent = false, suppressMotdButtonFocus = false } = {},
+) {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+  const pageErrors = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  if (missingTouchEvent) {
+    await page.addInitScript(() => {
+      // Desktop-Safari stellt TouchEvent nicht in jeder Umgebung bereit.
+      Object.defineProperty(window, 'TouchEvent', { value: undefined, configurable: true });
+    });
+  }
+  if (suppressMotdButtonFocus) {
+    await page.addInitScript(() => {
+      // Safari fokussiert Buttons bei einem Mausklick standardmäßig nicht. Das
+      // No-op hält zugleich den vorherigen Fokus für den CDK-Trap-Restore aktiv.
+      const nativeFocus = HTMLElement.prototype.focus;
+      HTMLElement.prototype.focus = function patchedFocus(...args) {
+        if (this.closest?.('.home-motd-sheet') && this.matches('button')) return;
+        nativeFocus.apply(this, args);
+      };
+    });
+  }
+
+  try {
+    if (name === 'keyboard-close') {
+      const motd = await openHomeWithMotd(page);
+      const close = motd.getByRole('button', { name: 'Meldung schließen' });
+      await close.waitFor({ state: 'visible' });
+      await close.focus();
+      await close.press('Enter');
+      await motd.waitFor({ state: 'hidden', timeout: 5_000 });
+      await assertKeyboardReturn(page);
+    } else if (name === 'keyboard-ack') {
+      const motd = await openHomeWithMotd(page);
+      const ack = motd.getByRole('button', { name: 'Alles klar!' });
+      await ack.focus();
+      await ack.press('Enter');
+      await motd.waitFor({ state: 'hidden', timeout: 5_000 });
+      await assertKeyboardReturn(page);
+    } else if (name === 'pointer-close-after-code-focus') {
+      const motd = await openHomeWithMotd(page, { focusCodeInput: true });
+      await motd.getByRole('button', { name: 'Meldung schließen' }).click();
+      await motd.waitFor({ state: 'hidden', timeout: 5_000 });
+      await assertPointerReturn(page);
+    } else if (name === 'pointer-ack') {
+      const motd = await openHomeWithMotd(page);
+      const close = motd.getByRole('button', { name: 'Meldung schließen' });
+      await page.waitForFunction(
+        () =>
+          document.querySelector('.home-motd-sheet button[aria-label="Meldung schließen"]') ===
+          document.activeElement,
+        undefined,
+        { timeout: 2_000 },
+      );
+      assert(
+        await close.evaluate((element) => element === document.activeElement),
+        'Vor dem ACK-Mausklick liegt der Fokus nicht auf dem Schließen-Button.',
+      );
+      await motd.getByRole('button', { name: 'Alles klar!' }).click();
+      await motd.waitFor({ state: 'hidden', timeout: 5_000 });
+      await assertPointerReturn(page);
+    } else {
+      throw new Error(`Unbekanntes MOTD-Fokusszenario: ${name}`);
+    }
+    assert(pageErrors.length === 0, `Browserfehler: ${pageErrors.join(' | ')}`);
+    console.log(`  ${name} … OK`);
+  } catch (error) {
+    await page
+      .screenshot({ path: join(ARTIFACT_DIR, `${BROWSER_NAME}-${name}.png`), fullPage: true })
+      .catch(() => undefined);
+    throw new Error(`${name}: ${error.message}`, { cause: error });
+  } finally {
+    await context.close();
+  }
+}
+
+async function main() {
+  if (!['chromium', 'webkit'].includes(BROWSER_NAME)) {
+    throw new Error(
+      `PLAYWRIGHT_BROWSER muss "chromium" oder "webkit" sein (erhalten: ${BROWSER_NAME}).`,
+    );
+  }
+  const browserType = BROWSER_NAME === 'webkit' ? webkit : chromium;
+
+  await mkdir(ARTIFACT_DIR, { recursive: true });
+  await waitForServer(HOME_URL);
+  console.log(`MOTD-Fokusfluss mit ${BROWSER_NAME}: ${HOME_URL}`);
+  const browser = await browserType.launch({ headless: true });
+
+  try {
+    await runScenario(browser, 'keyboard-close');
+    await runScenario(browser, 'keyboard-ack');
+    await runScenario(browser, 'pointer-close-after-code-focus', {
+      missingTouchEvent: true,
+      suppressMotdButtonFocus: true,
+    });
+    await runScenario(browser, 'pointer-ack', { missingTouchEvent: true });
+  } finally {
+    await browser.close();
+  }
+
+  console.log(`✓ MOTD-Fokusfluss mit ${BROWSER_NAME} bestanden.`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/frontend/scripts/check-session-question-progress-flow.mjs
+++ b/apps/frontend/scripts/check-session-question-progress-flow.mjs
@@ -28,6 +28,7 @@ const ARTIFACT_DIR =
 const HOST_TOKEN_STORAGE_PREFIX = 'arsnova-host-token:';
 const DESKTOP = { width: 1440, height: 1000 };
 const MOBILE = { width: 430, height: 932 };
+const VOTE_RATE_LIMIT_HEADROOM_MS = 1_100;
 const START_QUESTION_RE = /erste frage starten|start first question/i;
 const RELEASE_ANSWERS_RE = /antwortoptionen freigeben|release answer options/i;
 const REVEAL_RESULTS_RE = /ergebnis(?: trotzdem)? zeigen|show results/i;
@@ -40,6 +41,8 @@ const QUESTIONS = {
   skipped: 'Smoke-Verlauf: Diese beantwortete Frage wird ausgelassen',
   conducted: 'Smoke-Verlauf: Nur diese Frage gehört in die Nachbesprechung',
 };
+
+let lastVoteRequestStartedAt = 0;
 
 const QUIZ_PAYLOAD = {
   name: `Session Question Progress Smoke ${Date.now()}`,
@@ -225,12 +228,25 @@ async function assertCurrentQuestion(page, selector, expected, excluded = []) {
 }
 
 async function submitFirstAnswer(participant) {
+  const remainingRateLimitWindow =
+    lastVoteRequestStartedAt + VOTE_RATE_LIMIT_HEADROOM_MS - Date.now();
+  if (remainingRateLimitWindow > 0) {
+    await participant.waitForTimeout(remainingRateLimitWindow);
+  }
+
   const answer = participant.locator('.vote-answer').first();
   await answer.waitFor({ state: 'visible', timeout: 20_000 });
   await answer.click();
   const submit = participant.locator('#vote-submit').first();
   await submit.waitFor({ state: 'visible', timeout: 10_000 });
+  const voteResponse = participant.waitForResponse(
+    (response) => response.request().method() === 'POST' && response.url().includes('/vote.submit'),
+    { timeout: 20_000 },
+  );
+  lastVoteRequestStartedAt = Date.now();
   await submit.click();
+  const response = await voteResponse;
+  ensure(response.ok(), `Vote-Submit wurde mit HTTP ${response.status()} abgewiesen.`);
   await participant.waitForFunction(
     () =>
       !document.querySelector('#vote-submit') ||

--- a/apps/frontend/scripts/check-viewport-320.mjs
+++ b/apps/frontend/scripts/check-viewport-320.mjs
@@ -31,7 +31,7 @@ async function waitForServer(url, maxAttempts = 30) {
   return false;
 }
 
-async function dismissOptionalOverlay(page, waitForMotd = false) {
+async function dismissOptionalOverlay(page, waitForMotd = false, activation = 'pointer') {
   if (waitForMotd) {
     await page
       .waitForFunction(
@@ -57,9 +57,16 @@ async function dismissOptionalOverlay(page, waitForMotd = false) {
     )
     .first();
   if (await closeButton.isVisible().catch(() => false)) {
-    await closeButton.click();
+    if (activation === 'keyboard') {
+      await closeButton.focus();
+      await page.keyboard.press('Enter');
+    } else {
+      await closeButton.click();
+    }
     await page.locator('.home-motd-sheet').waitFor({ state: 'hidden', timeout: 5_000 });
+    return true;
   }
+  return false;
 }
 
 async function dismissOptionalInstallSnackbar(page) {
@@ -219,7 +226,28 @@ async function inspectKeyboardFocus(page) {
 async function inspectHomeKeyboardNavigation(page) {
   const issues = [];
   // Idle-MOTD kann nach dem ersten Dismiss noch nachziehen und Fokus stehlen.
-  await dismissOptionalOverlay(page, true);
+  const motdDismissedWithKeyboard = await dismissOptionalOverlay(page, true, 'keyboard');
+  if (
+    motdDismissedWithKeyboard &&
+    !(await page
+      .locator('.home-hero-code-enter')
+      .evaluate((element) => element === document.activeElement))
+  ) {
+    issues.push('MOTD-Return-Fokus landet nicht auf dem sichtbaren Hero-CTA');
+  }
+  if (
+    motdDismissedWithKeyboard &&
+    !(await page.locator('.home-hero-code-enter').evaluate((element) => {
+      const style = getComputedStyle(element);
+      return (
+        element.classList.contains('cdk-keyboard-focused') &&
+        style.outlineStyle !== 'none' &&
+        Number.parseFloat(style.outlineWidth) >= 3
+      );
+    }))
+  ) {
+    issues.push('MOTD-Return-Fokus hat keinen sichtbaren Tastatur-Fokusrahmen');
+  }
   // Footer-Mehr zuerst: Skip-Link/#main-content und Mobile-Menü dürfen Material-
   // restoreFocus für den Footer-Auslöser nicht als vorherigen Fokus „vergiften“.
   issues.push(...(await inspectFooterMoreKeyboardNavigation(page)));
@@ -678,7 +706,11 @@ async function main() {
     const url = `${BASE_URL}${path}`;
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
     await page.waitForLoadState('networkidle').catch(() => {});
-    await dismissOptionalOverlay(page, /^\/(?:de|en|fr|es|it)\/$/.test(path));
+    // Auf /de/ prüft inspectHomeKeyboardNavigation den echten MOTD-Dismiss
+    // mit Return. Ein vorheriger Pointer-Dismiss würde die Regression verdecken.
+    if (path !== '/de/') {
+      await dismissOptionalOverlay(page, /^\/(?:en|fr|es|it)\/$/.test(path));
+    }
     await dismissOptionalInstallSnackbar(page);
 
     const initialJoinFocus = path === '/de/join' ? await inspectMobileJoinEntry(page) : [];

--- a/apps/frontend/scripts/check-viewport-320.mjs
+++ b/apps/frontend/scripts/check-viewport-320.mjs
@@ -248,6 +248,37 @@ async function inspectHomeKeyboardNavigation(page) {
   ) {
     issues.push('MOTD-Return-Fokus hat keinen sichtbaren Tastatur-Fokusrahmen');
   }
+
+  // Der initial fokussierte Schließen-Button behält in Chromium bei einem
+  // Mausklick teils :focus-visible. Nach Reload denselben Pfad als Pointer
+  // prüfen: Material darf diesen Zustand nicht als Fokusring weitertragen.
+  await page.evaluate(() => localStorage.removeItem('arsnova-motd-v2'));
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: 15_000 });
+  await page.waitForLoadState('networkidle').catch(() => {});
+  const motdDismissedWithPointer = await dismissOptionalOverlay(page, true, 'pointer');
+  if (motdDismissedWithPointer) {
+    await page
+      .waitForFunction(
+        () => document.querySelector('.home-hero-code-enter') === document.activeElement,
+        undefined,
+        { timeout: 1_000 },
+      )
+      .catch(() => undefined);
+    const pointerFocus = await page.locator('.home-hero-code-enter').evaluate((element) => {
+      const indicator = element.querySelector('.mat-focus-indicator');
+      const indicatorStyle = indicator ? getComputedStyle(indicator, '::before') : null;
+      return {
+        active: element === document.activeElement,
+        keyboard: element.classList.contains('cdk-keyboard-focused'),
+        indicatorDisplay: indicatorStyle?.display ?? null,
+      };
+    });
+    if (!pointerFocus.active || pointerFocus.keyboard || pointerFocus.indicatorDisplay !== 'none') {
+      issues.push(
+        `MOTD-Pointer-Rücksprung zeigt einen Tastatur-Fokusrahmen (${JSON.stringify(pointerFocus)})`,
+      );
+    }
+  }
   // Footer-Mehr zuerst: Skip-Link/#main-content und Mobile-Menü dürfen Material-
   // restoreFocus für den Footer-Auslöser nicht als vorherigen Fokus „vergiften“.
   issues.push(...(await inspectFooterMoreKeyboardNavigation(page)));

--- a/apps/frontend/src/app/app.component.scss
+++ b/apps/frontend/src/app/app.component.scss
@@ -80,7 +80,8 @@
 }
 
 /*
- * Skip-Link: visuell aus dem Viewport, bei Fokus sofort sichtbar.
+ * Skip-Link: visuell aus dem Viewport, bei sichtbarem Tastaturfokus sofort sichtbar.
+ * Programmgesteuerter Fokus nach Touch-/Pointer-Aktionen darf ihn nicht einblenden.
  * Kein clip/clip-path (Tab-Reihenfolge) und keine Transform-Transition
  * (a11y:layout misst den fokussierten Zustand synchron).
  */
@@ -100,7 +101,6 @@
   transform: translateY(calc(-100% - 1rem));
 }
 
-.app-skip-link:focus,
 .app-skip-link:focus-visible {
   transform: none;
   outline: 2px solid var(--mat-sys-on-primary);

--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -153,6 +153,17 @@ describe('AppComponent', () => {
     fixture.destroy();
   });
 
+  it('blendet den Skip-Link nur für sichtbaren Tastaturfokus ein', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, join } = await import('node:path');
+    const componentDir = dirname(fileURLToPath(import.meta.url));
+    const styles = readFileSync(join(componentDir, 'app.component.scss'), 'utf8');
+
+    expect(styles).toContain('.app-skip-link:focus-visible');
+    expect(styles).not.toMatch(/\.app-skip-link:focus(?:\s|,|\{)/);
+  });
+
   it('führt den Fokus beim Öffnen der mobilen Einstellungen in das Panel', async () => {
     configureAppTestBed();
     const fixture = TestBed.createComponent(AppComponent);

--- a/apps/frontend/src/app/features/home/home.component.html
+++ b/apps/frontend/src/app/features/home/home.component.html
@@ -546,7 +546,7 @@
         class="home-motd-backdrop"
         aria-hidden="true"
         tabindex="-1"
-        (click)="onMotdBackdropClick()"
+        (click)="onMotdBackdropClick($event)"
       ></button>
       <dialog
         class="home-motd-sheet"
@@ -580,7 +580,7 @@
             type="button"
             matIconButton
             cdkFocusInitial
-            (click)="dismissMotdOverlay('DISMISS_CLOSE')"
+            (click)="dismissMotdOverlay('DISMISS_CLOSE', $event)"
             i18n-aria-label="@@motd.overlayCloseAria"
             aria-label="Meldung schließen"
           >
@@ -596,7 +596,7 @@
           ></div>
         }
         <div class="home-motd-sheet__actions">
-          <button mat-flat-button type="button" (click)="ackMotd()" i18n="@@motd.ack">
+          <button mat-flat-button type="button" (click)="ackMotd($event)" i18n="@@motd.ack">
             Alles klar!
           </button>
           <div

--- a/apps/frontend/src/app/features/home/home.component.scss
+++ b/apps/frontend/src/app/features/home/home.component.scss
@@ -307,6 +307,13 @@
   outline-offset: 3px;
 }
 
+// Der initial fokussierte MOTD-Schließen-Button kann :focus-visible bei einem
+// Mausklick behalten. Beim Pointer-Rücksprung darf dieser Browserzustand nicht
+// als Material-Strong-Focus-Ring auf den Hero-CTA vererbt werden.
+.home-hero-code-enter:is(.cdk-mouse-focused, .cdk-touch-focused) {
+  --mat-focus-indicator-display: none;
+}
+
 .home-hero-serious-tagline {
   grid-column: 1 / -1;
   margin: 0.35rem 0 0.5rem;

--- a/apps/frontend/src/app/features/home/home.component.scss
+++ b/apps/frontend/src/app/features/home/home.component.scss
@@ -299,6 +299,14 @@
   font-weight: 600;
 }
 
+// CDK bewahrt den Tastatur-Ursprung beim Fokus-Rücksprung aus der MOTD.
+// Der explizite MD3-Strong-Focus-Ring bleibt auch sichtbar, wenn der Browser
+// einen nachträglich gesetzten Fokus nicht mehr als :focus-visible einstuft.
+.home-hero-code-enter.cdk-keyboard-focused {
+  outline: 3px solid var(--mat-sys-secondary);
+  outline-offset: 3px;
+}
+
 .home-hero-serious-tagline {
   grid-column: 1 / -1;
   margin: 0.35rem 0 0.5rem;

--- a/apps/frontend/src/app/features/home/home.component.spec.ts
+++ b/apps/frontend/src/app/features/home/home.component.spec.ts
@@ -1246,6 +1246,7 @@ describe('HomeComponent', () => {
       });
       other.focus();
       fixture.componentInstance['clearMotdOverlay']();
+      fixture.detectChanges();
       await Promise.resolve();
 
       expect(document.activeElement).toBe(other);
@@ -1253,7 +1254,7 @@ describe('HomeComponent', () => {
       other.remove();
     });
 
-    it('setzt nach MOTD-Dismiss den Fokus auf den Skip-Link wenn kein Rücksprungziel existiert', async () => {
+    it('setzt nach MOTD-Dismiss per Tastatur sichtbaren Fokus auf den Primaer-CTA', async () => {
       const skip = document.createElement('a');
       skip.href = '#main';
       skip.className = 'app-skip-link';
@@ -1270,6 +1271,9 @@ describe('HomeComponent', () => {
       });
       fixture.detectChanges();
 
+      const primaryAction = fixture.nativeElement.querySelector(
+        '.home-hero-code-enter',
+      ) as HTMLButtonElement;
       const closeInMotd = fixture.nativeElement.querySelector(
         '.home-motd-sheet button',
       ) as HTMLButtonElement | null;
@@ -1277,12 +1281,48 @@ describe('HomeComponent', () => {
       closeInMotd?.focus();
       expect(document.activeElement).toBe(closeInMotd);
 
-      fixture.componentInstance['clearMotdOverlay']();
+      fixture.componentInstance['clearMotdOverlay'](true);
       fixture.detectChanges();
       await Promise.resolve();
 
-      expect(document.activeElement).toBe(skip);
+      expect(document.activeElement).toBe(primaryAction);
+      expect(document.activeElement).not.toBe(skip);
+      expect(primaryAction.classList.contains('cdk-keyboard-focused')).toBe(true);
       skip.remove();
+    });
+
+    it('zeigt nach Pointer-Dismiss keinen Tastatur-Fokusrahmen', async () => {
+      const fixture = createHomeFixture();
+      fixture.componentInstance['motdFocusReturn'] = null;
+      fixture.componentInstance.motd.set({
+        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        contentVersion: 7,
+        markdown: 'Meldung',
+        endsAt: '2099-12-31T12:00:00.000Z',
+      });
+      fixture.detectChanges();
+
+      const primaryAction = fixture.nativeElement.querySelector(
+        '.home-hero-code-enter',
+      ) as HTMLButtonElement;
+      fixture.componentInstance['clearMotdOverlay'](false);
+      fixture.detectChanges();
+      await Promise.resolve();
+
+      expect(document.activeElement).toBe(primaryAction);
+      expect(primaryAction.classList.contains('cdk-keyboard-focused')).toBe(false);
+    });
+
+    it('definiert für den MOTD-Tastatur-Rücksprung einen sichtbaren Fokusrahmen', async () => {
+      const { readFileSync } = await import('node:fs');
+      const { fileURLToPath } = await import('node:url');
+      const { dirname, join } = await import('node:path');
+      const scssPath = join(dirname(fileURLToPath(import.meta.url)), 'home.component.scss');
+      const scss = readFileSync(scssPath, 'utf8');
+
+      expect(scss).toMatch(
+        /\.home-hero-code-enter\.cdk-keyboard-focused\s*\{[^}]*outline:\s*3px solid var\(--mat-sys-secondary\)/,
+      );
     });
 
     it('lädt nach dem Schließen nicht sofort die nächste MOTD nach', async () => {

--- a/apps/frontend/src/app/features/home/home.component.spec.ts
+++ b/apps/frontend/src/app/features/home/home.component.spec.ts
@@ -1281,7 +1281,7 @@ describe('HomeComponent', () => {
       closeInMotd?.focus();
       expect(document.activeElement).toBe(closeInMotd);
 
-      fixture.componentInstance['clearMotdOverlay'](true);
+      fixture.componentInstance['clearMotdOverlay']('keyboard');
       fixture.detectChanges();
       await Promise.resolve();
 
@@ -1305,12 +1305,13 @@ describe('HomeComponent', () => {
       const primaryAction = fixture.nativeElement.querySelector(
         '.home-hero-code-enter',
       ) as HTMLButtonElement;
-      fixture.componentInstance['clearMotdOverlay'](false);
+      fixture.componentInstance['clearMotdOverlay']('mouse');
       fixture.detectChanges();
       await Promise.resolve();
 
       expect(document.activeElement).toBe(primaryAction);
       expect(primaryAction.classList.contains('cdk-keyboard-focused')).toBe(false);
+      expect(primaryAction.classList.contains('cdk-mouse-focused')).toBe(true);
     });
 
     it('definiert für den MOTD-Tastatur-Rücksprung einen sichtbaren Fokusrahmen', async () => {
@@ -1322,6 +1323,9 @@ describe('HomeComponent', () => {
 
       expect(scss).toMatch(
         /\.home-hero-code-enter\.cdk-keyboard-focused\s*\{[^}]*outline:\s*3px solid var\(--mat-sys-secondary\)/,
+      );
+      expect(scss).toMatch(
+        /\.home-hero-code-enter:is\(\.cdk-mouse-focused, \.cdk-touch-focused\)\s*\{[^}]*--mat-focus-indicator-display:\s*none/,
       );
     });
 

--- a/apps/frontend/src/app/features/home/home.component.spec.ts
+++ b/apps/frontend/src/app/features/home/home.component.spec.ts
@@ -1291,6 +1291,41 @@ describe('HomeComponent', () => {
       skip.remove();
     });
 
+    it('kehrt vom automatisch überlagerten Code-Eingabefeld zum sichtbaren Primaer-CTA zurück', async () => {
+      const fixture = createHomeFixture();
+      fixture.detectChanges();
+      const comp = fixture.componentInstance;
+      const input = fixture.nativeElement.querySelector(
+        '.home-code-segments__input',
+      ) as HTMLInputElement;
+      input.focus();
+      expect(document.activeElement).toBe(input);
+
+      comp['openMotdOverlay'](
+        {
+          id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          contentVersion: 7,
+          markdown: 'Meldung',
+          endsAt: '2099-12-31T12:00:00.000Z',
+        },
+        input,
+      );
+      fixture.detectChanges();
+      document.body.setAttribute('tabindex', '-1');
+      document.body.focus();
+      document.body.removeAttribute('tabindex');
+      expect(document.activeElement).toBe(document.body);
+      comp['clearMotdOverlay']('mouse');
+      fixture.detectChanges();
+      await Promise.resolve();
+
+      const primaryAction = fixture.nativeElement.querySelector(
+        '.home-hero-code-enter',
+      ) as HTMLButtonElement;
+      expect(document.activeElement).toBe(primaryAction);
+      expect(primaryAction.classList.contains('cdk-mouse-focused')).toBe(true);
+    });
+
     it('zeigt nach Pointer-Dismiss keinen Tastatur-Fokusrahmen', async () => {
       const fixture = createHomeFixture();
       fixture.componentInstance['motdFocusReturn'] = null;
@@ -1311,6 +1346,36 @@ describe('HomeComponent', () => {
 
       expect(document.activeElement).toBe(primaryAction);
       expect(primaryAction.classList.contains('cdk-keyboard-focused')).toBe(false);
+      expect(primaryAction.classList.contains('cdk-mouse-focused')).toBe(true);
+    });
+
+    it('schließt per Mausklick auch wenn Desktop-Safari keinen TouchEvent-Konstruktor anbietet', async () => {
+      vi.stubGlobal('TouchEvent', undefined);
+      const fixture = createHomeFixture();
+      const comp = fixture.componentInstance;
+      comp.motd.set({
+        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        contentVersion: 7,
+        markdown: 'Meldung',
+        endsAt: '2099-12-31T12:00:00.000Z',
+      });
+      fixture.detectChanges();
+
+      const ackButton = Array.from(
+        fixture.nativeElement.querySelectorAll<HTMLButtonElement>('.home-motd-sheet button'),
+      ).find((button) => button.textContent?.includes('Alles klar'));
+      expect(ackButton).toBeDefined();
+
+      ackButton?.dispatchEvent(new MouseEvent('click', { bubbles: true, detail: 1 }));
+      fixture.detectChanges();
+      await Promise.resolve();
+
+      expect(comp.motd()).toBeNull();
+      expect(fixture.nativeElement.querySelector('.home-motd-sheet')).toBeNull();
+      const primaryAction = fixture.nativeElement.querySelector(
+        '.home-hero-code-enter',
+      ) as HTMLButtonElement;
+      expect(document.activeElement).toBe(primaryAction);
       expect(primaryAction.classList.contains('cdk-mouse-focused')).toBe(true);
     });
 

--- a/apps/frontend/src/app/features/home/home.component.ts
+++ b/apps/frontend/src/app/features/home/home.component.ts
@@ -77,6 +77,8 @@ import { hideMotdDecorativeEmojiInHeadingHtml } from '../../shared/motd-decorati
 import { InfoLandingLinkComponent } from '../../shared/info-landing-link/info-landing-link.component';
 import { INFO_LANDING_ANCHORS } from '../../core/info-landing-url';
 
+type MotdReturnFocusOrigin = 'keyboard' | 'mouse' | 'touch' | 'program';
+
 @Component({
   selector: 'app-home',
   host: { class: 'route-home' },
@@ -983,7 +985,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     this.animationFrameIds.clear();
   }
 
-  private clearMotdOverlay(returnFocusViaKeyboard = false): void {
+  private clearMotdOverlay(returnFocusOrigin: MotdReturnFocusOrigin = 'program'): void {
     const focusReturn = this.motdFocusReturn;
     this.motdFocusReturn = null;
     const activeBefore = document.activeElement;
@@ -995,11 +997,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     afterNextRender(
       () => {
         if (focusReturn?.isConnected === true) {
-          if (returnFocusViaKeyboard) {
-            this.focusMonitor.focusVia(focusReturn, 'keyboard', { preventScroll: true });
-          } else {
-            focusReturn.focus({ preventScroll: true });
-          }
+          this.focusMonitor.focusVia(focusReturn, returnFocusOrigin, { preventScroll: true });
           return;
         }
         const active = document.activeElement;
@@ -1018,18 +1016,12 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
         // primäre Einstieg den Fokus, nie der Skip-Link.
         const primaryAction = this.codeEnterBtn?.nativeElement;
         if (primaryAction?.isConnected && !primaryAction.disabled) {
-          if (returnFocusViaKeyboard) {
-            this.focusMonitor.focusVia(primaryAction, 'keyboard', { preventScroll: true });
-          } else {
-            primaryAction.focus({ preventScroll: true });
-          }
+          this.focusMonitor.focusVia(primaryAction, returnFocusOrigin, { preventScroll: true });
           return;
         }
         const input = this.sessionCodeInput?.nativeElement;
-        if (input && returnFocusViaKeyboard) {
-          this.focusMonitor.focusVia(input, 'keyboard', { preventScroll: true });
-        } else {
-          input?.focus({ preventScroll: true });
+        if (input) {
+          this.focusMonitor.focusVia(input, returnFocusOrigin, { preventScroll: true });
         }
       },
       { injector: this.injector },
@@ -1062,20 +1054,20 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!t) return;
     const dy = t.clientY - this.motdTouchStartY;
     if (dy > 88) {
-      void this.dismissMotdOverlay('DISMISS_SWIPE');
+      void this.dismissMotdOverlay('DISMISS_SWIPE', event);
     }
   }
 
   async dismissMotdOverlay(
     kind: Extract<MotdInteractionKind, 'DISMISS_CLOSE' | 'DISMISS_SWIPE'>,
-    activationEvent?: MouseEvent | KeyboardEvent,
+    activationEvent?: MouseEvent | KeyboardEvent | TouchEvent,
   ): Promise<void> {
     const m = this.motd();
     if (!m) return;
     // Overlay sofort schließen — recordInteraction darf die UI nicht blockieren
     // (sonst flake in a11y:layout bei langsamem CI / >1s API).
     markMotdDismissed(m.id, m.contentVersion);
-    this.clearMotdOverlay(this.isKeyboardActivation(activationEvent));
+    this.clearMotdOverlay(this.resolveMotdReturnFocusOrigin(activationEvent));
     this.motdCurrent.invalidate();
     await this.tryRecordMotdInteractionFor(m.id, m.contentVersion, kind);
   }
@@ -1084,13 +1076,24 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     const m = this.motd();
     if (!m) return;
     markMotdDismissed(m.id, m.contentVersion);
-    this.clearMotdOverlay(this.isKeyboardActivation(activationEvent));
+    this.clearMotdOverlay(this.resolveMotdReturnFocusOrigin(activationEvent));
     this.motdCurrent.invalidate();
     await this.tryRecordMotdInteractionFor(m.id, m.contentVersion, 'ACK');
   }
 
-  private isKeyboardActivation(event?: MouseEvent | KeyboardEvent): boolean {
-    return event instanceof KeyboardEvent || (event instanceof MouseEvent && event.detail === 0);
+  private resolveMotdReturnFocusOrigin(
+    event?: MouseEvent | KeyboardEvent | TouchEvent,
+  ): MotdReturnFocusOrigin {
+    if (event instanceof KeyboardEvent || (event instanceof MouseEvent && event.detail === 0)) {
+      return 'keyboard';
+    }
+    if (event instanceof TouchEvent) {
+      return 'touch';
+    }
+    if (event instanceof MouseEvent) {
+      return 'mouse';
+    }
+    return 'program';
   }
 
   async thumbMotd(up: boolean): Promise<void> {

--- a/apps/frontend/src/app/features/home/home.component.ts
+++ b/apps/frontend/src/app/features/home/home.component.ts
@@ -834,12 +834,16 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private openMotdOverlay(motd: MotdPublicDTO, activeElement: Element | null): void {
     this.clearToolbarMotdDefer();
-    this.motdFocusReturn =
+    const focusReturnCandidate =
       activeElement instanceof HTMLElement &&
       activeElement !== document.body &&
       activeElement !== document.documentElement
         ? activeElement
         : null;
+    // Die MOTD öffnet automatisch: Ein zuvor aktives Codefeld ist daher kein
+    // Dialog-Öffner. Nach dem Schließen dient der sichtbare CTA als Rücksprungziel.
+    this.motdFocusReturn =
+      focusReturnCandidate === this.sessionCodeInput?.nativeElement ? null : focusReturnCandidate;
     this.motd.set(motd);
     const html = hideMotdDecorativeEmojiInHeadingHtml(
       appendMotdContentVersionToAssetImgSrc(
@@ -989,9 +993,11 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     const focusReturn = this.motdFocusReturn;
     this.motdFocusReturn = null;
     const activeBefore = document.activeElement;
-    const activeWasInMotd =
-      activeBefore instanceof HTMLElement &&
-      !!activeBefore.closest('.home-motd-layer, .home-motd-sheet');
+    const activeNeedsReturn =
+      activeBefore === document.body ||
+      activeBefore === document.documentElement ||
+      (activeBefore instanceof HTMLElement &&
+        !!activeBefore.closest('.home-motd-layer, .home-motd-sheet, [inert]'));
     this.motd.set(null);
     this.motdBodyHtml.set(null);
     afterNextRender(
@@ -1002,7 +1008,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
         }
         const active = document.activeElement;
         if (
-          !activeWasInMotd &&
+          !activeNeedsReturn &&
           active instanceof HTMLElement &&
           active.isConnected &&
           active !== document.body &&
@@ -1084,16 +1090,22 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   private resolveMotdReturnFocusOrigin(
     event?: MouseEvent | KeyboardEvent | TouchEvent,
   ): MotdReturnFocusOrigin {
-    if (event instanceof KeyboardEvent || (event instanceof MouseEvent && event.detail === 0)) {
+    if (!event) {
+      return 'program';
+    }
+    // Desktop-Safari kann TouchEvent als globalen Konstruktor auslassen.
+    // Event-Typen funktionieren ohne instanceof außerdem über Realm-Grenzen hinweg.
+    const eventType = event.type;
+    if (
+      eventType.startsWith('key') ||
+      (eventType === 'click' && 'detail' in event && event.detail === 0)
+    ) {
       return 'keyboard';
     }
-    if (event instanceof TouchEvent) {
+    if (eventType.startsWith('touch')) {
       return 'touch';
     }
-    if (event instanceof MouseEvent) {
-      return 'mouse';
-    }
-    return 'program';
+    return 'mouse';
   }
 
   async thumbMotd(up: boolean): Promise<void> {

--- a/apps/frontend/src/app/features/home/home.component.ts
+++ b/apps/frontend/src/app/features/home/home.component.ts
@@ -15,7 +15,7 @@ import {
   signal,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { CdkTrapFocus } from '@angular/cdk/a11y';
+import { CdkTrapFocus, FocusMonitor } from '@angular/cdk/a11y';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatBadge } from '@angular/material/badge';
@@ -184,6 +184,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly sanitizer = inject(DomSanitizer);
   private readonly motdCurrent = inject(MotdCurrentService);
+  private readonly focusMonitor = inject(FocusMonitor);
   private readonly localeId = inject(LOCALE_ID) as string;
   private readonly injector = inject(Injector);
   @ViewChild('motdCloseBtn') private readonly motdCloseBtn?: ElementRef<HTMLButtonElement>;
@@ -378,7 +379,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!this.motd()) return;
     if (e.key !== 'Escape') return;
     e.preventDefault();
-    void this.dismissMotdOverlay('DISMISS_CLOSE');
+    void this.dismissMotdOverlay('DISMISS_CLOSE', e);
   }
 
   /** Entfernt Sessions, die nicht mehr besucht werden können (cron gelöscht, beendet). */
@@ -982,7 +983,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     this.animationFrameIds.clear();
   }
 
-  private clearMotdOverlay(): void {
+  private clearMotdOverlay(returnFocusViaKeyboard = false): void {
     const focusReturn = this.motdFocusReturn;
     this.motdFocusReturn = null;
     const activeBefore = document.activeElement;
@@ -991,35 +992,52 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
       !!activeBefore.closest('.home-motd-layer, .home-motd-sheet');
     this.motd.set(null);
     this.motdBodyHtml.set(null);
-    queueMicrotask(() => {
-      if (focusReturn?.isConnected === true) {
-        focusReturn.focus({ preventScroll: true });
-        return;
-      }
-      const active = document.activeElement;
-      if (
-        !activeWasInMotd &&
-        active instanceof HTMLElement &&
-        active.isConnected &&
-        active !== document.body &&
-        active !== document.documentElement
-      ) {
-        // Nutzer:in hat bereits woanders Fokus — nicht verschieben.
-        return;
-      }
-      // Nach Entfernen des MOTD-Dialogs bleibt der Sequential-Focus-Start oft hinter
-      // dem Dialog → nächstes Tab landet im Footer. Skip-Link setzt den Start zurück.
-      const skip = document.querySelector<HTMLElement>('a.app-skip-link');
-      if (skip) {
-        skip.focus({ preventScroll: true });
-        return;
-      }
-      this.sessionCodeInput?.nativeElement?.focus({ preventScroll: true });
-    });
+    afterNextRender(
+      () => {
+        if (focusReturn?.isConnected === true) {
+          if (returnFocusViaKeyboard) {
+            this.focusMonitor.focusVia(focusReturn, 'keyboard', { preventScroll: true });
+          } else {
+            focusReturn.focus({ preventScroll: true });
+          }
+          return;
+        }
+        const active = document.activeElement;
+        if (
+          !activeWasInMotd &&
+          active instanceof HTMLElement &&
+          active.isConnected &&
+          active !== document.body &&
+          active !== document.documentElement
+        ) {
+          // Nutzer:in hat bereits woanders Fokus — nicht verschieben.
+          return;
+        }
+        // Erst nach dem Render ist der Dialog-Fokus-Trap entfernt und der
+        // Hintergrund nicht mehr inert. Ohne Öffner erhält dann der sichtbare
+        // primäre Einstieg den Fokus, nie der Skip-Link.
+        const primaryAction = this.codeEnterBtn?.nativeElement;
+        if (primaryAction?.isConnected && !primaryAction.disabled) {
+          if (returnFocusViaKeyboard) {
+            this.focusMonitor.focusVia(primaryAction, 'keyboard', { preventScroll: true });
+          } else {
+            primaryAction.focus({ preventScroll: true });
+          }
+          return;
+        }
+        const input = this.sessionCodeInput?.nativeElement;
+        if (input && returnFocusViaKeyboard) {
+          this.focusMonitor.focusVia(input, 'keyboard', { preventScroll: true });
+        } else {
+          input?.focus({ preventScroll: true });
+        }
+      },
+      { injector: this.injector },
+    );
   }
 
-  onMotdBackdropClick(): void {
-    void this.dismissMotdOverlay('DISMISS_CLOSE');
+  onMotdBackdropClick(event: MouseEvent): void {
+    void this.dismissMotdOverlay('DISMISS_CLOSE', event);
   }
 
   onMotdTouchStart(event: TouchEvent): void {
@@ -1050,24 +1068,29 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
 
   async dismissMotdOverlay(
     kind: Extract<MotdInteractionKind, 'DISMISS_CLOSE' | 'DISMISS_SWIPE'>,
+    activationEvent?: MouseEvent | KeyboardEvent,
   ): Promise<void> {
     const m = this.motd();
     if (!m) return;
     // Overlay sofort schließen — recordInteraction darf die UI nicht blockieren
     // (sonst flake in a11y:layout bei langsamem CI / >1s API).
     markMotdDismissed(m.id, m.contentVersion);
-    this.clearMotdOverlay();
+    this.clearMotdOverlay(this.isKeyboardActivation(activationEvent));
     this.motdCurrent.invalidate();
     await this.tryRecordMotdInteractionFor(m.id, m.contentVersion, kind);
   }
 
-  async ackMotd(): Promise<void> {
+  async ackMotd(activationEvent?: MouseEvent): Promise<void> {
     const m = this.motd();
     if (!m) return;
     markMotdDismissed(m.id, m.contentVersion);
-    this.clearMotdOverlay();
+    this.clearMotdOverlay(this.isKeyboardActivation(activationEvent));
     this.motdCurrent.invalidate();
     await this.tryRecordMotdInteractionFor(m.id, m.contentVersion, 'ACK');
+  }
+
+  private isKeyboardActivation(event?: MouseEvent | KeyboardEvent): boolean {
+    return event instanceof KeyboardEvent || (event instanceof MouseEvent && event.detail === 0);
   }
 
   async thumbMotd(up: boolean): Promise<void> {

--- a/docs/CI-WORKFLOW.md
+++ b/docs/CI-WORKFLOW.md
@@ -19,7 +19,7 @@ Wenn du neu im Projekt bist, reicht dieses mentale Modell:
 
 1. **Vorstufe (früh):** `changes` erkennt docs-only Änderungen; parallel dazu prüfen `dependency-review`, `actionlint`, `format` und `migration` frühe PR-, Workflow-, Format- und Datenbankschemarisiken.
 2. **Technische Basis:** Das Projekt muss in einer realistischen Umgebung bauen (`build`, `landing-build`, `typecheck`, `lint`, i18n-Konsistenz). `lint` umfasst Angular-Template-A11y; `landing-build` prüft Astro 7 mit `astro check`, baut die Landing und führt danach axe aus.
-3. **Verhalten:** Tests müssen grün sein und Mindestqualität halten (`test:coverage`, `e2e`, `classroom-smokes`, `lighthouse`, `pdfua`).
+3. **Verhalten:** Tests müssen grün sein und Mindestqualität halten (`test:coverage`, Chromium-/WebKit-`e2e`, `classroom-smokes`, `lighthouse`, `pdfua`).
 4. **Sicherheit:** `audit`, Dependency Review und Trivy blockieren ab High; CodeQL prüft SAST, die CI erzeugt ein CycloneDX-SBOM.
 5. **Release:** Nur wenn alles grün ist und der Commit noch aktueller `main`-HEAD ist (`deploy-freshness`), darf deployed werden (`deploy`), danach kommt der Gesundheitscheck (`post-deploy-smoke`).
 
@@ -78,7 +78,10 @@ flowchart TD
   D --> H[lint]
   D --> I[test:coverage]
   D --> J[lighthouse]
-  D --> K[e2e smoke]
+  D --> KC[Chromium e2e smoke]
+  D --> KW[WebKit MOTD + Fokus]
+  KC --> K[e2e Aggregator]
+  KW --> K
   D --> K2[classroom smokes]
   D --> L[docker build<br/>ein Image + Artefakt]
   L --> M[trivy-image<br/>load/scan, read-only]
@@ -225,19 +228,35 @@ Wichtig: Jobs ohne direkte Abhängigkeit laufen **parallel**.
   Performance 0,79–0,80 und LCP 3,705–3,829 s; siehe
   [QA-Nachlauf](implementation/LOCAL-QA-RECHECK-2026-07-11.md).
 
-### 4.9 e2e
+### 4.9 e2e-chromium und e2e
 
-- **Was?** Sechs Playwright-Smokes mit echten Services (Postgres + Redis),
+- **Was?** `e2e-chromium` führt Playwright-Smokes mit echten Services (Postgres + Redis),
   produktionsnahen Migrationen und Backend-/Frontend-Start: Host-/Presenter-Auth,
   Host-Musik, `SHORT_TEXT`, `NUMERIC_ESTIMATE`, Quiz-Sync und Unified Session.
   Vor den Flows laufen axe auf statischen Kernrouten sowie Reflow-, Fokus- und
   Zielgrößenprüfungen. `SHORT_TEXT` und Unified Session führen axe zusätzlich
-  in aktiven, Ergebnis-, Q&A-, Blitzlicht- und Session-Ende-Zuständen aus.
+  in aktiven, Ergebnis-, Q&A-, Blitzlicht- und Session-Ende-Zuständen aus. Der
+  stabile Required-Check `e2e` aggregiert `e2e-chromium` und `webkit-e2e` und
+  wird nur bei zwei erfolgreichen Browser-Jobs grün.
 - **Wo?** Job und Skriptinventar in [../.github/workflows/ci.yml](../.github/workflows/ci.yml)
   und [../apps/frontend/package.json](../apps/frontend/package.json).
 - **Wann?** Nach `build`, außer bei `schedule`.
 - **Warum?** Testet den Nutzerfluss und Accessibility-Regressionen systemnah
   (nicht nur isolierte Unit-Tests).
+
+### 4.9a webkit-e2e
+
+- **Was?** Installiert WebKit explizit und führt einen Desktop-MOTD-Smoke aus.
+  Der Smoke prüft Tastatur- und Pointer-Rücksprung, die anschließende Tab-Reihe und bildet
+  Safaris fehlenden Pointer-Buttonfokus sowie ein fehlendes globales
+  `TouchEvent` nach.
+- **Wo?** Job in [../.github/workflows/ci.yml](../.github/workflows/ci.yml),
+  Browserwahl und Fokus-Smoke in
+  [../apps/frontend/scripts/check-motd-focus-flow.mjs](../apps/frontend/scripts/check-motd-focus-flow.mjs).
+- **Wann?** Parallel zu `e2e-chromium` nach `build`, außer bei `schedule`.
+- **Warum?** Verhindert, dass WebKit nur als nie genutzter Chromium-Fallback
+  existiert. Playwright WebKit ersetzt dennoch keinen manuellen Safari-Smoke,
+  weil Safari- und macOS-Tastatureinstellungen außerhalb der Engine liegen.
 
 ### 4.10 classroom-smokes
 
@@ -407,7 +426,7 @@ Vor dem eigentlichen Deploy müssen erfolgreich sein:
 8. docker
 9. typecheck
 10. lighthouse
-11. e2e einschließlich axe und Reflow/Fokus/Zielgrößen
+11. e2e-Aggregator mit Chromium (inklusive axe und Reflow/Fokus/Zielgrößen) und WebKit (MOTD-/Fokus-Smokes)
 12. classroom-smokes
 13. audit
 14. trivy-fs
@@ -467,16 +486,17 @@ In GitHub findest du Artefakte so:
 3. Gewünschten CI-Run öffnen
 4. Unten im Bereich Artifacts die Downloads auswählen
 
-| Artefaktname             | Erzeugender Job | Inhalt                                                        | Fundstelle im Runner                                                | Retention |
-| ------------------------ | --------------- | ------------------------------------------------------------- | ------------------------------------------------------------------- | --------- |
-| `frontend-dist-browser`  | `build`         | Lokalisierter Frontend-Produktionsbuild                       | `apps/frontend/dist/browser`                                        | 1 Tag     |
-| `coverage-reports`       | `test`          | Backend- und Frontend-Coverage (HTML + Textsummary-Dateien)   | `apps/backend/coverage`, `apps/frontend/coverage`                   | 7 Tage    |
-| `verapdf-ua1-report`     | `pdfua`         | veraPDF-Textbericht der fünf PDF/UA-1-Locale-Demos            | `tmp/pdfua-validation/verapdf-ua1.txt`                              | 30 Tage   |
-| `lighthouse-reports`     | `lighthouse`    | Lighthouse-Ausgabe (A11y/Performance/SEO/Best-Practices)      | `.lighthouseci`, `.lighthouseci-a11y`                               | 7 Tage    |
-| `e2e-service-logs`       | `e2e`           | Laufzeitlogs von Backend und Frontend während des Smoke-Tests | `${{ runner.temp }}/backend.log`, `${{ runner.temp }}/frontend.log` | 7 Tage    |
-| `trivy-fs-report`        | `trivy-fs`      | Trivy Filesystem Security Report (SARIF)                      | `trivy-fs.sarif`                                                    | 7 Tage    |
-| `production-image-<sha>` | `docker`        | Komprimiertes Produktionsimage + Integritätsmeta              | `arsnova-eu-production.tar.gz`, `arsnova-eu-production.meta.json`   | 1 Tag     |
-| `trivy-image-report`     | `trivy-image`   | Trivy Container Image Security Report (SARIF)                 | `trivy-image.sarif`                                                 | 7 Tage    |
+| Artefaktname              | Erzeugender Job | Inhalt                                                        | Fundstelle im Runner                                                                                            | Retention |
+| ------------------------- | --------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------- |
+| `frontend-dist-browser`   | `build`         | Lokalisierter Frontend-Produktionsbuild                       | `apps/frontend/dist/browser`                                                                                    | 1 Tag     |
+| `coverage-reports`        | `test`          | Backend- und Frontend-Coverage (HTML + Textsummary-Dateien)   | `apps/backend/coverage`, `apps/frontend/coverage`                                                               | 7 Tage    |
+| `verapdf-ua1-report`      | `pdfua`         | veraPDF-Textbericht der fünf PDF/UA-1-Locale-Demos            | `tmp/pdfua-validation/verapdf-ua1.txt`                                                                          | 30 Tage   |
+| `lighthouse-reports`      | `lighthouse`    | Lighthouse-Ausgabe (A11y/Performance/SEO/Best-Practices)      | `.lighthouseci`, `.lighthouseci-a11y`                                                                           | 7 Tage    |
+| `e2e-service-logs`        | `e2e-chromium`  | Laufzeitlogs von Backend und Frontend während des Smoke-Tests | `${{ runner.temp }}/backend.log`, `${{ runner.temp }}/frontend.log`                                             | 7 Tage    |
+| `webkit-e2e-service-logs` | `webkit-e2e`    | WebKit-Laufzeitlogs und Screenshots bei Browserfehlern        | `${{ runner.temp }}/backend.log`, `${{ runner.temp }}/frontend.log`, `${{ runner.temp }}/webkit-browser-smokes` | 7 Tage    |
+| `trivy-fs-report`         | `trivy-fs`      | Trivy Filesystem Security Report (SARIF)                      | `trivy-fs.sarif`                                                                                                | 7 Tage    |
+| `production-image-<sha>`  | `docker`        | Komprimiertes Produktionsimage + Integritätsmeta              | `arsnova-eu-production.tar.gz`, `arsnova-eu-production.meta.json`                                               | 1 Tag     |
+| `trivy-image-report`      | `trivy-image`   | Trivy Container Image Security Report (SARIF)                 | `trivy-image.sarif`                                                                                             | 7 Tage    |
 
 Hinweise:
 
@@ -555,7 +575,7 @@ Kanonische Quelle: [`.github/required-checks.json`](../.github/required-checks.j
 | lint                           | CI-CD          | workflow: .github/workflows/ci.yml#lint                           | Anwendungs- und laufzeitspezifisches Skript-Linting.                      |
 | Migration Drift                | CI-CD          | workflow: .github/workflows/ci.yml#migration                      | Prisma-Migrationskette und Schema-Drift auf leerer Datenbank.             |
 | PDF/UA-1 Validation            | CI-CD          | workflow: .github/workflows/ci.yml#pdfua                          | PDF/UA-1-Konformität der lokalisierten Handouts.                          |
-| Playwright Smoke E2E           | CI-CD          | workflow: .github/workflows/ci.yml#e2e                            | End-to-End-, axe-, Reflow- und Fokus-Smokes.                              |
+| Playwright Smoke E2E           | CI-CD          | workflow: .github/workflows/ci.yml#e2e                            | Chromium-Axe-/Reflow-Smokes und WebKit-MOTD-/Fokus-Regressionen.          |
 | PR-Template vollständig        | main protected | workflow: .github/workflows/pr-template-gate.yml#validate-pr-body | Vollständige Risiko-, Validierungs- und Rollback-Beschreibung vor Review. |
 | Security Audit                 | CI-CD          | workflow: .github/workflows/ci.yml#audit                          | Produktionsabhängigkeits-Audit und SBOM-Erzeugung.                        |
 | Tests                          | CI-CD          | workflow: .github/workflows/ci.yml#test                           | Workspace-Tests mit absoluten Coverage-Gates.                             |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -147,7 +147,9 @@ Auslöser: **Push** und **Pull Request** auf `main`.
 | **trivy-fs**                           | Trivy-Scan des Repository-Dateisystems (HIGH/CRITICAL, blockierend)                                                                                                                                                              |
 | **trivy-image**                        | Docker-Image-Build für Scan + Trivy-Image-Scan (HIGH/CRITICAL, blockierend)                                                                                                                                                      |
 | **lighthouse**                         | Lighthouse Performance gegen Home DE/EN; separater A11y-Lauf gegen Home DE/EN, Quiz-Liste, Hilfe und Datenschutz, inklusive blockierender Einzelaudits                                                                           |
-| **e2e**                                | Playwright Smoke E2E mit Postgres/Redis, statischen und dynamischen axe-Scans sowie Reflow-/Fokus-/Zielgrößen-Gate                                                                                                               |
+| **e2e-chromium**                       | Chromium Smoke E2E mit Postgres/Redis, statischen und dynamischen axe-Scans sowie Reflow-/Fokus-/Zielgrößen-Gate                                                                                                                 |
+| **webkit-e2e**                         | Expliziter WebKit-Lauf Safari-naher MOTD-Pointer-, Fokus- und Tab-Regressionen                                                                                                                                                   |
+| **e2e**                                | Stabiler Required-Check, der die erfolgreichen Chromium- und WebKit-Jobs aggregiert                                                                                                                                              |
 | **classroom-smokes**                   | Sechs Unterrichts-Szenario-Smokes (inkl. WS Vote-Progress, Reconnect und Q&A-/Blitzlicht-Fan-out, je 30 TN) gegen lokales Backend; JSON-/JUnit-Reports als Artifact                                                              |
 | **docker**                             | Docker-Image-Build (ohne Push), vollständiger Production-Compose-Start mit Migration/Healthcheck sowie Runtime-Smokes für Container-Härtung/Chromium-Maximalbericht und Yjs-Konvergenz inkl. Offline-Reconnect gegen Port 3002   |
 | **deploy**                             | Nur bei Push auf `main` und `DEPLOY_ENABLED=true`; nach Quality-Gates inkl. `publish-image`; übergibt `DEPLOY_IMAGE`/`DEPLOY_SHA`, checkt `DEPLOY_SHA` per SSH vor `scripts/deploy.sh` aus, dann Digest-Pull (kein Server-Build) |
@@ -167,7 +169,8 @@ Artifacts findest du in einem Run unter: **Actions → CI-Run öffnen → Artifa
 | `coverage-reports`        | `test`             | Coverage-Reports aus `apps/backend/coverage` und `apps/frontend/coverage`                             | 7 Tage    |
 | `verapdf-ua1-report`      | `pdfua`            | veraPDF-Textbericht für die PDF/UA-1-Demos aller fünf Locales                                         | 30 Tage   |
 | `lighthouse-reports`      | `lighthouse`       | Performance- und A11y-Ausgabe aus `.lighthouseci` und `.lighthouseci-a11y`                            | 7 Tage    |
-| `e2e-service-logs`        | `e2e`              | `backend.log` und `frontend.log`                                                                      | 7 Tage    |
+| `e2e-service-logs`        | `e2e-chromium`     | `backend.log` und `frontend.log`                                                                      | 7 Tage    |
+| `webkit-e2e-service-logs` | `webkit-e2e`       | Backend-/Frontend-Logs und WebKit-Screenshots bei Browserfehlern                                      | 7 Tage    |
 | `classroom-smoke-reports` | `classroom-smokes` | Standardisiertes JSON + JUnit XML für sechs Szenarien (inkl. `channel-ws-fanout`) sowie `backend.log` | 7 Tage    |
 | `artillery-500-reports`   | `artillery-500`    | Artillery-Rohreport, JSON/JUnit für Unified, Vote, Yjs, Freitext und Soak sowie `backend.log`         | 30 Tage   |
 | `trivy-fs-report`         | `trivy-fs`         | SARIF-Report (`trivy-fs.sarif`)                                                                       | 7 Tage    |
@@ -304,6 +307,7 @@ Auf dem Server übernimmt `scripts/deploy.sh` die Reihenfolge **Digest-Image pul
 | `smoke:numeric-estimate`          | Numerische-Schätzfrage-Flow-Smoke                                       |
 | `smoke:session-question-progress` | Zwei-Client-Smoke für späteren Start, Vote, Skip und Nachbesprechung    |
 | `e2e:confidence-summary-demo`     | Demo-Quiz: 30 TN + Confidence-Abschluss                                 |
+| `e2e:motd-focus`                  | Desktop-MOTD: Tastatur-/Pointer-Rücksprung und fortgesetzte Tab-Reihe   |
 | `smoke:quiz-sync`                 | Quiz-Sync-Flow-Skript                                                   |
 | `smoke:unified-session`           | Unified-Session-Flow inklusive axe                                      |
 | `lighthouse:a11y`                 | Score und A11y-Einzelaudits (lokal)                                     |
@@ -321,11 +325,45 @@ gegen das Profil `ua1`. Das manuelle Prüfprotokoll steht unter
 
 `a11y:axe:static`, `a11y:layout`, `smoke:short-text`,
 `smoke:session-question-progress` und `smoke:unified-session` sind Bestandteile
-des CI-Jobs `e2e`. `smoke:short-text` und `smoke:unified-session` schreiben bei
+des Chromium-Jobs `e2e-chromium`. Der Job `webkit-e2e` startet dieselben echten
+Backend-/Frontend-Services, wählt WebKit explizit und führt `e2e:motd-focus`
+aus. Der Required-Check `e2e` wird nur grün, wenn beide
+Browser-Jobs erfolgreich sind. `smoke:short-text` und `smoke:unified-session` schreiben bei
 gesetztem `SMOKE_ARTIFACT_DIR` zusätzlich axe-JSON-Berichte; der
 Session-Verlaufs-Smoke schreibt einen Abschluss- oder Fehler-Screenshot. Mit
 `A11Y_SCAN=0` lassen sich nur die axe-Schritte lokal deaktivieren; CI setzt diese
 Ausnahme nicht.
+
+Lokal lassen sich dieselben browserabhängigen Prüfungen gezielt ausführen:
+
+```bash
+BASE_URL=http://localhost:4200 PLAYWRIGHT_BROWSER=chromium npm run a11y:layout -w @arsnova/frontend
+BASE_URL=http://localhost:4200 PLAYWRIGHT_BROWSER=webkit npm run e2e:motd-focus -w @arsnova/frontend
+```
+
+Playwright WebKit prüft die WebKit-Engine reproduzierbar, ist aber nicht die
+Safari-App und übernimmt weder deren Browseroberfläche noch die macOS-Einstellung
+für vollständige Tastaturnavigation. Vor Releases mit Änderungen an Dialogen,
+Fokus oder Tab-Reihenfolge daher zusätzlich Safari auf macOS manuell prüfen:
+
+1. In Safari unter **Einstellungen → Erweitert** die Option zum Hervorheben aller
+   Webseitenobjekte per Tabulator einmal aus- und einmal einschalten; zusätzlich
+   die macOS-Tastaturnavigation einmal aus- und einmal einschalten. Je nach
+   Einstellung mit `Tab` beziehungsweise `⌥ Tab` durch die Seite navigieren.
+2. MOTD per Tastatur über **Schließen** und **Alles klar** beenden: Danach muss
+   **Code eingeben** den sichtbaren Tastatur-Fokusrahmen erhalten; der nächste
+   Navigationstastendruck führt zu **Quiz erstellen**, nicht zum Skip-Link.
+3. MOTD jeweils per Maus über **Schließen** und **Alles klar** beenden, während
+   der Fokus noch auf dem Schließen-Button liegt: Beide Klicks müssen reagieren;
+   **Code eingeben** ist danach das Fokusziel, aber ohne Tastatur-Fokusrahmen.
+4. Vor dem verzögerten MOTD-Öffnen das Codefeld fokussieren und dann per Maus
+   schließen: Nach dem Schließen liegt der Fokus auf **Code eingeben**, nicht im
+   Codefeld oder im entfernten Dialog.
+
+Siehe auch Apples Dokumentation zu
+[Safari-Tastaturkurzbefehlen](https://support.apple.com/de-de/guide/safari/cpsh003/mac)
+und zur
+[macOS-Tastaturnavigation](https://support.apple.com/de-de/guide/mac-help/mchlc06d1059/mac).
 
 Prisma-Schema lokal: `npx prisma validate` (in CI ohne DB).
 


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Auf mobilen Touch-Geräten konnte der Skip-Link „Zum Inhalt springen“ nach programmgesteuertem Fokus sichtbar erscheinen. Zusätzlich fokussierte der automatisch geöffnete MOTD-Dialog nach Return ohne ursprünglichen Öffner den Skip-Link; ein erster Ersatzfokus wurde noch vor dem Abbau von Dialog und Fokus-Trap gesetzt und dadurch im realen Browser wieder verloren. Desktop-Safari kann außerdem den globalen `TouchEvent`-Konstruktor auslassen: Die neue `instanceof TouchEvent`-Erkennung brach dann Maus-Dismiss ab. Weil Safari Dialog-Buttons per Maus nicht fokussiert, konnte der CDK-Focus-Trap anschließend das zuvor aktive Codefeld statt des sichtbaren CTA wiederherstellen.
- **Lösung:** Der Skip-Link wird nur noch über `:focus-visible` eingeblendet. Nach dem MOTD-Abbau setzt `afterNextRender` den Fokus auf den sichtbaren primären Hero-CTA. Der konkrete Ursprung (`keyboard`, `mouse`, `touch`) wird ohne browserabhängige Event-Konstruktoren aus dem Event-Typ abgeleitet und über Angular CDK `FocusMonitor` bis zum Rücksprung erhalten; Tastatur zeigt einen MD3-Strong-Focus-Ring, Pointer/Touch nicht. Fokus in `body`, Dialog oder inertem Hintergrund wird nach dem Trap-Abbau zuverlässig ersetzt. Ein expliziter WebKit-E2E-Job prüft diese Safari-nahen Fokuspfade; der vorhandene Required-Check aggregiert Chromium und WebKit blockierend.
- **Bewusste Nicht-Ziele:** Der Skip-Link wird weder entfernt noch auf mobilen Breakpoints deaktiviert. MOTD-Inhalt, Interaktionsprotokollierung und allgemeine Button-Hierarchie bleiben unverändert.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Maßgeblich sind WCAG 2.2 AA, die bestehende Skip-Link-Reihenfolge sowie das Fokusmanagement des modalen MOTD-Overlays. Der Skip-Link bleibt der erste Tastatur-Tabstopp und aktiviert weiterhin `#main-content`. Reine Touch-/Pointer-Interaktion darf ihn nicht sichtbar machen. Nach dem Entfernen des Dialog-DOM muss ein sichtbares, nicht verdecktes und fachlich sinnvolles Fokusziel existieren; Tastatur- und Pointer-Ursprung bleiben unterscheidbar.

**Betroffene externe Verträge:**

Keine Netzwerk- oder Datenverträge. Verwendet werden die standardisierte CSS-Pseudoklasse `:focus-visible` sowie Angular CDK `FocusMonitor` und Angular `afterNextRender`. Der Browservertrag wird durch Playwright Chromium und WebKit geprüft; Playwright WebKit ersetzt nicht die Safari-App oder deren macOS-/Safari-Einstellungen.

## Implementierung

- Den allgemeinen Selektor `.app-skip-link:focus` entfernt und die sichtbare Darstellung auf `.app-skip-link:focus-visible` begrenzt.
- MOTD-Aktivierungsereignis an Close-, ACK-, Backdrop- und Escape-Pfade weitergereicht, damit Keyboard- und Pointer-Dismiss getrennt behandelt werden.
- Fokus-Rücksprung hinter den abgeschlossenen Angular-Render gelegt; damit sind Dialog-Fokus-Trap und `inert` bereits entfernt.
- Ohne ursprünglichen Öffner dient der sichtbare Hero-CTA „Code eingeben“ als Rücksprungziel. Keyboard-Dismiss nutzt CDK-Tastaturfokus samt 3-px-MD3-Ring. Maus/Touch/Backdrop erhalten explizit ihren jeweiligen CDK-Ursprung und keinen Strong-Focus-Ring – auch wenn macOS beim Klick auf „Alles klar“ den Fokus noch auf dem initial fokussierten Schließen-Button belässt.
- Event-Ursprung über `event.type` statt `instanceof TouchEvent` bestimmt, damit Mausaktionen auch in Desktop-Safari ohne globale Touch-API ausführbar bleiben.
- Das automatisch überlagerte Codefeld nicht als Dialog-Öffner gespeichert; `body`-, Dialog- und `inert`-Fokus gelten beim Abbau als rücksprungpflichtig, sodass der CDK-Trap das Codefeld nicht dauerhaft wiederherstellt.
- Unit- und Playwright-Regressionen für Skip-Link, tatsächliches MOTD-Return-Ziel, Safari ohne `TouchEvent`, CDK-Trap-Restore, Fokusklasse, berechneten Fokusrahmen und Pointer-Abgrenzung ergänzt.
- Eigenen WebKit-Job mit produktionsnahem Frontend, Backend, Postgres und Redis ergänzt. Der stabile Ruleset-Kontext `Playwright Smoke E2E` aggregiert den Chromium- und WebKit-Job und wird nur grün, wenn beide Browserläufe erfolgreich sind. Browser-Smoke-Kommandos, Artefakte und die manuelle Safari-Prüfmatrix sind in `docs/TESTING.md` und `docs/CI-WORKFLOW.md` dokumentiert.
- Den bestehenden Session-Progress-Smoke gegenüber seinem bekannten Vote-Limit deterministisch gemacht: aufeinanderfolgende Votes desselben Testteilnehmers halten die serverseitige Sekunde mit 100 ms Reserve ein, und der Smoke prüft die tatsächliche `vote.submit`-HTTP-Antwort statt einen 429 erst als späteren Host-Timeout zu melden.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run lint` | Erfolgreich, einschließlich Script-Lint-Gate |
| Commit-Hook `npm run typecheck` | Shared Types, Report, Backend und Frontend erfolgreich |
| Commit-Hook `npm test` | Shared Types 47, Report 81, Backend 886 und Frontend 1.237 Tests erfolgreich; 13 vorgesehene Backend-Skips |
| `npm run test -w @arsnova/frontend -- src/app/features/home/home.component.spec.ts` | 78 Tests erfolgreich |
| `npm run test -w @arsnova/frontend -- --run src/app/features/home/home.component.spec.ts src/app/app.component.spec.ts` | 108 Tests erfolgreich |
| `npm run typecheck -w @arsnova/frontend` | Erfolgreich |
| `npm run build:prod` | Shared-Types- und Backend-Build sowie lokalisierter Frontend-Produktionsbuild; MOTD-Asset-Check für 5 Locales × 14 Assets erfolgreich |
| `npm run a11y:layout -w @arsnova/frontend` | 49 Zustände plus Desktop-Join und Footer-Breakpoints erfolgreich; MOTD per Return und nach Reload per Pointer geschlossen, Ziel, berechneter 3-px-Tastaturrahmen und fehlender Pointer-Ring geprüft |
| Realer Chromium-Check bei 390 × 844 | Return: `cdk-keyboard-focused`, sichtbare 3-px-Outline mit 3-px-Offset. Schließen per Maus und macOS-naher „Alles klar“-Klick ohne Fokusübernahme: `cdk-mouse-focused`, Material-Indikator `display: none`. |
| `PLAYWRIGHT_BROWSER=webkit BASE_URL=http://localhost:4201 npm run e2e:motd-focus -w @arsnova/frontend` | Vier Szenarien erfolgreich: Schließen/ACK per Tastatur, Pointer-Schließen nach vorherigem Codefeldfokus und Pointer-ACK bei Fokus auf Schließen; einschließlich fehlendem `TouchEvent`, Safari-reduzierter `Tab`-/`⌥ Tab`-Reihe, CTA-Rücksprung und Fokusdarstellung. |
| `PLAYWRIGHT_BROWSER=chromium BASE_URL=http://localhost:4201 npm run e2e:motd-focus -w @arsnova/frontend` | Dieselben vier Szenarien als Chromium-Gegenprobe erfolgreich. |
| `BASE_URL=http://localhost:4201/de TRPC_URL=http://localhost:3000/trpc npm run smoke:session-question-progress -w @arsnova/frontend` | Erfolgreich: zwei akzeptierte Votes desselben Teilnehmers, Skip auf Frage 3, Live-Ergebnis und abschließende Nachbesprechung. |
| `npm run lint:scripts:changed` | Neuer Playwright-Test vollständig inventarisiert; 0 Fehler und 0 Warnungen. |
| `npm run validate:required-checks:test && npm run validate:required-checks` | 14 Validator-Tests und Required-Check-Vertrag erfolgreich. |
| Workflow-YAML-Parse und `npx prettier --check` für alle geänderten Dateien | Erfolgreich; 28 Workflow-Jobs erkannt. |
| `git diff --check` | Erfolgreich |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Touch-/Pointer-Fokus blendet den Skip-Link nicht mehr ein. Nach Tastatur-Dismiss der MOTD landet der sichtbare Fokus nach abgeschlossenem Dialogabbau auf „Code eingeben“; Backdrop-/Pointer-Dismiss zeigt keinen Tastatur-Ring.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine Secrets oder Deployment-Schritte. GitHub Actions installiert WebKit im neuen parallelen Job; der bestehende Required-Check-Name bleibt unverändert.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Der WebKit-Job lädt bei Erfolg oder Fehler Backend-/Frontend-Logs und bei Browserfehlern Screenshots als `webkit-e2e-service-logs` hoch.
- **Rollback:** Die PR-Commits `127e43c2`, `c74aa357`, `5fb7699b`, `5e3785fd`, `fdbfd14b` und `e2bcce15` revertieren beziehungsweise den späteren Merge-Commit revertieren.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Reale mobile Chromium-Reproduktion vor dem finalen Fix: Nach Return war `document.activeElement` noch `<body>`; die Microtask lief vor dem vollständigen Dialog-/`inert`-Abbau.
- Reale mobile Chromium-Reproduktion nach dem Fix: aktiver Hero-CTA mit sichtbarem MD3-Strong-Focus-Ring nach Return; kein Skip-Link.
- Reale Pointer-Reproduktion umfasst den Schließen-Button sowie einen synthetischen macOS-nahen „Alles klar“-Klick, bei dem der Dialogfokus noch auf Schließen liegt. Beide ergeben `cdk-mouse-focused` ohne Material-Fokusindikator.
- Derselbe Ablauf ist zusätzlich mit Playwright WebKit 26.5 geprüft: `window.TouchEvent` fehlt, Dialog-Buttonfokus wird Safari-typisch unterdrückt und der CDK-Trap stellt das Codefeld beim Abbau zunächst wieder her. Beide Dismiss-Aktionen bleiben ausführbar und der abschließende Fokus liegt auf „Code eingeben“. WebKit deckt die Browser-Engine ab, ersetzt aber keinen manuellen Test in der Safari-App mit den konkreten macOS-/Safari-Einstellungen zur vollständigen Tastaturnavigation.
- Der eingecheckte `e2e:motd-focus`-Smoke führt alle vier Fokuspfade unter Chromium und WebKit aus. Auf WebKit akzeptiert er beide engineabhängigen Vollnavigationsmodi: direktes `Tab` oder Safaris reduziertes `Tab` mit `⌥ Tab` für Links und Buttons. Der Ruleset-Kontext `Playwright Smoke E2E` wartet als Aggregator auf beide Jobs.
- Der verschärfte 320-px-WCAG-Lauf klickt die MOTD auf `/de/` nicht mehr vorab weg, sondern prüft Return und nach frischem Reload Pointer einschließlich aktiver Fokusklasse und berechneter Darstellung.
- Der erste kombinierte Chromium-CI-Lauf legte im bereits vorhandenen Session-Progress-Smoke einen `vote.submit`-429 offen: Frage 3 wurde weniger als eine Sekunde nach dem Vote auf Frage 2 beantwortet. Der Test wartet nun gezielt bis zum Ende dieses teilnehmerbezogenen Limits und wertet die Vote-Antwort direkt aus; der fokussierte reale Browser-Nachtest ist grün.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Realtime, Backend-Verträge, Reconnect, Migration, Datenpersistenz, Parallelität, Sicherheitsgrenzen und Last sind nicht betroffen. Die bestehende nicht blockierende MOTD-Interaktionsprotokollierung wird nicht verändert; ihr Pending-Pfad bleibt durch den vorhandenen Test abgedeckt.
- **Verbleibende Risiken:** Die konkrete Tab-Reihenfolge in Safari hängt zusätzlich von „Tastaturnavigation“ in macOS und „Über Tabulator jedes Objekt auf einer Webseite hervorheben“ in Safari ab. Der Rücksprung nutzt deshalb zusätzlich den von Angular Material unterstützten CDK-Fokusursprung und einen expliziten MD3-Token-Ring; der Ablauf wurde in Chromium und Playwright WebKit geprüft. Playwright WebKit automatisiert die Engine, nicht die Safari-App. Ein manueller Safari-Smoke mit beiden Systemeinstellungen bleibt daher Teil der dokumentierten Release-Prüfmatrix. Das 320-px-Reflow-/Zielgrößen-Gate bleibt unter Chromium; eine Kombination aus iPhone-Mobile-Emulation und Desktop-Safari-`⌥ Tab` wurde bewusst nicht als zusätzlicher CI-Vertrag definiert, weil sie keinen realen Gerätemodus abbildet.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
