### PR TITLE
fix(ui): redundantes Home-Icon aus der Toolbar entfernen

### DIFF
--- a/apps/frontend/src/app/core/locale-router.spec.ts
+++ b/apps/frontend/src/app/core/locale-router.spec.ts
@@ -21,7 +21,7 @@ describe('locale-router', () => {
     document.querySelectorAll('base').forEach((el) => el.remove());
   });
 
-  describe('isAppHomeRouterUrl (Toolbar showHomeLink)', () => {
+  describe('isAppHomeRouterUrl', () => {
     it('erkennt Startseite ohne und mit Locale-Präfix', () => {
       expect(isAppHomeRouterUrl('/')).toBe(true);
       expect(isAppHomeRouterUrl('/de')).toBe(true);

--- a/apps/frontend/src/app/core/locale-router.ts
+++ b/apps/frontend/src/app/core/locale-router.ts
@@ -84,7 +84,7 @@ function normalizePath(path: string): string {
 
 /**
  * True, wenn die URL der Startseite entspricht (ohne Query/Hash; optionales /{locale}-Präfix wie in Dev entfernt).
- * Deckt Base `/de/` (Router.url oft `/`) und Dev `/de` bzw. `/de/` ab — konsistent mit `showHomeLink` in der Toolbar.
+ * Deckt Base `/de/` (Router.url oft `/`) und Dev `/de` bzw. `/de/` ab.
  */
 export function isAppHomeRouterUrl(pathOrUrl: string): boolean {
   const pathOnly = pathOrUrl.split(/[?#]/)[0] ?? '';

--- a/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.html
+++ b/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.html
@@ -37,18 +37,6 @@
         </svg>
         <span class="top-toolbar__brand-title">arsnova.eu</span>
       </a>
-      @if (showHomeLink()) {
-        <a
-          [routerLink]="localizedPath('/')"
-          class="top-toolbar__home-link"
-          i18n-matTooltip="@@topToolbar.homeTooltip"
-          matTooltip="Zur Startseite"
-          i18n-aria-label="@@topToolbar.homeLinkAria"
-          aria-label="Zur Startseite"
-        >
-          <mat-icon>home</mat-icon>
-        </a>
-      }
       @if (motdHeaderState.motdToolbarIcon()) {
         <button
           type="button"

--- a/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.scss
+++ b/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.scss
@@ -98,7 +98,6 @@
   min-height: 48px;
 }
 
-/* Brand + Home-Icon gruppieren, damit auf Mobile beides links bleibt. */
 .top-toolbar__start {
   display: flex;
   align-items: center;
@@ -111,35 +110,6 @@
 /* MD3: Badge überlappt die Ecke des Icon-Buttons (matBadgeOverlap). */
 .top-toolbar__motd-btn {
   overflow: visible;
-}
-
-.top-toolbar__home-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 48px;
-  height: 48px;
-  margin-inline: -8px;
-  color: var(--mat-sys-on-surface-variant);
-  text-decoration: none;
-  border-radius: 50%;
-  transition:
-    color 0.2s ease,
-    background-color 0.2s ease;
-  flex-shrink: 0;
-  .mat-icon {
-    font-size: 1.5rem;
-    width: 1.5rem;
-    height: 1.5rem;
-  }
-  &:hover {
-    color: var(--mat-sys-on-surface);
-    background-color: var(--mat-sys-surface-container-high);
-  }
-  &:focus-visible {
-    outline: 2px solid var(--mat-sys-primary);
-    outline-offset: 2px;
-  }
 }
 
 @media (min-width: 600px) {

--- a/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.spec.ts
+++ b/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.spec.ts
@@ -173,6 +173,20 @@ describe('TopToolbarComponent', () => {
     fixture.destroy();
   });
 
+  it('bietet die Startseite nur über Logo und Produktname an', () => {
+    const fixture = createToolbar();
+    const brand = fixture.nativeElement.querySelector('.top-toolbar__brand') as HTMLAnchorElement;
+    expect(brand).not.toBeNull();
+    expect(brand.getAttribute('aria-label')).toBe('arsnova.eu Startseite');
+    expect(fixture.nativeElement.querySelector('.top-toolbar__home-link')).toBeNull();
+    expect(
+      Array.from(fixture.nativeElement.querySelectorAll('.top-toolbar__start mat-icon')).every(
+        (icon) => (icon as HTMLElement).textContent?.trim() !== 'home',
+      ),
+    ).toBe(true);
+    fixture.destroy();
+  });
+
   it('stilisiert Fokus direkt am Toggle-Button', async () => {
     const { readFileSync } = await import('node:fs');
     const { fileURLToPath } = await import('node:url');

--- a/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.ts
+++ b/apps/frontend/src/app/shared/top-toolbar/top-toolbar.component.ts
@@ -12,9 +12,7 @@ import {
 } from '@angular/core';
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { tryExitDocumentFullscreen } from '../../core/document-fullscreen.util';
-import { Router, RouterLink } from '@angular/router';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
+import { RouterLink } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { MatBadge } from '@angular/material/badge';
 import { MatIconButton } from '@angular/material/button';
@@ -36,7 +34,7 @@ import { MotdArchiveDialogComponent } from '../motd-archive-dialog/motd-archive-
 import { ThemePresetService } from '../../core/theme-preset.service';
 import { PresetSnackbarFocusService } from '../../core/preset-snackbar-focus.service';
 import { LocaleSwitchGuardService } from '../../core/locale-switch-guard.service';
-import { isAppHomeRouterUrl, localizePath } from '../../core/locale-router';
+import { localizePath } from '../../core/locale-router';
 import { markHomeLocaleReloadSideEffects } from '../../core/locale-reload-focus';
 import {
   ConfirmLeaveDialogComponent,
@@ -70,13 +68,8 @@ export class TopToolbarComponent {
   private readonly localeId = inject(LOCALE_ID);
   private readonly document = inject(DOCUMENT);
   private readonly focusService = inject(PresetSnackbarFocusService);
-  private readonly router = inject(Router);
   private readonly localeGuard = inject(LocaleSwitchGuardService);
   private readonly dialog = inject(MatDialog);
-  readonly showHomeLink = toSignal(
-    this.router.events.pipe(map(() => !isAppHomeRouterUrl(this.router.url))),
-    { initialValue: !isAppHomeRouterUrl(this.router.url) },
-  );
 
   readonly supportedLanguages = [
     { code: 'de' as const, label: 'Deutsch' },

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -22650,22 +22650,6 @@
           <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="topToolbar.homeTooltip" datatype="html">
-        <source>Zur Startseite</source>
-        <target>To home</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">45</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="topToolbar.homeLinkAria" datatype="html">
-        <source>Zur Startseite</source>
-        <target>To home</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="topToolbar.openMenuAria" datatype="html">
         <source>Einstellungen öffnen</source>
         <target>Open settings</target>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -22593,22 +22593,6 @@
           <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="topToolbar.homeTooltip" datatype="html">
-        <source>Zur Startseite</source>
-        <target>A la pagina de inicio</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">45</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="topToolbar.homeLinkAria" datatype="html">
-        <source>Zur Startseite</source>
-        <target>A la pagina de inicio</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="topToolbar.openMenuAria" datatype="html">
         <source>Einstellungen öffnen</source>
         <target>Abrir configuración</target>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -22593,22 +22593,6 @@
           <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="topToolbar.homeTooltip" datatype="html">
-        <source>Zur Startseite</source>
-        <target>Vers la page d&apos;accueil</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">45</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="topToolbar.homeLinkAria" datatype="html">
-        <source>Zur Startseite</source>
-        <target>Vers la page d&apos;accueil</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="topToolbar.openMenuAria" datatype="html">
         <source>Einstellungen öffnen</source>
         <target>Ouvrir les paramètres</target>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -22593,22 +22593,6 @@
           <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="topToolbar.homeTooltip" datatype="html">
-        <source>Zur Startseite</source>
-        <target>Alla home page</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">45</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="topToolbar.homeLinkAria" datatype="html">
-        <source>Zur Startseite</source>
-        <target>Alla home page</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="topToolbar.openMenuAria" datatype="html">
         <source>Einstellungen öffnen</source>
         <target>Apri Impostazioni</target>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -19991,20 +19991,6 @@
           <context context-type="linenumber">14</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="topToolbar.homeTooltip" datatype="html">
-        <source>Zur Startseite</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">45</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="topToolbar.homeLinkAria" datatype="html">
-        <source>Zur Startseite</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/top-toolbar/top-toolbar.component.html</context>
-          <context context-type="linenumber">47</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="topToolbar.openMenuAria" datatype="html">
         <source>Einstellungen öffnen</source>
         <context-group purpose="location">

--- a/docs/ui/STYLEGUIDE.md
+++ b/docs/ui/STYLEGUIDE.md
@@ -334,7 +334,7 @@ Die App richtet sich auch an Trainer:innen, Workshop- und Event-Moderation sowie
 
 ## Seitenuebergreifend: UX und Wording
 
-- **Zurueck zur Startseite:** Nur ueber Logo oder Home-Icon in der Top-Toolbar; keine expliziten "Startseite"-Links auf Inhaltseiten (NN/G: auf der Startseite selbst keinen aktiven Home-Link anbieten).
+- **Zurueck zur Startseite:** Nur ueber Logo und Produktname in der Top-Toolbar; keine expliziten "Startseite"-Links auf Inhaltseiten und kein zusaetzliches Home-Icon neben der Marke.
 - **Ladezustaende:** Kurz "Wird geladen…" (ohne "Session" oder Kontext, wenn der Kontext schon klar ist).
 - **Fehlermeldungen:** Nutzerorientiert, kein Technik-Jargon. "Ungültiger Code." statt "Ungültiger Session-Code."; "Nicht gefunden. Code prüfen oder neu eingeben."; "Seite konnte nicht geladen werden." statt "Inhalt konnte nicht geladen werden.".
 - **Platzhalter-Hinweise:** Keine Story-/Epic-Referenzen in der UI. Stattdessen kurze nutzerorientierte Hinweise (z. B. "Hier Quizzes anlegen und verwalten.", "Lobby und Steuerung werden hier angezeigt.").


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Neben Logo und Produktname `arsnova.eu` stand in der Top-Toolbar ein zusätzliches Haus-Icon als Startseiten-Link. Das war redundant und nahm Platz.
- **Lösung:** Home-Icon und zugehörige i18n-Strings entfernt. Startseite bleibt über Logo und Produktname erreichbar. Docs im Styleguide angepasst.
- **Bewusste Nicht-Ziele:** Session-Endgate „Zur Startseite“, MOTD-/Archiv-Icon und Vollbild-Exit der Marke bleiben. Keine Vermischung mit der parallelen MOTD-Overlay-Änderung.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

- [`docs/ui/STYLEGUIDE.md`](docs/ui/STYLEGUIDE.md): Zurück zur Startseite nur über Logo und Produktname; kein zusätzliches Home-Icon.
- WCAG 2.2 AA: der verbleibende Marken-Link bleibt tastatur- und screenreader-bedienbar; entfernte Strings sind in allen Locales gelöscht.

**Betroffene externe Verträge:**

Keine.

## Implementierung

- Home-`<a>` aus `top-toolbar.component.html` entfernt, inkl. Styles und `showHomeLink`.
- i18n: `topToolbar.homeTooltip` / `topToolbar.homeLinkAria` in `de/en/fr/es/it` entfernt.
- Spec prüft, dass `.top-toolbar__home-link` nicht mehr gerendert wird.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [x] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

Der Startseiten-Link ist die Marke; kein Fokusverlust durch das entfernte Icon, weil es kein Pflicht-Fokusziel mehr ist.

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` (Pre-Commit-Hook) | erfolgreich |
| `npm test` (Pre-Commit-Hook: shared-types, session-export-report, backend, frontend) | erfolgreich (Frontend 1335 Tests) |
| `npm run check:i18n -w @arsnova/frontend` | erfolgreich (2655 Einheiten, alle Locales) |
| `npx prettier --check docs/ui/STYLEGUIDE.md` | erfolgreich |
| gezielte Tests `top-toolbar.component.spec.ts` + `locale-router.spec.ts` | erfolgreich |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [ ] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

Locales sind über `check:i18n` synchron (entfernte Units in allen fünf Dateien). Tastatur/Screenreader: der Marken-Link bleibt. Keine manuelle Viewport-Prüfung des Toolbar-Reflows in diesem PR; Layout wird schmaler, Kontrast unverändert.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Ein Toolbar-Icon weniger; Startseite weiter über Logo/Produktname.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Nicht betroffen.
- **Rollback:** Revert dieses Commits.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Pre-Commit: vollständiger `npm test` und `npm run typecheck` grün.
- `check:i18n` grün.
- Toolbar-Spec: kein `.top-toolbar__home-link`.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** `npm run lint` nicht separat (ESLint/Prettier liefen im Pre-Commit auf den gestagten Dateien). `npm run build:prod` / `build:localize` nicht lokal ausgeführt (Template-, Style- und XLF-Änderung; CI muss den lokalisierten Production-Build prüfen). Realtime/Migration/Last/Sicherheit nicht betroffen. Ablehnungspfad nicht anwendbar (reines Entfernen eines redundanten Links).
- **Verbleibende Risiken:** Keine visuelle Browser-Prüfung der schmalen Toolbar in diesem PR. Nutzer:innen, die das Haus-Icon gewohnt waren, nutzen Logo/Produktname.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Kein asynchroner UI-Lifecycle; nur Entfernen eines Links.

Made with [Cursor](https://cursor.com)