### PR TITLE
fix(ci): hängendes Playwright-Install nicht als E2E-Pflichtcheck werten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,7 +453,7 @@ jobs:
 
       - name: Install Playwright Chromium
         if: needs.changes.outputs.docs_only != 'true'
-        timeout-minutes: 10
+        timeout-minutes: 16
         run: bash scripts/ci/playwright-install.sh chromium
 
       - name: Landing accessibility gate
@@ -687,7 +687,7 @@ jobs:
 
       - name: Install matching Playwright Chromium
         if: needs.changes.outputs.docs_only != 'true'
-        timeout-minutes: 10
+        timeout-minutes: 16
         run: bash scripts/ci/playwright-install.sh chromium
 
       - name: Run tests with coverage gate
@@ -830,7 +830,7 @@ jobs:
 
       - name: Install Playwright Chromium
         if: needs.changes.outputs.docs_only != 'true'
-        timeout-minutes: 10
+        timeout-minutes: 16
         run: bash scripts/ci/playwright-install.sh chromium
 
       - name: Generate five current PDF/UA locale demos
@@ -1035,7 +1035,7 @@ jobs:
 
       - name: Install Playwright Chromium
         if: needs.changes.outputs.docs_only != 'true'
-        timeout-minutes: 10
+        timeout-minutes: 16
         run: bash scripts/ci/playwright-install.sh chromium
 
       - name: Run Playwright smoke flow
@@ -1204,7 +1204,7 @@ jobs:
 
       - name: Install Playwright WebKit
         if: needs.changes.outputs.docs_only != 'true'
-        timeout-minutes: 10
+        timeout-minutes: 16
         run: bash scripts/ci/playwright-install.sh webkit
 
       - name: Run WebKit MOTD and tab focus flows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,11 +451,15 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: npm run test:theme-static -w @arsnova/landing
 
+      - name: Install Playwright Chromium
+        if: needs.changes.outputs.docs_only != 'true'
+        timeout-minutes: 10
+        run: bash scripts/ci/playwright-install.sh chromium
+
       - name: Landing accessibility gate
         if: needs.changes.outputs.docs_only != 'true'
         run: |
           set -euo pipefail
-          node node_modules/playwright/cli.js install --with-deps chromium
           mkdir -p "$RUNNER_TEMP/landing-a11y"
           cp -R apps/landing/dist/. "$RUNNER_TEMP/landing-a11y/"
           node scripts/serve-static-compressed.mjs "$RUNNER_TEMP/landing-a11y" 4321 > "$RUNNER_TEMP/landing-static.log" 2>&1 &
@@ -683,7 +687,8 @@ jobs:
 
       - name: Install matching Playwright Chromium
         if: needs.changes.outputs.docs_only != 'true'
-        run: node node_modules/playwright/cli.js install --with-deps chromium
+        timeout-minutes: 10
+        run: bash scripts/ci/playwright-install.sh chromium
 
       - name: Run tests with coverage gate
         if: needs.changes.outputs.docs_only != 'true'
@@ -754,7 +759,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: github.event_name != 'schedule'
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     services:
       postgres:
@@ -822,7 +827,11 @@ jobs:
           npx prisma generate --schema prisma/schema.prisma
           npx prisma migrate deploy --schema prisma/schema.prisma
           npm run build:libs
-          node node_modules/playwright/cli.js install --with-deps chromium
+
+      - name: Install Playwright Chromium
+        if: needs.changes.outputs.docs_only != 'true'
+        timeout-minutes: 10
+        run: bash scripts/ci/playwright-install.sh chromium
 
       - name: Generate five current PDF/UA locale demos
         if: needs.changes.outputs.docs_only != 'true'
@@ -1026,7 +1035,8 @@ jobs:
 
       - name: Install Playwright Chromium
         if: needs.changes.outputs.docs_only != 'true'
-        run: node node_modules/playwright/cli.js install --with-deps chromium
+        timeout-minutes: 10
+        run: bash scripts/ci/playwright-install.sh chromium
 
       - name: Run Playwright smoke flow
         if: needs.changes.outputs.docs_only != 'true'
@@ -1110,7 +1120,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, build]
     if: github.event_name != 'schedule'
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     services:
       postgres:
@@ -1194,7 +1204,8 @@ jobs:
 
       - name: Install Playwright WebKit
         if: needs.changes.outputs.docs_only != 'true'
-        run: node node_modules/playwright/cli.js install --with-deps webkit
+        timeout-minutes: 10
+        run: bash scripts/ci/playwright-install.sh webkit
 
       - name: Run WebKit MOTD and tab focus flows
         if: needs.changes.outputs.docs_only != 'true'
@@ -1268,7 +1279,7 @@ jobs:
     name: Playwright Smoke E2E
     runs-on: ubuntu-latest
     needs: [e2e-chromium, webkit-e2e]
-    if: always() && github.event_name != 'schedule'
+    if: always() && !cancelled() && github.event_name != 'schedule'
     steps:
       - name: Verify Chromium and WebKit results
         env:
@@ -1278,6 +1289,9 @@ jobs:
           set -euo pipefail
           if [ "$CHROMIUM_RESULT" != 'success' ] || [ "$WEBKIT_RESULT" != 'success' ]; then
             echo "Browser-E2E fehlgeschlagen: chromium=$CHROMIUM_RESULT webkit=$WEBKIT_RESULT"
+            if [ "$CHROMIUM_RESULT" = 'cancelled' ] || [ "$WEBKIT_RESULT" = 'cancelled' ]; then
+              echo "cancelled bedeutet meist Job-Timeout (z. B. hängendes Playwright-Install)."
+            fi
             exit 1
           fi
           echo "Browser-E2E bestanden: chromium=$CHROMIUM_RESULT webkit=$WEBKIT_RESULT"

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -96,10 +96,13 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
         run: npm run test:theme-static -w @arsnova/landing
 
+      - name: Install Playwright Chromium
+        timeout-minutes: 10
+        run: bash scripts/ci/playwright-install.sh chromium
+
       - name: Accessibility gate
         run: |
           set -euo pipefail
