### PR TITLE
Block broken Samsung PWA install prompt

### DIFF
--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -346,6 +346,64 @@ describe('AppComponent', () => {
     fixture.destroy();
   });
 
+  it('unterdrueckt den eigenen Installationshinweis in Samsung Internet', async () => {
+    localStorage.removeItem('pwa-install-dismissed');
+    const userAgentSpy = vi
+      .spyOn(window.navigator, 'userAgent', 'get')
+      .mockReturnValue(
+        'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 SamsungBrowser/28.0 Chrome/130.0 Mobile Safari/537.36',
+      );
+    const prompt = vi.fn().mockResolvedValue(undefined);
+    const installEvent = Object.assign(new Event('beforeinstallprompt', { cancelable: true }), {
+      prompt,
+      userChoice: Promise.resolve({ outcome: 'accepted' as const }),
+    });
+    configureAppTestBed();
+    const fixture = TestBed.createComponent(AppComponent);
+
+    try {
+      fixture.detectChanges();
+      window.dispatchEvent(installEvent);
+      fixture.detectChanges();
+
+      expect(installEvent.defaultPrevented).toBe(true);
+      expect(fixture.nativeElement.querySelector('.app-install-snackbar')).toBeNull();
+
+      await fixture.componentInstance.triggerInstall();
+      expect(prompt).not.toHaveBeenCalled();
+    } finally {
+      fixture.destroy();
+      userAgentSpy.mockRestore();
+    }
+  });
+
+  it('zeigt den eigenen Installationshinweis weiterhin in unterstuetztem Chromium', () => {
+    localStorage.removeItem('pwa-install-dismissed');
+    const userAgentSpy = vi
+      .spyOn(window.navigator, 'userAgent', 'get')
+      .mockReturnValue(
+        'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/130.0 Mobile Safari/537.36',
+      );
+    const installEvent = Object.assign(new Event('beforeinstallprompt', { cancelable: true }), {
+      prompt: vi.fn().mockResolvedValue(undefined),
+      userChoice: Promise.resolve({ outcome: 'dismissed' as const }),
+    });
+    configureAppTestBed();
+    const fixture = TestBed.createComponent(AppComponent);
+
+    try {
+      fixture.detectChanges();
+      window.dispatchEvent(installEvent);
+      fixture.detectChanges();
+
+      expect(installEvent.defaultPrevented).toBe(true);
+      expect(fixture.nativeElement.querySelector('.app-install-snackbar')).toBeTruthy();
+    } finally {
+      fixture.destroy();
+      userAgentSpy.mockRestore();
+    }
+  });
+
   it('rendert den Update-Banner als auffaelliges Callout mit primaerer CTA', async () => {
     TestBed.configureTestingModule({
       imports: [AppComponent],

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -630,6 +630,13 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private onBeforeInstallPrompt(e: BeforeInstallPromptEvent): void {
     e.preventDefault();
+    // Samsung Internet erzeugt derzeit auf Android 14+ teils veraltete WebAPKs.
+    // Nur unseren Custom-Prompt unterdruecken; Details: docs/architecture/pwa-webapk-android.md.
+    if (/\bSamsungBrowser\//i.test(navigator.userAgent)) {
+      this.deferredInstallPrompt = null;
+      this.installSnackbarVisible.set(false);
+      return;
+    }
     this.deferredInstallPrompt = e;
     this.installSnackbarVisible.set(true);
   }

--- a/docs/architecture/pwa-webapk-android.md
+++ b/docs/architecture/pwa-webapk-android.md
@@ -1,12 +1,28 @@
 # PWA & Android WebAPK (Chrome „Add to Home Screen“)
 
-**Stand:** 2026-05-31
+**Stand:** 2026-08-14
 
 ## Hintergrund: WebAPK und Target SDK
 
 Unter Android erzeugt Chrome beim „App installieren“ (Add to Home Screen) kein einfaches Lesezeichen, sondern fordert bei Googles **WebAPK Minting Server** eine generierte APK an. Deren `targetSdkVersion` muss aktuell sein, sonst blockiert Android 14+ bzw. Play Protect die Installation mit einer Warnung („für ältere Android-Version entwickelt“).
 
 Ursachen können sein: veraltete Chrome-Version beim Nutzer oder **gecachte alte WebAPKs** auf Googles Servern.
+
+## Temporärer Schutz für Samsung Internet
+
+Für Samsung Internet ist seit April 2026 ein noch offener Fehlerbericht bekannt,
+nach dem der Browser auf Android 14+ ein WebAPK mit veraltetem Target SDK erzeugen
+kann. Android blockiert die Installation dann als unsicher, während dieselbe PWA
+über Chrome installierbar bleibt:
+[`SamsungInternet/support#123`](https://github.com/SamsungInternet/support/issues/123).
+
+arsnova.eu unterdrückt deshalb vorübergehend nur seinen eigenen
+Installationshinweis, wenn das `beforeinstallprompt`-Event aus einem User-Agent mit
+dem von Samsung dokumentierten Token `SamsungBrowser/` stammt. Die
+browser-eigenen Menüfunktionen bleiben davon unberührt. Firefox und allgemeine
+In-App-Browser werden nicht per User-Agent gesperrt: Ohne unterstütztes
+`beforeinstallprompt`-Event erscheint der eigene Installationshinweis ohnehin
+nicht.
 
 ## Was wir tun: Manifest-Cache-Busting
 


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Samsung Internet kann auf Android 14+ derzeit ein veraltetes WebAPK erzeugen. Obwohl `beforeinstallprompt` ausgelöst wird, führt der von arsnova.eu angebotene Installationsbutton dann in eine Android-Sicherheitswarnung.
- **Lösung:** Der bestehende Custom-Installationshinweis wird ausschließlich für den dokumentierten Samsung-UA-Token `SamsungBrowser/` unterdrückt. Das reguläre Chromium-Verhalten bleibt unverändert und wird durch einen Gegenbeispieltest abgesichert.
- **Bewusste Nicht-Ziele:** Keine dauerhafte Einstufung von Samsung Internet als PWA-inkompatibel, keine Firefox- oder allgemeine In-App-Browser-Blacklist und keine Änderung browser-eigener Installationsmenüs.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Der vorhandene `beforeinstallprompt`-Ablauf in `AppComponent` bleibt die maßgebliche Quelle. Ein Installationshinweis darf nur erscheinen, wenn ein wiederverwendbarer Prompt gespeichert wurde. Für Samsung Internet wird das Event weiterhin mit `preventDefault()` abgefangen, aber weder gespeichert noch als arsnova.eu-Hinweis dargestellt.

**Betroffene externe Verträge:**

Browser-API `beforeinstallprompt` sowie der von Samsung dokumentierte User-Agent-Token `SamsungBrowser/`. Der temporäre Workaround basiert auf dem offenen Bericht `SamsungInternet/support#123` und ist in `docs/architecture/pwa-webapk-android.md` dokumentiert.

## Implementierung

- Samsung Internet im bestehenden Installationshandler gezielt erkennen, den gespeicherten Prompt löschen und die Installations-Snackbar verborgen halten.
- Regressionstest für Samsung Internet sowie positiver Gegenbeispieltest für unterstütztes Chromium ergänzen.
- WebAPK-Dokumentation um Zweck, Grenzen und Rückbaukriterium des temporären Workarounds ergänzen.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [x] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run test -w @arsnova/frontend -- src/app/app.component.spec.ts` | 32/32 Tests bestanden |
| `npm run test -w @arsnova/frontend` | 86 Testdateien, 1.247/1.247 Tests bestanden |
| `npm run typecheck -w @arsnova/frontend` | bestanden |
| `npm run typecheck` | bestanden (Commit-Hook) |
| `npm test` | Shared Types 47/47, Report 81/81, Backend 888 bestanden/13 übersprungen, Frontend 1.247/1.247 |
| `npm run lint` | bestanden |
| `npm run build:prod` | bestanden; lokalisierter Produktionsbuild und 5 Locales × 14 MOTD-Assets geprüft |
| `npx prettier --check apps/frontend/src/app/app.component.ts apps/frontend/src/app/app.component.spec.ts docs/architecture/pwa-webapk-android.md` | bestanden |
| `git diff --check` | bestanden |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Nutzer von Samsung Internet sehen den arsnova.eu-eigenen Installationshinweis vorübergehend nicht mehr. Andere Chromium-Browser bleiben unverändert. Browser-eigene Installationsoptionen werden nicht entfernt.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine; reguläres Frontend-Deployment genügt.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Logs oder Metriken. Der offene Samsung-Fehlerbericht dient als Rückbauindikator.
- **Rollback:** Commit zurücknehmen; dadurch wird der bisherige Installationshandler vollständig wiederhergestellt.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Regressionstest simuliert einen Samsung-Internet-UA, prüft `defaultPrevented`, die verborgene Snackbar und dass `prompt()` nicht aufgerufen werden kann.
- Positiver Gegenbeispieltest simuliert Chrome auf Android und prüft, dass der vorhandene Installationshinweis weiterhin erscheint.
- Vollständige lokale Test-, Lint-, Typecheck- und Produktionsbuild-Ergebnisse sind oben dokumentiert.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Keine neue sichtbare UI, keine Texte, keine Fokusänderung, keine Realtime-/Datenbank-/Sicherheitsgrenzen und kein neuer asynchroner Ablauf. Manuelle Screenreader-, Reflow- und Lasttests sind deshalb nicht erforderlich.
- **Verbleibende Risiken:** User-Agent-Erkennung bleibt ein bewusst enger, temporärer Workaround. Samsung kann seinen Token oder das Installationsverhalten ändern; nach Behebung von `SamsungInternet/support#123` muss die Ausnahme erneut bewertet und möglichst entfernt werden. Die browser-eigene Installationsfunktion kann weiterhin angeboten werden.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft
