### PR TITLE
fix(word-cloud): Q&A-Glättung im Themenmodus nicht nach LEXICAL umschalten

### DIFF
--- a/apps/frontend/src/app/features/session/session-host/qa-word-cloud-dialog.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/qa-word-cloud-dialog.component.spec.ts
@@ -44,7 +44,7 @@ describe('QaWordCloudDialogComponent', () => {
       smoothingStatus: () => 'idle',
       smoothingLabel: () => 'Sprachformen glätten',
       smoothingHint: () => null,
-      smoothingDisabled: () => false,
+      smoothingDisabled: () => analysisVariant === 'SEMANTIC',
       toggleSmoothing: vi.fn(),
       lemmaLocale: () => 'de',
       setLemmaLocale: vi.fn(),
@@ -89,5 +89,11 @@ describe('QaWordCloudDialogComponent', () => {
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain('Themen sind noch nicht verfügbar');
     expect(fixture.nativeElement.querySelector('.qa-word-cloud-dialog__cloud')).not.toBeNull();
+
+    const smoothButton = fixture.nativeElement.querySelector(
+      '.qa-word-cloud-dialog__smooth',
+    ) as HTMLButtonElement;
+    expect(smoothButton.disabled).toBe(true);
+    expect(smoothButton.getAttribute('aria-pressed')).toBe('false');
   });
 });

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -4347,8 +4347,22 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     expect(fixture.componentInstance.qaWordCloudThemeFallbackHint()).toBe(
       'Themen sind noch nicht verfügbar. Es gelten Wörter und Phrasen.',
     );
+    expect(fixture.componentInstance.qaWordCloudSmoothingDisabled()).toBe(true);
+    expect(fixture.componentInstance.qaWordCloudSmoothingStatus()).toBe('idle');
+    expect(fixture.componentInstance.qaWordCloudSmoothingHint()).toBeNull();
     expect(fixture.componentInstance.qaWordCloudAnalysisEntries()?.[0]?.label).toBe('Kapitel 4');
     expect(fixture.componentInstance.qaWordCloudVisibleTerms()).toBeNull();
+
+    const lemmaCallsBeforeToggle = wordCloudAnalyzeQueryMock.mock.calls.filter(
+      (call) => (call[0] as { normalization?: string }).normalization === 'LEMMA',
+    ).length;
+    await fixture.componentInstance.toggleQaWordCloudSmoothing();
+    expect(fixture.componentInstance.qaWordCloudAnalysisVariant()).toBe('SEMANTIC');
+    expect(
+      wordCloudAnalyzeQueryMock.mock.calls.filter(
+        (call) => (call[0] as { normalization?: string }).normalization === 'LEMMA',
+      ),
+    ).toHaveLength(lemmaCallsBeforeToggle);
 
     const [, config] = dialogOpenMock.mock.calls[0] as [unknown, Record<string, unknown>];
     const data = config['data'] as {
@@ -4356,11 +4370,15 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
       themeFallbackHint: () => string | null;
       analysisEntries: () => Array<{ label: string }> | null;
       terms: () => unknown[] | null;
+      smoothingDisabled: () => boolean;
+      smoothingStatus: () => string;
     };
     expect(data.analysisVariant()).toBe('SEMANTIC');
     expect(data.themeFallbackHint()).toContain('Themen sind noch nicht verfügbar');
     expect(data.analysisEntries()?.[0]?.label).toBe('Kapitel 4');
     expect(data.terms()).toBeNull();
+    expect(data.smoothingDisabled()).toBe(true);
+    expect(data.smoothingStatus()).toBe('idle');
     fixture.destroy();
   });
 
@@ -4541,6 +4559,113 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     expect(fixture.componentInstance.qaWordCloudSmoothingStatus()).toBe('idle');
     expect(fixture.componentInstance.qaWordCloudVisibleTerms()?.length).toBeGreaterThan(0);
     expect(fixture.componentInstance.qaWordCloudAnalysisEntries()).toBeNull();