-          node node_modules/playwright/cli.js install --with-deps chromium
           mkdir -p "$RUNNER_TEMP/landing-a11y"
           cp -R apps/landing/dist/. "$RUNNER_TEMP/landing-a11y/"
           node scripts/serve-static-compressed.mjs "$RUNNER_TEMP/landing-a11y" 4321 > "$RUNNER_TEMP/landing-static.log" 2>&1 &

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -97,7 +97,7 @@ jobs:
         run: npm run test:theme-static -w @arsnova/landing
 
       - name: Install Playwright Chromium
-        timeout-minutes: 10
+        timeout-minutes: 16
         run: bash scripts/ci/playwright-install.sh chromium
 
       - name: Accessibility gate

--- a/docs/CI-WORKFLOW.md
+++ b/docs/CI-WORKFLOW.md
@@ -203,7 +203,10 @@ Wichtig: Jobs ohne direkte Abhängigkeit laufen **parallel**.
 ### 4.7a pdfua
 
 - **Was?** Validiert die fünf PDF/UA-Demoexporte mit veraPDF 1.30.2 gegen
-  PDF/UA-1. Ein einzelner Normverstoß blockiert den Job.
+  PDF/UA-1. Ein einzelner Normverstoß blockiert den Job. Playwright Chromium
+  für die PDF-Erzeugung installiert [../scripts/ci/playwright-install.sh](../scripts/ci/playwright-install.sh)
+  mit Zeitlimit und Wiederholung, damit ein hängender CDN-/apt-Download nicht
+  den gesamten Job bis `timeout-minutes` blockiert.
 - **Wo?** Job in [../.github/workflows/ci.yml](../.github/workflows/ci.yml),
   Runner in [../scripts/validate-pdfua.mjs](../scripts/validate-pdfua.mjs).
 - **Wann?** Parallel zu den übrigen Qualitätsjobs, außer bei `schedule` und
@@ -237,7 +240,13 @@ Wichtig: Jobs ohne direkte Abhängigkeit laufen **parallel**.
   Zielgrößenprüfungen. `SHORT_TEXT` und Unified Session führen axe zusätzlich
   in aktiven, Ergebnis-, Q&A-, Blitzlicht- und Session-Ende-Zuständen aus. Der
   stabile Required-Check `e2e` aggregiert `e2e-chromium` und `webkit-e2e` und
-  wird nur bei zwei erfolgreichen Browser-Jobs grün.
+  wird nur bei zwei erfolgreichen Browser-Jobs grün. Die Aggregator-Bedingung
+  ist `always() && !cancelled()`, damit ein abgebrochener Workflow den
+  Required-Check nicht nachträglich rot färbt. Ein Job-Timeout eines
+  Browser-Jobs bleibt `cancelled` und lässt den Aggregator weiterhin rot
+  werden. Playwright-Browser werden über
+  [../scripts/ci/playwright-install.sh](../scripts/ci/playwright-install.sh)
+  mit Zeitlimit und Wiederholung installiert.
 - **Wo?** Job und Skriptinventar in [../.github/workflows/ci.yml](../.github/workflows/ci.yml)
   und [../apps/frontend/package.json](../apps/frontend/package.json).
 - **Wann?** Nach `build`, außer bei `schedule`.
@@ -246,7 +255,9 @@ Wichtig: Jobs ohne direkte Abhängigkeit laufen **parallel**.
 
 ### 4.9a webkit-e2e
 
-- **Was?** Installiert WebKit explizit und führt einen Desktop-MOTD-Smoke aus.
+- **Was?** Installiert WebKit explizit über
+  [../scripts/ci/playwright-install.sh](../scripts/ci/playwright-install.sh)
+  und führt einen Desktop-MOTD-Smoke aus.
   Der Smoke prüft Tastatur- und Pointer-Rücksprung, die anschließende Tab-Reihe und bildet
   Safaris fehlenden Pointer-Buttonfokus sowie ein fehlendes globales
   `TouchEvent` nach.

--- a/docs/CI-WORKFLOW.md
+++ b/docs/CI-WORKFLOW.md
@@ -205,10 +205,10 @@ Wichtig: Jobs ohne direkte Abhängigkeit laufen **parallel**.
 - **Was?** Validiert die fünf PDF/UA-Demoexporte mit veraPDF 1.30.2 gegen
   PDF/UA-1. Ein einzelner Normverstoß blockiert den Job. Playwright Chromium
   für die PDF-Erzeugung installiert [../scripts/ci/playwright-install.sh](../scripts/ci/playwright-install.sh)
-  mit Zeitlimit (7 Minuten je Versuch) und Wiederholung, damit ein hängender
-  CDN-Download nicht den gesamten Job bis `timeout-minutes` blockiert. Ein
-  abgewürgtes `apt-get` aus `--with-deps` wird vor dem Retry auf den apt-Lock
-  geprüft.
+  in zwei Schritten: Browser-Binary mit Zeitlimit und Wiederholung, danach
+  `install-deps` ohne kurzen Kill. Auf GitHub-Runnern wird
+  `azure.archive.ubuntu.com` auf `archive.ubuntu.com` umgebogen, weil der
+  Azure-Spiegel `apt-get update` minutenlang blockieren kann.
 - **Wo?** Job in [../.github/workflows/ci.yml](../.github/workflows/ci.yml),
   Runner in [../scripts/validate-pdfua.mjs](../scripts/validate-pdfua.mjs).
 - **Wann?** Parallel zu den übrigen Qualitätsjobs, außer bei `schedule` und
@@ -248,7 +248,7 @@ Wichtig: Jobs ohne direkte Abhängigkeit laufen **parallel**.
   Browser-Jobs bleibt `cancelled` und lässt den Aggregator weiterhin rot
   werden. Playwright-Browser werden über
   [../scripts/ci/playwright-install.sh](../scripts/ci/playwright-install.sh)
-  mit Zeitlimit und Wiederholung installiert.
+  (Browser-Binary mit Zeitlimit, OS-Deps ohne kurzen apt-Kill) installiert.
 - **Wo?** Job und Skriptinventar in [../.github/workflows/ci.yml](../.github/workflows/ci.yml)
   und [../apps/frontend/package.json](../apps/frontend/package.json).
 - **Wann?** Nach `build`, außer bei `schedule`.

