### PR TITLE
fix(host): Kompass-Hinweise für Umfrage und Rating ohne Lösungslogik

### DIFF
--- a/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.spec.ts
@@ -90,6 +90,20 @@ describe('ModerationCompassDialogComponent', () => {
     ).toContain('thumbs_up_down');
   });
 
+  it('zeigt für Umfragen keinen Lösungshinweis', () => {
+    const { fixture } = setup([
+      {
+        kind: 'clarification',
+        nextStepReason: 'quiz-survey',
+        sources: [{ kind: 'quiz-result', label: 'Häufigste Antwort: Ganz okay' }],
+      },
+    ]);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Fass kurz die Antwortverteilung zusammen.');
+    expect(text).not.toContain('Erkläre kurz die Lösung');
+  });
+
   it('macht Quellen klickbar und schließt den Dialog', () => {
     const source = {
       kind: 'qa-question' as const,

--- a/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/moderation-compass-dialog.component.ts
@@ -102,6 +102,10 @@ export class ModerationCompassDialogComponent {
         return $localize`:@@sessionHost.moderationNextPending:Schau zuerst in die Fragen, die noch auf Freigabe warten.`;
       case 'quiz-confusion':
         return $localize`:@@sessionHost.moderationNextQuiz:Erkläre kurz die Lösung und die typischen Fehler.`;
+      case 'quiz-survey':
+        return $localize`:@@sessionHost.moderationNextQuizSurvey:Fass kurz die Antwortverteilung zusammen.`;
+      case 'quiz-rating':
+        return $localize`:@@sessionHost.moderationNextQuizRating:Sprich die Bewertungen kurz an.`;
       case 'controversy':
         return $localize`:@@sessionHost.moderationNextFriction:Greif die umstrittenen Fragen kurz auf.`;
       case 'tempo':

--- a/apps/frontend/src/app/features/session/session-host/moderation-compass.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/moderation-compass.spec.ts
@@ -251,6 +251,7 @@ describe('buildModerationCompassCards', () => {
   it('nimmt Quiz-Verwirrung erst nach Ergebnisfreigabe auf', () => {
     const cards = buildModerationCompassCards({
       ...emptySnapshot,
+      quizInsightKind: 'scorable',
       quizSources: [
         {
           kind: 'quiz-result',
@@ -265,9 +266,42 @@ describe('buildModerationCompassCards', () => {
     expect(cards.some((card) => card.kind === 'nextStep')).toBe(false);
   });
 
+  it('nutzt für Umfragen keinen Lösungshinweis', () => {
+    const cards = buildModerationCompassCards({
+      ...emptySnapshot,
+      quizInsightKind: 'survey',
+      quizSources: [
+        {
+          kind: 'quiz-result',
+          label: 'Häufigste Antwort: :neutral_face: Ganz okay',
+        },
+      ],
+    });
+
+    const clarification = cards.find((card) => card.kind === 'clarification');
+    expect(clarification?.nextStepReason).toBe('quiz-survey');
+    expect(clarification?.nextStepReason).not.toBe('quiz-confusion');
+  });
+
+  it('nutzt für Bewertungen einen eigenen Moderationshinweis', () => {
+    const cards = buildModerationCompassCards({
+      ...emptySnapshot,
+      quizInsightKind: 'rating',
+      quizSources: [
+        {
+          kind: 'quiz-result',
+          label: 'Durchschnitt 2,0 von 5',
+        },
+      ],
+    });
+
+    expect(cards.find((card) => card.kind === 'clarification')?.nextStepReason).toBe('quiz-rating');
+  });
+
   it('stellt Quiz-Verwirrung vor offenen Moderationsfragen', () => {
     const cards = buildModerationCompassCards({
       ...emptySnapshot,
+      quizInsightKind: 'scorable',
       qaQuestions: [
         {
           id: '11111111-1111-4111-8111-111111111111',
@@ -583,11 +617,35 @@ describe('collectModerationQuizFacts', () => {
   it('erkennt niedrige Bewertungen und wiederholte Freitexte', () => {
     expect(
       collectModerationQuizFacts({
+        type: 'RATING',
         ratingAvg: 2.0,
         ratingCount: 5,
         freeTextResponses: ['Bitte langsamer sprechen', 'Bitte langsamer sprechen'],
       }).map((fact) => fact.type),
     ).toEqual(['rating-low', 'freetext-repeat']);
+  });
+
+  it('leitet Umfragen ohne Lösungslogik und mit häufigster Antwort', () => {
+    expect(
+      collectModerationQuizFacts({
+        type: 'SURVEY',
+        totalVotes: 10,
+        voteDistribution: [
+          { text: ':neutral_face: Ganz okay', isCorrect: false, voteCount: 6 },
+          { text: 'Genervt', isCorrect: false, voteCount: 4 },
+        ],
+      }).map((fact) => fact.type),
+    ).toEqual(['survey-top']);
+    expect(
+      collectModerationQuizFacts({
+        type: 'SURVEY',
+        totalVotes: 10,
+        voteDistribution: [
+          { text: 'Ja', isCorrect: false, voteCount: 6 },
+          { text: 'Nein', isCorrect: false, voteCount: 4 },
+        ],
+      }).some((fact) => fact.type === 'wrong-option'),
+    ).toBe(false);
   });
 
   it('nimmt den häufigsten Histogramm-Bereich außerhalb des Bands auf', () => {

--- a/apps/frontend/src/app/features/session/session-host/moderation-compass.ts
+++ b/apps/frontend/src/app/features/session/session-host/moderation-compass.ts
@@ -1,10 +1,21 @@
 import { extractExportQuestionText } from '../../../core/markdown-plain-text.util';
+import type { QuestionType } from '@arsnova/shared-types';
 
 export type ModerationCompassCardKind =
   'topics' | 'clarification' | 'friction' | 'tempo' | 'nextStep';
 
 export type ModerationCompassNextStepReason =
-  'pending-qa' | 'quiz-confusion' | 'controversy' | 'tempo' | 'feedback' | 'topics' | 'steady';
+  | 'pending-qa'
+  | 'quiz-confusion'
+  | 'quiz-survey'
+  | 'quiz-rating'
+  | 'controversy'
+  | 'tempo'
+  | 'feedback'
+  | 'topics'
+  | 'steady';
+
+export type ModerationCompassQuizInsightKind = 'scorable' | 'survey' | 'rating';
 
 export type ModerationCompassSourceKind =
   'qa-question' | 'qa-term' | 'freetext-term' | 'tempo' | 'quiz-result';
@@ -44,6 +55,7 @@ export type ModerationCompassCard = {
 
 export type ModerationCompassQuizSourceCacheEntry = {
   readonly questionId: string;
+  readonly questionType?: QuestionType;
   readonly sources: readonly ModerationCompassSource[];
 };
 
@@ -90,9 +102,11 @@ export type ModerationCompassSnapshot = {
   readonly topicWeightLabel: string | null;
   readonly tempo: ModerationCompassTempo | null;
   readonly quizSources: readonly ModerationCompassSource[];
+  readonly quizInsightKind?: ModerationCompassQuizInsightKind | null;
 };
 
 export type ModerationCompassQuizQuestion = {
+  readonly type?: QuestionType;
   readonly totalVotes?: number;
   readonly correctVoterCount?: number;
   readonly incorrectVoterCount?: number;
@@ -168,6 +182,7 @@ export type ModerationQuizFact =
   | { readonly type: 'ordering-swap'; readonly a: string; readonly b: string }
   | { readonly type: 'categorization-miss'; readonly item: string; readonly wrongCategory: string }
   | { readonly type: 'wrong-option'; readonly option: string }
+  | { readonly type: 'survey-top'; readonly option: string; readonly share: number }
   | { readonly type: 'numeric-median'; readonly median: number; readonly reference: number }
   | { readonly type: 'numeric-spread' }
   | {
@@ -214,6 +229,67 @@ export function compassQuestionStem(text: string, max = 56): string {
 export function collectModerationQuizFacts(
   question: ModerationCompassQuizQuestion,
 ): ModerationQuizFact[] {
+  if (question.type === 'SURVEY') {
+    return collectSurveyQuizFacts(question);
+  }
+  if (question.type === 'RATING') {
+    return collectRatingQuizFacts(question);
+  }
+  if (question.type === 'FREETEXT') {
+    return collectFreetextQuizFacts(question);
+  }
+  return collectScorableQuizFacts(question);
+}
+
+function topVoteDistributionOption(
+  voteDistribution: ModerationCompassQuizQuestion['voteDistribution'],
+): { text: string; voteCount: number } | null {
+  const top = [...(voteDistribution ?? [])]
+    .filter((option) => option.voteCount > 0)
+    .sort((left, right) => right.voteCount - left.voteCount)[0];
+  return top ?? null;
+}
+
+function collectSurveyQuizFacts(question: ModerationCompassQuizQuestion): ModerationQuizFact[] {
+  const facts: ModerationQuizFact[] = [];
+  const total = question.totalVotes ?? 0;
+  const top = topVoteDistributionOption(question.voteDistribution);
+  if (top && total > 0) {
+    facts.push({
+      type: 'survey-top',
+      option: top.text,
+      share: Math.round((top.voteCount / total) * 100),
+    });
+  }
+  const repeat = mostCommonFreeText(question.freeTextResponses ?? []);
+  if (repeat) {
+    facts.push(repeat);
+  }
+  return facts.slice(0, 6);
+}
+
+function collectRatingQuizFacts(question: ModerationCompassQuizQuestion): ModerationQuizFact[] {
+  const facts: ModerationQuizFact[] = [];
+  if (
+    typeof question.ratingAvg === 'number' &&
+    (question.ratingCount ?? 0) >= 3 &&
+    question.ratingAvg <= 2.5
+  ) {
+    facts.push({ type: 'rating-low', avg: question.ratingAvg });
+  }
+  const repeat = mostCommonFreeText(question.freeTextResponses ?? []);
+  if (repeat) {
+    facts.push(repeat);
+  }
+  return facts.slice(0, 6);
+}
+
+function collectFreetextQuizFacts(question: ModerationCompassQuizQuestion): ModerationQuizFact[] {
+  const repeat = mostCommonFreeText(question.freeTextResponses ?? []);
+  return repeat ? [repeat] : [];
+}
+
+function collectScorableQuizFacts(question: ModerationCompassQuizQuestion): ModerationQuizFact[] {
   const facts: ModerationQuizFact[] = [];
   const correct = question.correctVoterCount;
   const incorrect = question.incorrectVoterCount;
@@ -311,14 +387,6 @@ export function collectModerationQuizFacts(
   const round2 = question.roundComparison?.round2CorrectCount;
   if (typeof round1 === 'number' && typeof round2 === 'number' && round2 < round1) {
     facts.push({ type: 'round-drop' });
-  }
-
-  if (
-    typeof question.ratingAvg === 'number' &&
-    (question.ratingCount ?? 0) >= 3 &&
-    question.ratingAvg <= 2.5
-  ) {
-    facts.push({ type: 'rating-low', avg: question.ratingAvg });
   }
 
   const repeat = mostCommonFreeText(question.freeTextResponses ?? []);
@@ -462,6 +530,7 @@ export function rememberModerationQuizSnapshot(
   existing: readonly ModerationCompassQuizSourceCacheEntry[],
   questionId: string,
   sources: readonly ModerationCompassSource[],
+  questionType?: QuestionType,
   maxQuestions = MAX_SOURCES,
 ): readonly ModerationCompassQuizSourceCacheEntry[] {
   const nextSources = sources
@@ -472,7 +541,7 @@ export function rememberModerationQuizSnapshot(
     nextSources.length === 0
       ? existing.filter((entry) => entry.questionId !== questionId)
       : [
-          { questionId, sources: nextSources },
+          { questionId, questionType, sources: nextSources },
           ...existing.filter((entry) => entry.questionId !== questionId),
         ].slice(0, maxQuestions);
 
@@ -737,6 +806,7 @@ function nextStepCardTone(
 function nextStepReason(input: {
   pendingCount: number;
   hasQuizConfusion: boolean;
+  quizInsightKind?: ModerationCompassQuizInsightKind | null;
   hasFriction: boolean;
   tempoTone: ModerationCompassTempo['tone'] | null;
   tempoVariant: ModerationCompassTempo['variant'];
@@ -746,6 +816,12 @@ function nextStepReason(input: {
     return input.tempoVariant === 'feedback' ? 'feedback' : 'tempo';
   }
   if (input.hasQuizConfusion) {
+    if (input.quizInsightKind === 'survey') {
+      return 'quiz-survey';
+    }
+    if (input.quizInsightKind === 'rating') {
+      return 'quiz-rating';
+    }
     return 'quiz-confusion';
   }
   if (input.tempoTone === 'caution') {
@@ -770,6 +846,8 @@ function nextStepSourceKind(reason: ModerationCompassNextStepReason): Moderation
   switch (reason) {
     case 'pending-qa':
     case 'quiz-confusion':
+    case 'quiz-survey':
+    case 'quiz-rating':
       return 'clarification';
     case 'controversy':
       return 'friction';
@@ -864,6 +942,7 @@ export function buildModerationCompassCards(
   const reason = nextStepReason({
     pendingCount: pending.length,
     hasQuizConfusion: quizSources.length > 0,
+    quizInsightKind: snapshot.quizInsightKind,
     hasFriction: frictionSources.length > 0,
     tempoTone,
     tempoVariant: snapshot.tempo?.variant,

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -139,6 +139,7 @@ import {
   notableQuickFeedbackSplit,
   rememberModerationQuizSnapshot,
   truncateCompassLabel,
+  type ModerationCompassQuizInsightKind,
   type ModerationCompassQuizSourceCacheEntry,
   type ModerationCompassSource,
   type ModerationCompassTempo,
@@ -1763,6 +1764,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       topicWeightLabel: this.moderationCompassTopicWeightLabel(),
       tempo: this.moderationCompassFeedback(),
       quizSources: this.moderationCompassQuizSources(),
+      quizInsightKind: this.moderationCompassQuizInsightKind(),
     }),
   );
   readonly moderationCompassHasSignals = computed(() => this.moderationCompassCards().length > 0);
@@ -2261,6 +2263,33 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     );
   }
 
+  private moderationCompassQuizInsightKind(): ModerationCompassQuizInsightKind | null {
+    const question = this.displayedCurrentQuestionForHost();
+    if (this.effectiveStatus() === 'RESULTS' && question) {
+      return this.moderationCompassQuizInsightKindForType(question.type);
+    }
+    const cached = this.moderationQuizSourceCache().find((entry) => entry.sources.length > 0);
+    if (cached?.questionType) {
+      return this.moderationCompassQuizInsightKindForType(cached.questionType);
+    }
+    return this.moderationCompassQuizSources().length > 0 ? 'scorable' : null;
+  }
+
+  private moderationCompassQuizInsightKindForType(
+    type: HostCurrentQuestionDTO['type'],
+  ): ModerationCompassQuizInsightKind | null {
+    switch (type) {
+      case 'SURVEY':
+        return 'survey';
+      case 'RATING':
+        return 'rating';
+      case 'FREETEXT':
+        return null;
+      default:
+        return 'scorable';
+    }
+  }
+
   private localizeCurrentQuestionQuizSources(
     question: HostCurrentQuestionDTO,
   ): ModerationCompassSource[] {
@@ -2323,6 +2352,10 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       case 'wrong-option':
         return quizSource(
           $localize`:@@sessionHost.moderationQuizWrongOption:Häufigste andere Antwort: ${truncateCompassLabel(fact.option, 64)}:option:`,
+        );
+      case 'survey-top':
+        return quizSource(
+          $localize`:@@sessionHost.moderationQuizSurveyTop:Häufigste Antwort: ${truncateCompassLabel(fact.option, 64)}:option:`,
         );
       case 'numeric-median':
         return quizSource(
@@ -2776,7 +2809,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       }
       untracked(() => {
         this.moderationQuizSourceCache.update((existing) =>
-          rememberModerationQuizSnapshot(existing, question.questionId, sources),
+          rememberModerationQuizSnapshot(existing, question.questionId, sources, question.type),
         );
       });
     });

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -13763,6 +13763,14 @@
         <source>Erkläre kurz die Lösung und die typischen Fehler.</source>
         <target>Take a moment for the solution and typical mistakes.</target>
       </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizSurvey" datatype="html">
+        <source>Fass kurz die Antwortverteilung zusammen.</source>
+        <target>Summarize the response distribution briefly.</target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizRating" datatype="html">
+        <source>Sprich die Bewertungen kurz an.</source>
+        <target>Briefly address the ratings.</target>
+      </trans-unit>
       <trans-unit id="sessionHost.moderationNextFriction" datatype="html">
         <source>Greif die umstrittenen Fragen kurz auf.</source>
         <target>Pick up the contested questions briefly.</target>
@@ -13846,6 +13854,10 @@
       <trans-unit id="sessionHost.moderationQuizWrongOption" datatype="html">
         <source>Häufigste andere Antwort: <x id="option" equiv-text="truncateCompassLabel(wrongOption.text, 64)"/></source>
         <target>Most common other answer: <x id="option" equiv-text="truncateCompassLabel(wrongOption.text, 64)"/></target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationQuizSurveyTop" datatype="html">
+        <source>Häufigste Antwort: <x id="option" equiv-text="truncateCompassLabel(fact.option, 64)"/></source>
+        <target>Most common answer: <x id="option" equiv-text="truncateCompassLabel(fact.option, 64)"/></target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardFeedback" datatype="html">
         <source>Rückmeldungen</source>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -13707,6 +13707,14 @@
         <source>Erkläre kurz die Lösung und die typischen Fehler.</source>
         <target>Dedica un momento a la solución y a los errores típicos.</target>
       </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizSurvey" datatype="html">
+        <source>Fass kurz die Antwortverteilung zusammen.</source>
+        <target>Resume brevemente la distribución de respuestas.</target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizRating" datatype="html">
+        <source>Sprich die Bewertungen kurz an.</source>
+        <target>Comenta brevemente las valoraciones.</target>
+      </trans-unit>
       <trans-unit id="sessionHost.moderationNextFriction" datatype="html">
         <source>Greif die umstrittenen Fragen kurz auf.</source>
         <target>Retoma en breve las preguntas controvertidas.</target>
@@ -13790,6 +13798,10 @@
       <trans-unit id="sessionHost.moderationQuizWrongOption" datatype="html">
         <source>Häufigste andere Antwort: <x id="option" equiv-text="truncateCompassLabel(wrongOption.text, 64)"/></source>
         <target>Otra respuesta más frecuente: <x id="option" equiv-text="truncateCompassLabel(wrongOption.text, 64)"/></target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationQuizSurveyTop" datatype="html">
+        <source>Häufigste Antwort: <x id="option" equiv-text="truncateCompassLabel(fact.option, 64)"/></source>
+        <target>Respuesta más frecuente: <x id="option" equiv-text="truncateCompassLabel(fact.option, 64)"/></target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardFeedback" datatype="html">
         <source>Rückmeldungen</source>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -13707,6 +13707,14 @@
         <source>Erkläre kurz die Lösung und die typischen Fehler.</source>
         <target>Prends un moment pour la solution et les erreurs typiques.</target>
       </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizSurvey" datatype="html">
+        <source>Fass kurz die Antwortverteilung zusammen.</source>
+        <target>Résume brièvement la répartition des réponses.</target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizRating" datatype="html">
+        <source>Sprich die Bewertungen kurz an.</source>
+        <target>Aborde brièvement les évaluations.</target>
+      </trans-unit>
       <trans-unit id="sessionHost.moderationNextFriction" datatype="html">
         <source>Greif die umstrittenen Fragen kurz auf.</source>
         <target>Reprend brièvement les questions controversées.</target>
@@ -13790,6 +13798,10 @@
       <trans-unit id="sessionHost.moderationQuizWrongOption" datatype="html">
         <source>Häufigste andere Antwort: <x id="option" equiv-text="truncateCompassLabel(wrongOption.text, 64)"/></source>
         <target>Autre réponse la plus fréquente : <x id="option" equiv-text="truncateCompassLabel(wrongOption.text, 64)"/></target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationQuizSurveyTop" datatype="html">
+        <source>Häufigste Antwort: <x id="option" equiv-text="truncateCompassLabel(fact.option, 64)"/></source>
+        <target>Réponse la plus fréquente : <x id="option" equiv-text="truncateCompassLabel(fact.option, 64)"/></target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardFeedback" datatype="html">
         <source>Rückmeldungen</source>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -13707,6 +13707,14 @@
         <source>Erkläre kurz die Lösung und die typischen Fehler.</source>
         <target>Prenditi un momento per la soluzione e gli errori tipici.</target>
       </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizSurvey" datatype="html">
+        <source>Fass kurz die Antwortverteilung zusammen.</source>
+        <target>Riassumi brevemente la distribuzione delle risposte.</target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizRating" datatype="html">
+        <source>Sprich die Bewertungen kurz an.</source>
+        <target>Commenta brevemente le valutazioni.</target>
+      </trans-unit>
       <trans-unit id="sessionHost.moderationNextFriction" datatype="html">
         <source>Greif die umstrittenen Fragen kurz auf.</source>
         <target>Riprendi in breve le domande controverse.</target>
@@ -13790,6 +13798,10 @@
       <trans-unit id="sessionHost.moderationQuizWrongOption" datatype="html">
         <source>Häufigste andere Antwort: <x id="option" equiv-text="truncateCompassLabel(wrongOption.text, 64)"/></source>
         <target>Altra risposta più frequente: <x id="option" equiv-text="truncateCompassLabel(wrongOption.text, 64)"/></target>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationQuizSurveyTop" datatype="html">
+        <source>Häufigste Antwort: <x id="option" equiv-text="truncateCompassLabel(fact.option, 64)"/></source>
+        <target>Risposta più frequente: <x id="option" equiv-text="truncateCompassLabel(fact.option, 64)"/></target>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardFeedback" datatype="html">
         <source>Rückmeldungen</source>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -12168,6 +12168,12 @@
       <trans-unit id="sessionHost.moderationNextQuiz" datatype="html">
         <source>Erkläre kurz die Lösung und die typischen Fehler.</source>
       </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizSurvey" datatype="html">
+        <source>Fass kurz die Antwortverteilung zusammen.</source>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationNextQuizRating" datatype="html">
+        <source>Sprich die Bewertungen kurz an.</source>
+      </trans-unit>
       <trans-unit id="sessionHost.moderationNextFriction" datatype="html">
         <source>Greif die umstrittenen Fragen kurz auf.</source>
       </trans-unit>
@@ -12230,6 +12236,9 @@
       </trans-unit>
       <trans-unit id="sessionHost.moderationQuizWrongOption" datatype="html">
         <source>Häufigste andere Antwort: <x id="option" equiv-text="truncateCompassLabel(wrongOption.text, 64)"/></source>
+      </trans-unit>
+      <trans-unit id="sessionHost.moderationQuizSurveyTop" datatype="html">
+        <source>Häufigste Antwort: <x id="option" equiv-text="truncateCompassLabel(fact.option, 64)"/></source>
       </trans-unit>
       <trans-unit id="sessionHost.moderationCardFeedback" datatype="html">
         <source>Rückmeldungen</source>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17490,9 +17490,19 @@
       "license": "MIT"
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
   },
   "overrides": {
     "@hono/node-server": "2.0.11",
+    "deepmerge-ts": "^8.0.1",
     "fast-uri": "^3.1.5",
     "find-my-way": "^9.7.0",
     "hono": "^4.12.5",


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Der Moderationskompass behandelte Umfragen (`SURVEY`) und Bewertungen (`RATING`) wie bewertbare Quizfragen. Weil Umfrage-Optionen alle `isCorrect: false` sind, erschien „Häufigste andere Antwort“ plus der Hinweis „Erkläre kurz die Lösung und die typischen Fehler.“ – obwohl es dort kein Richtig/Falsch gibt.
- **Lösung:** Fakten und nächster Schritt hängen am Fragetyp. Umfragen zeigen „Häufigste Antwort“ und „Fass kurz die Antwortverteilung zusammen.“ Ratings behalten den niedrigen Durchschnitt und bekommen „Sprich die Bewertungen kurz an.“ Bewertbare Quizfragen bleiben beim Lösungshinweis.
- **Bewusste Nicht-Ziele:** Keine Änderung an Scoring, Ergebnisanzeige oder Teilnehmer-DTOs. Freitext bleibt ohne Lösungshinweis. Das Demo-Seed befüllt Umfragen weiterhin nicht automatisch (nur manuell über `seed:session-votes`).

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Story 8.9a: Kompass bleibt hostgebunden, quellenbelegt und regelbasiert. Umfrage und Rating sind unbewertet (kein `isCorrect`, 0 Punkte). Quiz-Signale erst nach `RESULTS`. Keine Lösungshinweise für Typen ohne Lösung.

**Betroffene externe Verträge:**

Keine.

## Implementierung

- `collectModerationQuizFacts` trennt `SURVEY` / `RATING` / `FREETEXT` von bewertbaren Typen; Umfragen erzeugen `survey-top` statt `wrong-option`.
- Nächster Schritt: `quiz-survey` und `quiz-rating` statt `quiz-confusion`.
- Quiz-Quellen-Cache merkt `questionType`, damit der Hinweis nach Fragenwechsel zur letzten Ergebnisfreigabe passt.
- i18n in `de`, `en`, `fr`, `es`, `it`.
- Transitives `deepmerge-ts` auf 8.0.1 überschrieben (CVE-2026-40345 / HIGH), weil Prisma 7.9 noch 7.1.5 zieht und das Audit-/Trivy-Gate sonst blockiert.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [x] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` (pre-commit) | bestanden |
| `npm test` (pre-commit) | bestanden: shared-types 61, session-export-report 81, backend 968, frontend 1356 |
| lint-staged (eslint + prettier auf den gestagten Dateien) | bestanden |
| `npm run check:i18n -w @arsnova/frontend` | bestanden (2667 Einheiten) |
| `npm run test -w @arsnova/frontend -- moderation-compass.spec.ts moderation-compass-dialog.component.spec.ts` | 41 bestanden |
| `npm run spacy:macos-dev` inkl. `build:prod` | lokal gegen Demo-Session geprüft |
| `npm audit --audit-level=high --omit=dev` | bestanden nach deepmerge-ts-Override |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [ ] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [ ] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

Dialog-Layout und Fokussteuerung unverändert; nur Kartentext und Quellenlabel. Mobile: bestehende Dialog-Tokens. Screenreader: bestehendes `role="status"` bleibt, neuer Text ist sichtbarer Dialoginhalt.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Host-only Kompass-Copy und Faktensammlung; keine Schema-, Redis- oder API-Vertragsänderung.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen Metriken.
- **Rollback:** Commit revertieren; kein Daten-Rollback nötig.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Pre-commit: Typecheck und `npm test`.
- i18n-Konsistenzprüfung und Kompass-Unit-/Dialogtests.
- Manuelle Prüfung in Chrome gegen Demo-Session mit Umfrage-Ergebnissen.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:**
  - `npm run lint` vollständig nicht separat ausgeführt; eslint/prettier liefen über lint-staged, das Lint-Gate läuft in CI.
  - Tastatur/Fokus und Reflow/Zoom: keine neue Steuerung, nur Text.
  - Wiederholung/Reconnect/Token/Migration/Parallelität: keine neuen Netz- oder Persistenzpfade.
  - Asynchroner Dialogfluss unverändert (`MatDialog`).
- **Verbleibende Risiken:** Ohne `question.type` im Cache fällt der Hinweis auf den bewertbaren Lösungstext zurück. Das Kompass-Demo-Seed überspringt `SURVEY` weiterhin.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

