### PR TITLE
fix(host): Moderationskompass-Dialogtexte und Intro-Zeilenumbruch

### DIFF
--- a/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.html
+++ b/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.html
@@ -6,8 +6,13 @@
     <span class="dialog-title-header__heading" i18n="@@sessionHost.moderationDialogTitle">
       Moderationskompass
     </span>
-    <span class="dialog-title-header__sub" i18n="@@sessionHost.moderationDialogIntro">
-      Überblick aus Quiz, Fragen und Blitzlicht. Du entscheidest, was du aufgreifst.
+    <span class="dialog-title-header__sub moderation-compass-dialog__intro">
+      <span i18n="@@sessionHost.moderationDialogIntro">
+        Dein Live-Überblick über Quiz, Q&amp;A und Blitzlicht.
+      </span>
+      <span i18n="@@sessionHost.moderationDialogIntroDecide">
+        Du entscheidest, welche Themen behandelt werden.
+      </span>
     </span>
   </span>
 </h2>
@@ -24,10 +29,6 @@
 </button>
 
 <mat-dialog-content class="moderation-compass-dialog__content">
-  <p class="moderation-compass-dialog__mode" i18n="@@sessionHost.moderationRuleBasedHint">
-    Nur aus den Signalen dieser Session. Es ändert sich nichts von selbst.
-  </p>
-
   @if (hasCards()) {
     <div class="moderation-compass-dialog__cards">
       @for (card of cards(); track card.kind) {
@@ -68,7 +69,7 @@
     </div>
   } @else {
     <p class="moderation-compass-dialog__empty" role="status" i18n="@@sessionHost.moderationEmpty">
-      Sobald Fragen, Ergebnisse oder Blitzlicht da sind, siehst du hier Hinweise.
+      Hier erscheinen wichtige Trends und Auswertungen, sobald die Teilnehmenden aktiv werden.
     </p>
   }
 </mat-dialog-content>

--- a/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.scss
+++ b/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.scss
@@ -13,6 +13,12 @@
   height: 1.375rem;
 }
 