--- a/docs/CI-WORKFLOW.md
+++ b/docs/CI-WORKFLOW.md
@@ -205,8 +205,10 @@ Wichtig: Jobs ohne direkte Abhängigkeit laufen **parallel**.
 - **Was?** Validiert die fünf PDF/UA-Demoexporte mit veraPDF 1.30.2 gegen
   PDF/UA-1. Ein einzelner Normverstoß blockiert den Job. Playwright Chromium
   für die PDF-Erzeugung installiert [../scripts/ci/playwright-install.sh](../scripts/ci/playwright-install.sh)
-  mit Zeitlimit und Wiederholung, damit ein hängender CDN-/apt-Download nicht
-  den gesamten Job bis `timeout-minutes` blockiert.
+  mit Zeitlimit (7 Minuten je Versuch) und Wiederholung, damit ein hängender
+  CDN-Download nicht den gesamten Job bis `timeout-minutes` blockiert. Ein
+  abgewürgtes `apt-get` aus `--with-deps` wird vor dem Retry auf den apt-Lock
+  geprüft.
 - **Wo?** Job in [../.github/workflows/ci.yml](../.github/workflows/ci.yml),
   Runner in [../scripts/validate-pdfua.mjs](../scripts/validate-pdfua.mjs).
 - **Wann?** Parallel zu den übrigen Qualitätsjobs, außer bei `schedule` und

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -154,7 +154,7 @@ Auslöser: **Push** und **Pull Request** auf `main`.
 | **lighthouse**                         | Lighthouse Performance gegen Home DE/EN; separater A11y-Lauf gegen Home DE/EN, Quiz-Liste, Hilfe und Datenschutz, inklusive blockierender Einzelaudits                                                                           |
 | **e2e-chromium**                       | Chromium Smoke E2E mit Postgres/Redis, statischen und dynamischen axe-Scans sowie Reflow-/Fokus-/Zielgrößen-Gate                                                                                                                 |
 | **webkit-e2e**                         | Expliziter WebKit-Lauf Safari-naher MOTD-Pointer-, Fokus- und Tab-Regressionen                                                                                                                                                   |
-| **e2e**                                | Stabiler Required-Check, der die erfolgreichen Chromium- und WebKit-Jobs aggregiert                                                                                                                                              |
+| **e2e**                                | Stabiler Required-Check, der die erfolgreichen Chromium- und WebKit-Jobs aggregiert; bei Workflow-Abbruch nicht nachträglich rot, bei Job-Timeout eines Browsers weiterhin rot                                                   |
 | **classroom-smokes**                   | Sechs Unterrichts-Szenario-Smokes (inkl. WS Vote-Progress, Reconnect und Q&A-/Blitzlicht-Fan-out, je 30 TN) gegen lokales Backend; JSON-/JUnit-Reports als Artifact                                                              |
 | **docker**                             | Docker-Image-Build (ohne Push), vollständiger Production-Compose-Start mit Migration/Healthcheck sowie Runtime-Smokes für Container-Härtung/Chromium-Maximalbericht und Yjs-Konvergenz inkl. Offline-Reconnect gegen Port 3002   |
 | **deploy**                             | Nur bei Push auf `main` und `DEPLOY_ENABLED=true`; nach Quality-Gates inkl. `publish-image`; übergibt `DEPLOY_IMAGE`/`DEPLOY_SHA`, checkt `DEPLOY_SHA` per SSH vor `scripts/deploy.sh` aus, dann Digest-Pull (kein Server-Build) |
@@ -381,7 +381,10 @@ gegen das Profil `ua1`. Das manuelle Prüfprotokoll steht unter
 des Chromium-Jobs `e2e-chromium`. Der Job `webkit-e2e` startet dieselben echten
 Backend-/Frontend-Services, wählt WebKit explizit und führt `e2e:motd-focus`
 aus. Der Required-Check `e2e` wird nur grün, wenn beide
-Browser-Jobs erfolgreich sind. `smoke:short-text` und `smoke:unified-session` schreiben bei
+Browser-Jobs erfolgreich sind; ein abgebrochener Workflow färbt ihn nicht
+nachträglich rot. Playwright-Browser installiert
+[`scripts/ci/playwright-install.sh`](../scripts/ci/playwright-install.sh) mit
+Zeitlimit und Wiederholung. `smoke:short-text` und `smoke:unified-session` schreiben bei
 gesetztem `SMOKE_ARTIFACT_DIR` zusätzlich axe-JSON-Berichte; der
 Session-Verlaufs-Smoke schreibt einen Abschluss- oder Fehler-Screenshot. Mit
 `A11Y_SCAN=0` lassen sich nur die axe-Schritte lokal deaktivieren; CI setzt diese

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -383,8 +383,8 @@ Backend-/Frontend-Services, wählt WebKit explizit und führt `e2e:motd-focus`
 aus. Der Required-Check `e2e` wird nur grün, wenn beide
 Browser-Jobs erfolgreich sind; ein abgebrochener Workflow färbt ihn nicht
 nachträglich rot. Playwright-Browser installiert
-[`scripts/ci/playwright-install.sh`](../scripts/ci/playwright-install.sh) mit
-Zeitlimit und Wiederholung. `smoke:short-text` und `smoke:unified-session` schreiben bei
+[`scripts/ci/playwright-install.sh`](../scripts/ci/playwright-install.sh)
+(Browser-Binary mit Zeitlimit, OS-Deps ohne kurzen apt-Kill). `smoke:short-text` und `smoke:unified-session` schreiben bei
 gesetztem `SMOKE_ARTIFACT_DIR` zusätzlich axe-JSON-Berichte; der
 Session-Verlaufs-Smoke schreibt einen Abschluss- oder Fehler-Screenshot. Mit
 `A11Y_SCAN=0` lassen sich nur die axe-Schritte lokal deaktivieren; CI setzt diese

