### PR TITLE
feat(motd): einzelne Archiv-Meldungen als gelesen markieren

### DIFF
--- a/.github/trpc-dod-baseline.json
+++ b/.github/trpc-dod-baseline.json
@@ -154,7 +154,7 @@
     },
     "motd.getHeaderState": {
       "kind": "query",
-      "fingerprint": "sha256:43fc15cf2f5cda58c96d60c9e5f7fabaa9e3a69d948d0f9957f5214e8b8ed51c",
+      "fingerprint": "sha256:0cda0a5afbe858f1fc2b70338526692882b6119eff62c325dcde59c823f31ad7",
       "missing": []
     },
     "motd.listArchive": {

--- a/apps/backend/src/__tests__/motd.test.ts
+++ b/apps/backend/src/__tests__/motd.test.ts
@@ -632,6 +632,55 @@ describe('motd router', () => {
     expect(r.archiveMaxEndsAtIso).toBe('2099-12-31T23:59:59.999Z');
   });
 
+  it('getHeaderState zieht einzeln gelesene Archiv-MOTDs vom Ungelesen-Zähler ab', async () => {
+    const welcomeId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    prismaMock.motd.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: welcomeId,
+        contentVersion: 1,
+        startsAt: new Date('2025-01-01T00:00:00.000Z'),
+        endsAt: new Date('2099-12-31T23:59:59.999Z'),
+        locales: [{ locale: 'de', markdown: 'Willkommen' }],
+      },
+      {
+        id: M1,
+        contentVersion: 1,
+        startsAt: new Date('2026-06-10T00:00:00.000Z'),
+        endsAt: new Date('2027-03-31T23:59:59.999Z'),
+        locales: [{ locale: 'de', markdown: 'Neue Vision' }],
+      },
+    ]);
+
+    const caller = motdRouter.createCaller(ctx);
+    const r = await caller.getHeaderState({
+      locale: 'de',
+      archiveReadItems: [{ motdId: M1, contentVersion: 1 }],
+    });
+
+    expect(r.archiveCount).toBe(2);
+    expect(r.archiveUnreadCount).toBe(1);
+  });
+
+  it('getHeaderState lässt eine höhere contentVersion trotz älterem Einzel-Gelesen ungelesen', async () => {
+    prismaMock.motd.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: M1,
+        contentVersion: 2,
+        startsAt: new Date('2026-06-10T00:00:00.000Z'),
+        endsAt: new Date('2027-03-31T23:59:59.999Z'),
+        locales: [{ locale: 'de', markdown: 'Aktualisierte Vision' }],
+      },
+    ]);
+
+    const caller = motdRouter.createCaller(ctx);
+    const r = await caller.getHeaderState({
+      locale: 'de',
+      archiveReadItems: [{ motdId: M1, contentVersion: 1 }],
+    });
+
+    expect(r.archiveUnreadCount).toBe(1);
+  });
+
   it('recordInteraction wirft TOO_MANY_REQUESTS wenn Rate-Limit greift', async () => {
     motdRateMocks.checkMotdRecordInteractionRate.mockResolvedValue({
       allowed: false,

--- a/apps/backend/src/routers/motd.ts
+++ b/apps/backend/src/routers/motd.ts
@@ -3,7 +3,12 @@
  */
 import { TRPCError } from '@trpc/server';
 import type { Prisma } from '@prisma/client';
-import type { AppLocale, MotdArchiveReadCursor, MotdPublicDTO } from '@arsnova/shared-types';
+import type {
+  AppLocale,
+  MotdArchiveReadCursor,
+  MotdArchiveReadItem,
+  MotdPublicDTO,
+} from '@arsnova/shared-types';
 import {
   MotdGetCurrentInputSchema,
   MotdGetCurrentOutputSchema,
@@ -192,6 +197,16 @@ function archiveReadCursorForItem(item: {
   };
 }
 
+function isArchiveItemIndividuallyRead(
+  item: { id: string; contentVersion: number },
+  readItems: ReadonlyArray<MotdArchiveReadItem> | undefined,
+): boolean {
+  if (!readItems?.length) return false;
+  return readItems.some(
+    (read) => read.motdId === item.id && read.contentVersion >= item.contentVersion,
+  );
+}
+
 /** Positiv, wenn `a` in der Archivsortierung neuer als `b` ist. */
 function compareArchiveReadCursors(a: MotdArchiveReadCursor, b: MotdArchiveReadCursor): number {
   const startsAtDifference = Date.parse(a.startsAtIso) - Date.parse(b.startsAtIso);
@@ -205,6 +220,7 @@ async function fetchArchiveHeaderStats(
   now: Date,
   seenCursor: MotdArchiveReadCursor | null,
   legacySeenEndsAt: Date | null,
+  archiveReadItems: ReadonlyArray<MotdArchiveReadItem> | undefined,
 ) {
   const rows = await prisma.motd.findMany({
     where: motdArchiveListWhere(now),
@@ -227,19 +243,18 @@ async function fetchArchiveHeaderStats(
     (latest, item) => (latest === null || item.endsAt > latest ? item.endsAt : latest),
     null,
   );
-  const archiveUnreadCount = seenCursor
-    ? visible.reduce(
-        (count, item) =>
-          count +
-          (compareArchiveReadCursors(archiveReadCursorForItem(item), seenCursor) > 0 ? 1 : 0),
-        0,
-      )
-    : legacySeenEndsAt
-      ? visible.reduce(
-          (count, item) => count + (new Date(item.endsAt) > legacySeenEndsAt ? 1 : 0),
-          0,
-        )
-      : archiveCount;
+  const archiveUnreadCount = visible.reduce((count, item) => {
+    if (isArchiveItemIndividuallyRead(item, archiveReadItems)) return count;
+    if (seenCursor) {
+      return (
+        count + (compareArchiveReadCursors(archiveReadCursorForItem(item), seenCursor) > 0 ? 1 : 0)
+      );
+    }
+    if (legacySeenEndsAt) {
+      return count + (new Date(item.endsAt) > legacySeenEndsAt ? 1 : 0);
+    }
+    return count + 1;
+  }, 0);
   return {
     archiveCount,
     archiveMaxCursor,
@@ -336,7 +351,8 @@ export const motdRouter = router({
 
   /**
    * Toolbar/Header: aktives Overlay?, Archiv-Anzahl und ungelesene Meldungen relativ zum
-   * publikationsbasierten Archiv-Lesecursor (mit Legacy-`endsAt`-Kompatibilität).
+   * publikationsbasierten Archiv-Lesecursor, optional abzüglich einzeln gelesener Einträge
+   * (mit Legacy-`endsAt`-Kompatibilität).
    */
   getHeaderState: publicProcedure
     .input(MotdHeaderStateInputSchema)
@@ -366,7 +382,7 @@ export const motdRouter = router({
       const dismissed = input.overlayDismissedUpTo;
       const [motd, archiveStats] = await Promise.all([
         fetchCurrentMotdDto(locale, now, dismissed),
-        fetchArchiveHeaderStats(locale, now, seenCursor, legacySeenEndsAt),
+        fetchArchiveHeaderStats(locale, now, seenCursor, legacySeenEndsAt, input.archiveReadItems),
       ]);
 
       const { archiveCount, archiveMaxCursor, archiveMaxEndsAtIso, archiveUnreadCount } =

--- a/apps/frontend/src/app/core/motd-header-state.service.ts
+++ b/apps/frontend/src/app/core/motd-header-state.service.ts
@@ -8,7 +8,7 @@ import { debounceTime, filter } from 'rxjs/operators';
 import type { AppLocale } from '@arsnova/shared-types';
 import { trpc } from './trpc.client';
 import { getEffectiveLocale, localeIdToSupported } from './locale-from-path';
-import { getMotdArchiveSeenUpToCursor, motdDismissedPairsForApi } from './motd-storage';
+import { motdGetHeaderStateClientInput } from './motd-storage';
 import { MotdHeaderRefreshService } from './motd-header-refresh.service';
 
 /**
@@ -33,12 +33,13 @@ export class MotdHeaderStateService {
    */
   private inFlight: Promise<void> | null = null;
   private lastRefreshAtMs = 0;
+  private pendingForceRefresh = false;
   private static readonly MIN_REFRESH_INTERVAL_MS = 1500;
 
   /** Aktive Meldung oder Archiv-Einträge → Campaign-Icon in der Toolbar. */
   readonly motdToolbarIcon = signal(false);
 
-  /** Ungelesene Archiv-MOTDs relativ zum Client-Wasserzeichen. */
+  /** Ungelesene Archiv-MOTDs relativ zum Client-Wasserzeichen und einzeln Gelesenen. */
   readonly archiveUnreadCount = signal(0);
 
   /** Anzahl Einträge im Archiv (Server, gleiche Filterlogik wie listArchive). */
@@ -47,7 +48,7 @@ export class MotdHeaderStateService {
   constructor() {
     if (isPlatformBrowser(this.platformId)) {
       this.scheduleInitialRefresh();
-      this.motdHeaderRefresh.requests.subscribe(() => void this.refresh());
+      this.motdHeaderRefresh.requests.subscribe(() => void this.refresh({ force: true }));
       this.passiveRefresh$.pipe(debounceTime(500)).subscribe(() => void this.refresh());
       this.router.events
         .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
@@ -56,28 +57,41 @@ export class MotdHeaderStateService {
     }
   }
 
-  async refresh(): Promise<void> {
+  /** Sofortiger Badge-Stand, bevor `getHeaderState` den Server bestätigt. */
+  decrementArchiveUnreadCount(): void {
+    this.archiveUnreadCount.update((n) => Math.max(0, n - 1));
+  }
+
+  setArchiveUnreadCount(count: number): void {
+    this.archiveUnreadCount.set(Math.max(0, count));
+  }
+
+  async refresh(options?: { force?: boolean }): Promise<void> {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
     if (this.inFlight) {
+      if (options?.force) {
+        this.pendingForceRefresh = true;
+      }
       return this.inFlight;
     }
     const now = Date.now();
-    if (now - this.lastRefreshAtMs < MotdHeaderStateService.MIN_REFRESH_INTERVAL_MS) {
+    if (
+      !options?.force &&
+      now - this.lastRefreshAtMs < MotdHeaderStateService.MIN_REFRESH_INTERVAL_MS
+    ) {
       return;
     }
     this.lastRefreshAtMs = now;
+    this.pendingForceRefresh = false;
 
     const locale = getEffectiveLocale(localeIdToSupported(this.localeId)) as AppLocale;
     this.inFlight = (async () => {
       try {
-        const seen = getMotdArchiveSeenUpToCursor();
-        const dismissed = motdDismissedPairsForApi();
         const s = await trpc.motd.getHeaderState.query({
           locale,
-          ...(seen ? { archiveSeenUpToCursor: seen } : {}),
-          ...(dismissed.length ? { overlayDismissedUpTo: dismissed } : {}),
+          ...motdGetHeaderStateClientInput(),
         });
         this.motdToolbarIcon.set(s.hasActiveOverlay || s.hasArchiveEntries);
         this.archiveUnreadCount.set(s.archiveUnreadCount);
@@ -91,7 +105,11 @@ export class MotdHeaderStateService {
       this.inFlight = null;
     });
 
-    return this.inFlight;
+    await this.inFlight;
+    if (this.pendingForceRefresh) {
+      this.pendingForceRefresh = false;
+      return this.refresh({ force: true });
+    }
   }
 
   private readonly onVisibilityChange = (): void => {

--- a/apps/frontend/src/app/core/motd-storage.spec.ts
+++ b/apps/frontend/src/app/core/motd-storage.spec.ts
@@ -10,12 +10,15 @@ import {
   getMotdArchiveSeenUpToCursor,
   hasMotdOverlayBeenOfferedThisSession,
   isMotdDismissedForVersion,
+  markMotdArchiveItemRead,
   markMotdDismissed,
   markMotdInteractionRecorded,
   markMotdOverlayOfferedThisSession,
   markMotdOverlayReloadSuppress,
   hasMotdInteractionRecorded,
   motdDismissedPairsForApi,
+  getMotdArchiveReadItems,
+  motdGetHeaderStateClientInput,
   setMotdArchiveSeenUpToCursor,
   shouldSkipQueuedMotdAutoOverlay,
   shouldSuppressMotdOverlayOnMobileFirstHomeVisit,
@@ -69,6 +72,28 @@ describe('motd-storage', () => {
     setMotdArchiveSeenUpToCursor(cursor);
     expect(getMotdArchiveSeenUpToCursor()).toEqual(cursor);
     expect(localStorage.getItem(MOTD_LOCAL_STORAGE_KEY)).toContain('archiveSeenUpToCursor');
+  });
+
+  it('merkt einzelne Archiv-MOTDs als gelesen und sendet sie an getHeaderState', () => {
+    const id = '00000000-0000-4000-8000-000000000005';
+    expect(markMotdArchiveItemRead(id, 1)).toBe(true);
+    expect(markMotdArchiveItemRead(id, 1)).toBe(false);
+    expect(getMotdArchiveReadItems()).toEqual([{ motdId: id, contentVersion: 1 }]);
+    expect(motdGetHeaderStateClientInput()).toEqual({
+      archiveReadItems: [{ motdId: id, contentVersion: 1 }],
+    });
+  });
+
+  it('löscht einzeln gelesene Archiv-MOTDs beim Setzen der Wasserlinie', () => {
+    const id = '00000000-0000-4000-8000-000000000006';
+    markMotdArchiveItemRead(id, 1);
+    setMotdArchiveSeenUpToCursor({
+      startsAtIso: '2026-05-01T00:00:00.000Z',
+      motdId: id,
+      contentVersion: 1,
+    });
+    expect(getMotdArchiveReadItems()).toEqual([]);
+    expect(motdGetHeaderStateClientInput().archiveReadItems).toBeUndefined();
   });
 
   it('ignoriert das alte endsAt-Wasserzeichen, damit neue Publikationen wieder auffallen', () => {

--- a/apps/frontend/src/app/core/motd-storage.ts
+++ b/apps/frontend/src/app/core/motd-storage.ts
@@ -1,7 +1,11 @@
 /**
  * Browser-Persistenz für MOTD (Epic 10): Dismiss-Versionen und einmalige Interaktionen pro Build.
  */
-import type { MotdArchiveReadCursor } from '@arsnova/shared-types';
+import {
+  MOTD_ARCHIVE_READ_ITEMS_MAX,
+  type MotdArchiveReadCursor,
+  type MotdArchiveReadItem,
+} from '@arsnova/shared-types';
 
 export const MOTD_LOCAL_STORAGE_KEY = 'arsnova-motd-v2';
 
@@ -31,6 +35,12 @@ export type MotdClientStorageV1 = {
   interactions: Record<string, true>;
   /** Globaler Lesecursor in der publikationsbasierten Archivsortierung (Epic 10). */
   archiveSeenUpToCursor?: MotdArchiveReadCursor;
+  /**
+   * Einzeln gelesene Archiv-MOTDs. Ergänzt den Wasserlinien-Cursor, damit
+   * „Gelesen“ auf einem Eintrag den Badge um 1 senkt, ohne ältere ungelesene
+   * mitzuziehen.
+   */
+  archiveReadItems?: MotdArchiveReadItem[];
 };
 
 const empty = (): MotdClientStorageV1 => ({ dismissed: {}, interactions: {} });
@@ -52,6 +62,30 @@ function isMotdArchiveReadCursor(value: unknown): value is MotdArchiveReadCursor
   );
 }
 
+function isMotdArchiveReadItem(value: unknown): value is MotdArchiveReadItem {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const item = value as Record<string, unknown>;
+  return (
+    typeof item.motdId === 'string' &&
+    MOTD_UUID_PATTERN.test(item.motdId) &&
+    typeof item.contentVersion === 'number' &&
+    Number.isInteger(item.contentVersion) &&
+    item.contentVersion >= 1
+  );
+}
+
+function parseArchiveReadItems(raw: unknown): MotdArchiveReadItem[] {
+  if (!Array.isArray(raw)) return [];
+  const byId = new Map<string, number>();
+  for (const entry of raw) {
+    if (!isMotdArchiveReadItem(entry)) continue;
+    const prev = byId.get(entry.motdId) ?? 0;
+    byId.set(entry.motdId, Math.max(prev, entry.contentVersion));
+    if (byId.size >= MOTD_ARCHIVE_READ_ITEMS_MAX) break;
+  }
+  return [...byId.entries()].map(([motdId, contentVersion]) => ({ motdId, contentVersion }));
+}
+
 export function readMotdClientStorage(): MotdClientStorageV1 {
   if (typeof localStorage === 'undefined') return empty();
   try {
@@ -70,10 +104,12 @@ export function readMotdClientStorage(): MotdClientStorageV1 {
         : {};
     const cursorRaw = o.archiveSeenUpToCursor;
     const archiveSeenUpToCursor = isMotdArchiveReadCursor(cursorRaw) ? cursorRaw : undefined;
+    const archiveReadItems = parseArchiveReadItems(o.archiveReadItems);
     return {
       dismissed,
       interactions,
       ...(archiveSeenUpToCursor ? { archiveSeenUpToCursor } : {}),
+      ...(archiveReadItems.length ? { archiveReadItems } : {}),
     };
   } catch {
     return empty();
@@ -190,7 +226,7 @@ export function shouldSuppressMotdOverlayOnMobileFirstHomeVisit(): boolean {
 }
 
 /** Für `motd.getCurrent` / `getHeaderState`: lokal dismissierte Overlay-MOTDs (nächste Priorität). */
-export function motdDismissedPairsForApi(): { motdId: string; contentVersion: number }[] {
+export function motdDismissedPairsForApi(): MotdArchiveReadItem[] {
   const dismissed = readMotdClientStorage().dismissed;
   return Object.entries(dismissed).map(([motdId, contentVersion]) => ({
     motdId,
@@ -240,5 +276,60 @@ export function getMotdArchiveSeenUpToCursor(): MotdArchiveReadCursor | undefine
 export function setMotdArchiveSeenUpToCursor(cursor: MotdArchiveReadCursor): void {
   const cur = readMotdClientStorage();
   cur.archiveSeenUpToCursor = cursor;
+  delete cur.archiveReadItems;
   writeMotdClientStorage(cur);
+}
+
+export function getMotdArchiveReadItems(): MotdArchiveReadItem[] {
+  return readMotdClientStorage().archiveReadItems ?? [];
+}
+
+export function motdArchiveReadItemsForApi(): MotdArchiveReadItem[] {
+  return getMotdArchiveReadItems();
+}
+
+export function isMotdArchiveItemMarkedRead(motdId: string, contentVersion: number): boolean {
+  return getMotdArchiveReadItems().some(
+    (item) => item.motdId === motdId && item.contentVersion >= contentVersion,
+  );
+}
+
+/**
+ * Markiert eine Archiv-MOTD einzeln als gelesen.
+ * @returns `false`, wenn diese Version (oder eine höhere) bereits gespeichert war.
+ */
+export function markMotdArchiveItemRead(motdId: string, contentVersion: number): boolean {
+  if (isMotdArchiveItemMarkedRead(motdId, contentVersion)) {
+    return false;
+  }
+  const cur = readMotdClientStorage();
+  const items = [...(cur.archiveReadItems ?? [])];
+  const index = items.findIndex((item) => item.motdId === motdId);
+  if (index >= 0) {
+    items[index] = { motdId, contentVersion };
+  } else if (items.length >= MOTD_ARCHIVE_READ_ITEMS_MAX) {
+    items.shift();
+    items.push({ motdId, contentVersion });
+  } else {
+    items.push({ motdId, contentVersion });
+  }
+  cur.archiveReadItems = items;
+  writeMotdClientStorage(cur);
+  return true;
+}
+
+/** Locale-unabhängige Clientfelder für `motd.getHeaderState`. */
+export function motdGetHeaderStateClientInput(): {
+  archiveSeenUpToCursor?: MotdArchiveReadCursor;
+  overlayDismissedUpTo?: MotdArchiveReadItem[];
+  archiveReadItems?: MotdArchiveReadItem[];
+} {
+  const seen = getMotdArchiveSeenUpToCursor();
+  const dismissed = motdDismissedPairsForApi();
+  const readItems = motdArchiveReadItemsForApi();
+  return {
+    ...(seen ? { archiveSeenUpToCursor: seen } : {}),
+    ...(dismissed.length ? { overlayDismissedUpTo: dismissed } : {}),
+    ...(readItems.length ? { archiveReadItems: readItems } : {}),
+  };
 }

--- a/apps/frontend/src/app/features/news-archive/news-archive-initial.ts
+++ b/apps/frontend/src/app/features/news-archive/news-archive-initial.ts
@@ -3,10 +3,14 @@ import type { AppLocale, MotdArchiveItemDTO, MotdArchiveReadCursor } from '@arsn
 import { trpc } from '../../core/trpc.client';
 import { resolveMotdAssetOrigin } from '../../core/motd-asset-origin';
 import { localizeKnownServerError } from '../../core/localize-known-server-message';
-import { getMotdArchiveSeenUpToCursor, motdDismissedPairsForApi } from '../../core/motd-storage';
+import {
+  getMotdArchiveReadItems,
+  getMotdArchiveSeenUpToCursor,
+  motdGetHeaderStateClientInput,
+} from '../../core/motd-storage';
 import { buildMotdArchiveItemDisplay } from '../../shared/motd-archive-render.util';
 import {
-  isMotdArchiveItemNewerThanCursor,
+  countMotdArchiveUnreadItems,
   newestMotdArchiveReadCursor,
   sortMotdArchiveItemsNewFirst,
 } from '../../shared/motd-archive-sort.util';
@@ -65,12 +69,9 @@ export async function loadNewsArchivePageModel(
   fallbackTitle: string,
   loadErrorMessage: string,
 ): Promise<NewsArchiveInitialModel> {
-  const seen = getMotdArchiveSeenUpToCursor();
-  const dismissed = motdDismissedPairsForApi();
   const headerInput = {
     locale,
-    ...(seen ? { archiveSeenUpToCursor: seen } : {}),
-    ...(dismissed.length ? { overlayDismissedUpTo: dismissed } : {}),
+    ...motdGetHeaderStateClientInput(),
   };
 
   const [stateResult, listResult] = await Promise.allSettled([
@@ -108,10 +109,11 @@ export async function loadNewsArchivePageModel(
 
   if (!headerOk) {
     if (items.length > 0) {
-      const seenAgain = getMotdArchiveSeenUpToCursor();
-      archiveUnreadCount = seenAgain
-        ? items.filter((it) => isMotdArchiveItemNewerThanCursor(it, seenAgain)).length
-        : items.length;
+      archiveUnreadCount = countMotdArchiveUnreadItems(
+        items,
+        getMotdArchiveSeenUpToCursor(),
+        getMotdArchiveReadItems(),
+      );
     } else {
       archiveUnreadCount = 0;
     }

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.html
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.html
@@ -78,7 +78,12 @@
               @for (it of items(); track it.id) {
                 @let archiveMeta = formatArchiveDate(it.startsAt);
                 @let titleDisplay = archiveItemTitleDisplay(it.id);
-                <section class="news-archive-page__entry" [attr.id]="'motd-archive-' + it.id">
+                @let itemUnread = isArchiveItemUnread(it);
+                <section
+                  class="news-archive-page__entry"
+                  [class.news-archive-page__entry--read]="!itemUnread"
+                  [attr.id]="'motd-archive-' + it.id"
+                >
                   <h2 class="news-archive-page__entry-title">
                     <a
                       class="news-archive-page__entry-title-link"
@@ -93,16 +98,43 @@
                       <span>{{ titleDisplay.title }}</span></a
                     >
                   </h2>
-                  @if (archiveMeta) {
-                    <p class="news-archive-page__entry-meta">
+                  <p class="news-archive-page__entry-meta">
+                    @if (archiveMeta) {
                       <time [attr.datetime]="it.startsAt">{{ archiveMeta }}</time>
-                    </p>
-                  }
+                    }
+                    <span
+                      class="news-archive-page__read-state"
+                      [class.news-archive-page__read-state--unread]="itemUnread"
+                    >
+                      @if (itemUnread) {
+                        <span class="news-archive-page__unread-dot" aria-hidden="true"></span>
+                        <span i18n="@@motd.archiveItemUnreadStatus">Ungelesen</span>
+                      } @else {
+                        <mat-icon aria-hidden="true">done</mat-icon>
+                        <span i18n="@@motd.archiveMarkItemRead">Gelesen</span>
+                      }
+                    </span>
+                  </p>
                   @if (htmlById()[it.id]; as safe) {
                     <div
                       class="news-archive-page__md motd-archive__body markdown-body"
                       [innerHTML]="safe"
                     ></div>
+                  }
+                  @if (itemUnread) {
+                    <div class="news-archive-page__item-actions">
+                      <button
+                        mat-stroked-button
+                        type="button"
+                        class="news-archive-page__mark-read"
+                        i18n-aria-label="@@motd.archiveMarkItemReadAria"
+                        aria-label="Diese Meldung als gelesen markieren"
+                        (click)="markArchiveItemRead(it, $event)"
+                      >
+                        <mat-icon aria-hidden="true">done</mat-icon>
+                        <span i18n="@@motd.archiveMarkItemRead">Gelesen</span>
+                      </button>
+                    </div>
                   }
                 </section>
               }

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.scss
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.scss
@@ -116,6 +116,10 @@
 }
 
 .news-archive-page__entry-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
   margin: 0 0 1rem;
   font: var(--mat-sys-body-large);
   color: var(--mat-sys-on-surface-variant);
@@ -124,6 +128,50 @@
 .news-archive-page__entry-meta time {
   font: inherit;
   color: inherit;
+}
+
+.news-archive-page__read-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font: var(--mat-sys-label-large);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.news-archive-page__read-state--unread {
+  color: var(--mat-sys-primary);
+}
+
+.news-archive-page__read-state mat-icon {
+  flex: 0 0 auto;
+  width: 1.125rem;
+  height: 1.125rem;
+  font-size: 1.125rem;
+}
+
+.news-archive-page__unread-dot {
+  flex: 0 0 auto;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--mat-sys-primary);
+}
+
+.news-archive-page__entry--read .news-archive-page__entry-title {
+  font-weight: 500;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.news-archive-page__item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 0.75rem 0 0;
+}
+
+.news-archive-page__mark-read {
+  min-height: 2.5rem;
 }
 
 /* Markdown-Rumpf: gleiche Lesespur wie .legal-article :deep in legal-page */

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.spec.ts
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.spec.ts
@@ -7,6 +7,8 @@ import { Location } from '@angular/common';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NewsArchivePageComponent } from './news-archive-page.component';
 import { MotdHeaderRefreshService } from '../../core/motd-header-refresh.service';
+import { MotdHeaderStateService } from '../../core/motd-header-state.service';
+import { MOTD_LOCAL_STORAGE_KEY } from '../../core/motd-storage';
 import type { NewsArchiveInitialModel } from './news-archive-initial';
 
 const listArchiveQuery = vi.fn();
@@ -63,6 +65,10 @@ describe('NewsArchivePageComponent', () => {
         },
         { provide: MatSnackBar, useValue: { open: vi.fn() } },
         { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+        {
+          provide: MotdHeaderStateService,
+          useValue: { decrementArchiveUnreadCount: vi.fn(), setArchiveUnreadCount: vi.fn() },
+        },
       ],
     }).compileComponents();
 
@@ -130,6 +136,10 @@ describe('NewsArchivePageComponent', () => {
         },
         { provide: MatSnackBar, useValue: { open: vi.fn() } },
         { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+        {
+          provide: MotdHeaderStateService,
+          useValue: { decrementArchiveUnreadCount: vi.fn(), setArchiveUnreadCount: vi.fn() },
+        },
       ],
     }).compileComponents();
 
@@ -208,6 +218,10 @@ describe('NewsArchivePageComponent', () => {
         },
         { provide: MatSnackBar, useValue: { open: vi.fn() } },
         { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+        {
+          provide: MotdHeaderStateService,
+          useValue: { decrementArchiveUnreadCount: vi.fn(), setArchiveUnreadCount: vi.fn() },
+        },
       ],
     }).compileComponents();
 
@@ -324,6 +338,10 @@ describe('NewsArchivePageComponent', () => {
         },
         { provide: MatSnackBar, useValue: { open: vi.fn() } },
         { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+        {
+          provide: MotdHeaderStateService,
+          useValue: { decrementArchiveUnreadCount: vi.fn(), setArchiveUnreadCount: vi.fn() },
+        },
       ],
     }).compileComponents();
 
@@ -374,6 +392,10 @@ describe('NewsArchivePageComponent', () => {
         },
         { provide: MatSnackBar, useValue: { open: vi.fn() } },
         { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+        {
+          provide: MotdHeaderStateService,
+          useValue: { decrementArchiveUnreadCount: vi.fn(), setArchiveUnreadCount: vi.fn() },
+        },
       ],
     }).compileComponents();
 
@@ -419,6 +441,10 @@ describe('NewsArchivePageComponent', () => {
         },
         { provide: MatSnackBar, useValue: { open: vi.fn() } },
         { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+        {
+          provide: MotdHeaderStateService,
+          useValue: { decrementArchiveUnreadCount: vi.fn(), setArchiveUnreadCount: vi.fn() },
+        },
       ],
     }).compileComponents();
 
@@ -435,5 +461,76 @@ describe('NewsArchivePageComponent', () => {
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('markArchiveItemRead senkt den Zähler um 1 und zeigt den Gelesen-Status', () => {
+    const itemId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const withItems: NewsArchiveInitialModel = {
+      ...emptyResolved,
+      items: [
+        {
+          id: itemId,
+          contentVersion: 1,
+          markdown: '# Erste Meldung\n\nText',
+          startsAt: '2026-01-10T10:00:00.000Z',
+          endsAt: '2026-01-15T18:00:00.000Z',
+        },
+      ],
+      titleById: { [itemId]: 'Erste Meldung' },
+      htmlById: {},
+      archiveMaxCursor: {
+        startsAtIso: '2026-01-10T10:00:00.000Z',
+        motdId: itemId,
+        contentVersion: 1,
+      },
+      archiveUnreadCount: 1,
+    };
+
+    const headerState = {
+      decrementArchiveUnreadCount: vi.fn(),
+      setArchiveUnreadCount: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [NewsArchivePageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: MatDialog, useValue: { openDialogs: [] } },
+        { provide: LOCALE_ID, useValue: 'de' },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { data: { newsArchive: withItems } } },
+        },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+        { provide: MotdHeaderStateService, useValue: headerState },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(NewsArchivePageComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.news-archive-page__mark-read')).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('.news-archive-page__read-state--unread'),
+    ).toBeTruthy();
+
+    const item = fixture.componentInstance.items()[0]!;
+    fixture.componentInstance.markArchiveItemRead(item, {
+      currentTarget: document.createElement('button'),
+    } as unknown as Event);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.archiveUnreadCount()).toBe(0);
+    expect(fixture.nativeElement.querySelector('.news-archive-page__mark-read')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.news-archive-page__entry--read')).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('.news-archive-page__read-state')?.textContent,
+    ).toContain('Gelesen');
+    expect(
+      fixture.nativeElement.querySelector('.news-archive-page__read-state--unread'),
+    ).toBeNull();
+    const stored = JSON.parse(localStorage.getItem(MOTD_LOCAL_STORAGE_KEY)!);
+    expect(stored.archiveReadItems).toEqual([{ motdId: itemId, contentVersion: 1 }]);
+    expect(headerState.decrementArchiveUnreadCount).toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.ts
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.ts
@@ -20,7 +20,13 @@ import { MatDialog } from '@angular/material/dialog';
 import type { AppLocale, MotdArchiveItemDTO, MotdArchiveReadCursor } from '@arsnova/shared-types';
 import { trpc } from '../../core/trpc.client';
 import { MotdHeaderRefreshService } from '../../core/motd-header-refresh.service';
-import { setMotdArchiveSeenUpToCursor } from '../../core/motd-storage';
+import { MotdHeaderStateService } from '../../core/motd-header-state.service';
+import {
+  getMotdArchiveReadItems,
+  getMotdArchiveSeenUpToCursor,
+  markMotdArchiveItemRead,
+  setMotdArchiveSeenUpToCursor,
+} from '../../core/motd-storage';
 import { resolveMotdAssetOrigin } from '../../core/motd-asset-origin';
 import { formatMotdArchiveStartsAtForDisplay } from '../../core/motd-ends-display';
 import { localizeKnownServerError } from '../../core/localize-known-server-message';
@@ -32,6 +38,7 @@ import {
 import { MarkdownImageLightboxDirective } from '../../shared/markdown-image-lightbox/markdown-image-lightbox.directive';
 import {
   compareMotdArchiveReadCursors,
+  isMotdArchiveItemUnread,
   newestMotdArchiveReadCursor,
   sortMotdArchiveItemsNewFirst,
 } from '../../shared/motd-archive-sort.util';
@@ -94,6 +101,7 @@ export class NewsArchivePageComponent {
   private readonly sanitizer = inject(DomSanitizer);
   private readonly snackBar = inject(MatSnackBar);
   private readonly motdHeaderRefresh = inject(MotdHeaderRefreshService);
+  private readonly motdHeaderState = inject(MotdHeaderStateService);
   private readonly location = inject(Location);
   private readonly router = inject(Router);
   private readonly dialog = inject(MatDialog);
@@ -112,6 +120,7 @@ export class NewsArchivePageComponent {
   readonly nextCursor = signal<string | null>(null);
   readonly archiveMaxCursor = signal<MotdArchiveReadCursor | null>(null);
   readonly archiveUnreadCount = signal(0);
+  readonly archiveReadItems = signal(getMotdArchiveReadItems());
   readonly titleById = signal<Record<string, string>>({});
   readonly htmlById = signal<Record<string, SafeHtml>>({});
 
@@ -135,6 +144,7 @@ export class NewsArchivePageComponent {
     this.nextCursor.set(data.nextCursor);
     this.archiveMaxCursor.set(data.archiveMaxCursor);
     this.archiveUnreadCount.set(data.archiveUnreadCount);
+    this.archiveReadItems.set(getMotdArchiveReadItems());
     this.titleById.set(data.titleById);
     this.htmlById.set(data.htmlById);
     this.error.set(data.errorMessage);
@@ -219,13 +229,41 @@ export class NewsArchivePageComponent {
       return;
     }
     setMotdArchiveSeenUpToCursor(max);
+    this.archiveReadItems.set([]);
     this.archiveUnreadCount.set(0);
+    this.motdHeaderState.setArchiveUnreadCount(0);
     this.snackBar.open(
       $localize`:@@motd.archiveMarkedAllReadSnack:Archiv als gelesen markiert.`,
       undefined,
       { duration: 2800 },
     );
     this.motdHeaderRefresh.notifyMotdHeaderRefresh();
+  }
+
+  isArchiveItemUnread(item: MotdArchiveItemDTO): boolean {
+    return isMotdArchiveItemUnread(item, getMotdArchiveSeenUpToCursor(), this.archiveReadItems());
+  }
+
+  markArchiveItemRead(item: MotdArchiveItemDTO, event: Event): void {
+    if (!this.isArchiveItemUnread(item)) {
+      return;
+    }
+    if (!markMotdArchiveItemRead(item.id, item.contentVersion)) {
+      return;
+    }
+    this.archiveReadItems.set(getMotdArchiveReadItems());
+    this.archiveUnreadCount.update((n) => Math.max(0, n - 1));
+    this.motdHeaderState.decrementArchiveUnreadCount();
+    this.focusArchiveEntryTitle(event);
+    this.motdHeaderRefresh.notifyMotdHeaderRefresh();
+  }
+
+  private focusArchiveEntryTitle(event: Event): void {
+    const current = event.currentTarget as HTMLElement | null;
+    current
+      ?.closest('.news-archive-page__entry')
+      ?.querySelector<HTMLElement>('.news-archive-page__entry-title-link')
+      ?.focus();
   }
 
   async loadMoreArchive(): Promise<void> {

--- a/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html
+++ b/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html
@@ -55,7 +55,12 @@
           @for (it of items(); track it.id) {
             @let archiveMeta = formatArchiveDate(it.startsAt);
             @let titleDisplay = archiveItemTitleDisplay(it.id);
-            <mat-expansion-panel #archivePanel class="motd-archive__panel">
+            @let itemUnread = isArchiveItemUnread(it);
+            <mat-expansion-panel
+              #archivePanel
+              class="motd-archive__panel"
+              [class.motd-archive__panel--read]="!itemUnread"
+            >
               <mat-expansion-panel-header>
                 <mat-panel-title class="motd-archive__panel-title">
                   @if (titleDisplay.decorativeEmoji) {
@@ -67,11 +72,23 @@
                     titleDisplay.title
                   }}</span>
                 </mat-panel-title>
-                @if (archiveMeta) {
-                  <mat-panel-description class="motd-archive__panel-meta">
+                <mat-panel-description class="motd-archive__panel-meta">
+                  <span
+                    class="motd-archive__read-state"
+                    [class.motd-archive__read-state--unread]="itemUnread"
+                  >
+                    @if (itemUnread) {
+                      <span class="motd-archive__unread-dot" aria-hidden="true"></span>
+                      <span class="sr-only" i18n="@@motd.archiveItemUnreadStatus">Ungelesen</span>
+                    } @else {
+                      <mat-icon aria-hidden="true">done</mat-icon>
+                      <span i18n="@@motd.archiveMarkItemRead">Gelesen</span>
+                    }
+                  </span>
+                  @if (archiveMeta) {
                     <span class="motd-archive__panel-meta-text">{{ archiveMeta }}</span>
-                  </mat-panel-description>
-                }
+                  }
+                </mat-panel-description>
               </mat-expansion-panel-header>
               @if (htmlById()[it.id]; as safe) {
                 <div
@@ -80,6 +97,29 @@
                   [innerHTML]="safe"
                 ></div>
               }
+              <div
+                class="motd-archive__item-actions"
+                [attr.inert]="archivePanel.expanded ? null : ''"
+              >
+                @if (itemUnread) {
+                  <button
+                    mat-stroked-button
+                    type="button"
+                    class="motd-archive__mark-read"
+                    i18n-aria-label="@@motd.archiveMarkItemReadAria"
+                    aria-label="Diese Meldung als gelesen markieren"
+                    (click)="markArchiveItemRead(it, $event)"
+                  >
+                    <mat-icon aria-hidden="true">done</mat-icon>
+                    <span i18n="@@motd.archiveMarkItemRead">Gelesen</span>
+                  </button>
+                } @else {
+                  <p class="motd-archive__read-state motd-archive__read-state--confirmed">
+                    <mat-icon aria-hidden="true">done</mat-icon>
+                    <span i18n="@@motd.archiveMarkItemRead">Gelesen</span>
+                  </p>
+                }
+              </div>
             </mat-expansion-panel>
           }
         </mat-accordion>

--- a/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.scss
+++ b/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.scss
@@ -157,6 +157,11 @@
 }
 
 .motd-archive__panel-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 0.15rem;
   flex-shrink: 0;
   min-width: auto;
   max-width: none;
@@ -165,6 +170,40 @@
 .motd-archive__panel-meta-text {
   display: block;
   white-space: nowrap;
+}
+
+.motd-archive__read-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 0;
+  font: var(--mat-sys-label-large);
+  color: var(--mat-sys-on-surface-variant);
+  white-space: nowrap;
+}
+
+.motd-archive__read-state--unread {
+  color: var(--mat-sys-primary);
+}
+
+.motd-archive__read-state mat-icon {
+  flex: 0 0 auto;
+  width: 1.125rem;
+  height: 1.125rem;
+  font-size: 1.125rem;
+}
+
+.motd-archive__unread-dot {
+  flex: 0 0 auto;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--mat-sys-primary);
+}
+
+.motd-archive__panel--read .motd-archive__panel-title-text {
+  font-weight: 500;
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .motd-archive__body {
@@ -191,4 +230,20 @@
   color: var(--mat-sys-on-surface);
   margin: 0 0 0.75rem;
   line-height: 1.3;
+}
+
+.motd-archive__item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+  margin-block-start: 0.75rem;
+}
+
+.motd-archive__mark-read {
+  min-height: 2.5rem;
+}
+
+.motd-archive__read-state--confirmed {
+  min-height: 2.5rem;
 }

--- a/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.spec.ts
+++ b/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.spec.ts
@@ -4,6 +4,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MotdArchiveDialogComponent } from './motd-archive-dialog.component';
 import { MotdHeaderRefreshService } from '../../core/motd-header-refresh.service';
+import { MotdHeaderStateService } from '../../core/motd-header-state.service';
 import { MOTD_LOCAL_STORAGE_KEY } from '../../core/motd-storage';
 
 const listArchiveQuery = vi.fn();
@@ -27,6 +28,11 @@ const defaultHeaderState = {
   archiveUnreadCount: 0,
 };
 
+const motdHeaderStateMock = {
+  decrementArchiveUnreadCount: vi.fn(),
+  setArchiveUnreadCount: vi.fn(),
+};
+
 describe('MotdArchiveDialogComponent', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -34,6 +40,8 @@ describe('MotdArchiveDialogComponent', () => {
     listArchiveQuery.mockResolvedValue({ items: [], nextCursor: null });
     getHeaderStateQuery.mockReset();
     getHeaderStateQuery.mockResolvedValue({ ...defaultHeaderState });
+    motdHeaderStateMock.decrementArchiveUnreadCount.mockReset();
+    motdHeaderStateMock.setArchiveUnreadCount.mockReset();
   });
 
   afterEach(() => {
@@ -47,6 +55,7 @@ describe('MotdArchiveDialogComponent', () => {
         { provide: MAT_DIALOG_DATA, useValue: { locale } },
         { provide: MatSnackBar, useValue: { open: vi.fn() } },
         MotdHeaderRefreshService,
+        { provide: MotdHeaderStateService, useValue: motdHeaderStateMock },
       ],
     });
   }
@@ -232,6 +241,70 @@ describe('MotdArchiveDialogComponent', () => {
     expect(fixture.componentInstance.archiveUnreadCount()).toBe(0);
     expect(snackSpy).toHaveBeenCalled();
     expect(notifySpy).toHaveBeenCalled();
+    expect(motdHeaderStateMock.setArchiveUnreadCount).toHaveBeenCalledWith(0);
+  });
+
+  it('markArchiveItemRead senkt den Zähler um 1 ohne die Wasserlinie zu verschieben', async () => {
+    const olderId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const newerId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    getHeaderStateQuery.mockResolvedValue({
+      ...defaultHeaderState,
+      hasArchiveEntries: true,
+      archiveCount: 2,
+      archiveMaxCursor: {
+        startsAtIso: '2026-03-15T12:00:00.000Z',
+        motdId: newerId,
+        contentVersion: 1,
+      },
+      archiveUnreadCount: 2,
+    });
+    listArchiveQuery.mockResolvedValue({
+      items: [
+        {
+          id: newerId,
+          contentVersion: 1,
+          markdown: 'Neu',
+          startsAt: '2026-03-15T12:00:00.000Z',
+          endsAt: '2026-04-01T12:00:00.000Z',
+        },
+        {
+          id: olderId,
+          contentVersion: 1,
+          markdown: 'Alt',
+          startsAt: '2026-02-01T12:00:00.000Z',
+          endsAt: '2026-03-01T12:00:00.000Z',
+        },
+      ],
+      nextCursor: null,
+    });
+    configureDialog();
+    const notifySpy = vi.spyOn(TestBed.inject(MotdHeaderRefreshService), 'notifyMotdHeaderRefresh');
+    const fixture = TestBed.createComponent(MotdArchiveDialogComponent);
+    fixture.detectChanges();
+    await vi.waitFor(() => expect(fixture.componentInstance.loading()).toBe(false));
+
+    const newer = fixture.componentInstance.items().find((item) => item.id === newerId);
+    expect(newer).toBeTruthy();
+    fixture.componentInstance.markArchiveItemRead(newer!, {
+      currentTarget: document.createElement('button'),
+    } as unknown as Event);
+
+    expect(fixture.componentInstance.archiveUnreadCount()).toBe(1);
+    expect(fixture.componentInstance.isArchiveItemUnread(newer!)).toBe(false);
+    const stored = JSON.parse(localStorage.getItem(MOTD_LOCAL_STORAGE_KEY)!);
+    expect(stored.archiveReadItems).toEqual([{ motdId: newerId, contentVersion: 1 }]);
+    expect(stored.archiveSeenUpToCursor).toBeUndefined();
+    expect(motdHeaderStateMock.decrementArchiveUnreadCount).toHaveBeenCalledTimes(1);
+    expect(notifySpy).toHaveBeenCalled();
+
+    fixture.detectChanges();
+    const root = fixture.nativeElement as HTMLElement;
+    const panels = [...root.querySelectorAll('.motd-archive__panel')];
+    expect(panels).toHaveLength(2);
+    expect(panels[0]!.classList.contains('motd-archive__panel--read')).toBe(true);
+    expect(panels[1]!.classList.contains('motd-archive__panel--read')).toBe(false);
+    expect(panels[0]!.querySelector('.motd-archive__read-state')?.textContent).toContain('Gelesen');
+    expect(panels[1]!.querySelector('.motd-archive__read-state--unread')).toBeTruthy();
   });
 
   it('setzt inert auf zugeklappte Panel-Inhalte, damit Tab die Header erreicht', async () => {

--- a/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.ts
+++ b/apps/frontend/src/app/shared/motd-archive-dialog/motd-archive-dialog.component.ts
@@ -21,9 +21,12 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import type { AppLocale, MotdArchiveItemDTO, MotdArchiveReadCursor } from '@arsnova/shared-types';
 import { trpc } from '../../core/trpc.client';
 import { MotdHeaderRefreshService } from '../../core/motd-header-refresh.service';
+import { MotdHeaderStateService } from '../../core/motd-header-state.service';
 import {
+  getMotdArchiveReadItems,
   getMotdArchiveSeenUpToCursor,
-  motdDismissedPairsForApi,
+  markMotdArchiveItemRead,
+  motdGetHeaderStateClientInput,
   setMotdArchiveSeenUpToCursor,
 } from '../../core/motd-storage';
 import { resolveMotdAssetOrigin } from '../../core/motd-asset-origin';
@@ -34,7 +37,8 @@ import { buildMotdArchiveItemDisplay } from '../motd-archive-render.util';
 import { splitMotdDecorativeEmoji, type MotdTitleDisplay } from '../motd-decorative-emoji.util';
 import {
   compareMotdArchiveReadCursors,
-  isMotdArchiveItemNewerThanCursor,
+  countMotdArchiveUnreadItems,
+  isMotdArchiveItemUnread,
   newestMotdArchiveReadCursor,
   sortMotdArchiveItemsNewFirst,
 } from '../motd-archive-sort.util';
@@ -76,6 +80,7 @@ export class MotdArchiveDialogComponent implements OnInit {
   private readonly sanitizer = inject(DomSanitizer);
   private readonly snackBar = inject(MatSnackBar);
   private readonly motdHeaderRefresh = inject(MotdHeaderRefreshService);
+  private readonly motdHeaderState = inject(MotdHeaderStateService);
   readonly data = inject<MotdArchiveDialogData>(MAT_DIALOG_DATA);
 
   readonly loading = signal(true);
@@ -87,8 +92,10 @@ export class MotdArchiveDialogComponent implements OnInit {
   readonly nextCursor = signal<string | null>(null);
   /** Neuester Publikationscursor; null wenn leer oder Header-Anfrage fehlgeschlagen. */
   readonly archiveMaxCursor = signal<MotdArchiveReadCursor | null>(null);
-  /** Ungelesen relativ zum Client-Wasserzeichen. */
+  /** Ungelesen relativ zum Client-Wasserzeichen und einzeln gelesenen Einträgen. */
   readonly archiveUnreadCount = signal(0);
+  /** Lokal einzeln als gelesen markierte MOTDs (für den Gelesen-Button). */
+  readonly archiveReadItems = signal(getMotdArchiveReadItems());
 
   /** motd id → Anzeige-Titel (Markdown-Überschrift oder Fallback) */
   readonly titleById = signal<Record<string, string>>({});
@@ -124,7 +131,9 @@ export class MotdArchiveDialogComponent implements OnInit {
       return;
     }
     setMotdArchiveSeenUpToCursor(max);
+    this.archiveReadItems.set([]);
     this.archiveUnreadCount.set(0);
+    this.motdHeaderState.setArchiveUnreadCount(0);
     this.snackBar.open(
       $localize`:@@motd.archiveMarkedAllReadSnack:Archiv als gelesen markiert.`,
       undefined,
@@ -133,15 +142,39 @@ export class MotdArchiveDialogComponent implements OnInit {
     this.motdHeaderRefresh.notifyMotdHeaderRefresh();
   }
 
+  isArchiveItemUnread(item: MotdArchiveItemDTO): boolean {
+    return isMotdArchiveItemUnread(item, getMotdArchiveSeenUpToCursor(), this.archiveReadItems());
+  }
+
+  markArchiveItemRead(item: MotdArchiveItemDTO, event: Event): void {
+    if (!this.isArchiveItemUnread(item)) {
+      return;
+    }
+    if (!markMotdArchiveItemRead(item.id, item.contentVersion)) {
+      return;
+    }
+    this.archiveReadItems.set(getMotdArchiveReadItems());
+    this.archiveUnreadCount.update((n) => Math.max(0, n - 1));
+    this.motdHeaderState.decrementArchiveUnreadCount();
+    this.focusArchivePanelHeader(event);
+    this.motdHeaderRefresh.notifyMotdHeaderRefresh();
+  }
+
+  private focusArchivePanelHeader(event: Event): void {
+    const current = event.currentTarget as HTMLElement | null;
+    current
+      ?.closest('.mat-expansion-panel')
+      ?.querySelector<HTMLElement>('.mat-expansion-panel-header')
+      ?.focus();
+  }
+
   async ngOnInit(): Promise<void> {
     this.loading.set(true);
     this.error.set(null);
-    const seen = getMotdArchiveSeenUpToCursor();
-    const dismissed = motdDismissedPairsForApi();
+    this.archiveReadItems.set(getMotdArchiveReadItems());
     const headerInput = {
       locale: this.data.locale,
-      ...(seen ? { archiveSeenUpToCursor: seen } : {}),
-      ...(dismissed.length ? { overlayDismissedUpTo: dismissed } : {}),
+      ...motdGetHeaderStateClientInput(),
     };
     const [stateResult, listResult] = await Promise.allSettled([
       trpc.motd.getHeaderState.query(headerInput),
@@ -238,11 +271,8 @@ export class MotdArchiveDialogComponent implements OnInit {
     }
 
     if (!headerOk && items.length > 0) {
-      const seen = getMotdArchiveSeenUpToCursor();
       this.archiveUnreadCount.set(
-        seen
-          ? items.filter((it) => isMotdArchiveItemNewerThanCursor(it, seen)).length
-          : items.length,
+        countMotdArchiveUnreadItems(items, getMotdArchiveSeenUpToCursor(), this.archiveReadItems()),
       );
     }
   }

--- a/apps/frontend/src/app/shared/motd-archive-sort.util.spec.ts
+++ b/apps/frontend/src/app/shared/motd-archive-sort.util.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { MotdArchiveItemDTO } from '@arsnova/shared-types';
 import {
   isMotdArchiveItemNewerThanCursor,
+  isMotdArchiveItemUnread,
   newestMotdArchiveReadCursor,
   sortMotdArchiveItemsNewFirst,
 } from './motd-archive-sort.util';
@@ -42,5 +43,16 @@ describe('MOTD-Archivsortierung und Lesecursor', () => {
       motdId: newerVision.id,
       contentVersion: newerVision.contentVersion,
     });
+  });
+
+  it('zählt einzeln gelesene neuere MOTDs nicht als ungelesen', () => {
+    const seenWelcome = newestMotdArchiveReadCursor([permanentWelcome]);
+    expect(isMotdArchiveItemUnread(newerVision, seenWelcome, [])).toBe(true);
+    expect(
+      isMotdArchiveItemUnread(newerVision, seenWelcome, [
+        { motdId: newerVision.id, contentVersion: 1 },
+      ]),
+    ).toBe(false);
+    expect(isMotdArchiveItemUnread(permanentWelcome, seenWelcome, [])).toBe(false);
   });
 });

--- a/apps/frontend/src/app/shared/motd-archive-sort.util.ts
+++ b/apps/frontend/src/app/shared/motd-archive-sort.util.ts
@@ -1,4 +1,8 @@
-import type { MotdArchiveItemDTO, MotdArchiveReadCursor } from '@arsnova/shared-types';
+import type {
+  MotdArchiveItemDTO,
+  MotdArchiveReadCursor,
+  MotdArchiveReadItem,
+} from '@arsnova/shared-types';
 
 function safeTime(iso: string): number {
   const t = Date.parse(iso);
@@ -53,4 +57,35 @@ export function isMotdArchiveItemNewerThanCursor(
   cursor: MotdArchiveReadCursor,
 ): boolean {
   return compareMotdArchiveReadCursors(motdArchiveReadCursorForItem(item), cursor) > 0;
+}
+
+export function isMotdArchiveItemIndividuallyRead(
+  item: Pick<MotdArchiveItemDTO, 'id' | 'contentVersion'>,
+  readItems: ReadonlyArray<MotdArchiveReadItem>,
+): boolean {
+  return readItems.some(
+    (read) => read.motdId === item.id && read.contentVersion >= item.contentVersion,
+  );
+}
+
+export function isMotdArchiveItemUnread(
+  item: MotdArchiveItemDTO,
+  seen: MotdArchiveReadCursor | undefined,
+  readItems: ReadonlyArray<MotdArchiveReadItem>,
+): boolean {
+  if (seen && !isMotdArchiveItemNewerThanCursor(item, seen)) {
+    return false;
+  }
+  return !isMotdArchiveItemIndividuallyRead(item, readItems);
+}
+
+export function countMotdArchiveUnreadItems(
+  items: MotdArchiveItemDTO[],
+  seen: MotdArchiveReadCursor | undefined,
+  readItems: ReadonlyArray<MotdArchiveReadItem>,
+): number {
+  return items.reduce(
+    (count, item) => count + (isMotdArchiveItemUnread(item, seen, readItems) ? 1 : 0),
+    0,
+  );
 }

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -7824,6 +7824,42 @@
           <context context-type="linenumber">45,47</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="motd.archiveMarkItemRead" datatype="html">
+        <source>Gelesen</source>
+        <target>Read</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveMarkItemReadAria" datatype="html">
+        <source>Diese Meldung als gelesen markieren</source>
+        <target>Mark this message as read</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveItemUnreadStatus" datatype="html">
+        <source>Ungelesen</source>
+        <target>Unread</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="motd.archiveEmpty" datatype="html">
         <source> Keine archivierten Meldungen.</source>
         <target>No archived messages.</target>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -7819,6 +7819,42 @@
           <context context-type="linenumber">45,47</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="motd.archiveMarkItemRead" datatype="html">
+        <source>Gelesen</source>
+        <target>Leído</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveMarkItemReadAria" datatype="html">
+        <source>Diese Meldung als gelesen markieren</source>
+        <target>Marcar este mensaje como leído</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveItemUnreadStatus" datatype="html">
+        <source>Ungelesen</source>
+        <target>No leído</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="motd.archiveEmpty" datatype="html">
         <source> Keine archivierten Meldungen.</source>
         <target>No hay mensajes archivados.</target>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -7819,6 +7819,42 @@
           <context context-type="linenumber">45,47</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="motd.archiveMarkItemRead" datatype="html">
+        <source>Gelesen</source>
+        <target>Lu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveMarkItemReadAria" datatype="html">
+        <source>Diese Meldung als gelesen markieren</source>
+        <target>Marquer ce message comme lu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveItemUnreadStatus" datatype="html">
+        <source>Ungelesen</source>
+        <target>Non lu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="motd.archiveEmpty" datatype="html">
         <source> Keine archivierten Meldungen.</source>
         <target>Aucun message archivé.</target>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -7819,6 +7819,42 @@
           <context context-type="linenumber">45,47</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="motd.archiveMarkItemRead" datatype="html">
+        <source>Gelesen</source>
+        <target>Letto</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveMarkItemReadAria" datatype="html">
+        <source>Diese Meldung als gelesen markieren</source>
+        <target>Segna questo messaggio come letto</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveItemUnreadStatus" datatype="html">
+        <source>Ungelesen</source>
+        <target>Non letto</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="motd.archiveEmpty" datatype="html">
         <source> Keine archivierten Meldungen.</source>
         <target>Nessun messaggio archiviato.</target>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -6935,6 +6935,39 @@
           <context context-type="linenumber">45,47</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="motd.archiveMarkItemRead" datatype="html">
+        <source>Gelesen</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveMarkItemReadAria" datatype="html">
+        <source>Diese Meldung als gelesen markieren</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="motd.archiveItemUnreadStatus" datatype="html">
+        <source>Ungelesen</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">111</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/motd-archive-dialog/motd-archive-dialog.component.html</context>
+          <context context-type="linenumber">82</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="motd.archiveEmpty" datatype="html">
         <source> Keine archivierten Meldungen. </source>
         <context-group purpose="location">

--- a/docs/APP-FUNKTIONSUEBERSICHT.md
+++ b/docs/APP-FUNKTIONSUEBERSICHT.md
@@ -749,12 +749,13 @@ Nutzende sehen:
 - Archiv-Dialog im Header
 - Archiv-Seite unter `/news-archive`
 - Ungelesen-Zähler in der Toolbar nur bei ungelesenen Meldungen
+- **Gelesen**-Button pro Archiv-Meldung (Zähler sinkt um 1); gelesene Einträge bleiben als **Gelesen** sichtbar
 
 ### 9.2 Interaktionen
 
 Für MOTDs existieren getrennte Interaktionsarten:
 
-- Kenntnisnahme
+- Kenntnisnahme (Overlay) bzw. **Gelesen** (Archiv, einzeln oder alle)
 - Daumen hoch
 - Daumen runter
 - Schließen per Button

--- a/docs/features/motd.md
+++ b/docs/features/motd.md
@@ -69,17 +69,25 @@ Der Betreiber kann **kuratierte Hinweise** an **alle Nutzer:innen** ausspielen �
 - **Archiv-Lesestatus:** publikationsbasierter Cursor aus `startsAt`, `motdId` und
   `contentVersion`; dadurch kann eine dauerhafte Meldung mit spätem `endsAt` später
   veröffentlichte Meldungen nicht versehentlich als bereits gelesen markieren.
+  Zusätzlich speichert der Client **einzeln gelesene** Archiv-MOTDs (`archiveReadItems`,
+  max. 64 Paare `motdId` + `contentVersion`). So senkt der Button **Gelesen** den
+  Toolbar-Zähler um 1, ohne ältere ungelesene Einträge mitzuziehen.
+  Gelesene Meldungen bleiben in Archiv-Dialog und Archiv-Seite mit Status **Gelesen**
+  erkennbar (Häkchen); ungelesene tragen einen Ungelesen-Hinweis.
+  **Alles als gelesen markieren** setzt den Cursor auf den neuesten Eintrag und leert
+  die Einzelliste.
 - **Schema-Version** im Key-Namespace für spätere Migration (aktuell **`arsnova-motd-v2`**).
 - Zusätzlich steuern **`arsnova-motd-mobile-home-seen`** (localStorage) und **`arsnova-motd-mobile-first-home-session`** (sessionStorage) die Unterdrückung beim ersten mobilen Startseiten-Besuch.
 - **`arsnova-motd-overlay-offered-session`** (sessionStorage) merkt, dass in dieser Browsersitzung bereits ein Auto-Overlay angeboten wurde; Reload und Rückkehr zur Startseite öffnen dann keines mehr.
 
 ### 3.7 Nutzerinteraktionen (getrennte Dimensionen)
 
-| Dimension         | Bedeutung                                 | Umsetzungshinweis                                                                                       |
-| ----------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Dismiss**       | Overlay geschlossen (X, Swipe, Backdrop)  | Im aktuellen Frontend lokal gespeichert und zusätzlich per `recordInteraction` aggregierbar             |
-| **Kenntnisnahme** | Expliziter Button (aktuell „Alles klar!“) | Lokal + optionale Mutation für Aggregation                                                              |
-| **Feedback**      | Daumen hoch/runter                        | Optional; **ein Vote pro MOTD-Version pro Browser** über localStorage erzwingbar; Server nur aggregiert |
+| Dimension         | Bedeutung                                                       | Umsetzungshinweis                                                                                         |
+| ----------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Dismiss**       | Overlay geschlossen (X, Swipe, Backdrop)                        | Im aktuellen Frontend lokal gespeichert und zusätzlich per `recordInteraction` aggregierbar               |
+| **Kenntnisnahme** | Expliziter Button (Overlay: „Alles klar!“; Archiv: **Gelesen**) | Overlay: lokal + optionale Mutation. Archiv: lokal (`archiveReadItems` bzw. Wasserlinie) + Header-Refresh |
+| **Alles gelesen** | Archiv-Aktion für alle sichtbaren Meldungen                     | Setzt den publikationsbasierten Cursor auf das neueste Item; Badge wird 0                                 |
+| **Feedback**      | Daumen hoch/runter                                              | Optional; **ein Vote pro MOTD-Version pro Browser** über localStorage erzwingbar; Server nur aggregiert   |
 
 **Semantik:** Dismiss ≠ Kenntnisnahme — beides getrennt auswertbar, falls Analytics gewünscht.
 
@@ -100,7 +108,7 @@ Der Betreiber kann **kuratierte Hinweise** an **alle Nutzer:innen** ausspielen �
 
 - `motd.getCurrent` — Input: `locale`, optional `overlayDismissedUpTo` (vom Client gemerkte Dismiss-Versionen pro `motdId`, damit die nächstpriore MOTD gewählt wird); Output: aktive MOTD oder leer.
 - `motd.listArchive` — Input: `locale`, Pagination; Output: nur freigegebene, vergangene/außerhalb Fenster.
-- `motd.getHeaderState` — Input: `locale`, optional `archiveSeenUpToCursor`, optional `overlayDismissedUpTo`; Output: ob aktives Overlay bzw. Archiv-Einträge existieren, `archiveMaxCursor` und ungelesene Archiv-Meldungen (Toolbar-Icon). `archiveSeenUpToEndsAtIso` / `archiveMaxEndsAtIso` bleiben vorübergehend für ältere Clients kompatibel.
+- `motd.getHeaderState` — Input: `locale`, optional `archiveSeenUpToCursor`, optional `archiveReadItems`, optional `overlayDismissedUpTo`; Output: ob aktives Overlay bzw. Archiv-Einträge existieren, `archiveMaxCursor` und ungelesene Archiv-Meldungen (Toolbar-Icon; einzeln Gelesene werden vom Zähler abgezogen). `archiveSeenUpToEndsAtIso` / `archiveMaxEndsAtIso` bleiben vorübergehend für ältere Clients kompatibel.
 - `motd.recordInteraction` — Input: `motdId`, `contentVersion`, `kind` (`ACK` | `THUMB_UP` | `THUMB_DOWN` | `DISMISS_CLOSE` | `DISMISS_SWIPE`); streng rate-limited; Zähler in DB.
 - **Rendering:** Endnutzer- und Admin-Vorschau nutzen **`renderMarkdownWithoutKatex`** + **DomSanitizer** (`bypassSecurityTrustHtml` nur auf dieser Pipeline), analog zu anderen sicheren Markdown-Ansichten — kein rohes HTML aus dem MOTD-Text.
 - `admin.motd.*` — CRUD MOTD, Templates, Publish/Schedule, Archiv-Flag, Priorität.
@@ -164,3 +172,4 @@ Synergie: [`docs/didaktik/zweiter-kurs-und-agentische-ki.md`](../didaktik/zweite
 | 2026-08-14 | Abschnitte 3.5/3.6: Overlay auf Handy erst nach dem ersten Startseiten-Besuch (Reload derselben Sitzung bleibt unterdrückt; Desktop und Toolbar-Archiv unverändert).                                                               |
 | 2026-08-17 | Abschnitte 3.5/3.6/9: Auto-Overlay höchstens einmal pro Sitzung; nächste andere MOTD nach Dismiss nur noch über Badge/Archiv, nicht bei Reload.                                                                                    |
 | 2026-08-17 | Abschnitt 3.8: Toolbar-Zähler bei null ungelesenen MOTDs vollständig ausblenden.                                                                                                                                                   |
+| 2026-08-19 | Abschnitte 3.6/3.7/4.1: Pro-MOTD-Button **Gelesen**; `archiveReadItems` ergänzt den Wasserlinien-Cursor (Badge −1); gelesene Meldungen bleiben in der Liste als **Gelesen** erkennbar.                                             |

--- a/libs/shared-types/src/schemas.ts
+++ b/libs/shared-types/src/schemas.ts
@@ -5348,6 +5348,16 @@ export const MotdOverlayDismissedPairSchema = z.object({
 export type MotdOverlayDismissedPair = z.infer<typeof MotdOverlayDismissedPairSchema>;
 
 /**
+ * Einzeln als gelesen markierte Archiv-MOTD. Identisch zum Overlay-Paar:
+ * `contentVersion` gilt als Untergrenze (höhere Version bleibt ungelesen).
+ */
+export const MotdArchiveReadItemSchema = MotdOverlayDismissedPairSchema;
+export type MotdArchiveReadItem = MotdOverlayDismissedPair;
+
+/** Max. einzeln gelesene Archiv-Einträge, die `getHeaderState` berücksichtigt. */
+export const MOTD_ARCHIVE_READ_ITEMS_MAX = 64;
+
+/**
  * tRPC-HTTP kann ohne Transformer bei Batch/Prefetch ein fehlendes `input` liefern (`undefined`).
  * `locale` ist optional; der Server leitet sie aus `Accept-Language` ab (s. Backend).
  */
@@ -5415,6 +5425,11 @@ const MotdHeaderStateInputPayloadSchema = z.object({
   /** @deprecated Kompatibilität für Clients vor dem publikationsbasierten Lesecursor. */
   archiveSeenUpToEndsAtIso: z.string().optional(),
   overlayDismissedUpTo: z.array(MotdOverlayDismissedPairSchema).max(32).optional(),
+  /**
+   * Einzeln gelesene Archiv-MOTDs (zusätzlich zum Wasserlinien-Cursor).
+   * Verhindert, dass „Gelesen“ auf einem Eintrag ältere ungelesene mitzieht.
+   */
+  archiveReadItems: z.array(MotdArchiveReadItemSchema).max(MOTD_ARCHIVE_READ_ITEMS_MAX).optional(),
 });
 
 export const MotdHeaderStateInputSchema = z.preprocess(
@@ -5432,7 +5447,10 @@ export const MotdHeaderStateOutputSchema = z.object({
   archiveMaxCursor: MotdArchiveReadCursorSchema.nullable(),
   /** @deprecated Kompatibilität für Clients vor dem publikationsbasierten Lesecursor. */
   archiveMaxEndsAtIso: z.string().nullable(),
-  /** Ungelesen relativ zum Cursor; ohne gültigen Cursor bzw. Legacy-Wasserzeichen = `archiveCount`. */
+  /**
+   * Ungelesen relativ zum Cursor, abzüglich `archiveReadItems`.
+   * Ohne gültigen Cursor bzw. Legacy-Wasserzeichen = sichtbare Archivanzahl minus einzeln Gelesene.
+   */
   archiveUnreadCount: z.number().int().min(0),
 });
 export type MotdHeaderStateOutput = z.infer<typeof MotdHeaderStateOutputSchema>;


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Im News-Archiv gab es nur „Alles als gelesen markieren“. Einzelne MOTDs ließen sich nicht als gelesen kennzeichnen; den publikationsbasierten Cursor auf einen Eintrag zu setzen, würde ältere ungelesene Meldungen fälschlich mitzählen. Nach dem Lesen war außerdem nicht sichtbar, welche Einträge bereits gelesen waren.
- **Lösung:** Pro MOTD gibt es einen MD3-Outlined-Button **Gelesen**. Der Client speichert einzeln gelesene Paare (`archiveReadItems`) zusätzlich zur Wasserlinie. `motd.getHeaderState` zieht diese vom Ungelesen-Zähler ab, der Toolbar-Badge sinkt um 1. Gelesene Einträge bleiben in Dialog und Archiv-Seite mit Status **Gelesen** erkennbar.
- **Bewusste Nicht-Ziele:** Kein serverseitiger persönlicher Lesestatus (weiterhin lokal im Browser). Overlay-Kenntnisnahme („Alles klar!“) unverändert. Keine Änderung der Archiv-Paginierung oder Overlay-Auswahl.

## Risiko und Verträge

- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

- Archiv-Lesestatus bleibt publikationsbasiert (`startsAt` + `motdId` + `contentVersion`); „Alles als gelesen“ setzt weiterhin den Cursor auf das neueste Item.
- Einzelnes **Gelesen** darf die Wasserlinie nicht auf diesen Eintrag vorschieben.
- `archiveUnreadCount` zählt sichtbare Archiv-MOTDs neuer als den Cursor, abzüglich `archiveReadItems` (Version als Untergrenze, analog Overlay-Dismiss).
- Badge nur bei `archiveUnreadCount > 0`; bei 0 vollständig unsichtbar.
- Öffentliche MOTD-API bleibt tRPC mit Shared-Zod; Rate-Limit von `getHeaderState` unverändert.

**Betroffene externe Verträge:**

- `motd.getHeaderState`-Input: optionales `archiveReadItems` (max. 64 Paare). Ältere Clients ohne das Feld verhalten sich wie bisher (nur Cursor/Legacy-`endsAt`).

## Implementierung

- Shared Zod: `archiveReadItems` am Header-State-Input; Backend zieht passende Einträge vom Ungelesen-Zähler ab.
- Client: `archiveReadItems` in `arsnova-motd-v2`; „Alles als gelesen“ leert die Einzelliste und setzt den Cursor.
- Archiv-Dialog und `/news-archive`: Button **Gelesen**, sofortiges Badge-Dekrement, Header-Refresh; gelesene Einträge mit Häkchen/**Gelesen**, ungelesene mit Punkt/**Ungelesen**.
- Nach dem Einzel-Klick Fokus zurück auf den Panel-Header bzw. den Meldungstitel.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [x] Migration oder Legacy-Daten
- [x] Parallelität oder Race Conditions
- [x] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

Doppelklick auf **Gelesen** ist idempotent (`markMotdArchiveItemRead` gibt `false` zurück). Lesestatus liegt in `localStorage` und überlebt Reload. Beschädigte Cursor werden ignoriert (bestehend); `archiveReadItems` werden validiert und gedeckelt. Header-Refresh nach Markieren erzwingt eine Folgeabfrage, falls bereits ein Request läuft. Fehlt `getHeaderState`, leitet der Client den Zähler aus der geladenen Archivseite plus lokalem Lesestatus ab.

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| Pre-commit: `npm run typecheck` (shared-types, backend, frontend) | erfolgreich |
| Pre-commit: `npm test` (shared-types 75, session-export-report 81, backend 1043, frontend 1379) | erfolgreich |
| lint-staged: ESLint + Prettier auf gestagten Dateien | erfolgreich |
| `npm run check:i18n -w @arsnova/frontend` | 2688/2688 Einheiten, alle Locales |
| `npm run lint` (voller Repo-Lauf) | nicht ausgeführt; ESLint der geänderten TS/HTML-Dateien und lint-staged sind grün |
| `npm run build:prod` / `build:localize` | nicht ausgeführt (Prerender/Prod-Build); i18n-IDs per `check:i18n` geprüft |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [ ] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [ ] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [ ] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [ ] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [ ] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

Fokus nach **Gelesen** auf Panel-Header bzw. Titel-Link. Status **Gelesen**/**Ungelesen** ist sichtbar bzw. für Screenreader im Header hinterlegt (`sr-only` im Dialog). Contract: Backend-Tests für `archiveReadItems` und höhere `contentVersion`.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Nutzer können einzelne Archiv-MOTDs als gelesen markieren; der Badge folgt dem lokalen Lesestatus. Alte Clients ignorieren `archiveReadItems` und zählen weiter nur über den Cursor.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine. Schema-Änderung nur im tRPC-Input; keine Prisma-Migration.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Unverändert (`getHeaderState` bleibt rate-limited).
- **Rollback:** Deploy der vorherigen Version. Lokal gespeicherte `archiveReadItems` bleiben harmlos im `localStorage`, bis ein neuer Client sie wieder nutzt.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Pre-commit-Lauf lokal: Typecheck und volle Workspace-Tests grün (siehe Tabelle).
- CI dieses PRs nach dem Push.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Kein WebSocket/Yjs, keine DB-Migration, keine Auth-Grenze, kein Lastpfad. Voller `npm run lint` und `build:prod` wurden lokal nicht gefahren; CI muss Lint, lokalisierten Frontend-Build und Template-A11y abdecken. Visuelles 320-px-/Kontrast-Smoke und axe-Gates sind nicht lokal gelaufen.
- **Verbleibende Risiken:** Mehr als 64 einzeln gelesene Einträge ohne „Alles als gelesen“ können den ältesten lokalen Eintrag verdrängen (dann zählt er wieder als ungelesen). Header-Refresh kann bei Netzfehler den Badge kurz auf 0 setzen (bestehendes Catch-Verhalten). Manuelle Prüfung von Dark/Light und 320 px steht aus.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft


Made with [Cursor](https://cursor.com)