+    fixture.destroy();
+  });
+
+  it('blendet Q&A-Glaettung in Themen aus und wechselt nicht still auf Einzelwoerter', async () => {
+    getInfoQueryMock.mockResolvedValue({
+      ...defaultSession,
+      status: 'ACTIVE',
+      channels: {
+        quiz: { enabled: true },
+        qa: { enabled: true, open: true, title: 'Fragen aus dem Publikum', moderationMode: true },
+        quickFeedback: { enabled: false, open: false },
+      },
+    });
+    qaListQueryMock.mockResolvedValue([
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        text: 'Kommt Kapitel 4 in der Klausur vor?',
+        upvoteCount: 9,
+        status: 'ACTIVE',
+        createdAt: '2026-03-13T12:00:00.000Z',
+        myVote: null,
+        isOwn: false,
+        hasUpvoted: false,
+      },
+    ]);
+    wordCloudAnalyzeQueryMock.mockImplementation(
+      async (input: { mode?: string; normalization?: string }) => {
+        if (input.normalization === 'LEMMA') {
+          return wordCloudAnalyzeResult({
+            mode: 'LEXICAL',
+            normalization: 'LEMMA',
+            normalizationApplied: 'LEMMA',
+            modelId: 'de_core_news_sm@3.8.0',
+            entries: [
+              {
+                key: 'klausur',
+                label: 'Klausur',
+                count: 4,
+                basisLabel: 'Klausur',
+                members: [
+                  {
+                    sourceId: '11111111-1111-4111-8111-111111111111',
+                    text: 'Kommt Kapitel 4 in der Klausur vor?',
+                    weight: 4,
+                  },
+                ],
+                variants: ['Klausur'],
+                confidence: 0.9,
+              },
+            ],
+          });
+        }
+
+        return wordCloudAnalyzeResult({
+          mode: input.mode ?? 'THEME',
+          status: input.mode === 'SEMANTIC' ? 'disabled' : 'ready',
+          fallbackUsed: input.mode === 'SEMANTIC',
+          entries: [
+            {
+              key: 'kapitel-4',
+              label: 'Kapitel 4',
+              count: 4,
+              basisLabel: 'Kapitel 4',
+              members: [
+                {
+                  sourceId: '11111111-1111-4111-8111-111111111111',
+                  text: 'Kommt Kapitel 4 in der Klausur vor?',
+                  weight: 4,
+                },
+              ],
+              variants: ['Kapitel 4'],
+              confidence: 0.8,
+            },
+          ],
+        });
+      },
+    );
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await vi.waitUntil(() => fixture.componentInstance.qaWordCloudQuestions().length === 1, {
+      timeout: 5000,
+      interval: 25,
+    });
+
+    dialogOpenMock.mockReturnValueOnce({ afterClosed: () => NEVER });
+    await fixture.componentInstance.openQaWordCloudDialog();
+    await fixture.componentInstance.toggleQaWordCloudSmoothing();
+    await vi.waitUntil(() => fixture.componentInstance.qaWordCloudSmoothingStatus() === 'active', {
+      timeout: 5000,
+      interval: 25,
+    });
+    expect(fixture.componentInstance.qaWordCloudEffectiveAnalysisVariant()).toBe('LEXICAL');
+
+    fixture.componentInstance.setQaWordCloudAnalysisVariant('SEMANTIC');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.qaWordCloudSmoothingDisabled()).toBe(true);
+    expect(fixture.componentInstance.qaWordCloudSmoothingStatus()).toBe('idle');
+    expect(fixture.componentInstance.qaWordCloudSmoothingHint()).toBeNull();
+    expect(fixture.componentInstance.qaWordCloudLemmaSnapshotVisible()).toBe(false);
+
+    const lemmaCount = lemmaAnalyzeCalls().length;
+    await fixture.componentInstance.toggleQaWordCloudSmoothing();
+    expect(fixture.componentInstance.qaWordCloudAnalysisVariant()).toBe('SEMANTIC');
+    expect(lemmaAnalyzeCalls()).toHaveLength(lemmaCount);
     fixture.destroy();
   });
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -1604,6 +1604,10 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     return this.qaWordCloudLemmaFingerprint() !== snapshotKey;
   });
   readonly qaWordCloudSmoothingStatus = computed<'idle' | 'pending' | 'active' | 'stale'>(() => {
+    if (this.qaWordCloudEffectiveAnalysisVariant() === 'SEMANTIC') {
+      return 'idle';
+    }
+
     if (this.qaWordCloudLemmaPending()) {
       return 'pending';
     }
@@ -1615,6 +1619,10 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     return 'idle';
   });
   readonly qaWordCloudSmoothingDisabled = computed(() => {
+    if (this.qaWordCloudEffectiveAnalysisVariant() === 'SEMANTIC') {
+      return true;
+    }
+
     if (this.qaWordCloudLemmaPending()) {
       return true;
     }
@@ -1638,7 +1646,10 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     }
   });
   readonly qaWordCloudSmoothingHint = computed(() => {
-    if (this.qaWordCloudLemmaPending()) {
+    if (
+      this.qaWordCloudEffectiveAnalysisVariant() === 'SEMANTIC' ||
+      this.qaWordCloudLemmaPending()
+    ) {
       return null;
     }
 
@@ -6891,7 +6902,10 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   }
 
   async toggleQaWordCloudSmoothing(): Promise<void> {
-    if (this.qaWordCloudLemmaPending()) {
+    if (
+      this.qaWordCloudEffectiveAnalysisVariant() === 'SEMANTIC' ||
+      this.qaWordCloudLemmaPending()
+    ) {
       return;
     }
 
@@ -7825,6 +7839,10 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   }
 
   private async requestQaWordCloudLemmaSmoothing(): Promise<void> {
+    if (this.qaWordCloudAnalysisVariant() === 'SEMANTIC') {
+      return;
+    }
+
     if (this.qaWordCloudAnalysisVariant() !== 'LEXICAL') {
       this.setQaWordCloudAnalysisVariant('LEXICAL');
     }

--- a/docs/features/word-cloud-spacy.md
+++ b/docs/features/word-cloud-spacy.md
@@ -32,10 +32,10 @@ Nicht in der Host-UI: `spaCy`, `NLP`, `Lemma`, `Lemmatisierung`. Modell- und Ver
 
 Nur der Host löst die Analyse aus. Es gibt keinen Participant-Toggle und keine automatische Runde bei jeder neuen Antwort, Frage oder Abstimmung.
 
-| Kanal    | Vollansicht                                          | Ansichtsachsen                                                                     | Glättung                                                   |
-| -------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| Freitext | dieselbe `app-word-cloud`-Instanz, In-Place-Maximize | `Einzelwörter` / `Wörter & Phrasen` / `Themen` (`SEMANTIC`, Stufe 0: 2.x-Fallback) | `WORDS` und `PHRASES`; `SEMANTIC` blendet die Glättung aus |
-| Q&A      | eigener `MatDialog`                                  | `Einzelwörter` (`LEXICAL`) / `Wörter & Phrasen` (`THEME`) / `Themen` (`SEMANTIC`)  | nur `LEXICAL`; Einschalten erzwingt `LEXICAL`              |
+| Kanal    | Vollansicht                                          | Ansichtsachsen                                                                     | Glättung                                                                                               |
+| -------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Freitext | dieselbe `app-word-cloud`-Instanz, In-Place-Maximize | `Einzelwörter` / `Wörter & Phrasen` / `Themen` (`SEMANTIC`, Stufe 0: 2.x-Fallback) | `WORDS` und `PHRASES`; `SEMANTIC` blendet die Glättung aus                                             |
+| Q&A      | eigener `MatDialog`                                  | `Einzelwörter` (`LEXICAL`) / `Wörter & Phrasen` (`THEME`) / `Themen` (`SEMANTIC`)  | `LEXICAL` und `THEME`; `SEMANTIC` blendet die Glättung aus; Einschalten bei `THEME` erzwingt `LEXICAL` |
 
 Presenter zeigt die Wolke ohne Glättungssteuerung, ohne Wolkensprache und ohne den Modus `Themen`.
 
@@ -48,7 +48,7 @@ Die **Wolkensprache** steht klein neben **Sprachformen glätten** (Freitext und 
 - **Wolkensprache wechseln** bei aktiver Glättung: dieselbe Datenmenge mit dem anderen Modell neu analysieren.
 - **Q&A-Sortierung** `Meist unterstützt` / `Beste Fragen` / `Umstritten` bei aktiver `LEXICAL`-Glättung: dieselbe Fragenmenge mit der neuen Metrik neu glätten.
 - **Q&A `Wörter & Phrasen`:** Sortwechsel startet die bestehende Themenanalyse mit `normalization: NONE`, nicht den Lemma-Pfad. `THEME + LEMMA` ist `MODE_UNSUPPORTED`.
-- **Q&A `Themen`:** Story 1.14c Stufe 0. Kein Encoder und kein LLM. `SEMANTIC + LEMMA` ist `MODE_UNSUPPORTED`. Ohne Inferenzserver bleibt die Karte auf dem 2.x-Phrasenpfad (`status: disabled`, `fallbackUsed: true`).
+- **Q&A `Themen`:** Story 1.14c Stufe 0. Kein Encoder und kein LLM. `SEMANTIC + LEMMA` ist `MODE_UNSUPPORTED`. Die Glättung bleibt wie im Freitext ausgeblendet und wechselt nicht still auf `LEXICAL`. Ohne Inferenzserver bleibt die Karte auf dem 2.x-Phrasenpfad (`status: disabled`, `fallbackUsed: true`).
 - **Freitext `Themen`:** derselbe Host-Toggle und 2.x-Fallback; Presenter bleibt ohne den dritten Modus. `maxNgramLength` 1 bzw. 3 gilt weiter für `Einzelwörter` / `Wörter & Phrasen`.
 
 Während der Analyse bleibt die lexikalische Wolke sichtbar und bedienbar. Sidecar-Ausfall, Timeout oder unsupported Locale fallen hart auf den 2.x-Pfad zurück.


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Nach #306 blieb die Q&A-Glättung im Modus **Themen** (`SEMANTIC`) klickbar. Der Klick rief `requestQaWordCloudLemmaSmoothing()` auf und wechselte still auf `LEXICAL`. Ein aktiver Lemma-Snapshot ließ den Button außerdem gedrückt wirken, obwohl die Glättung nicht angezeigt wird.
- **Lösung:** Dieselbe Regel wie im Freitext: im Themenmodus ist die Glättung deaktiviert (`status` idle, Hint aus). Toggle und Lemma-Refresh erzwingen `SEMANTIC` nicht mehr auf `LEXICAL`.
- **Bewusste Nicht-Ziele:** Encoder/Clustering, Presenter-Toggle, Änderung des THEME-Pfads (Einschalten der Glättung dort erzwingt weiter `LEXICAL`).

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

- Folgefix zu #306 / Codex-Review: Q&A-Glättung im Themenmodus wie Freitext behandeln
- `SEMANTIC + LEMMA` bleibt `MODE_UNSUPPORTED`
- `THEME` + Glättung erzwingt weiter `LEXICAL`

**Betroffene externe Verträge:**

Keine.

## Implementierung

- `qaWordCloudSmoothingDisabled` / `Status` / `Hint` und `toggleQaWordCloudSmoothing` berücksichtigen `SEMANTIC`.
- `requestQaWordCloudLemmaSmoothing` bricht bei `SEMANTIC` ab statt auf `LEXICAL` zu schalten.
- Host- und Dialog-Tests für Disable, Idle und Rest-Lemma-Snapshot.
- Produktdoku in `docs/features/word-cloud-spacy.md` nachgezogen.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` (Pre-Commit des Cherry-Picks) | bestanden |
| `npm test` (Pre-Commit: shared-types 84, session-export-report 81, backend 1055, frontend 1407) | bestanden |
| Frontend-Fokus `qa-word-cloud-dialog` + `session-host` | 228 Tests bestanden |
| `npm run lint` | nicht erneut auf diesem Branch; identischer Diff zum bereits gelinteten Commit |
| `npm run build:prod` | nicht lokal; CI localized Build |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [ ] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [ ] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [ ] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Im Q&A-Themenmodus ist **Sprachformen glätten** deaktiviert und ändert den Analysemodus nicht mehr.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen.
- **Rollback:** Revert dieses PRs. #306 bleibt davon unabhängig.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Regressionstest: aktiver Lemma-Snapshot, Wechsel auf **Themen**, Toggle bleibt ohne `LEXICAL`.
- CI dieses PRs nach Push.
- Codex-Fund auf #306: Q&A-Glättung im Themenmodus.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:**
  - Keine i18n-Stringänderung, daher kein Locale-Rebuild.
  - `npm run lint` auf diesem Cherry-Pick nicht extra wiederholt; der Commit ging durch ESLint/Prettier im Hook.
  - Keine manuelle A11y-Session: der Button bleibt im DOM, ist aber `disabled` und nicht `aria-pressed`.
- **Verbleibende Risiken:** Die Wolkensprache bleibt im Themenmodus sichtbar (wie im Freitext). Ein Locale-Wechsel startet keine Lemma-Analyse mehr, solange `SEMANTIC` aktiv ist.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft


Made with [Cursor](https://cursor.com)