--- a/scripts/ci/playwright-install.sh
+++ b/scripts/ci/playwright-install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Installiert ein Playwright-Browser mit Zeitlimit und Wiederholung.
+# Hängende CDN- oder apt-Downloads sollen den CI-Job nicht bis timeout-minutes
+# blockieren und als cancelled den Required-Check e2e rot färben.
+# Usage: playwright-install.sh <chromium|webkit|firefox>
+set -euo pipefail
+
+browser="${1:-}"
+case "$browser" in
+  chromium | webkit | firefox) ;;
+  *)
+    echo "Usage: $0 <chromium|webkit|firefox>" >&2
+    exit 2
+    ;;
+esac
+
+cli="${PLAYWRIGHT_CLI:-node_modules/playwright/cli.js}"
+timeout_bin="${PLAYWRIGHT_TIMEOUT_BIN:-timeout}"
+max_attempts="${PLAYWRIGHT_INSTALL_ATTEMPTS:-3}"
+per_attempt_sec="${PLAYWRIGHT_INSTALL_TIMEOUT_SEC:-180}"
+retry_sleep_sec="${PLAYWRIGHT_INSTALL_RETRY_SLEEP_SEC:-5}"
+
+if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PLAYWRIGHT_INSTALL_ATTEMPTS muss eine positive Ganzzahl sein." >&2
+  exit 2
+fi
+if ! [[ "$per_attempt_sec" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PLAYWRIGHT_INSTALL_TIMEOUT_SEC muss eine positive Ganzzahl sein." >&2
+  exit 2
+fi
+
+if [[ ! -e "$cli" ]]; then
+  echo "Playwright CLI nicht gefunden: $cli" >&2
+  exit 1
+fi
+
+if [[ ! -x "$timeout_bin" ]] && ! command -v "$timeout_bin" >/dev/null 2>&1; then
+  echo "timeout-Kommando nicht gefunden: $timeout_bin" >&2
+  exit 1
+fi
+
+attempt=1
+while ((attempt <= max_attempts)); do
+  echo "Playwright-Install $browser Versuch $attempt/$max_attempts (Timeout ${per_attempt_sec}s)"
+  set +e
+  "$timeout_bin" --kill-after=15s "${per_attempt_sec}s" node "$cli" install --with-deps "$browser"
+  status=$?
+  set -e
+  if ((status == 0)); then
+    echo "Playwright-Install $browser erfolgreich."
+    exit 0
+  fi
+  echo "Playwright-Install $browser Versuch $attempt fehlgeschlagen (Exit $status)."
+  if ((attempt == max_attempts)); then
+    break
+  fi
+  sleep "$retry_sleep_sec"
+  attempt=$((attempt + 1))
+done
+
+echo "Playwright-Install $browser nach $max_attempts Versuchen fehlgeschlagen." >&2
+exit 1

--- a/scripts/ci/playwright-install.sh
+++ b/scripts/ci/playwright-install.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-# Installiert ein Playwright-Browser mit Zeitlimit und Wiederholung.
-# Hängende CDN-Downloads sollen den CI-Job nicht bis timeout-minutes blockieren.
-# `--with-deps` startet apt-get als root außerhalb der timeout-Prozessgruppe;
-# nach einem Timeout muss der apt-Lock freigegeben werden, sonst scheitern
-# Folgeversuche mit Exit 100.
+# Installiert ein Playwright-Browser mit Zeitlimit für den Binary-Download
+# und ohne --with-deps im Timeout-Pfad.
+#
+# `install --with-deps` startet apt-get als root außerhalb der timeout-
+# Prozessgruppe. Ein 3–7-Minuten-Kill während apt-get update (langsamer
+# azure.archive.ubuntu.com-Spiegel) hinterlässt den apt-Lock; Folgeversuche
+# scheitern mit Exit 100 oder laufen in timeout-minutes.
+#
+# Deshalb: Binary-Download mit Retry, OS-Deps danach ohne kurzen Kill,
+# auf GitHub-Runnern Ubuntu-Spiegel auf archive.ubuntu.com umbiegen.
 # Usage: playwright-install.sh <chromium|webkit|firefox>
 set -euo pipefail
 
@@ -19,11 +24,8 @@ esac
 cli="${PLAYWRIGHT_CLI:-node_modules/playwright/cli.js}"
 timeout_bin="${PLAYWRIGHT_TIMEOUT_BIN:-timeout}"
 max_attempts="${PLAYWRIGHT_INSTALL_ATTEMPTS:-3}"
-# 3 Minuten waren zu knapp: langsames apt-get update (Azure-Spiegel) wurde
-# abgewürgt, obwohl noch Fortschritt da war.
 per_attempt_sec="${PLAYWRIGHT_INSTALL_TIMEOUT_SEC:-420}"
 retry_sleep_sec="${PLAYWRIGHT_INSTALL_RETRY_SLEEP_SEC:-5}"
-apt_lock_wait_sec="${PLAYWRIGHT_APT_LOCK_WAIT_SEC:-90}"
 
 if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
   echo "PLAYWRIGHT_INSTALL_ATTEMPTS muss eine positive Ganzzahl sein." >&2
@@ -31,10 +33,6 @@ if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
 fi
 if ! [[ "$per_attempt_sec" =~ ^[1-9][0-9]*$ ]]; then
   echo "PLAYWRIGHT_INSTALL_TIMEOUT_SEC muss eine positive Ganzzahl sein." >&2
-  exit 2
-fi
-if ! [[ "$apt_lock_wait_sec" =~ ^[0-9]+$ ]]; then
-  echo "PLAYWRIGHT_APT_LOCK_WAIT_SEC muss eine nichtnegative Ganzzahl sein." >&2
   exit 2
 fi
 
@@ -48,76 +46,54 @@ if [[ ! -x "$timeout_bin" ]] && ! command -v "$timeout_bin" >/dev/null 2>&1; the
   exit 1
 fi
 
-apt_lock_paths=(
-  /var/lib/apt/lists/lock
-  /var/lib/dpkg/lock-frontend
-  /var/lib/dpkg/lock
-)
-
-apt_lock_held() {
-  local lock
-  for lock in "${apt_lock_paths[@]}"; do
-    if [[ -e "$lock" ]] && command -v fuser >/dev/null 2>&1 && fuser "$lock" >/dev/null 2>&1; then
-      return 0
-    fi
-    if [[ "${GITHUB_ACTIONS:-}" == 'true' ]] && command -v sudo >/dev/null 2>&1; then
-      if [[ -e "$lock" ]] && sudo fuser "$lock" >/dev/null 2>&1; then
-        return 0
-      fi
-    fi
-  done
-  return 1
-}
-
-release_stale_apt_locks() {
-  local waited=0
-  if ((apt_lock_wait_sec > 0)); then
-    while ((waited < apt_lock_wait_sec)); do
-      if ! apt_lock_held; then
-        return 0
-      fi
-      echo "apt-Lock noch gehalten, warte (${waited}s/${apt_lock_wait_sec}s)…"
-      sleep 5
-      waited=$((waited + 5))
-    done
-  fi
-  if ! apt_lock_held; then
+prefer_archive_ubuntu_mirrors() {
+  if [[ "${GITHUB_ACTIONS:-}" != 'true' ]]; then
     return 0
   fi
-  if [[ "${GITHUB_ACTIONS:-}" != 'true' ]] || ! command -v sudo >/dev/null 2>&1; then
-    echo "apt-Lock weiterhin gehalten, kein CI-sudo verfügbar."
+  if ! command -v sudo >/dev/null 2>&1; then
     return 0
   fi
-  echo "apt-Lock nach ${apt_lock_wait_sec}s noch gehalten — beende blockierende Prozesse."
-  local lock
-  for lock in "${apt_lock_paths[@]}"; do
-    sudo fuser -k -TERM "$lock" >/dev/null 2>&1 || true
+  echo "CI: Ubuntu-Spiegel von azure.archive.ubuntu.com auf archive.ubuntu.com umbiegen."
+  local files=()
+  local candidate
+  for candidate in /etc/apt/sources.list /etc/apt/apt-mirrors.txt /etc/apt/sources.list.d/ubuntu.sources; do
+    if [[ -f "$candidate" ]]; then
+      files+=("$candidate")
+    fi
   done
-  sleep 2
-  for lock in "${apt_lock_paths[@]}"; do
-    sudo fuser -k -KILL "$lock" >/dev/null 2>&1 || true
+  shopt -s nullglob
+  for candidate in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+    files+=("$candidate")
   done
+  shopt -u nullglob
+  if ((${#files[@]} == 0)); then
+    return 0
+  fi
+  sudo sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' "${files[@]}" || true
 }
+
+prefer_archive_ubuntu_mirrors
 
 attempt=1
 while ((attempt <= max_attempts)); do
-  echo "Playwright-Install $browser Versuch $attempt/$max_attempts (Timeout ${per_attempt_sec}s)"
+  echo "Playwright-Install $browser Versuch $attempt/$max_attempts (Timeout ${per_attempt_sec}s, nur Browser-Binary)"
   set +e
-  "$timeout_bin" --kill-after=20s "${per_attempt_sec}s" node "$cli" install --with-deps "$browser"
+  "$timeout_bin" --kill-after=20s "${per_attempt_sec}s" node "$cli" install "$browser"
   status=$?
   set -e
   if ((status == 0)); then
-    echo "Playwright-Install $browser erfolgreich."
-    exit 0
+    echo "Playwright-Browser $browser heruntergeladen."
+    break
   fi
   echo "Playwright-Install $browser Versuch $attempt fehlgeschlagen (Exit $status)."
   if ((attempt == max_attempts)); then
-    break
+    echo "Playwright-Install $browser nach $max_attempts Versuchen fehlgeschlagen." >&2
+    exit 1
   fi
-  release_stale_apt_locks
   sleep "$retry_sleep_sec"
   attempt=$((attempt + 1))
 done
 
-echo "Playwright-Install $browser nach $max_attempts Versuchen fehlgeschlagen." >&2
-exit 1
+echo "Playwright-OS-Deps für $browser installieren (ohne kurzen Timeout)."
+node "$cli" install-deps "$browser"
+echo "Playwright-Install $browser erfolgreich."

--- a/scripts/ci/playwright-install.sh
+++ b/scripts/ci/playwright-install.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Installiert ein Playwright-Browser mit Zeitlimit und Wiederholung.
-# Hängende CDN- oder apt-Downloads sollen den CI-Job nicht bis timeout-minutes
-# blockieren und als cancelled den Required-Check e2e rot färben.
+# Hängende CDN-Downloads sollen den CI-Job nicht bis timeout-minutes blockieren.
+# `--with-deps` startet apt-get als root außerhalb der timeout-Prozessgruppe;
+# nach einem Timeout muss der apt-Lock freigegeben werden, sonst scheitern
+# Folgeversuche mit Exit 100.
 # Usage: playwright-install.sh <chromium|webkit|firefox>
 set -euo pipefail
 
@@ -17,8 +19,11 @@ esac
 cli="${PLAYWRIGHT_CLI:-node_modules/playwright/cli.js}"
 timeout_bin="${PLAYWRIGHT_TIMEOUT_BIN:-timeout}"
 max_attempts="${PLAYWRIGHT_INSTALL_ATTEMPTS:-3}"
-per_attempt_sec="${PLAYWRIGHT_INSTALL_TIMEOUT_SEC:-180}"
+# 3 Minuten waren zu knapp: langsames apt-get update (Azure-Spiegel) wurde
+# abgewürgt, obwohl noch Fortschritt da war.
+per_attempt_sec="${PLAYWRIGHT_INSTALL_TIMEOUT_SEC:-420}"
 retry_sleep_sec="${PLAYWRIGHT_INSTALL_RETRY_SLEEP_SEC:-5}"
+apt_lock_wait_sec="${PLAYWRIGHT_APT_LOCK_WAIT_SEC:-90}"
 
 if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
   echo "PLAYWRIGHT_INSTALL_ATTEMPTS muss eine positive Ganzzahl sein." >&2
@@ -26,6 +31,10 @@ if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
 fi
 if ! [[ "$per_attempt_sec" =~ ^[1-9][0-9]*$ ]]; then
   echo "PLAYWRIGHT_INSTALL_TIMEOUT_SEC muss eine positive Ganzzahl sein." >&2
+  exit 2
+fi
+if ! [[ "$apt_lock_wait_sec" =~ ^[0-9]+$ ]]; then
+  echo "PLAYWRIGHT_APT_LOCK_WAIT_SEC muss eine nichtnegative Ganzzahl sein." >&2
   exit 2
 fi
 
@@ -39,11 +48,62 @@ if [[ ! -x "$timeout_bin" ]] && ! command -v "$timeout_bin" >/dev/null 2>&1; the
   exit 1
 fi
 
+apt_lock_paths=(
+  /var/lib/apt/lists/lock
+  /var/lib/dpkg/lock-frontend
+  /var/lib/dpkg/lock
+)
+
+apt_lock_held() {
+  local lock
+  for lock in "${apt_lock_paths[@]}"; do
+    if [[ -e "$lock" ]] && command -v fuser >/dev/null 2>&1 && fuser "$lock" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == 'true' ]] && command -v sudo >/dev/null 2>&1; then
+      if [[ -e "$lock" ]] && sudo fuser "$lock" >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+release_stale_apt_locks() {
+  local waited=0
+  if ((apt_lock_wait_sec > 0)); then
+    while ((waited < apt_lock_wait_sec)); do
+      if ! apt_lock_held; then
+        return 0
+      fi
+      echo "apt-Lock noch gehalten, warte (${waited}s/${apt_lock_wait_sec}s)…"
+      sleep 5
+      waited=$((waited + 5))
+    done
+  fi
+  if ! apt_lock_held; then
+    return 0
+  fi
+  if [[ "${GITHUB_ACTIONS:-}" != 'true' ]] || ! command -v sudo >/dev/null 2>&1; then
+    echo "apt-Lock weiterhin gehalten, kein CI-sudo verfügbar."
+    return 0
+  fi
+  echo "apt-Lock nach ${apt_lock_wait_sec}s noch gehalten — beende blockierende Prozesse."
+  local lock
+  for lock in "${apt_lock_paths[@]}"; do
+    sudo fuser -k -TERM "$lock" >/dev/null 2>&1 || true
+  done
+  sleep 2
+  for lock in "${apt_lock_paths[@]}"; do
+    sudo fuser -k -KILL "$lock" >/dev/null 2>&1 || true
+  done
+}
+
 attempt=1
 while ((attempt <= max_attempts)); do
   echo "Playwright-Install $browser Versuch $attempt/$max_attempts (Timeout ${per_attempt_sec}s)"
   set +e
-  "$timeout_bin" --kill-after=15s "${per_attempt_sec}s" node "$cli" install --with-deps "$browser"
+  "$timeout_bin" --kill-after=20s "${per_attempt_sec}s" node "$cli" install --with-deps "$browser"
   status=$?
   set -e
   if ((status == 0)); then
@@ -54,6 +114,7 @@ while ((attempt <= max_attempts)); do
   if ((attempt == max_attempts)); then
     break
   fi
+  release_stale_apt_locks
   sleep "$retry_sleep_sec"
   attempt=$((attempt + 1))
 done

--- a/scripts/ci/playwright-install.test.mjs
+++ b/scripts/ci/playwright-install.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -15,7 +15,6 @@ function runInstall(args, env = {}) {
     env: {
       ...process.env,
       PLAYWRIGHT_INSTALL_RETRY_SLEEP_SEC: '0',
-      PLAYWRIGHT_APT_LOCK_WAIT_SEC: '0',
       ...env,
     },
   });
@@ -26,12 +25,15 @@ function makeTimeoutStub(succeedOnAttempt) {
   const cliPath = join(dir, 'cli.js');
   const timeoutPath = join(dir, 'timeout');
   const countPath = join(dir, 'count');
-  writeFileSync(cliPath, 'console.log("stub-cli");\n');
+  const argsPath = join(dir, 'timeout.args');
+  writeFileSync(cliPath, 'console.log("stub-cli " + process.argv.slice(2).join(" "));\n');
   writeFileSync(countPath, '0\n');
+  writeFileSync(argsPath, '');
   writeFileSync(
     timeoutPath,
     `#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\\n' "$*" >> ${JSON.stringify(argsPath)}
 count_file=${JSON.stringify(countPath)}
 succeed_on=${String(succeedOnAttempt)}
 count="$(cat "$count_file")"
@@ -44,7 +46,7 @@ exit 124
 `,
   );
   chmodSync(timeoutPath, 0o755);
-  return { dir, cliPath, timeoutPath, countPath };
+  return { dir, cliPath, timeoutPath, countPath, argsPath };
 }
 
 test('playwright-install rejects missing browser argument', () => {
@@ -67,7 +69,7 @@ test('playwright-install rejects missing Playwright CLI', () => {
   assert.match(result.stderr, /Playwright CLI nicht gefunden/);
 });
 
-test('playwright-install succeeds on the first attempt', () => {
+test('playwright-install downloads the browser without --with-deps then installs OS deps', () => {
   const stub = makeTimeoutStub(1);
   const result = runInstall(['webkit'], {
     PLAYWRIGHT_CLI: stub.cliPath,
@@ -76,11 +78,17 @@ test('playwright-install succeeds on the first attempt', () => {
   });
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Versuch 1\/3/);
+  assert.match(result.stdout, /nur Browser-Binary/);
+  assert.match(result.stdout, /OS-Deps/);
   assert.match(result.stdout, /erfolgreich/);
   assert.doesNotMatch(result.stdout, /Versuch 2\//);
+  const timeoutArgs = readFileSync(stub.argsPath, 'utf8');
+  assert.match(timeoutArgs, /install webkit/);
+  assert.doesNotMatch(timeoutArgs, /--with-deps/);
+  assert.match(result.stdout, /stub-cli install-deps webkit/);
 });
 
-test('playwright-install retries after a timed-out attempt', () => {
+test('playwright-install retries after a timed-out browser download', () => {
   const stub = makeTimeoutStub(2);
   const result = runInstall(['chromium'], {
     PLAYWRIGHT_CLI: stub.cliPath,
@@ -91,6 +99,7 @@ test('playwright-install retries after a timed-out attempt', () => {
   assert.match(result.stdout, /Versuch 1 fehlgeschlagen \(Exit 124\)/);
   assert.match(result.stdout, /Versuch 2\/3/);
   assert.match(result.stdout, /erfolgreich/);
+  assert.match(result.stdout, /stub-cli install-deps chromium/);
 });
 
 test('playwright-install fails after the configured number of attempts', () => {
@@ -104,6 +113,7 @@ test('playwright-install fails after the configured number of attempts', () => {
   assert.match(result.stdout, /Versuch 1 fehlgeschlagen/);
   assert.match(result.stdout, /Versuch 2 fehlgeschlagen/);
   assert.match(result.stderr, /nach 2 Versuchen fehlgeschlagen/);
+  assert.doesNotMatch(result.stdout, /install-deps/);
 });
 
 test('playwright-install uses a seven-minute per-attempt timeout by default', () => {

--- a/scripts/ci/playwright-install.test.mjs
+++ b/scripts/ci/playwright-install.test.mjs
@@ -15,6 +15,7 @@ function runInstall(args, env = {}) {
     env: {
       ...process.env,
       PLAYWRIGHT_INSTALL_RETRY_SLEEP_SEC: '0',
+      PLAYWRIGHT_APT_LOCK_WAIT_SEC: '0',
       ...env,
     },
   });
@@ -103,4 +104,14 @@ test('playwright-install fails after the configured number of attempts', () => {
   assert.match(result.stdout, /Versuch 1 fehlgeschlagen/);
   assert.match(result.stdout, /Versuch 2 fehlgeschlagen/);
   assert.match(result.stderr, /nach 2 Versuchen fehlgeschlagen/);
+});
+
+test('playwright-install uses a seven-minute per-attempt timeout by default', () => {
+  const stub = makeTimeoutStub(1);
+  const result = runInstall(['chromium'], {
+    PLAYWRIGHT_CLI: stub.cliPath,
+    PLAYWRIGHT_TIMEOUT_BIN: stub.timeoutPath,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Timeout 420s/);
 });

--- a/scripts/ci/playwright-install.test.mjs
+++ b/scripts/ci/playwright-install.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const script = join(repoRoot, 'scripts/ci/playwright-install.sh');
+
+function runInstall(args, env = {}) {
+  return spawnSync('bash', [script, ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PLAYWRIGHT_INSTALL_RETRY_SLEEP_SEC: '0',
+      ...env,
+    },
+  });
+}
+
+function makeTimeoutStub(succeedOnAttempt) {
+  const dir = mkdtempSync(join(tmpdir(), 'arsnova-pw-install-'));
+  const cliPath = join(dir, 'cli.js');
+  const timeoutPath = join(dir, 'timeout');
+  const countPath = join(dir, 'count');
+  writeFileSync(cliPath, 'console.log("stub-cli");\n');
+  writeFileSync(countPath, '0\n');
+  writeFileSync(
+    timeoutPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+count_file=${JSON.stringify(countPath)}
+succeed_on=${String(succeedOnAttempt)}
+count="$(cat "$count_file")"
+count=$((count + 1))
+printf '%s\\n' "$count" > "$count_file"
+if [ "$count" -ge "$succeed_on" ]; then
+  exit 0
+fi
+exit 124
+`,
+  );
+  chmodSync(timeoutPath, 0o755);
+  return { dir, cliPath, timeoutPath, countPath };
+}
+
+test('playwright-install rejects missing browser argument', () => {
+  const result = runInstall([]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Usage:/);
+});
+
+test('playwright-install rejects unknown browser', () => {
+  const result = runInstall(['chrome']);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Usage:/);
+});
+
+test('playwright-install rejects missing Playwright CLI', () => {
+  const result = runInstall(['webkit'], {
+    PLAYWRIGHT_CLI: join(tmpdir(), 'missing-playwright-cli.js'),
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Playwright CLI nicht gefunden/);
+});
+
+test('playwright-install succeeds on the first attempt', () => {
+  const stub = makeTimeoutStub(1);
+  const result = runInstall(['webkit'], {
+    PLAYWRIGHT_CLI: stub.cliPath,
+    PLAYWRIGHT_TIMEOUT_BIN: stub.timeoutPath,
+    PLAYWRIGHT_INSTALL_ATTEMPTS: '3',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Versuch 1\/3/);
+  assert.match(result.stdout, /erfolgreich/);
+  assert.doesNotMatch(result.stdout, /Versuch 2\//);
+});
+
+test('playwright-install retries after a timed-out attempt', () => {
+  const stub = makeTimeoutStub(2);
+  const result = runInstall(['chromium'], {
+    PLAYWRIGHT_CLI: stub.cliPath,
+    PLAYWRIGHT_TIMEOUT_BIN: stub.timeoutPath,
+    PLAYWRIGHT_INSTALL_ATTEMPTS: '3',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Versuch 1 fehlgeschlagen \(Exit 124\)/);
+  assert.match(result.stdout, /Versuch 2\/3/);
+  assert.match(result.stdout, /erfolgreich/);
+});
+
+test('playwright-install fails after the configured number of attempts', () => {
+  const stub = makeTimeoutStub(99);
+  const result = runInstall(['webkit'], {
+    PLAYWRIGHT_CLI: stub.cliPath,
+    PLAYWRIGHT_TIMEOUT_BIN: stub.timeoutPath,
+    PLAYWRIGHT_INSTALL_ATTEMPTS: '2',
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /Versuch 1 fehlgeschlagen/);
+  assert.match(result.stdout, /Versuch 2 fehlgeschlagen/);
+  assert.match(result.stderr, /nach 2 Versuchen fehlgeschlagen/);
+});


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Der Required-Check Playwright Smoke E2E auf `main` ist in [CI-Lauf 32267890133](https://github.com/kqc-real/arsnova.eu/actions/runs/32267890133/job/96129354757) rot geworden (`chromium=success webkit=cancelled`). Ursache war kein fehlgeschlagener MOTD-Smoke, sondern ein hängendes `playwright install --with-deps` (langsamer `azure.archive.ubuntu.com`-Spiegel in `apt-get update`). GitHub wertet Job-Timeout als `cancelled`; der Aggregator mit `if: always()` färbte den Pflichtcheck trotzdem rot.
- **Lösung:** `scripts/ci/playwright-install.sh` lädt zuerst nur das Browser-Binary mit Zeitlimit und Retry (kein `--with-deps`, damit `timeout` kein root-`apt-get` abwürgt und den apt-Lock hinterlässt). OS-Deps folgen danach ohne kurzen Kill. Auf GitHub-Runnern wird der Ubuntu-Spiegel auf `archive.ubuntu.com` umgebogen. Der E2E-Aggregator nutzt `always() && !cancelled()`, damit ein abgebrochener Workflow den Pflichtcheck nicht nachträglich rot färbt; ein Job-Timeout eines Browser-Jobs bleibt ein roter Aggregator.
- **Bewusste Nicht-Ziele:** Kein Playwright-Browser-Cache, kein neues LLM/QA-Summary, kein Ändern der MOTD-/axe-Smokes, kein Re-Run des alten `main`-Laufs in diesem PR.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

GitHub Actions: Job-Timeout setzt das Job-Ergebnis auf `cancelled`; `cancelled()` gilt für den Workflow, nicht für ein einzelnes Job-Timeout. GNU `timeout` beendet nicht zuverlässig ein von `--with-deps` gestartetes root-`apt-get`. Der Required-Check `e2e` bleibt nur bei zwei erfolgreichen Browser-Jobs grün.

**Betroffene externe Verträge:**

Playwright CLI `install <browser>` und `install-deps <browser>` (statt `install --with-deps` unter kurzem Timeout) sowie GNU `timeout` auf `ubuntu-latest`. Keine Produkt-API.

## Implementierung

- Hilfsskript `scripts/ci/playwright-install.sh`: Binary-Download mit drei Versuchen à 420 s und `--kill-after=20s`; danach `install-deps` ohne kurzen Kill; auf `GITHUB_ACTIONS` Spiegel `azure.archive.ubuntu.com` → `archive.ubuntu.com`.
- Alle bisherigen `node node_modules/playwright/cli.js install --with-deps …`-Aufrufe in `ci.yml` und `deploy-landing.yml` nutzen das Skript; Install-Steps haben `timeout-minutes: 16`.
- PDF/UA-Install ist ein eigener Step; Job-Timeouts von WebKit und PDF/UA von 20 auf 25 Minuten.
- E2E-Aggregator: `if: always() && !cancelled() && github.event_name != 'schedule'`.
- Doku in `docs/CI-WORKFLOW.md` und `docs/TESTING.md` nachgezogen.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [x] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `node --test scripts/ci/playwright-install.test.mjs` | 7/7 bestanden (fehlendes Argument, unbekannter Browser, fehlende CLI, Binary ohne `--with-deps` plus `install-deps`, Retry nach Exit 124, endgültiger Fehlschlag ohne `install-deps`) |
| `bash -n scripts/ci/playwright-install.sh` | erfolgreich |
| `docker run --rm koalaman/shellcheck:stable scripts/ci/playwright-install.sh` | Exit 0 |
| `npx prettier --check docs/CI-WORKFLOW.md docs/TESTING.md scripts/ci/playwright-install.test.mjs` | All matched files use Prettier code style |
| `git diff --check` | keine Whitespace-Fehler |
| Pre-Commit `npm run typecheck` | erfolgreich (shared-types, session-export-report, backend, frontend) |
| Pre-Commit `npm test` | erfolgreich (67 shared-types, 81 session-export-report, 1019 backend, 1370 frontend) |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

Die Tests prüfen, dass der zeitbegrenzte Pfad `install <browser>` ohne `--with-deps` ist und `install-deps` nur nach erfolgreichem Binary-Download folgt.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Kein Laufzeitcode. Nach Merge auf `main` müssen WebKit- und PDF/UA-Jobs wieder durchlaufen, damit Deploy startet. Ein Workflow-Abbruch färbt `e2e` nicht mehr nachträglich rot; Deploy bleibt über `needs` trotzdem aus, solange `e2e` nicht erfolgreich ist.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine. GNU `timeout` und `sudo` sind auf `ubuntu-latest` vorhanden.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Install-Logs enthalten Versuchszähler, Exit-Status und den Spiegel-Hinweis; bei `cancelled` erklärt der Aggregator den Timeout-Hinweis.
- **Rollback:** Revert dieses PRs stellt die direkten `playwright install --with-deps`-Aufrufe und `if: always()` ohne `!cancelled()` wieder her.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Auslöser: https://github.com/kqc-real/arsnova.eu/actions/runs/32267890133/job/96129354757
- Folgefail auf diesem PR ([Lauf 32277038610](https://github.com/kqc-real/arsnova.eu/actions/runs/32277038610/job/96148597238)): `timeout` beendete `--with-deps` nicht; apt hing 420 s am Azure-Spiegel, Lock-Wait plus zweiter Versuch überschritten `timeout-minutes: 16`.
- Gegenprobe: PR #297 WebKit 2m26s, PDF/UA 6m13s erfolgreich — der Hang ist transient, ohne Trennung von Binary-Download und apt aber fatal für den Required-Check.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** `npm run lint` und `npm run build:prod` wurden nicht lokal ausgeführt; geändert sind CI-YAML, ein Bash-Hilfsskript und Doku, kein Anwendungscode. `typecheck` und `npm test` liefen über den Pre-Commit-Hook. Ein echter CDN-Hang von `playwright install` wurde lokal nicht reproduziert, sondern über Exit 124 und Retry-Stubs abgebildet. actionlint läuft im CI-Job Workflow Lint.
- **Verbleibende Risiken:** `install-deps` kann bei einem langsamen Ubuntu-Spiegel länger brauchen; der Step hat `timeout-minutes: 16`, die Jobs WebKit/PDF/UA 25 Minuten. Ein Job-Timeout bleibt ein roter Aggregator. `!cancelled()` überspringt den Aggregator nur bei Workflow-Abbruch; Deploy hängt weiterhin an erfolgreichem `e2e`.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)