+.moderation-compass-dialog__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
 .moderation-compass-dialog__close {
   position: absolute;
   top: 0.55rem;
@@ -27,13 +33,6 @@
   max-height: min(70dvh, 40rem);
   padding-top: 0.15rem;
   padding-bottom: 0.75rem;
-}
-
-.moderation-compass-dialog__mode {
-  margin: 0;
-  color: var(--mat-sys-on-surface-variant);
-  font: var(--mat-sys-label-medium);
-  font-weight: 600;
 }
 
 .moderation-compass-dialog__empty {

--- a/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.spec.ts
@@ -30,7 +30,11 @@ describe('ModerationCompassDialogComponent', () => {
     const { fixture } = setup([]);
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain('Moderationskompass');
-    expect(text).toContain('Sobald Fragen, Ergebnisse oder Blitzlicht da sind');
+    expect(text).toContain('Dein Live-Überblick über Quiz, Q&A und Blitzlicht.');
+    expect(text).toContain('Du entscheidest, welche Themen behandelt werden.');
+    expect(text).toContain(
+      'Hier erscheinen wichtige Trends und Auswertungen, sobald die Teilnehmenden aktiv werden.',
+    );
     expect(
       fixture.nativeElement.querySelector('.dialog-title-header__icon .moderation-compass-icon'),
     ).not.toBeNull();
@@ -55,9 +59,6 @@ describe('ModerationCompassDialogComponent', () => {
     expect(text).toContain('Median · Wie berechnet man den Median?');
     expect(text).toContain('Nächster Schritt');
     expect(text).toContain('Fass die häufigsten Themen kurz zusammen.');
-    expect(text).toContain(
-      'Nur aus den Signalen dieser Session. Es ändert sich nichts von selbst.',
-    );
   });
 
   it('zeigt Blitzlicht-Rückmeldungen mit eigenem Kartentitel', () => {

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -13705,11 +13705,15 @@
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogTitle" datatype="html">
         <source> Moderationskompass </source>
-        <target>Moderation compass</target>
+        <target>Moderation Compass</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogIntro" datatype="html">
-        <source> Überblick aus Quiz, Fragen und Blitzlicht. Du entscheidest, was du aufgreifst. </source>
-        <target>A snapshot from the quiz, questions and live feedback. You decide what to pick up.</target>
+        <source> Dein Live-Überblick über Quiz, Q&amp;A und Blitzlicht. </source>
+        <target>Your live overview of Quiz, Q&amp;A, and Flash Polls.</target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationDialogIntroDecide" datatype="html">
+        <source> Du entscheidest, welche Themen behandelt werden. </source>
+        <target>You decide which topics take center stage.</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogCloseAria" datatype="html">
         <source>Moderationskompass schließen</source>
@@ -13719,13 +13723,9 @@
         <source>Zur Quelle: <x id="label" equiv-text="source.label"/></source>
         <target>Jump to source: <x id="label" equiv-text="source.label"/></target>
       </trans-unit>
-      <trans-unit id="sessionHost.moderationRuleBasedHint" datatype="html">
-        <source> Nur aus den Signalen dieser Session. Es ändert sich nichts von selbst. </source>
-        <target>Only from this session’s signals. Nothing changes on its own.</target>
-      </trans-unit>
       <trans-unit id="sessionHost.moderationEmpty" datatype="html">
-        <source> Sobald Fragen, Ergebnisse oder Blitzlicht da sind, siehst du hier Hinweise. </source>
-        <target>Once questions, results or live feedback come in, you’ll see hints here.</target>
+        <source> Hier erscheinen wichtige Trends und Auswertungen, sobald die Teilnehmenden aktiv werden. </source>
+        <target>Key trends and insights will appear here as soon as your audience gets active.</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardTopics" datatype="html">
         <source>Häufige Themen</source>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -13652,8 +13652,12 @@
         <target>Brújula de moderación</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogIntro" datatype="html">
-        <source> Überblick aus Quiz, Fragen und Blitzlicht. Du entscheidest, was du aufgreifst. </source>
-        <target>Una visión del cuestionario, las preguntas y el feedback en vivo. Tú decides qué retomas.</target>
+        <source> Dein Live-Überblick über Quiz, Q&amp;A und Blitzlicht. </source>
+        <target>Tu resumen en vivo de Quiz, Q&amp;A y Sondeos rápidos.</target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationDialogIntroDecide" datatype="html">
+        <source> Du entscheidest, welche Themen behandelt werden. </source>
+        <target>Tú decides qué temas abordar.</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogCloseAria" datatype="html">
         <source>Moderationskompass schließen</source>
@@ -13663,13 +13667,9 @@
         <source>Zur Quelle: <x id="label" equiv-text="source.label"/></source>
         <target>Ir a la fuente: <x id="label" equiv-text="source.label"/></target>
       </trans-unit>
-      <trans-unit id="sessionHost.moderationRuleBasedHint" datatype="html">
-        <source> Nur aus den Signalen dieser Session. Es ändert sich nichts von selbst. </source>
-        <target>Solo a partir de las señales de esta sesión. Nada cambia por sí solo.</target>
-      </trans-unit>
       <trans-unit id="sessionHost.moderationEmpty" datatype="html">
-        <source> Sobald Fragen, Ergebnisse oder Blitzlicht da sind, siehst du hier Hinweise. </source>
-        <target>Cuando haya preguntas, resultados o feedback relámpago, verás pistas aquí.</target>
+        <source> Hier erscheinen wichtige Trends und Auswertungen, sobald die Teilnehmenden aktiv werden. </source>
+        <target>Las tendencias clave y los resultados aparecerán aquí en cuanto tu audiencia empiece a participar.</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardTopics" datatype="html">
         <source>Häufige Themen</source>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -13652,8 +13652,12 @@
         <target>Boussole de modération</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogIntro" datatype="html">
-        <source> Überblick aus Quiz, Fragen und Blitzlicht. Du entscheidest, was du aufgreifst. </source>
-        <target>Un aperçu du quiz, des questions et du feedback live. C’est toi qui décides ce que tu reprends.</target>
+        <source> Dein Live-Überblick über Quiz, Q&amp;A und Blitzlicht. </source>
+        <target>Ton aperçu en direct des Quiz, Q&amp;A et Sondages éclair.</target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationDialogIntroDecide" datatype="html">
+        <source> Du entscheidest, welche Themen behandelt werden. </source>
+        <target>C'est toi qui décides des sujets à aborder.</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogCloseAria" datatype="html">
         <source>Moderationskompass schließen</source>
@@ -13663,13 +13667,9 @@
         <source>Zur Quelle: <x id="label" equiv-text="source.label"/></source>
         <target>Aller à la source : <x id="label" equiv-text="source.label"/></target>
       </trans-unit>
-      <trans-unit id="sessionHost.moderationRuleBasedHint" datatype="html">
-        <source> Nur aus den Signalen dieser Session. Es ändert sich nichts von selbst. </source>
-        <target>Uniquement à partir des signaux de cette session. Rien ne change tout seul.</target>
-      </trans-unit>
       <trans-unit id="sessionHost.moderationEmpty" datatype="html">
-        <source> Sobald Fragen, Ergebnisse oder Blitzlicht da sind, siehst du hier Hinweise. </source>
-        <target>Dès qu’il y a des questions, des résultats ou un feedback éclair, tu verras des pistes ici.</target>
+        <source> Hier erscheinen wichtige Trends und Auswertungen, sobald die Teilnehmenden aktiv werden. </source>
+        <target>Les tendances clés et les résultats apparaîtront ici dès que ton public commencera à participer.</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardTopics" datatype="html">
         <source>Häufige Themen</source>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -13652,8 +13652,12 @@
         <target>Bussola di moderazione</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogIntro" datatype="html">
-        <source> Überblick aus Quiz, Fragen und Blitzlicht. Du entscheidest, was du aufgreifst. </source>
-        <target>Una panoramica da quiz, domande e feedback live. Decidi tu cosa riprendere.</target>
+        <source> Dein Live-Überblick über Quiz, Q&amp;A und Blitzlicht. </source>
+        <target>La tua panoramica dal vivo su Quiz, Q&amp;A e Sondaggi rapidi.</target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationDialogIntroDecide" datatype="html">
+        <source> Du entscheidest, welche Themen behandelt werden. </source>
+        <target>Tu decidi quali argomenti trattare.</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogCloseAria" datatype="html">
         <source>Moderationskompass schließen</source>
@@ -13663,13 +13667,9 @@
         <source>Zur Quelle: <x id="label" equiv-text="source.label"/></source>
         <target>Vai alla fonte: <x id="label" equiv-text="source.label"/></target>
       </trans-unit>
-      <trans-unit id="sessionHost.moderationRuleBasedHint" datatype="html">
-        <source> Nur aus den Signalen dieser Session. Es ändert sich nichts von selbst. </source>
-        <target>Solo dai segnali di questa sessione. Non cambia nulla da solo.</target>
-      </trans-unit>
       <trans-unit id="sessionHost.moderationEmpty" datatype="html">
-        <source> Sobald Fragen, Ergebnisse oder Blitzlicht da sind, siehst du hier Hinweise. </source>
-        <target>Appena ci sono domande, risultati o feedback lampo, vedi qui dei suggerimenti.</target>
+        <source> Hier erscheinen wichtige Trends und Auswertungen, sobald die Teilnehmenden aktiv werden. </source>
+        <target>Le tendenze e gli insight principali appariranno qui non appena il pubblico inizierà a partecipare.</target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardTopics" datatype="html">
         <source>Häufige Themen</source>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -12127,7 +12127,10 @@
         <source> Moderationskompass </source>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogIntro" datatype="html">
-        <source> Überblick aus Quiz, Fragen und Blitzlicht. Du entscheidest, was du aufgreifst. </source>
+        <source> Dein Live-Überblick über Quiz, Q&amp;A und Blitzlicht. </source>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationDialogIntroDecide" datatype="html">
+        <source> Du entscheidest, welche Themen behandelt werden. </source>
       </trans-unit>
       <trans-unit id="sessionHost.moderationDialogCloseAria" datatype="html">
         <source>Moderationskompass schließen</source>
@@ -12135,11 +12138,8 @@
       <trans-unit id="sessionHost.moderationSourceJumpAria" datatype="html">
         <source>Zur Quelle: <x id="label" equiv-text="source.label"/></source>
       </trans-unit>
-      <trans-unit id="sessionHost.moderationRuleBasedHint" datatype="html">
-        <source> Nur aus den Signalen dieser Session. Es ändert sich nichts von selbst. </source>
-      </trans-unit>
       <trans-unit id="sessionHost.moderationEmpty" datatype="html">
-        <source> Sobald Fragen, Ergebnisse oder Blitzlicht da sind, siehst du hier Hinweise. </source>
+        <source> Hier erscheinen wichtige Trends und Auswertungen, sobald die Teilnehmenden aktiv werden. </source>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardTopics" datatype="html">
         <source>Häufige Themen</source>


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Die Dialogtexte des Moderationskompasses entsprachen noch nicht dem abgestimmten Wording; Intro, Disclaimer und Leerzustand wirkten unruhig bzw. veraltet.
- **Lösung:** Titel, zweizeiliges Intro und Empty-State-Copy aktualisiert (de/en/fr/es/it); Disclaimer entfernt; Entscheidungssatz als eigene Intro-Zeile gesetzt.
- **Bewusste Nicht-Ziele:** Keine neuen Leerzustand-Buttons; keine Änderung der Kompass-Kartenlogik; 8.9a bleibt teilweise offen.

## Risiko und Verträge

- [x] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Abgestimmtes Host-Wording für den Moderationskompass; Host-only Dialog auf `/session/:code/host`; keine Auto-Moderation.

**Betroffene externe Verträge:**

Keine.

## Implementierung

- Intro in zwei i18n-Einheiten aufgeteilt und zweizeilig dargestellt
- Disclaimer (`moderationRuleBasedHint`) entfernt
- Empty-State-Text aktualisiert
- Locales `de`/`en`/`fr`/`es`/`it` und Dialog-Tests angepasst

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [ ] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [x] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run check:i18n -w @arsnova/frontend` | bestanden |
| `npm run test -w @arsnova/frontend -- --run …/moderation-compass-dialog.component.spec.ts` | 4/4 bestanden |
| Pre-commit: `npm run typecheck` | bestanden |
| Pre-commit: `npm test` | bestanden (shared-types, session-export-report, backend, frontend) |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Nur sichtbare Dialogtexte/Layout des Moderationskompass-Intros.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Nicht betroffen.
- **Rollback:** Revert dieses Commits bzw. vorheriges Release.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Pre-commit-Lauf mit Typecheck und vollständigen Unit-Tests
- `check:i18n` und Dialog-Unit-Tests lokal grün

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** `build:prod`/`lint` nicht erneut ausgeführt (reine Text-/Layoutänderung; i18n-Konsistenz und Unit-Tests decken den Diff ab). Kein Regressionsfall eines Bugs, sondern Copy-Update. Mobile Layout nicht visuell im Browser geprüft; Zeilenumbruch ist bewusst zweizeilig und schmal begrenzt.
- **Verbleibende Risiken:** Sehr gering – längere Locale-Strings können den Intro-Block etwas höher machen.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)