### PR TITLE
fix(demo-quiz): Ein-Wort-Vorgabe aus Freitextfrage und Beschreibung entfernen

### DIFF
--- a/apps/frontend/scripts/apply-demo-quiz-locale-strings.mjs
+++ b/apps/frontend/scripts/apply-demo-quiz-locale-strings.mjs
@@ -316,7 +316,7 @@ const LOCALES = {
     freeTextQuestion: md`
 ### Was hilft dir beim Lernen?
 
-Antworte mit **einem Wort**. Die Antworten werden als Wortwolke dargestellt.
+Die Antworten werden als Wortwolke dargestellt.
     `,
     description: md`![Praxis-Showcase](${PI_IMAGE_URL})
 
@@ -324,7 +324,7 @@ Antworte mit **einem Wort**. Die Antworten werden als Wortwolke dargestellt.
 
 Die 13 Fragen zeigen alle zehn Quiz-Fragetypen von arsnova.eu in einem kompakten Live-Ablauf. Du kannst Bilder, Markdown und KaTeX einsetzen, die Antwortsicherheit als Selbsteinschätzung nach bewertbaren Fragen erheben und numerische Fragen auch in zwei Diskussionsrunden durchführen.
 
-Die Demo zeigt außerdem, wie du **Schritte sortierst**, **Begriffe eindeutig zuordnest**, **Beispiele kategorisierst** sowie mit einer offenen Ein-Wort-Frage Begriffe aus dem Raum sammelst und als Wortwolke besprichst. Nach der Auflösung machen Musterlösungen und Verteilungen typische Unsicherheiten und Verwechslungen sichtbar.
+Die Demo zeigt außerdem, wie du **Schritte sortierst**, **Begriffe eindeutig zuordnest**, **Beispiele kategorisierst** sowie mit einer offenen Freitextfrage Antworten aus dem Raum sammelst und als Wortwolke besprichst. Nach der Auflösung machen Musterlösungen und Verteilungen typische Unsicherheiten und Verwechslungen sichtbar.
 
 Timer, Teams, Rangliste und Bonus-Codes ergänzen den spielerischen Ablauf. Tritt der Session für die Demo auf einem zweiten Gerät bei und öffne das Quiz anschließend im Bearbeitungsmodus, um die Umsetzung zu erkunden.`,
     questions: [
@@ -575,7 +575,7 @@ _Ordne jedes Element einer der drei Literaturepochen zu._
     freeTextQuestion: md`
 ### What helps you learn?
 
-Answer in **one word**. The responses will be displayed as a word cloud.
+The responses will be displayed as a word cloud.
     `,
     description: md`![Teaching showcase](${PI_IMAGE_URL})
 
@@ -583,7 +583,7 @@ Answer in **one word**. The responses will be displayed as a word cloud.
 
 These 13 questions demonstrate all ten arsnova.eu quiz formats in one concise live sequence. You can use images, Markdown and KaTeX, collect answer confidence after graded questions, and run a numeric question in two discussion rounds.
 
-The showcase also demonstrates how learners **order steps**, **match terms one to one**, **categorise examples**, and collect one-word responses from the group and discuss them as a word cloud. Once results are revealed, model solutions and distributions expose uncertainty and common mix-ups.
+The showcase also demonstrates how learners **order steps**, **match terms one to one**, **categorise examples**, and collect open free-text responses from the group and discuss them as a word cloud. Once results are revealed, model solutions and distributions expose uncertainty and common mix-ups.
 
 Timers, teams, the leaderboard and bonus codes add a playful rhythm. Join on a second device during the demo, then open the quiz editor to explore how each question is built.`,
     questions: [
@@ -831,7 +831,7 @@ _Assign each item to one of the three literary movements._
     freeTextQuestion: md`
 ### Qu’est-ce qui t’aide à apprendre ?
 
-Réponds en **un mot**. Les réponses seront affichées sous forme de nuage de mots.
+Les réponses seront affichées sous forme de nuage de mots.
     `,
     description: md`![Démonstration pédagogique](${PI_IMAGE_URL})
 
@@ -839,7 +839,7 @@ Réponds en **un mot**. Les réponses seront affichées sous forme de nuage de m
 
 Ces 13 questions présentent les dix formats de quiz d’arsnova.eu dans un parcours en direct concis. Tu peux utiliser des images, Markdown et KaTeX, recueillir le degré de confiance après les questions notées et organiser une question numérique en deux tours de discussion.
 
-La démonstration montre aussi comment **ordonner des étapes**, **associer des termes un à un**, **classer des exemples** et recueillir des réponses libres en un mot et les discuter sous forme de nuage de mots. Après la révélation, les solutions modèles et les répartitions font apparaître les hésitations et les confusions fréquentes.
+La démonstration montre aussi comment **ordonner des étapes**, **associer des termes un à un**, **classer des exemples** et recueillir des réponses libres et les discuter sous forme de nuage de mots. Après la révélation, les solutions modèles et les répartitions font apparaître les hésitations et les confusions fréquentes.
 
 Les chronos, les équipes, le classement et les codes bonus donnent du rythme. Rejoins la session sur un deuxième appareil pendant la démo, puis ouvre l’éditeur pour découvrir la construction des questions.`,
     questions: [
@@ -1087,7 +1087,7 @@ _Associe chaque élément à l’un des trois mouvements littéraires._
     freeTextQuestion: md`
 ### ¿Qué te ayuda a aprender?
 
-Responde con **una palabra**. Las respuestas se mostrarán como una nube de palabras.
+Las respuestas se mostrarán como una nube de palabras.
     `,
     description: md`![Demostración didáctica](${PI_IMAGE_URL})
 
@@ -1095,7 +1095,7 @@ Responde con **una palabra**. Las respuestas se mostrarán como una nube de pala
 
 Estas 13 preguntas presentan los diez formatos de cuestionario de arsnova.eu en una secuencia breve y dinámica. Puedes usar imágenes, Markdown y KaTeX, recoger el grado de seguridad tras las preguntas evaluadas y plantear una pregunta numérica en dos rondas de debate.
 
-La demostración también muestra cómo **ordenar pasos**, **relacionar términos uno a uno**, **clasificar ejemplos** y recoger respuestas abiertas de una sola palabra y comentarlas en forma de nube de palabras. Al mostrar los resultados, las soluciones y distribuciones revelan dudas y confusiones frecuentes.
+La demostración también muestra cómo **ordenar pasos**, **relacionar términos uno a uno**, **clasificar ejemplos** y recoger respuestas abiertas y comentarlas en forma de nube de palabras. Al mostrar los resultados, las soluciones y distribuciones revelan dudas y confusiones frecuentes.
 
 Los temporizadores, los equipos, la clasificación y los códigos de bonificación aportan ritmo. Entra desde un segundo dispositivo durante la demostración y abre después el editor para explorar cada pregunta.`,
     questions: [
@@ -1343,7 +1343,7 @@ _Asigna cada elemento a uno de los tres movimientos literarios._
     freeTextQuestion: md`
 ### Che cosa ti aiuta a imparare?
 
-Rispondi con **una sola parola**. Le risposte saranno visualizzate sotto forma di nuvola di parole.
+Le risposte saranno visualizzate sotto forma di nuvola di parole.
     `,
     description: md`![Dimostrazione didattica](${PI_IMAGE_URL})
 
@@ -1351,7 +1351,7 @@ Rispondi con **una sola parola**. Le risposte saranno visualizzate sotto forma d
 
 Queste 13 domande presentano tutti i dieci formati di quiz di arsnova.eu in una sequenza dal vivo compatta. Puoi usare immagini, Markdown e KaTeX, raccogliere il grado di sicurezza dopo le domande valutate e proporre una domanda numerica in due turni di discussione.
 
-La dimostrazione mostra anche come **ordinare passaggi**, **abbinare termini uno a uno**, **classificare esempi** e raccogliere risposte aperte di una sola parola e discuterle sotto forma di nuvola di parole. Dopo la rivelazione, soluzioni e distribuzioni evidenziano incertezze e abbinamenti confusi.
+La dimostrazione mostra anche come **ordinare passaggi**, **abbinare termini uno a uno**, **classificare esempi** e raccogliere risposte aperte e discuterle sotto forma di nuvola di parole. Dopo la rivelazione, soluzioni e distribuzioni evidenziano incertezze e abbinamenti confusi.
 
 Timer, squadre, classifica e codici bonus danno ritmo. Partecipa da un secondo dispositivo durante la dimostrazione, poi apri l’editor per esplorare ogni domanda.`,
     questions: [

--- a/apps/frontend/src/app/features/quiz/data/demo-quiz-payload.spec.ts
+++ b/apps/frontend/src/app/features/quiz/data/demo-quiz-payload.spec.ts
@@ -136,29 +136,36 @@ describe('getDemoQuizSeedFingerprint', () => {
 
   it('zeigt 13 Fragen, alle zehn Typen und genau eine unbewertete Wortwolkenfrage', () => {
     const localeEvidence = {
-      de: ['Schritte sortierst', 'zuordnest', 'kategorisierst', 'Wortwolke', 'einem Wort'],
-      en: ['order steps', 'match terms', 'categorise examples', 'word cloud', 'one word'],
+      de: ['Schritte sortierst', 'zuordnest', 'kategorisierst', 'Wortwolke', 'Freitextfrage'],
+      en: ['order steps', 'match terms', 'categorise examples', 'word cloud', 'free-text'],
       fr: [
         'ordonner des étapes',
         'associer des termes',
         'classer des exemples',
         'nuage de mots',
-        'un mot',
+        'réponses libres',
       ],
       es: [
         'ordenar pasos',
         'relacionar términos',
         'clasificar ejemplos',
         'nube de palabras',
-        'una palabra',
+        'respuestas abiertas',
       ],
       it: [
         'ordinare passaggi',
         'abbinare termini',
         'classificare esempi',
         'nuvola di parole',
-        'una sola parola',
+        'risposte aperte',
       ],
+    } as const;
+    const oneWordConstraint = {
+      de: ['einem Wort', 'Ein-Wort'],
+      en: ['one word', 'one-word'],
+      fr: ['un mot'],
+      es: ['una palabra', 'una sola palabra'],
+      it: ['una sola parola'],
     } as const;
     const confidenceLabels = {
       de: ['Sehr unsicher', 'Sehr sicher'],
@@ -198,10 +205,12 @@ describe('getDemoQuizSeedFingerprint', () => {
       });
       expect(freeTextQuestions[0]?.answers?.some((answer) => answer.isCorrect)).toBe(false);
       expect(questions.some((question) => /> \*\*/u.test(question.text ?? ''))).toBe(false);
+      const localizedCopy = `${payload.quiz?.description ?? ''}\n${freeTextQuestions[0]?.text ?? ''}`;
       for (const phrase of localeEvidence[locale]) {
-        expect(`${payload.quiz?.description ?? ''}\n${freeTextQuestions[0]?.text ?? ''}`).toContain(
-          phrase,
-        );
+        expect(localizedCopy).toContain(phrase);
+      }
+      for (const phrase of oneWordConstraint[locale]) {
+        expect(localizedCopy).not.toContain(phrase);
       }
       for (const question of questions.filter((entry) => entry.confidenceEnabled)) {
         expect([question.confidenceLabelLow, question.confidenceLabelHigh]).toEqual(

--- a/apps/frontend/src/app/features/session/session-present/session-present.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-present/session-present.component.spec.ts
@@ -119,7 +119,7 @@ describe('SessionPresentComponent', () => {
       questionOrder: 1,
       questionType: 'FREETEXT',
       questionText:
-        '### Was hilft dir beim Lernen?\n\nAntworte mit **einem Wort**. Die Antworten werden als Wortwolke dargestellt.',
+        '### Was hilft dir beim Lernen?\n\nDie Antworten werden als **Wortwolke** dargestellt.',
       responses: ['Praxis', 'Beispiele'],
       updatedAt: '2026-03-08T12:00:00.000Z',
     });
@@ -132,9 +132,9 @@ describe('SessionPresentComponent', () => {
 
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain('Frage 2: Was hilft dir beim Lernen?');
-    expect(text).toContain('Antworte mit einem Wort.');
+    expect(text).toContain('Die Antworten werden als Wortwolke dargestellt.');
     expect(text).not.toContain('###');
-    expect(text).not.toContain('**einem Wort**');
+    expect(text).not.toContain('**Wortwolke**');
     fixture.destroy();
   });
 

--- a/apps/frontend/src/assets/demo/quiz-demo-showcase.de.json
+++ b/apps/frontend/src/assets/demo/quiz-demo-showcase.de.json
@@ -3,7 +3,7 @@
   "exportedAt": "2026-05-24T10:00:00.000Z",
   "quiz": {
     "name": "Praxis-Showcase: Team-Quiz",
-    "description": "![Praxis-Showcase](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Praxis-Showcase für den Unterricht\n\nDie 13 Fragen zeigen alle zehn Quiz-Fragetypen von arsnova.eu in einem kompakten Live-Ablauf. Du kannst Bilder, Markdown und KaTeX einsetzen, die Antwortsicherheit als Selbsteinschätzung nach bewertbaren Fragen erheben und numerische Fragen auch in zwei Diskussionsrunden durchführen.\n\nDie Demo zeigt außerdem, wie du **Schritte sortierst**, **Begriffe eindeutig zuordnest**, **Beispiele kategorisierst** sowie mit einer offenen Ein-Wort-Frage Begriffe aus dem Raum sammelst und als Wortwolke besprichst. Nach der Auflösung machen Musterlösungen und Verteilungen typische Unsicherheiten und Verwechslungen sichtbar.\n\nTimer, Teams, Rangliste und Bonus-Codes ergänzen den spielerischen Ablauf. Tritt der Session für die Demo auf einem zweiten Gerät bei und öffne das Quiz anschließend im Bearbeitungsmodus, um die Umsetzung zu erkunden.",
+    "description": "![Praxis-Showcase](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Praxis-Showcase für den Unterricht\n\nDie 13 Fragen zeigen alle zehn Quiz-Fragetypen von arsnova.eu in einem kompakten Live-Ablauf. Du kannst Bilder, Markdown und KaTeX einsetzen, die Antwortsicherheit als Selbsteinschätzung nach bewertbaren Fragen erheben und numerische Fragen auch in zwei Diskussionsrunden durchführen.\n\nDie Demo zeigt außerdem, wie du **Schritte sortierst**, **Begriffe eindeutig zuordnest**, **Beispiele kategorisierst** sowie mit einer offenen Freitextfrage Antworten aus dem Raum sammelst und als Wortwolke besprichst. Nach der Auflösung machen Musterlösungen und Verteilungen typische Unsicherheiten und Verwechslungen sichtbar.\n\nTimer, Teams, Rangliste und Bonus-Codes ergänzen den spielerischen Ablauf. Tritt der Session für die Demo auf einem zweiten Gerät bei und öffne das Quiz anschließend im Bearbeitungsmodus, um die Umsetzung zu erkunden.",
     "motifImageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b4/Sixteen_faces_expressing_the_human_passions._Wellcome_L0068375_%28cropped%29.jpg",
     "showLeaderboard": true,
     "allowCustomNicknames": false,
@@ -37,7 +37,7 @@
         ]
       },
       {
-        "text": "### Was hilft dir beim Lernen?\n\nAntworte mit **einem Wort**. Die Antworten werden als Wortwolke dargestellt.",
+        "text": "### Was hilft dir beim Lernen?\n\nDie Antworten werden als Wortwolke dargestellt.",
         "type": "FREETEXT",
         "timer": null,
         "difficulty": "EASY",

--- a/apps/frontend/src/assets/demo/quiz-demo-showcase.en.json
+++ b/apps/frontend/src/assets/demo/quiz-demo-showcase.en.json
@@ -3,7 +3,7 @@
   "exportedAt": "2026-05-24T10:00:00.000Z",
   "quiz": {
     "name": "Teaching Showcase: Live Team Demo",
-    "description": "![Teaching showcase](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Teaching Practice Showcase\n\nThese 13 questions demonstrate all ten arsnova.eu quiz formats in one concise live sequence. You can use images, Markdown and KaTeX, collect answer confidence after graded questions, and run a numeric question in two discussion rounds.\n\nThe showcase also demonstrates how learners **order steps**, **match terms one to one**, **categorise examples**, and collect one-word responses from the group and discuss them as a word cloud. Once results are revealed, model solutions and distributions expose uncertainty and common mix-ups.\n\nTimers, teams, the leaderboard and bonus codes add a playful rhythm. Join on a second device during the demo, then open the quiz editor to explore how each question is built.",
+    "description": "![Teaching showcase](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Teaching Practice Showcase\n\nThese 13 questions demonstrate all ten arsnova.eu quiz formats in one concise live sequence. You can use images, Markdown and KaTeX, collect answer confidence after graded questions, and run a numeric question in two discussion rounds.\n\nThe showcase also demonstrates how learners **order steps**, **match terms one to one**, **categorise examples**, and collect open free-text responses from the group and discuss them as a word cloud. Once results are revealed, model solutions and distributions expose uncertainty and common mix-ups.\n\nTimers, teams, the leaderboard and bonus codes add a playful rhythm. Join on a second device during the demo, then open the quiz editor to explore how each question is built.",
     "motifImageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b4/Sixteen_faces_expressing_the_human_passions._Wellcome_L0068375_%28cropped%29.jpg",
     "showLeaderboard": true,
     "allowCustomNicknames": false,
@@ -37,7 +37,7 @@
         ]
       },
       {
-        "text": "### What helps you learn?\n\nAnswer in **one word**. The responses will be displayed as a word cloud.",
+        "text": "### What helps you learn?\n\nThe responses will be displayed as a word cloud.",
         "type": "FREETEXT",
         "timer": null,
         "difficulty": "EASY",

--- a/apps/frontend/src/assets/demo/quiz-demo-showcase.es.json
+++ b/apps/frontend/src/assets/demo/quiz-demo-showcase.es.json
@@ -3,7 +3,7 @@
   "exportedAt": "2026-05-24T10:00:00.000Z",
   "quiz": {
     "name": "Demostración didáctica: cuestionario por equipos",
-    "description": "![Demostración didáctica](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Demostración didáctica\n\nEstas 13 preguntas presentan los diez formatos de cuestionario de arsnova.eu en una secuencia breve y dinámica. Puedes usar imágenes, Markdown y KaTeX, recoger el grado de seguridad tras las preguntas evaluadas y plantear una pregunta numérica en dos rondas de debate.\n\nLa demostración también muestra cómo **ordenar pasos**, **relacionar términos uno a uno**, **clasificar ejemplos** y recoger respuestas abiertas de una sola palabra y comentarlas en forma de nube de palabras. Al mostrar los resultados, las soluciones y distribuciones revelan dudas y confusiones frecuentes.\n\nLos temporizadores, los equipos, la clasificación y los códigos de bonificación aportan ritmo. Entra desde un segundo dispositivo durante la demostración y abre después el editor para explorar cada pregunta.",
+    "description": "![Demostración didáctica](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Demostración didáctica\n\nEstas 13 preguntas presentan los diez formatos de cuestionario de arsnova.eu en una secuencia breve y dinámica. Puedes usar imágenes, Markdown y KaTeX, recoger el grado de seguridad tras las preguntas evaluadas y plantear una pregunta numérica en dos rondas de debate.\n\nLa demostración también muestra cómo **ordenar pasos**, **relacionar términos uno a uno**, **clasificar ejemplos** y recoger respuestas abiertas y comentarlas en forma de nube de palabras. Al mostrar los resultados, las soluciones y distribuciones revelan dudas y confusiones frecuentes.\n\nLos temporizadores, los equipos, la clasificación y los códigos de bonificación aportan ritmo. Entra desde un segundo dispositivo durante la demostración y abre después el editor para explorar cada pregunta.",
     "motifImageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b4/Sixteen_faces_expressing_the_human_passions._Wellcome_L0068375_%28cropped%29.jpg",
     "showLeaderboard": true,
     "allowCustomNicknames": false,
@@ -37,7 +37,7 @@
         ]
       },
       {
-        "text": "### ¿Qué te ayuda a aprender?\n\nResponde con **una palabra**. Las respuestas se mostrarán como una nube de palabras.",
+        "text": "### ¿Qué te ayuda a aprender?\n\nLas respuestas se mostrarán como una nube de palabras.",
         "type": "FREETEXT",
         "timer": null,
         "difficulty": "EASY",

--- a/apps/frontend/src/assets/demo/quiz-demo-showcase.fr.json
+++ b/apps/frontend/src/assets/demo/quiz-demo-showcase.fr.json
@@ -3,7 +3,7 @@
   "exportedAt": "2026-05-24T10:00:00.000Z",
   "quiz": {
     "name": "Démonstration pédagogique : quiz en équipe",
-    "description": "![Démonstration pédagogique](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Démonstration pédagogique\n\nCes 13 questions présentent les dix formats de quiz d’arsnova.eu dans un parcours en direct concis. Tu peux utiliser des images, Markdown et KaTeX, recueillir le degré de confiance après les questions notées et organiser une question numérique en deux tours de discussion.\n\nLa démonstration montre aussi comment **ordonner des étapes**, **associer des termes un à un**, **classer des exemples** et recueillir des réponses libres en un mot et les discuter sous forme de nuage de mots. Après la révélation, les solutions modèles et les répartitions font apparaître les hésitations et les confusions fréquentes.\n\nLes chronos, les équipes, le classement et les codes bonus donnent du rythme. Rejoins la session sur un deuxième appareil pendant la démo, puis ouvre l’éditeur pour découvrir la construction des questions.",
+    "description": "![Démonstration pédagogique](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Démonstration pédagogique\n\nCes 13 questions présentent les dix formats de quiz d’arsnova.eu dans un parcours en direct concis. Tu peux utiliser des images, Markdown et KaTeX, recueillir le degré de confiance après les questions notées et organiser une question numérique en deux tours de discussion.\n\nLa démonstration montre aussi comment **ordonner des étapes**, **associer des termes un à un**, **classer des exemples** et recueillir des réponses libres et les discuter sous forme de nuage de mots. Après la révélation, les solutions modèles et les répartitions font apparaître les hésitations et les confusions fréquentes.\n\nLes chronos, les équipes, le classement et les codes bonus donnent du rythme. Rejoins la session sur un deuxième appareil pendant la démo, puis ouvre l’éditeur pour découvrir la construction des questions.",
     "motifImageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b4/Sixteen_faces_expressing_the_human_passions._Wellcome_L0068375_%28cropped%29.jpg",
     "showLeaderboard": true,
     "allowCustomNicknames": false,
@@ -37,7 +37,7 @@
         ]
       },
       {
-        "text": "### Qu’est-ce qui t’aide à apprendre ?\n\nRéponds en **un mot**. Les réponses seront affichées sous forme de nuage de mots.",
+        "text": "### Qu’est-ce qui t’aide à apprendre ?\n\nLes réponses seront affichées sous forme de nuage de mots.",
         "type": "FREETEXT",
         "timer": null,
         "difficulty": "EASY",

--- a/apps/frontend/src/assets/demo/quiz-demo-showcase.it.json
+++ b/apps/frontend/src/assets/demo/quiz-demo-showcase.it.json
@@ -3,7 +3,7 @@
   "exportedAt": "2026-05-24T10:00:00.000Z",
   "quiz": {
     "name": "Dimostrazione didattica: quiz a squadre",
-    "description": "![Dimostrazione didattica](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Dimostrazione didattica\n\nQueste 13 domande presentano tutti i dieci formati di quiz di arsnova.eu in una sequenza dal vivo compatta. Puoi usare immagini, Markdown e KaTeX, raccogliere il grado di sicurezza dopo le domande valutate e proporre una domanda numerica in due turni di discussione.\n\nLa dimostrazione mostra anche come **ordinare passaggi**, **abbinare termini uno a uno**, **classificare esempi** e raccogliere risposte aperte di una sola parola e discuterle sotto forma di nuvola di parole. Dopo la rivelazione, soluzioni e distribuzioni evidenziano incertezze e abbinamenti confusi.\n\nTimer, squadre, classifica e codici bonus danno ritmo. Partecipa da un secondo dispositivo durante la dimostrazione, poi apri l’editor per esplorare ogni domanda.",
+    "description": "![Dimostrazione didattica](https://upload.wikimedia.org/wikipedia/commons/2/2a/Pi-unrolled-720.gif)\n\n# Dimostrazione didattica\n\nQueste 13 domande presentano tutti i dieci formati di quiz di arsnova.eu in una sequenza dal vivo compatta. Puoi usare immagini, Markdown e KaTeX, raccogliere il grado di sicurezza dopo le domande valutate e proporre una domanda numerica in due turni di discussione.\n\nLa dimostrazione mostra anche come **ordinare passaggi**, **abbinare termini uno a uno**, **classificare esempi** e raccogliere risposte aperte e discuterle sotto forma di nuvola di parole. Dopo la rivelazione, soluzioni e distribuzioni evidenziano incertezze e abbinamenti confusi.\n\nTimer, squadre, classifica e codici bonus danno ritmo. Partecipa da un secondo dispositivo durante la dimostrazione, poi apri l’editor per esplorare ogni domanda.",
     "motifImageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b4/Sixteen_faces_expressing_the_human_passions._Wellcome_L0068375_%28cropped%29.jpg",
     "showLeaderboard": true,
     "allowCustomNicknames": false,
@@ -37,7 +37,7 @@
         ]
       },
       {
-        "text": "### Che cosa ti aiuta a imparare?\n\nRispondi con **una sola parola**. Le risposte saranno visualizzate sotto forma di nuvola di parole.",
+        "text": "### Che cosa ti aiuta a imparare?\n\nLe risposte saranno visualizzate sotto forma di nuvola di parole.",
         "type": "FREETEXT",
         "timer": null,
         "difficulty": "EASY",


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Die Demo-Quiz-Freitextfrage und die Quiz-Beschreibung legen Teilnehmende auf ein einzelnes Wort fest („Antworte mit einem Wort“ / „Ein-Wort-Frage“). Die Wortwolke nimmt inzwischen auch Phrasen und geglättete Formen auf; die Vorgabe ist fachlich falsch und steht so in Produktion.
- **Lösung:** Ein-Wort-Vorgabe in allen fünf Locales aus Freitextfrage und Beschreibung entfernen. Die Wortwolke bleibt erwähnt, aber als offene Freitextfrage.
- **Bewusste Nicht-Ziele:** Kein Character-Counter, keine Änderung der Analyse/spaCy-Pipeline, kein erzwungenes Reseed lokal geänderter Demo-Quizzes.

## Risiko und Verträge

- [x] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

- Demo-Quiz-Quelle: `apps/frontend/scripts/apply-demo-quiz-locale-strings.mjs` und `apps/frontend/src/assets/demo/quiz-demo-showcase.{de,en,fr,es,it}.json`.
- ADR-0008 / `docs/I18N-ANGULAR.md`: Quellsprache DE, alle Locales synchron.
- `docs/features/word-cloud-spacy.md`: Wortwolke ist nicht auf Ein-Wort-Antworten beschränkt (WORDS/PHRASES, optionale Glättung).
- Demo-Reseed: `QuizStoreService.ensureDemoQuiz()` ersetzt unveränderte Demo-Quizzes bei Fingerprint- oder Inhaltsabweichung; lokal geänderte Demos bleiben erhalten.

**Betroffene externe Verträge:**

Keine.

## Implementierung

- Freitextfrage DE: „Antworte mit **einem Wort**.“ entfernt; Hinweis auf die Wortwolke bleibt.
- Beschreibung DE: „offenen Ein-Wort-Frage Begriffe“ → „offenen Freitextfrage Antworten“.
- Entsprechende Copy in `en`, `fr`, `es`, `it`.
- Regressionstests verbieten Ein-Wort-Phrasen in Beschreibung und Freitextfrage.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [x] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

Bestehende `ensureDemoQuiz()`-Tests decken Reseed bei Fingerprint-/Inhaltsabweichung und das Nicht-Überschreiben lokal geänderter Demos ab.

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npx prettier --check` (angepasste Demo-Dateien) | bestanden |
| `git diff --check` | bestanden |
| `npm run typecheck` (Pre-Commit, Workspaces) | bestanden |
| `npm test` (Pre-Commit: Shared-Types 61, Export-Report 81, Backend 956, Frontend 1277) | bestanden |
| `npx eslint` auf geänderte Specs | bestanden (0 Errors) |
| `npm run demo-quiz:locales -w @arsnova/frontend` | idempotent, kein Diff |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

Locales sind in Quelle und generierten JSONs synchron. Keine Layout-, Fokus- oder Kontraständerung: nur Quiz-Markdown-Copy.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Nach Frontend-Deploy reseedet `ensureDemoQuiz()` unveränderte Demo-Quizzes automatisch (Fingerprint enthält den Payload-Hash). Lokal bearbeitete Demo-Quizzes behalten den alten Text.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Normales Frontend-Deploy; keine Env- oder Migrationsänderung.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** `[DemoQuiz] Reseed failed` / `Seeding failed` im Browser bei Importfehlern.
- **Rollback:** Vorheriges Frontend-Release; unveränderte Demos werden erneut auf den alten Seed zurückgesetzt.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Pre-Commit: Typecheck und `npm test` grün (Frontend 1277 Tests).
- Regression: `demo-quiz-payload.spec.ts` verbietet Ein-Wort-Phrasen in Beschreibung und Freitextfrage für `de`/`en`/`fr`/`es`/`it`.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** `npm run lint` (gesamtes Repo) nicht ausgeführt; Prettier und ESLint auf die geänderten Specs sind grün. `npm run build:prod` nicht ausgeführt: reine Copy in bereits gültigen Demo-JSONs, keine Templates, Styles oder Build-Konfiguration. Ablehnungspfade, DOM-Fokus, Realtime, Last und Prisma sind nicht betroffen.
- **Verbleibende Risiken:** Hosts mit lokal geändertem Demo-Quiz (`arsnova-demo-quiz-user-modified-v1`) sehen den neuen Text erst nach manuellem Zurücksetzen oder Löschen des Demo-Eintrags. PWA-Screenshots können noch die alte Freitext-Copy zeigen, bis sie neu erfasst werden.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)