### PR TITLE
fix(host): Quiz-Navigation an letzter Frage und bei Start ab hier klarstellen

### DIFF
--- a/apps/backend/src/__tests__/session.current-question-host.test.ts
+++ b/apps/backend/src/__tests__/session.current-question-host.test.ts
@@ -897,6 +897,133 @@ describe('session.getCurrentQuestionForHost (Story 2.3)', () => {
     expect(result!.peerInstructionSuggestion).toBeUndefined();
   });
 
+  it('setzt canShowPreviousResult nur wenn eine fachlich enthaltene Vorgängerfrage existiert', async () => {
+    const firstId = '11111111-1111-4111-8111-111111111111';
+    const secondId = '22222222-2222-4222-8222-222222222222';
+    const surveyAnswers = [
+      { id: 'aaaaaaaa-1111-4111-8111-111111111111', text: 'Gut', isCorrect: false },
+      { id: 'bbbbbbbb-2222-4222-8222-222222222222', text: 'Okay', isCorrect: false },
+    ];
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: '6a8edced-5f8f-4cfa-9176-454fac9570ad',
+      status: 'RESULTS',
+      currentQuestion: 1,
+      currentRound: 1,
+      answerDisplayOrder: null,
+      questionProgress: {
+        [firstId]: {
+          state: 'COMPLETED',
+          openedAt: '2026-08-21T10:00:00.000Z',
+          completedAt: '2026-08-21T10:01:00.000Z',
+        },
+        [secondId]: {
+          state: 'COMPLETED',
+          openedAt: '2026-08-21T10:01:00.000Z',
+          completedAt: '2026-08-21T10:02:00.000Z',
+        },
+      },
+      questionProgressComplete: true,
+      quiz: {
+        questions: [
+          {
+            id: firstId,
+            order: 0,
+            text: 'Wie fühlt sich der Raum an?',
+            type: 'SURVEY',
+            difficulty: 'EASY',
+            answers: surveyAnswers,
+          },
+          {
+            id: secondId,
+            order: 1,
+            text: 'Was hilft dir beim Lernen?',
+            type: 'FREETEXT',
+            difficulty: 'EASY',
+            answers: [],
+          },
+        ],
+      },
+    });
+
+    const result = await caller.getCurrentQuestionForHost({ code: CODE });
+
+    expect(result).toMatchObject({
+      questionId: secondId,
+      type: 'FREETEXT',
+      canShowPreviousResult: true,
+      hasNextQuestion: false,
+      hasUnopenedFollowingQuestion: false,
+    });
+  });
+
+  it('blendet den Vorgänger aus, wenn das Quiz erst ab einer späteren Frage geöffnet wurde', async () => {
+    const firstId = '11111111-1111-4111-8111-111111111111';
+    const secondId = '22222222-2222-4222-8222-222222222222';
+    const startId = '33333333-3333-4333-8333-333333333333';
+    const lastId = '44444444-4444-4444-8444-444444444444';
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: '6a8edced-5f8f-4cfa-9176-454fac9570ad',
+      status: 'RESULTS',
+      currentQuestion: 2,
+      currentRound: 1,
+      answerDisplayOrder: null,
+      questionProgress: {
+        [startId]: {
+          state: 'COMPLETED',
+          openedAt: '2026-08-21T10:00:00.000Z',
+          completedAt: '2026-08-21T10:01:00.000Z',
+        },
+      },
+      questionProgressComplete: true,
+      quiz: {
+        questions: [
+          {
+            id: firstId,
+            order: 0,
+            text: 'Frage 1',
+            type: 'SINGLE_CHOICE',
+            difficulty: 'EASY',
+            answers: [{ id: 'aaaaaaaa-1111-4111-8111-111111111111', text: 'A', isCorrect: true }],
+          },
+          {
+            id: secondId,
+            order: 1,
+            text: 'Frage 2',
+            type: 'SINGLE_CHOICE',
+            difficulty: 'EASY',
+            answers: [{ id: 'bbbbbbbb-2222-4222-8222-222222222222', text: 'B', isCorrect: true }],
+          },
+          {
+            id: startId,
+            order: 2,
+            text: 'Startfrage',
+            type: 'FREETEXT',
+            difficulty: 'EASY',
+            answers: [],
+          },
+          {
+            id: lastId,
+            order: 3,
+            text: 'Letzte Frage',
+            type: 'FREETEXT',
+            difficulty: 'EASY',
+            answers: [],
+          },
+        ],
+      },
+    });
+
+    const result = await caller.getCurrentQuestionForHost({ code: CODE });
+
+    expect(result).toMatchObject({
+      questionId: startId,
+      order: 2,
+      canShowPreviousResult: false,
+      hasNextQuestion: true,
+      hasUnopenedFollowingQuestion: true,
+    });
+  });
+
   it('liefert null wenn keine Session', async () => {
     prismaMock.session.findUnique.mockResolvedValue(null);
 

--- a/apps/backend/src/__tests__/session.steering.test.ts
+++ b/apps/backend/src/__tests__/session.steering.test.ts
@@ -205,6 +205,53 @@ describe('session.nextQuestion (Story 2.3)', () => {
     );
   });
 
+  it('oeffnet aus der Lobby die Startfrage, wenn currentQuestion auf den Vorgaenger zeigt', async () => {
+    const startId = '33333333-3333-4333-8333-333333333333';
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: SESSION_ID,
+      status: 'LOBBY',
+      currentQuestion: 1,
+      questionProgress: {},
+      questionProgressComplete: true,
+      quiz: {
+        readingPhaseEnabled: false,
+        questions: [
+          { id: '11111111-1111-4111-8111-111111111111', order: 0, type: 'SINGLE_CHOICE' },
+          { id: '22222222-2222-4222-8222-222222222222', order: 1, type: 'SINGLE_CHOICE' },
+          { id: startId, order: 2, type: 'SINGLE_CHOICE' },
+        ],
+      },
+    });
+    prismaMock.session.update.mockResolvedValue({
+      id: SESSION_ID,
+      status: 'ACTIVE',
+      currentQuestion: 2,
+    });
+
+    const result = await caller.nextQuestion({ code: CODE });
+
+    expect(result.status).toBe('ACTIVE');
+    expect(result.currentQuestion).toBe(2);
+    expect(prismaMock.session.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: SESSION_ID },
+        data: expect.objectContaining({
+          status: 'ACTIVE',
+          currentQuestion: 2,
+          questionProgress: expect.objectContaining({
+            [startId]: expect.objectContaining({ state: 'OPENED' }),
+          }),
+        }),
+      }),
+    );
+    const progress = prismaMock.session.update.mock.calls[0][0].data.questionProgress as Record<
+      string,
+      { state: string }
+    >;
+    expect(progress['11111111-1111-4111-8111-111111111111']).toBeUndefined();
+    expect(progress['22222222-2222-4222-8222-222222222222']).toBeUndefined();
+  });
+
   it('setzt FINISHED wenn nach letzter Frage', async () => {
     const questionId = '33333333-3333-4333-8333-333333333333';
     prismaMock.session.findUnique.mockResolvedValue({
@@ -994,17 +1041,149 @@ describe('session.prevQuestion', () => {
   );
 
   it('wirft BAD_REQUEST bei erster Frage (currentQuestion === 0)', async () => {
+    const firstId = '11111111-1111-4111-8111-111111111111';
+    const secondId = '22222222-2222-4222-8222-222222222222';
     prismaMock.session.findUnique.mockResolvedValue({
       id: SESSION_ID,
       status: 'RESULTS',
       currentQuestion: 0,
+      questionProgress: {
+        [firstId]: {
+          state: 'COMPLETED',
+          openedAt: '2026-08-21T10:00:00.000Z',
+          completedAt: '2026-08-21T10:01:00.000Z',
+        },
+      },
+      questionProgressComplete: true,
+      quiz: {
+        questions: [
+          { id: firstId, order: 0 },
+          { id: secondId, order: 1 },
+        ],
+      },
     });
 
     await expect(caller.prevQuestion({ code: CODE })).rejects.toMatchObject({
       code: 'BAD_REQUEST',
       message: 'Bereits bei der ersten Frage – Rückwärtsnavigation nicht möglich.',
     });
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
   });
+
+  it('wirft BAD_REQUEST wenn vor der Startfrage nie geöffnete Fragen liegen', async () => {
+    const firstId = '11111111-1111-4111-8111-111111111111';
+    const secondId = '22222222-2222-4222-8222-222222222222';
+    const startId = '33333333-3333-4333-8333-333333333333';
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: SESSION_ID,
+      status: 'RESULTS',
+      currentQuestion: 2,
+      questionProgress: {
+        [startId]: {
+          state: 'COMPLETED',
+          openedAt: '2026-08-21T10:00:00.000Z',
+          completedAt: '2026-08-21T10:01:00.000Z',
+        },
+      },
+      questionProgressComplete: true,
+      quiz: {
+        questions: [
+          { id: firstId, order: 0 },
+          { id: secondId, order: 1 },
+          { id: startId, order: 2 },
+        ],
+      },
+    });
+
+    await expect(caller.prevQuestion({ code: CODE })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Bereits bei der ersten Frage – Rückwärtsnavigation nicht möglich.',
+    });
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+  });
+
+  it('wirft BAD_REQUEST wenn die Vorgängerfrage ausgelassen wurde', async () => {
+    const firstId = '11111111-1111-4111-8111-111111111111';
+    const secondId = '22222222-2222-4222-8222-222222222222';
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: SESSION_ID,
+      status: 'RESULTS',
+      currentQuestion: 1,
+      questionProgress: {
+        [firstId]: {
+          state: 'SKIPPED',
+          openedAt: '2026-08-21T10:00:00.000Z',
+          skippedAt: '2026-08-21T10:00:01.000Z',
+        },
+        [secondId]: {
+          state: 'COMPLETED',
+          openedAt: '2026-08-21T10:00:02.000Z',
+          completedAt: '2026-08-21T10:01:00.000Z',
+        },
+      },
+      questionProgressComplete: true,
+      quiz: {
+        questions: [
+          { id: firstId, order: 0 },
+          { id: secondId, order: 1 },
+        ],
+      },
+    });
+
+    await expect(caller.prevQuestion({ code: CODE })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Bereits bei der ersten Frage – Rückwärtsnavigation nicht möglich.',
+    });
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+  });
+
+  it.each(['SURVEY', 'FREETEXT', 'ORDERING', 'RATING'] as const)(
+    'blaettert von RESULTS auf die vorherige %s-Frage ohne Musterloesung zurueck',
+    async (previousType) => {
+      const firstId = '11111111-1111-4111-8111-111111111111';
+      const secondId = '22222222-2222-4222-8222-222222222222';
+      prismaMock.session.findUnique.mockResolvedValue({
+        id: SESSION_ID,
+        status: 'RESULTS',
+        currentQuestion: 1,
+        questionProgress: {
+          [firstId]: {
+            state: 'COMPLETED',
+            openedAt: '2026-08-21T10:00:00.000Z',
+            completedAt: '2026-08-21T10:01:00.000Z',
+          },
+          [secondId]: {
+            state: 'COMPLETED',
+            openedAt: '2026-08-21T10:01:00.000Z',
+            completedAt: '2026-08-21T10:02:00.000Z',
+          },
+        },
+        questionProgressComplete: true,
+        quiz: {
+          questions: [
+            { id: firstId, order: 0, type: previousType },
+            { id: secondId, order: 1, type: 'SINGLE_CHOICE' },
+          ],
+        },
+      });
+      prismaMock.session.update.mockResolvedValue({
+        id: SESSION_ID,
+        status: 'RESULTS',
+        currentQuestion: 0,
+      });
+
+      const result = await caller.prevQuestion({ code: CODE });
+
+      expect(result.status).toBe('RESULTS');
+      expect(result.currentQuestion).toBe(0);
+      expect(prismaMock.session.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: SESSION_ID },
+          data: expect.objectContaining({ status: 'RESULTS', currentQuestion: 0, currentRound: 1 }),
+        }),
+      );
+    },
+  );
 
   it('öffnet eine unter der Sperre bereits beendete Session nicht rückwärts erneut', async () => {
     prismaMock.session.findUnique.mockResolvedValueOnce({ id: SESSION_ID }).mockResolvedValueOnce({

--- a/apps/backend/src/lib/sessionQuestionProgress.test.ts
+++ b/apps/backend/src/lib/sessionQuestionProgress.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   findNextUnskippedQuestionIndex,
+  findFollowingQuestionIndex,
   findPreviousIncludedQuestionIndex,
   getSessionQuestionProgressSummary,
   markSessionQuestionCompleted,
@@ -63,5 +64,42 @@ describe('sessionQuestionProgress', () => {
     progress = markSessionQuestionOpened(progress, questions[2].id, at);
 
     expect(findPreviousIncludedQuestionIndex(questions, progress, true, 2)).toBe(0);
+    expect(findPreviousIncludedQuestionIndex(questions, progress, true, 0)).toBeNull();
+    expect(findPreviousIncludedQuestionIndex(questions, progress, true, 2)).not.toBe(1);
+  });
+
+  it('findet keine Vorgängerfrage, wenn die erste durchgeführte Frage nicht order 0 ist', () => {
+    const at = new Date();
+    const progress = markSessionQuestionOpened(
+      markSessionQuestionSkipped({}, questions[0].id, at),
+      questions[1].id,
+      at,
+    );
+
+    expect(findPreviousIncludedQuestionIndex(questions, progress, true, 1)).toBeNull();
+  });
+
+  it('behandelt nie geöffnete Fragen vor einem späteren Start wie nicht enthalten', () => {
+    const at = new Date();
+    const progress = markSessionQuestionOpened({}, questions[2].id, at);
+
+    expect(findPreviousIncludedQuestionIndex(questions, progress, true, 2)).toBeNull();
+    expect(findFollowingQuestionIndex(questions, progress, true, 2, false)).toBe(3);
+    expect(findFollowingQuestionIndex(questions, progress, true, 3, false)).toBeNull();
+  });
+
+  it('unterscheidet die nächste Frage vom Weiter nach einem Ergebnis-Rückblick', () => {
+    const at = new Date();
+    let progress = markSessionQuestionCompleted({}, questions[0].id, at);
+    progress = markSessionQuestionCompleted(progress, questions[1].id, at);
+    progress = markSessionQuestionCompleted(progress, questions[2].id, at);
+    progress = markSessionQuestionCompleted(progress, questions[3].id, at);
+
+    expect(findFollowingQuestionIndex(questions, progress, true, 0, false)).toBe(1);
+    expect(findFollowingQuestionIndex(questions, progress, true, 1, false)).toBe(2);
+    expect(findFollowingQuestionIndex(questions, progress, true, 3, false)).toBeNull();
+    expect(findFollowingQuestionIndex(questions, progress, true, 1, true)).toBe(3);
+    expect(findFollowingQuestionIndex(questions, progress, true, 2, true)).toBeNull();
+    expect(findFollowingQuestionIndex(questions, progress, true, 3, true)).toBeNull();
   });
 });

--- a/apps/backend/src/lib/sessionQuestionProgress.ts
+++ b/apps/backend/src/lib/sessionQuestionProgress.ts
@@ -141,6 +141,22 @@ export function findNextUnskippedQuestionIndex(
   return null;
 }
 
+/**
+ * Nächste fachlich folgende Frage. `skipAlreadyOpened` entspricht
+ * `skipCurrentResultQuestion` in `session.nextQuestion` (Rückblick → weiter).
+ */
+export function findFollowingQuestionIndex(
+  questions: readonly SessionQuestionRef[],
+  progress: SessionQuestionProgressMap,
+  complete: boolean,
+  currentIndex: number,
+  skipAlreadyOpened = false,
+): number | null {
+  const startIndex = skipAlreadyOpened && !complete ? currentIndex + 1 : currentIndex;
+  const skipOpenedCount = skipAlreadyOpened && complete ? 1 : 0;
+  return findNextUnskippedQuestionIndex(questions, progress, startIndex, skipOpenedCount);
+}
+
 export function findPreviousIncludedQuestionIndex(
   questions: readonly SessionQuestionRef[],
   progress: SessionQuestionProgressMap,

--- a/apps/backend/src/routers/session.ts
+++ b/apps/backend/src/routers/session.ts
@@ -172,6 +172,7 @@ import {
 } from '../lib/readingReady';
 import {
   findNextUnskippedQuestionIndex,
+  findFollowingQuestionIndex,
   findPreviousIncludedQuestionIndex,
   getIncludedSessionQuestionIds,
   getSessionQuestionProgressSummary,
@@ -3266,6 +3267,8 @@ type HostCurrentQuestionSession = {
   currentQuestion: number | null;
   currentRound: number;
   answerDisplayOrder: Prisma.JsonValue | null;
+  questionProgress?: Prisma.JsonValue | null;
+  questionProgressComplete?: boolean | null;
   quiz: {
     defaultTimer: number | null;
     timerScaleByDifficulty: boolean | null;
@@ -3599,10 +3602,23 @@ async function buildHostCurrentQuestionDto(
     );
   }
 
+  const questionRefs = questions.map((entry) => ({ id: entry.id, order: entry.order }));
+  const progress = parseSessionQuestionProgress(session.questionProgress);
+  const complete = session.questionProgressComplete === true;
+  const canShowPreviousResult =
+    findPreviousIncludedQuestionIndex(questionRefs, progress, complete, idx) !== null;
+  const hasNextQuestion =
+    findFollowingQuestionIndex(questionRefs, progress, complete, idx) !== null;
+  const hasUnopenedFollowingQuestion =
+    findFollowingQuestionIndex(questionRefs, progress, complete, idx, true) !== null;
+
   const base = {
     questionId: question.id,
     order: question.order,
     totalQuestions: questions.length,
+    canShowPreviousResult,
+    hasNextQuestion,
+    hasUnopenedFollowingQuestion,
     text: question.text,
     type: question.type as QuestionType,
     difficulty: question.difficulty,
@@ -4051,6 +4067,8 @@ async function fetchHostCurrentQuestionEnvelope(
       currentQuestion: true,
       currentRound: true,
       answerDisplayOrder: true,
+      questionProgress: true,
+      questionProgressComplete: true,
       quiz: {
         select: {
           questions: {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -1426,8 +1426,13 @@
                       } @else {
                         <span i18n="@@sessionHost.questionNumber">Frage {{ q.order + 1 }}</span>
                       }
-                      @if (q.totalQuestions != null && q.order + 1 === q.totalQuestions) {
-                        <span class="session-host__question-last-badge" i18n>Letzte Frage</span>
+                      @if (showLastQuestionBadge()) {
+                        <span
+                          class="session-host__question-last-badge"
+                          role="status"
+                          i18n="@@sessionHost.lastQuestionBadge"
+                          >Letzte Frage</span
+                        >
                       }
                       <span class="session-host__question-phase">
                         {{ phaseLabel(effectiveStatus(), allHaveVoted(), countdownEnded()) }}
@@ -3266,8 +3271,8 @@
                     Frage wird aktualisiert …
                   </p>
                 } @else {
-                  <p class="session-host__no-question" i18n>
-                    Keine Frage aktiv. Mit „Nächste Frage“ starten.
+                  <p class="session-host__no-question" i18n="@@sessionHost.noActiveQuestion">
+                    Keine Frage aktiv.
                   </p>
                 }
               }
@@ -4107,7 +4112,7 @@
             (effectiveStatus() === 'QUESTION_OPEN' ||
               effectiveStatus() === 'DISCUSSION' ||
               ((effectiveStatus() === 'PAUSED' || effectiveStatus() === 'RESULTS') &&
-                !isLastQuestion()) ||
+                (canOpenFollowingQuestion() || showFinishEvaluationAnchor())) ||
               (effectiveStatus() === 'ACTIVE' &&
                 !quizStartQuestionPending() &&
                 hasCurrentQuizQuestionForHost())))
@@ -4130,8 +4135,7 @@
         @if (
           showQuizAnchorActions() &&
           (effectiveStatus() === 'RESULTS' || effectiveStatus() === 'DISCUSSION') &&
-          !isFirstQuestion() &&
-          !steppedBackToPreviousResult()
+          canShowPreviousResultAnchor()
         ) {
           <button
             matButton="tonal"
@@ -4140,7 +4144,7 @@
             [disabled]="controlPending()"
             (click)="prevQuestion()"
             i18n-matTooltip="@@sessionHost.prevQuestionTooltip"
-            matTooltip="Zeigt die letzte Frage mit Ergebnis und richtiger Lösung erneut an (ohne neue Abstimmung)."
+            matTooltip="Zeigt die vorherige Frage mit ihrem Ergebnis erneut an (ohne neue Abstimmung)."
             matTooltipTouchGestures="off"
           >
             <span
@@ -4303,7 +4307,7 @@
         @if (
           showQuizAnchorActions() &&
           (effectiveStatus() === 'PAUSED' || effectiveStatus() === 'RESULTS') &&
-          !isLastQuestion()
+          canOpenFollowingQuestion()
         ) {
           <button
             mat-flat-button
@@ -4315,6 +4319,33 @@
             i18n="@@sessionHost.nextQuestionAnchor"
           >
             Nächste Frage
+          </button>
+        }
+        @if (
+          showQuizAnchorActions() &&
+          (effectiveStatus() === 'PAUSED' || effectiveStatus() === 'RESULTS') &&
+          showFinishEvaluationAnchor()
+        ) {
+          <button
+            mat-flat-button
+            color="primary"
+            type="button"
+            class="session-host__exit-anchor-button session-host__exit-anchor-button--primary session-host__exit-anchor-button--finish-evaluation"
+            [disabled]="controlPending()"
+            (click)="nextQuestion()"
+            i18n-aria-label="@@sessionHost.finishEvaluationAnchorAria"
+            aria-label="Zur Gesamtauswertung"
+          >
+            <span
+              class="session-host__exit-anchor-label session-host__exit-anchor-label--finish-evaluation-full"
+              i18n="@@sessionHost.finishEvaluationAnchor"
+              >Zur Gesamtauswertung</span
+            >
+            <span
+              class="session-host__exit-anchor-label session-host__exit-anchor-label--finish-evaluation-compact"
+              i18n="@@sessionHost.finishEvaluationAnchorCompact"
+              >Auswertung</span
+            >
           </button>
         }
         @if (showQuizAnchorActions() && effectiveStatus() === 'DISCUSSION') {
@@ -4330,19 +4361,35 @@
               <mat-icon aria-hidden="true">replay</mat-icon>
               <span i18n>Zweite Abstimmung</span>
             </button>
-            <button
-              matButton="tonal"
-              type="button"
-              class="session-host__exit-anchor-button session-host__exit-anchor-button--paired-secondary"
-              [disabled]="controlPending()"
-              (click)="nextQuestion()"
-              i18n-aria-label="@@sessionHost.skipDiscussionNextQuestionAria"
-              aria-label="Zur nächsten Frage ohne zweite Abstimmung"
-            >
-              <span i18n="@@sessionHost.skipDiscussionNextQuestion"
-                >Zur nächsten Frage ohne zweite Abstimmung</span
+            @if (canOpenFollowingQuestion()) {
+              <button
+                matButton="tonal"
+                type="button"
+                class="session-host__exit-anchor-button session-host__exit-anchor-button--paired-secondary"
+                [disabled]="controlPending()"
+                (click)="nextQuestion()"
+                i18n-aria-label="@@sessionHost.skipDiscussionNextQuestionAria"
+                aria-label="Zur nächsten Frage ohne zweite Abstimmung"
               >
-            </button>
+                <span i18n="@@sessionHost.skipDiscussionNextQuestion"
+                  >Zur nächsten Frage ohne zweite Abstimmung</span
+                >
+              </button>
+            } @else if (showFinishEvaluationAnchor()) {
+              <button
+                matButton="tonal"
+                type="button"
+                class="session-host__exit-anchor-button session-host__exit-anchor-button--paired-secondary"
+                [disabled]="controlPending()"
+                (click)="nextQuestion()"
+                i18n-aria-label="@@sessionHost.skipDiscussionFinishEvaluationAria"
+                aria-label="Zur Gesamtauswertung ohne zweite Abstimmung"
+              >
+                <span i18n="@@sessionHost.skipDiscussionFinishEvaluation"
+                  >Zur Gesamtauswertung ohne zweite Abstimmung</span
+                >
+              </button>
+            }
           </div>
         }
       </div>

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.scss
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.scss
@@ -241,7 +241,8 @@
 }
 
 .session-host__exit-anchor-label--previous-compact,
-.session-host__exit-anchor-label--reveal-options-compact {
+.session-host__exit-anchor-label--reveal-options-compact,
+.session-host__exit-anchor-label--finish-evaluation-compact {
   display: none;
 }
 
@@ -335,17 +336,20 @@
 
 @media (max-width: 599px) and (orientation: portrait) {
   .session-host__exit-anchor-button--previous,
-  .session-host__exit-anchor-button--reveal-options {
+  .session-host__exit-anchor-button--reveal-options,
+  .session-host__exit-anchor-button--finish-evaluation {
     padding-inline: 0.5rem;
   }
 
   .session-host__exit-anchor-label--previous-full,
-  .session-host__exit-anchor-label--reveal-options-full {
+  .session-host__exit-anchor-label--reveal-options-full,
+  .session-host__exit-anchor-label--finish-evaluation-full {
     display: none;
   }
 
   .session-host__exit-anchor-label--previous-compact,
-  .session-host__exit-anchor-label--reveal-options-compact {
+  .session-host__exit-anchor-label--reveal-options-compact,
+  .session-host__exit-anchor-label--finish-evaluation-compact {
     display: inline;
     white-space: normal;
     overflow-wrap: anywhere;
@@ -4861,14 +4865,18 @@ button.session-host__btn-discussion {
 }
 
 .session-host__question-last-badge {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   font: var(--mat-sys-label-medium);
-  font-weight: 600;
-  color: var(--mat-sys-primary);
-  background: color-mix(in srgb, var(--mat-sys-primary) 14%, transparent);
-  border: 1.5px solid var(--mat-sys-primary);
-  border-radius: var(--mat-sys-corner-small, 6px);
-  padding: 0.25rem 0.6rem;
+  font-weight: 500;
+  letter-spacing: 0.00625em;
+  color: var(--mat-sys-on-surface-variant);
+  background: var(--mat-sys-surface-container-high);
+  border: 0;
+  border-radius: var(--mat-sys-corner-extra-small);
+  padding: 0.125rem 0.5rem;
+  pointer-events: none;
+  user-select: none;
 }
 
 .session-host__all-voted {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -9510,6 +9510,61 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     fixture.destroy();
   });
 
+  it('behält nach Reload im Rückblick Gesamtauswertung und überspringt die bereits geöffnete Folgefrage', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 11 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'bbbbbbbb-2222-4222-8222-222222222222',
+      order: 11,
+      totalQuestions: 13,
+      text: 'Was hilft dir beim Lernen?',
+      type: 'FREETEXT',
+      canShowPreviousResult: true,
+      hasNextQuestion: true,
+      hasUnopenedFollowingQuestion: false,
+      answers: [],
+      freeTextResponses: ['Notizen'],
+      totalVotes: 1,
+    });
+    nextQuestionMutateMock.mockResolvedValue({
+      status: 'FINISHED',
+      currentQuestion: null,
+      currentRound: 1,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 11,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.skipCurrentResultQuestionOnNext()).toBe(false);
+    const exitAnchor = fixture.nativeElement.querySelector(
+      '.session-host__exit-anchor',
+    ) as HTMLElement;
+    expect(exitAnchor.textContent).toContain('Zur Gesamtauswertung');
+    expect(
+      Array.from(exitAnchor.querySelectorAll('button'), (button) =>
+        (button.textContent ?? '').trim(),
+      ).some((text) => text === 'Nächste Frage'),
+    ).toBe(false);
+
+    await fixture.componentInstance.nextQuestion();
+    expect(nextQuestionMutateMock).toHaveBeenCalledWith({
+      code: 'ABC123',
+      skipCurrentResultQuestion: true,
+    });
+    fixture.destroy();
+  });
+
   it('zeigt nach einem Rückblick nicht den Hinweis "Letzte Frage"', async () => {
     const lastQuestion = {
       questionId: 'cccccccc-3333-4333-8333-333333333333',

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -41,6 +41,7 @@ const {
   qaToggleModerationMutateMock,
   qaOnQuestionsUpdatedSubscribeMock,
   nextQuestionMutateMock,
+  prevQuestionMutateMock,
   skipQuestionMutateMock,
   revealAnswersMutateMock,
   revealResultsMutateMock,
@@ -86,6 +87,7 @@ const {
   qaToggleModerationMutateMock: vi.fn(),
   qaOnQuestionsUpdatedSubscribeMock: vi.fn(() => ({ unsubscribe: unsubscribeMock })),
   nextQuestionMutateMock: vi.fn(),
+  prevQuestionMutateMock: vi.fn(),
   skipQuestionMutateMock: vi.fn(),
   revealAnswersMutateMock: vi.fn(),
   revealResultsMutateMock: vi.fn(),
@@ -130,6 +132,7 @@ vi.mock('../../../core/trpc.client', () => ({
       getExportData: { query: getExportDataQueryMock },
       getSessionConfidenceSummary: { query: getSessionConfidenceSummaryQueryMock },
       nextQuestion: { mutate: nextQuestionMutateMock },
+      prevQuestion: { mutate: prevQuestionMutateMock },
       skipQuestion: { mutate: skipQuestionMutateMock },
       revealAnswers: { mutate: revealAnswersMutateMock },
       revealResults: { mutate: revealResultsMutateMock },
@@ -471,6 +474,11 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
       currentQuestion: null,
       currentRound: 1,
       activeAt: null,
+    });
+    prevQuestionMutateMock.mockResolvedValue({
+      status: 'RESULTS',
+      currentQuestion: 0,
+      currentRound: 1,
     });
     skipQuestionMutateMock.mockResolvedValue({
       status: 'ACTIVE',
@@ -6528,6 +6536,61 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     fixture.destroy();
   });
 
+  it('weist beim Auslassen der letzten Frage darauf hin, dass die Session endet', async () => {
+    const questionId = 'bbbbbbbb-2222-4222-8222-222222222222';
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'ACTIVE' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'ACTIVE', currentQuestion: 0 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId,
+      order: 0,
+      totalQuestions: 1,
+      text: 'Letzte Frage im Quiz',
+      type: 'SINGLE_CHOICE',
+      hasNextQuestion: false,
+      hasUnopenedFollowingQuestion: false,
+      answers: [{ id: 'aaaaaaaa-1111-4111-8111-111111111111', text: 'A', isCorrect: true }],
+      totalVotes: 0,
+    });
+    skipQuestionMutateMock.mockResolvedValue({
+      status: 'FINISHED',
+      currentQuestion: null,
+      currentRound: 1,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 0,
+      { timeout: 5000, interval: 25 },
+    );
+
+    await fixture.componentInstance.skipQuestion();
+
+    expect(dialogOpenMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          consequences: ['Es folgt keine weitere Frage. Die Session wird beendet.'],
+        }),
+      }),
+    );
+    expect(skipQuestionMutateMock).toHaveBeenCalledWith({ code: 'ABC123', questionId });
+    const snackBar = TestBed.inject(MatSnackBar);
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Frage ausgelassen. Die Session ist beendet.',
+      '',
+      expect.objectContaining({ duration: 4000 }),
+    );
+    fixture.destroy();
+  });
+
   it('stellt den laufenden Countdown nach einem fehlgeschlagenen Skip wieder her', async () => {
     const questionId = 'bbbbbbbb-2222-4222-8222-222222222222';
     const serverTime = new Date().toISOString();
@@ -8884,7 +8947,11 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
   });
 
   it('ordnet bei Ergebnisstand Ausstieg und Rückblick vor der Aktion "Nächste Frage" an', async () => {
-    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    getInfoQueryMock.mockResolvedValue({
+      ...defaultSession,
+      status: 'RESULTS',
+      currentQuestion: 1,
+    });
     onStatusChangedSubscribeMock.mockImplementation(
       (_input: unknown, opts: { onData: (d: unknown) => void }) => {
         opts.onData({ status: 'RESULTS', currentQuestion: 1 });
@@ -8895,6 +8962,9 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
       questionId: 'bbbbbbbb-2222-4222-8222-222222222222',
       order: 1,
       totalQuestions: 3,
+      canShowPreviousResult: true,
+      hasNextQuestion: true,
+      hasUnopenedFollowingQuestion: true,
       text: 'Welche Antwort ist richtig?',
       type: 'SINGLE_CHOICE',
       answers: [
@@ -8925,6 +8995,11 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     fixture.detectChanges();
     await flushComponentAfterStable(fixture, 50);
     fixture.detectChanges();
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 1,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
 
     const exitAnchor = fixture.nativeElement.querySelector(
       '.session-host__exit-anchor',
@@ -8933,6 +9008,13 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
       (button.textContent ?? '').trim(),
     );
 
+    expect(exitAnchor.className).toContain('session-host__exit-anchor--with-primary');
+    expect(buttonTexts).toEqual([
+      'Session beenden',
+      'Letztes Ergebnis erneut anzeigenLetztes Ergebnis',
+      'Nächste Frage',
+    ]);
+
     const previousButton = exitAnchor.querySelector('.session-host__exit-anchor-button--previous');
     const previousFullLabel = previousButton?.querySelector(
       '.session-host__exit-anchor-label--previous-full',
@@ -8940,19 +9022,652 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     const previousTooltip = fixture.debugElement
       .query(By.css('.session-host__exit-anchor-button--previous'))
       .injector.get(MatTooltip);
-
-    expect(exitAnchor.className).toContain('session-host__exit-anchor--with-primary');
-    expect(buttonTexts).toEqual([
-      'Session beenden',
-      'Letztes Ergebnis erneut anzeigenLetztes Ergebnis',
-      'Nächste Frage',
-    ]);
     expect(previousFullLabel?.textContent).toBe('Letztes Ergebnis erneut anzeigen');
     expect(previousTooltip.touchGestures).toBe('off');
     expect(
       previousButton?.querySelector('.session-host__exit-anchor-label--previous-compact')
         ?.textContent,
     ).toBe('Letztes Ergebnis');
+    fixture.destroy();
+  });
+
+  it('blendet Letztes Ergebnis auf der ersten Frage aus', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 0 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'aaaaaaaa-1111-4111-8111-111111111111',
+      order: 0,
+      totalQuestions: 13,
+      text: 'Wie fühlt sich der Raum an?',
+      type: 'SURVEY',
+      canShowPreviousResult: false,
+      answers: [
+        { id: 'aaaaaaaa-1111-4111-8111-111111111111', text: 'Gut', isCorrect: false },
+        { id: 'bbbbbbbb-2222-4222-8222-222222222222', text: 'Okay', isCorrect: false },
+      ],
+      voteDistribution: [
+        {
+          id: 'aaaaaaaa-1111-4111-8111-111111111111',
+          text: 'Gut',
+          isCorrect: false,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+        {
+          id: 'bbbbbbbb-2222-4222-8222-222222222222',
+          text: 'Okay',
+          isCorrect: false,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+      ],
+      totalVotes: 0,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.querySelector('.session-host__exit-anchor-button--previous')).toBeNull();
+    expect(host.textContent).not.toContain('Letztes Ergebnis');
+    fixture.destroy();
+  });
+
+  it('blendet Letztes Ergebnis aus, wenn das Quiz ab einer späteren Frage gestartet wurde', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 2 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'cccccccc-3333-4333-8333-333333333333',
+      order: 2,
+      totalQuestions: 4,
+      text: 'Startfrage',
+      type: 'FREETEXT',
+      canShowPreviousResult: false,
+      hasNextQuestion: true,
+      hasUnopenedFollowingQuestion: true,
+      answers: [],
+      freeTextResponses: [],
+      totalVotes: 1,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 2,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const buttonTexts = [...host.querySelectorAll('button')].map((button) =>
+      (button.textContent ?? '').replace(/\s+/g, ' ').trim(),
+    );
+    expect(host.querySelector('.session-host__exit-anchor-button--previous')).toBeNull();
+    expect(host.textContent).not.toContain('Letztes Ergebnis');
+    expect(host.querySelector('.session-host__question-last-badge')).toBeNull();
+    expect(buttonTexts).toContain('Nächste Frage');
+    expect(buttonTexts.some((text) => text.includes('Zur Gesamtauswertung'))).toBe(false);
+    fixture.destroy();
+  });
+
+  it('zeigt auf der letzten Frage nach Start ab hier Gesamtauswertung statt Vorgänger', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 3 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'dddddddd-4444-4444-8444-444444444444',
+      order: 3,
+      totalQuestions: 4,
+      text: 'Letzte Frage',
+      type: 'FREETEXT',
+      canShowPreviousResult: false,
+      hasNextQuestion: false,
+      hasUnopenedFollowingQuestion: false,
+      answers: [],
+      freeTextResponses: ['ok'],
+      totalVotes: 1,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 3,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const buttonTexts = [...host.querySelectorAll('button')].map((button) =>
+      (button.textContent ?? '').replace(/\s+/g, ' ').trim(),
+    );
+    expect(host.querySelector('.session-host__exit-anchor-button--previous')).toBeNull();
+    expect(host.textContent).toContain('Letzte Frage');
+    expect(buttonTexts).not.toContain('Nächste Frage');
+    expect(buttonTexts.some((text) => text.includes('Zur Gesamtauswertung'))).toBe(true);
+    fixture.destroy();
+  });
+
+  it('blendet Letztes Ergebnis aus, wenn die Vorgängerfrage ausgelassen wurde', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 1 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'bbbbbbbb-2222-4222-8222-222222222222',
+      order: 1,
+      totalQuestions: 13,
+      text: 'Was hilft dir beim Lernen?',
+      type: 'FREETEXT',
+      canShowPreviousResult: false,
+      answers: [],
+      freeTextResponses: [],
+      totalVotes: 0,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('.session-host__exit-anchor-button--previous'),
+    ).toBeNull();
+    fixture.destroy();
+  });
+
+  it('zeigt nach prevQuestion das Umfrage-Ergebnis ohne Musterlösung und ohne Steuerungs-Callout', async () => {
+    const freetextQuestion = {
+      questionId: 'bbbbbbbb-2222-4222-8222-222222222222',
+      order: 1,
+      totalQuestions: 13,
+      text: 'Was hilft dir beim Lernen?',
+      type: 'FREETEXT' as const,
+      canShowPreviousResult: true,
+      answers: [] as { id: string; text: string; isCorrect: boolean }[],
+      freeTextResponses: [] as string[],
+      totalVotes: 0,
+    };
+    const surveyQuestion = {
+      questionId: 'aaaaaaaa-1111-4111-8111-111111111111',
+      order: 0,
+      totalQuestions: 13,
+      text: 'Wie fühlt sich der Raum an?',
+      type: 'SURVEY' as const,
+      canShowPreviousResult: false,
+      answers: [
+        { id: 'aaaaaaaa-1111-4111-8111-111111111111', text: 'Gut', isCorrect: false },
+        { id: 'bbbbbbbb-2222-4222-8222-222222222222', text: 'Okay', isCorrect: false },
+      ],
+      voteDistribution: [
+        {
+          id: 'aaaaaaaa-1111-4111-8111-111111111111',
+          text: 'Gut',
+          isCorrect: false,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+        {
+          id: 'bbbbbbbb-2222-4222-8222-222222222222',
+          text: 'Okay',
+          isCorrect: false,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+      ],
+      totalVotes: 0,
+    };
+
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 1 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue(freetextQuestion);
+    prevQuestionMutateMock.mockResolvedValue({
+      status: 'RESULTS',
+      currentQuestion: 0,
+      currentRound: 1,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('.session-host__exit-anchor-button--previous'),
+    ).not.toBeNull();
+
+    getCurrentQuestionForHostQueryMock.mockResolvedValue(surveyQuestion);
+    await fixture.componentInstance.prevQuestion();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    expect(prevQuestionMutateMock).toHaveBeenCalledWith({ code: 'ABC123' });
+    expect(fixture.componentInstance.steppedBackToPreviousResult()).toBe(true);
+    expect(fixture.componentInstance.displayedCurrentQuestionForHost()?.type).toBe('SURVEY');
+    expect(host.querySelector('.session-host__exit-anchor-button--previous')).toBeNull();
+    expect(host.querySelector('[data-testid="host-steering-retry"]')).toBeNull();
+    expect(host.textContent).toContain('Gut');
+    expect(host.querySelector('.session-host__extra--freetext')).toBeNull();
+    fixture.destroy();
+  });
+
+  it('zeigt bei fehlender Vorgängerfrage keinen WLAN-Steuerungs-Callout', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 1 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'bbbbbbbb-2222-4222-8222-222222222222',
+      order: 1,
+      totalQuestions: 13,
+      text: 'Was hilft dir beim Lernen?',
+      type: 'FREETEXT',
+      canShowPreviousResult: true,
+      answers: [],
+      freeTextResponses: [],
+      totalVotes: 0,
+    });
+    prevQuestionMutateMock.mockRejectedValueOnce(
+      new Error('BAD_REQUEST: Bereits bei der ersten Frage – Rückwärtsnavigation nicht möglich.'),
+    );
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+
+    await fixture.componentInstance.prevQuestion();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.hostSteeringCallout()).toBeNull();
+    expect(fixture.componentInstance.steppedBackToPreviousResult()).toBe(true);
+    fixture.destroy();
+  });
+
+  it('bietet auf der letzten Frage mit Ergebnissen "Zur Gesamtauswertung" statt "Nächste Frage"', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 12 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'cccccccc-3333-4333-8333-333333333333',
+      order: 12,
+      totalQuestions: 13,
+      text: 'Was nimmst du mit?',
+      type: 'FREETEXT',
+      canShowPreviousResult: true,
+      hasNextQuestion: false,
+      hasUnopenedFollowingQuestion: false,
+      answers: [],
+      freeTextResponses: ['Wiederholen'],
+      totalVotes: 1,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 12,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const exitAnchor = host.querySelector('.session-host__exit-anchor') as HTMLElement;
+    expect(host.querySelector('.session-host__question-last-badge')?.textContent).toContain(
+      'Letzte Frage',
+    );
+    expect(host.querySelector('.session-host__question-last-badge')?.tagName).toBe('SPAN');
+    expect(host.querySelector('.session-host__exit-anchor-button--last-question')).toBeNull();
+    expect(exitAnchor.textContent).toContain('Zur Gesamtauswertung');
+    expect(exitAnchor.textContent).toContain('Auswertung');
+    expect(
+      Array.from(exitAnchor.querySelectorAll('button'), (button) =>
+        (button.textContent ?? '').trim(),
+      ).some((text) => text === 'Nächste Frage'),
+    ).toBe(false);
+    fixture.destroy();
+  });
+
+  it('zeigt auf der letzten Frage ohne verwertbare Ergebnisse nur die Markierung "Letzte Frage"', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 0 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'aaaaaaaa-1111-4111-8111-111111111111',
+      order: 0,
+      totalQuestions: 1,
+      text: 'Wie fühlt sich der Raum an?',
+      type: 'SURVEY',
+      canShowPreviousResult: false,
+      hasNextQuestion: false,
+      hasUnopenedFollowingQuestion: false,
+      answers: [
+        { id: 'aaaaaaaa-1111-4111-8111-111111111111', text: 'Gut', isCorrect: false },
+        { id: 'bbbbbbbb-2222-4222-8222-222222222222', text: 'Okay', isCorrect: false },
+      ],
+      voteDistribution: [
+        {
+          id: 'aaaaaaaa-1111-4111-8111-111111111111',
+          text: 'Gut',
+          isCorrect: false,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+        {
+          id: 'bbbbbbbb-2222-4222-8222-222222222222',
+          text: 'Okay',
+          isCorrect: false,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+      ],
+      totalVotes: 0,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 0,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const lastHint = host.querySelector('.session-host__question-last-badge');
+    const exitAnchor = host.querySelector('.session-host__exit-anchor') as HTMLElement;
+    expect(lastHint?.tagName).toBe('SPAN');
+    expect(lastHint?.getAttribute('role')).toBe('status');
+    expect(lastHint?.textContent).toContain('Letzte Frage');
+    expect(host.querySelector('.session-host__exit-anchor-button--last-question')).toBeNull();
+    expect(
+      Array.from(exitAnchor.querySelectorAll('button'), (button) =>
+        (button.textContent ?? '').trim(),
+      ).some((text) => text.includes('Letzte Frage')),
+    ).toBe(false);
+    expect(host.textContent).not.toContain('Nächste Frage');
+    expect(host.textContent).not.toContain('Zur Gesamtauswertung');
+    fixture.destroy();
+  });
+
+  it('bietet nach Rückblick von der letzten Frage "Zur Gesamtauswertung" statt "Nächste Frage"', async () => {
+    const lastQuestion = {
+      questionId: 'cccccccc-3333-4333-8333-333333333333',
+      order: 12,
+      totalQuestions: 13,
+      text: 'Was nimmst du mit?',
+      type: 'FREETEXT' as const,
+      canShowPreviousResult: true,
+      hasNextQuestion: false,
+      hasUnopenedFollowingQuestion: false,
+      answers: [] as { id: string; text: string; isCorrect: boolean }[],
+      freeTextResponses: ['Wiederholen'],
+      totalVotes: 1,
+    };
+    const previousQuestion = {
+      questionId: 'bbbbbbbb-2222-4222-8222-222222222222',
+      order: 11,
+      totalQuestions: 13,
+      text: 'Was hilft dir beim Lernen?',
+      type: 'FREETEXT' as const,
+      canShowPreviousResult: true,
+      hasNextQuestion: true,
+      hasUnopenedFollowingQuestion: false,
+      answers: [] as { id: string; text: string; isCorrect: boolean }[],
+      freeTextResponses: ['Notizen'],
+      totalVotes: 1,
+    };
+
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 12 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue(lastQuestion);
+    prevQuestionMutateMock.mockResolvedValue({
+      status: 'RESULTS',
+      currentQuestion: 11,
+      currentRound: 1,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 12,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    getCurrentQuestionForHostQueryMock.mockResolvedValue(previousQuestion);
+    await fixture.componentInstance.prevQuestion();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 11,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    const exitAnchor = fixture.nativeElement.querySelector(
+      '.session-host__exit-anchor',
+    ) as HTMLElement;
+    expect(fixture.componentInstance.skipCurrentResultQuestionOnNext()).toBe(true);
+    expect(exitAnchor.textContent).toContain('Zur Gesamtauswertung');
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('.session-host__question-last-badge'),
+    ).toBeNull();
+    expect(exitAnchor.textContent).not.toContain('Letzte Frage');
+    expect(
+      Array.from(exitAnchor.querySelectorAll('button'), (button) =>
+        (button.textContent ?? '').trim(),
+      ).some((text) => text === 'Nächste Frage'),
+    ).toBe(false);
+    fixture.destroy();
+  });
+
+  it('zeigt nach einem Rückblick nicht den Hinweis "Letzte Frage"', async () => {
+    const lastQuestion = {
+      questionId: 'cccccccc-3333-4333-8333-333333333333',
+      order: 1,
+      totalQuestions: 2,
+      text: 'Zweite Frage',
+      type: 'SURVEY' as const,
+      canShowPreviousResult: true,
+      hasNextQuestion: false,
+      hasUnopenedFollowingQuestion: false,
+      answers: [
+        { id: 'aaaaaaaa-1111-4111-8111-111111111111', text: 'Gut', isCorrect: false },
+        { id: 'bbbbbbbb-2222-4222-8222-222222222222', text: 'Okay', isCorrect: false },
+      ],
+      voteDistribution: [
+        {
+          id: 'aaaaaaaa-1111-4111-8111-111111111111',
+          text: 'Gut',
+          isCorrect: false,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+        {
+          id: 'bbbbbbbb-2222-4222-8222-222222222222',
+          text: 'Okay',
+          isCorrect: false,
+          voteCount: 0,
+          votePercentage: 0,
+        },
+      ],
+      totalVotes: 0,
+    };
+    const previousQuestion = {
+      ...lastQuestion,
+      questionId: 'aaaaaaaa-1111-4111-8111-111111111111',
+      order: 0,
+      text: 'Erste Frage',
+      canShowPreviousResult: false,
+      hasNextQuestion: true,
+      hasUnopenedFollowingQuestion: false,
+    };
+
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'RESULTS' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'RESULTS', currentQuestion: 1 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue(lastQuestion);
+    prevQuestionMutateMock.mockResolvedValue({
+      status: 'RESULTS',
+      currentQuestion: 0,
+      currentRound: 1,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 1,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('.session-host__question-last-badge')
+        ?.textContent,
+    ).toContain('Letzte Frage');
+
+    getCurrentQuestionForHostQueryMock.mockResolvedValue(previousQuestion);
+    await fixture.componentInstance.prevQuestion();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 0,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    expect(fixture.componentInstance.steppedBackToPreviousResult()).toBe(true);
+    expect(host.querySelector('.session-host__question-last-badge')).toBeNull();
+    expect(host.querySelector('.session-host__exit-anchor-button--last-question')).toBeNull();
+    expect(host.textContent).not.toContain('Letzte Frage');
+    fixture.destroy();
+  });
+
+  it('zeigt in der Diskussionsphase der letzten Frage den Weg zur Gesamtauswertung', async () => {
+    getInfoQueryMock.mockResolvedValue({ ...defaultSession, status: 'DISCUSSION' });
+    onStatusChangedSubscribeMock.mockImplementation(
+      (_input: unknown, opts: { onData: (d: unknown) => void }) => {
+        opts.onData({ status: 'DISCUSSION', currentQuestion: 2 });
+        return { unsubscribe: unsubscribeMock };
+      },
+    );
+    getCurrentQuestionForHostQueryMock.mockResolvedValue({
+      questionId: 'bbbbbbbb-2222-4222-8222-222222222222',
+      order: 2,
+      totalQuestions: 3,
+      text: 'Welche Antwort ist richtig?',
+      type: 'SINGLE_CHOICE',
+      currentRound: 1,
+      timer: 30,
+      activeAt: null,
+      canShowPreviousResult: true,
+      hasNextQuestion: false,
+      hasUnopenedFollowingQuestion: false,
+      answers: [
+        { id: 'aaaaaaaa-1111-4111-8111-111111111111', text: 'A', isCorrect: false },
+        { id: 'bbbbbbbb-2222-4222-8222-222222222222', text: 'B', isCorrect: true },
+      ],
+      voteDistribution: [
+        {
+          id: 'aaaaaaaa-1111-4111-8111-111111111111',
+          text: 'A',
+          isCorrect: false,
+          voteCount: 1,
+          votePercentage: 50,
+        },
+        {
+          id: 'bbbbbbbb-2222-4222-8222-222222222222',
+          text: 'B',
+          isCorrect: true,
+          voteCount: 1,
+          votePercentage: 50,
+        },
+      ],
+      totalVotes: 2,
+      correctVoterCount: 1,
+    });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    fixture.detectChanges();
+    await vi.waitUntil(
+      () => fixture.componentInstance.displayedCurrentQuestionForHost()?.order === 2,
+      { timeout: 5000, interval: 25 },
+    );
+    fixture.detectChanges();
+
+    const exitAnchor = fixture.nativeElement.querySelector(
+      '.session-host__exit-anchor',
+    ) as HTMLElement;
+    const buttonTexts = Array.from(exitAnchor.querySelectorAll('button'), (button) =>
+      (button.textContent ?? '').replace(/^replay/, '').trim(),
+    );
+
+    expect(buttonTexts).toEqual([
+      'Session beenden',
+      'Letztes Ergebnis erneut anzeigenLetztes Ergebnis',
+      'Zweite Abstimmung',
+      'Zur Gesamtauswertung ohne zweite Abstimmung',
+    ]);
+    expect(exitAnchor.textContent).not.toContain('Zur nächsten Frage ohne zweite Abstimmung');
     fixture.destroy();
   });
 
@@ -8982,7 +9697,7 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     ]);
 
     expect(styles).toMatch(
-      /@media \(max-width: 599px\) and \(orientation: portrait\)[\s\S]*?session-host__exit-anchor-label--previous-compact,\s*\.session-host__exit-anchor-label--reveal-options-compact\s*\{[^}]*white-space:\s*normal[^}]*overflow-wrap:\s*anywhere[^}]*hyphens:\s*auto/,
+      /@media \(max-width: 599px\) and \(orientation: portrait\)[\s\S]*?session-host__exit-anchor-label--previous-compact,\s*\.session-host__exit-anchor-label--reveal-options-compact,\s*\.session-host__exit-anchor-label--finish-evaluation-compact\s*\{[^}]*white-space:\s*normal[^}]*overflow-wrap:\s*anywhere[^}]*hyphens:\s*auto/,
     );
     expect(styles).toMatch(
       /session-host__exit-anchor-action-pair\s*>\s*\.session-host__exit-anchor-button--paired-secondary\s*\{[^}]*grid-column:\s*1[^}]*grid-row:\s*1/,
@@ -9021,6 +9736,25 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
 
       expect(unitStart).toBeGreaterThanOrEqual(0);
       expect(unit).toContain(`<target>${expectedLabel}</target>`);
+    }
+
+    const finishEvaluationTranslations = new Map([
+      ['messages.en.xlf', 'Results'],
+      ['messages.fr.xlf', 'Bilan'],
+      ['messages.es.xlf', 'Resumen'],
+      ['messages.it.xlf', 'Sintesi'],
+    ]);
+    for (const [fileName, expectedLabel] of finishEvaluationTranslations) {
+      const catalog = readFileSync(join(componentDir, '../../../../locale', fileName), 'utf8');
+      const unitStart = catalog.indexOf(
+        '<trans-unit id="sessionHost.finishEvaluationAnchorCompact"',
+      );
+      const unitEnd = catalog.indexOf('</trans-unit>', unitStart);
+      const unit = catalog.slice(unitStart, unitEnd);
+
+      expect(unitStart).toBeGreaterThanOrEqual(0);
+      expect(unit).toContain(`<target>${expectedLabel}</target>`);
+      expect(expectedLabel.length).toBeLessThanOrEqual(11);
     }
   });
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -417,6 +417,11 @@ function isScoredQuestionType(type: HostCurrentQuestionDTO['type'] | null | unde
   );
 }
 
+function isPrevQuestionUnavailableError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.message.includes('Rückwärtsnavigation nicht möglich');
+}
+
 function sameStringArray(
   left: readonly string[] | null | undefined,
   right: readonly string[] | null | undefined,
@@ -5708,18 +5713,72 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     return this.session()?.currentQuestion;
   }
 
-  /** True, wenn die aktuelle Frage die letzte ist – dann zeigt der Steuerungs-Button „Session beenden“. */
+  /** Fallback: letzte Vorlagenfrage nach Reihenfolge, wenn das DTO keine Folgemarker liefert. */
   isLastQuestion(): boolean {
     const q = this.displayedCurrentQuestionForHost();
     if (!q || q.totalQuestions === null || q.totalQuestions === undefined) return false;
     return q.order + 1 >= q.totalQuestions;
   }
 
-  isFirstQuestion(): boolean {
+  /**
+   * True, wenn der Host aus RESULTS/DISCUSSION auf eine enthaltene Vorgängerfrage
+   * zurückblättern kann. Unabhängig von Musterlösung; ohne Frage-DTO unsichtbar.
+   */
+  canShowPreviousResultAnchor(): boolean {
+    if (this.steppedBackToPreviousResult()) return false;
     const q = this.displayedCurrentQuestionForHost();
     if (!q) return false;
-    return q.order === 0;
+    if (typeof q.canShowPreviousResult === 'boolean') {
+      return q.canShowPreviousResult;
+    }
+    return q.order !== 0;
   }
+
+  /** Ob nach der aktuellen (bzw. nach einem Rückblick) noch eine Frage geöffnet werden kann. */
+  readonly canOpenFollowingQuestion = computed(() => {
+    const q = this.displayedCurrentQuestionForHost();
+    if (!q) return false;
+    if (this.skipCurrentResultQuestionOnNext()) {
+      if (typeof q.hasUnopenedFollowingQuestion === 'boolean') {
+        return q.hasUnopenedFollowingQuestion;
+      }
+      return !this.isLastQuestion();
+    }
+    if (typeof q.hasNextQuestion === 'boolean') {
+      return q.hasNextQuestion;
+    }
+    return !this.isLastQuestion();
+  });
+
+  readonly hasOverallEvaluation = computed(() => {
+    if ((this.participantsPayload()?.participantCount ?? 0) > 0) return true;
+    if (this.leaderboard().length > 0 || this.teamLeaderboard().length > 0) return true;
+    if (this.freetextResponses().length > 0) return true;
+    const q = this.displayedCurrentQuestionForHost();
+    if (!q) return false;
+    if ((q.totalVotes ?? 0) > 0) return true;
+    if ((q.freeTextResponses?.length ?? 0) > 0) return true;
+    if ((q.ratingCount ?? 0) > 0) return true;
+    return q.voteDistribution?.some((entry) => entry.voteCount > 0) === true;
+  });
+
+  readonly showFinishEvaluationAnchor = computed(() => {
+    if (this.displayedCurrentQuestionForHost() === null) return false;
+    return !this.canOpenFollowingQuestion() && this.hasOverallEvaluation();
+  });
+
+  /** Statischer Hinweis auf der Fragenkarte, nicht in der Aktionsleiste. */
+  readonly showLastQuestionBadge = computed(() => {
+    if (this.steppedBackToPreviousResult() || this.skipCurrentResultQuestionOnNext()) {
+      return false;
+    }
+    const q = this.displayedCurrentQuestionForHost();
+    if (!q) return false;
+    if (typeof q.hasNextQuestion === 'boolean') {
+      return !q.hasNextQuestion;
+    }
+    return this.isLastQuestion();
+  });
 
   countdownAriaLabel(): string {
     const seconds = this.countdownSeconds() ?? 0;
@@ -7456,16 +7515,23 @@ export class SessionHostComponent implements OnInit, OnDestroy {
         : null;
 
     const voteCount = this.hostVoteCount(question);
+    const skipFinishesSession = !this.canOpenFollowingQuestion();
+    const consequences: string[] = [];
+    if (voteCount > 0) {
+      consequences.push(
+        $localize`:@@sessionHost.skipQuestionDialogVotes:Bereits abgegebene Antworten werden nicht ausgewertet.`,
+      );
+    }
+    if (skipFinishesSession) {
+      consequences.push(
+        $localize`:@@sessionHost.skipQuestionDialogEndsSession:Es folgt keine weitere Frage. Die Session wird beendet.`,
+      );
+    }
     const dialogRef = this.dialog.open(ConfirmLeaveDialogComponent, {
       data: {
         title: $localize`:@@sessionHost.skipQuestionDialogTitle:Frage auslassen?`,
         message: $localize`:@@sessionHost.skipQuestionDialogMessage:Diese Frage wird aus der laufenden Session und der Nachbesprechung ausgeschlossen.`,
-        consequences:
-          voteCount > 0
-            ? [
-                $localize`:@@sessionHost.skipQuestionDialogVotes:Bereits abgegebene Antworten werden nicht ausgewertet.`,
-              ]
-            : [],
+        consequences,
         confirmLabel: $localize`:@@sessionHost.skipQuestionConfirm:Frage auslassen`,
         cancelLabel: $localize`:@@sessionHost.skipQuestionCancel:Frage behalten`,
       } satisfies ConfirmLeaveDialogData,
@@ -7503,7 +7569,13 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       this.dismissHostSteeringCallout();
       await this.refreshCurrentQuestionForHost();
       this.focusAfterQuestionSkip(result.status);
-      if (result.status !== 'FINISHED') {
+      if (result.status === 'FINISHED') {
+        this.snackBar.open(
+          $localize`:@@sessionHost.skipQuestionSuccessFinished:Frage ausgelassen. Die Session ist beendet.`,
+          '',
+          { duration: 4000 },
+        );
+      } else {
         this.snackBar.open(
           $localize`:@@sessionHost.skipQuestionSuccess:Frage ausgelassen. Die nächste Frage wurde gestartet.`,
           '',
@@ -7567,6 +7639,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
 
   async prevQuestion(): Promise<void> {
     if (this.controlPending() || !this.code) return;
+    if (!this.canShowPreviousResultAnchor()) return;
     this.controlPending.set(true);
     try {
       const result = await trpc.session.prevQuestion.mutate({ code: this.code.toUpperCase() });
@@ -7576,7 +7649,14 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       this.dismissHostSteeringCallout();
       this.controlPending.set(false);
       await this.refreshCurrentQuestionForHost();
-    } catch {
+      if (this.shouldPollLiveFreetext()) {
+        await this.refreshLiveFreetext();
+      }
+    } catch (error) {
+      if (isPrevQuestionUnavailableError(error)) {
+        this.steppedBackToPreviousResult.set(true);
+        return;
+      }
       this.openHostSteeringCalloutForSteeringFailure(() => void this.prevQuestion());
     } finally {
       this.controlPending.set(false);

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -5738,10 +5738,10 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   readonly canOpenFollowingQuestion = computed(() => {
     const q = this.displayedCurrentQuestionForHost();
     if (!q) return false;
+    if (typeof q.hasUnopenedFollowingQuestion === 'boolean') {
+      return q.hasUnopenedFollowingQuestion;
+    }
     if (this.skipCurrentResultQuestionOnNext()) {
-      if (typeof q.hasUnopenedFollowingQuestion === 'boolean') {
-        return q.hasUnopenedFollowingQuestion;
-      }
       return !this.isLastQuestion();
     }
     if (typeof q.hasNextQuestion === 'boolean') {
@@ -5749,6 +5749,16 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     }
     return !this.isLastQuestion();
   });
+
+  /**
+   * Aus RESULTS/DISCUSSION immer die bereits geöffnete Folgefrage überspringen.
+   * Nach Reload ist `skipCurrentResultQuestionOnNext` weg; die DTO-Flags bleiben.
+   */
+  private shouldSkipCurrentResultQuestionOnNext(): boolean {
+    if (this.skipCurrentResultQuestionOnNext()) return true;
+    const status = this.effectiveStatus();
+    return status === 'RESULTS' || status === 'DISCUSSION';
+  }
 
   readonly hasOverallEvaluation = computed(() => {
     if ((this.participantsPayload()?.participantCount ?? 0) > 0) return true;
@@ -7469,7 +7479,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       this.countdownSeconds.set(null);
       const result = await trpc.session.nextQuestion.mutate({
         code: this.code.toUpperCase(),
-        ...(this.skipCurrentResultQuestionOnNext() && { skipCurrentResultQuestion: true }),
+        ...(this.shouldSkipCurrentResultQuestionOnNext() && { skipCurrentResultQuestion: true }),
       });
       if (startingQuizFromLobby && typeof result.currentQuestion !== 'number') {
         this.quizStartQuestionPending.set(false);

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -14803,7 +14803,7 @@
           <context context-type="linenumber">1441,1442</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1017989655370592681" datatype="html">
+      <trans-unit id="sessionHost.lastQuestionBadge" datatype="html">
         <source>Letzte Frage</source>
         <target>Last question</target>
         <context-group purpose="location">
@@ -15371,12 +15371,12 @@
           <context context-type="linenumber">3279,3281</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7435414614973406916" datatype="html">
-        <source> Keine Frage aktiv. Mit „Nächste Frage“ starten.</source>
-        <target>No question is live yet—tap “Next question” to begin.</target>
+      <trans-unit id="sessionHost.noActiveQuestion" datatype="html">
+        <source>Keine Frage aktiv.</source>
+        <target>No question is active.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3283,3285</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -15729,8 +15729,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
-        <source>Zeigt die letzte Frage mit Ergebnis und richtiger Lösung erneut an (ohne neue Abstimmung).</source>
-        <target>Shows the previous question again with its result and correct answer (without a new vote).</target>
+        <source>Zeigt die vorherige Frage mit ihrem Ergebnis erneut an (ohne neue Abstimmung).</source>
+        <target>Shows the previous question again with its result (without a new vote).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4146</context>
@@ -15852,6 +15852,30 @@
           <context context-type="linenumber">4319,4321</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorAria" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <target>To the overall results</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4337</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchor" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <target>To the overall results</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorCompact" datatype="html">
+        <source>Auswertung</source>
+        <target>Results</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4347</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
         <source>Zur nächsten Frage ohne zweite Abstimmung</source>
         <target>On to the next question without a second vote</target>
@@ -15866,6 +15890,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4346</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluationAria" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <target>To the overall results without a second vote</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4403</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluation" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <target>To the overall results without a second vote</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -18085,6 +18125,14 @@
           <context context-type="linenumber">7288</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionDialogEndsSession" datatype="html">
+        <source>Es folgt keine weitere Frage. Die Session wird beendet.</source>
+        <target>No further question follows. The session will end.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7527</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipQuestionConfirm" datatype="html">
         <source>Frage auslassen</source>
         <target>Skip question</target>
@@ -18107,6 +18155,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">7330</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionSuccessFinished" datatype="html">
+        <source>Frage ausgelassen. Die Session ist beendet.</source>
+        <target>Question skipped. The session has ended.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.moderationNlpCategoryContent" datatype="html">

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -14747,7 +14747,7 @@
           <context context-type="linenumber">1441,1442</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1017989655370592681" datatype="html">
+      <trans-unit id="sessionHost.lastQuestionBadge" datatype="html">
         <source>Letzte Frage</source>
         <target>Última pregunta</target>
         <context-group purpose="location">
@@ -15315,12 +15315,12 @@
           <context context-type="linenumber">3279,3281</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7435414614973406916" datatype="html">
-        <source> Keine Frage aktiv. Mit „Nächste Frage“ starten.</source>
-        <target>Ninguna pregunta activa. Comience con &quot;Siguiente pregunta&quot;.</target>
+      <trans-unit id="sessionHost.noActiveQuestion" datatype="html">
+        <source>Keine Frage aktiv.</source>
+        <target>Ninguna pregunta activa.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3283,3285</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -15672,8 +15672,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
-        <source>Zeigt die letzte Frage mit Ergebnis und richtiger Lösung erneut an (ohne neue Abstimmung).</source>
-        <target>Vuelve a mostrar la pregunta anterior con su resultado y la respuesta correcta (sin nueva votación).</target>
+        <source>Zeigt die vorherige Frage mit ihrem Ergebnis erneut an (ohne neue Abstimmung).</source>
+        <target>Vuelve a mostrar la pregunta anterior con su resultado (sin nueva votación).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4146</context>
@@ -15795,6 +15795,30 @@
           <context context-type="linenumber">4319,4321</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorAria" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <target>Ir al resumen general</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4337</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchor" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <target>Ir al resumen general</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorCompact" datatype="html">
+        <source>Auswertung</source>
+        <target>Resumen</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4347</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
         <source>Zur nächsten Frage ohne zweite Abstimmung</source>
         <target>A la siguiente pregunta sin segunda votación</target>
@@ -15809,6 +15833,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4346</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluationAria" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <target>Ir al resumen general sin segunda votación</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4403</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluation" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <target>Ir al resumen general sin segunda votación</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -18029,6 +18069,14 @@
           <context context-type="linenumber">7288</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionDialogEndsSession" datatype="html">
+        <source>Es folgt keine weitere Frage. Die Session wird beendet.</source>
+        <target>No hay más preguntas. La sesión terminará.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7527</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipQuestionConfirm" datatype="html">
         <source>Frage auslassen</source>
         <target>Omitir pregunta</target>
@@ -18051,6 +18099,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">7330</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionSuccessFinished" datatype="html">
+        <source>Frage ausgelassen. Die Session ist beendet.</source>
+        <target>Pregunta omitida. La sesión ha terminado.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.moderationNlpCategoryContent" datatype="html">

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -14747,7 +14747,7 @@
           <context context-type="linenumber">1441,1442</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1017989655370592681" datatype="html">
+      <trans-unit id="sessionHost.lastQuestionBadge" datatype="html">
         <source>Letzte Frage</source>
         <target>Dernière question</target>
         <context-group purpose="location">
@@ -15315,12 +15315,12 @@
           <context context-type="linenumber">3279,3281</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7435414614973406916" datatype="html">
-        <source> Keine Frage aktiv. Mit „Nächste Frage“ starten.</source>
-        <target>Aucune question active. Commencez par « Question suivante ».</target>
+      <trans-unit id="sessionHost.noActiveQuestion" datatype="html">
+        <source>Keine Frage aktiv.</source>
+        <target>Aucune question active.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3283,3285</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -15672,8 +15672,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
-        <source>Zeigt die letzte Frage mit Ergebnis und richtiger Lösung erneut an (ohne neue Abstimmung).</source>
-        <target>Réaffiche la question précédente avec son résultat et la bonne réponse (sans nouveau vote).</target>
+        <source>Zeigt die vorherige Frage mit ihrem Ergebnis erneut an (ohne neue Abstimmung).</source>
+        <target>Réaffiche la question précédente avec son résultat (sans nouveau vote).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4146</context>
@@ -15795,6 +15795,30 @@
           <context context-type="linenumber">4319,4321</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorAria" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <target>Vers le bilan</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4337</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchor" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <target>Vers le bilan</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorCompact" datatype="html">
+        <source>Auswertung</source>
+        <target>Bilan</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4347</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
         <source>Zur nächsten Frage ohne zweite Abstimmung</source>
         <target>Passons à la question suivante sans deuxième vote</target>
@@ -15809,6 +15833,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4346</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluationAria" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <target>Vers le bilan sans deuxième vote</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4403</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluation" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <target>Vers le bilan sans deuxième vote</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -18029,6 +18069,14 @@
           <context context-type="linenumber">7288</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionDialogEndsSession" datatype="html">
+        <source>Es folgt keine weitere Frage. Die Session wird beendet.</source>
+        <target>Aucune autre question ne suit. La session sera terminée.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7527</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipQuestionConfirm" datatype="html">
         <source>Frage auslassen</source>
         <target>Ignorer la question</target>
@@ -18051,6 +18099,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">7330</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionSuccessFinished" datatype="html">
+        <source>Frage ausgelassen. Die Session ist beendet.</source>
+        <target>Question ignorée. La session est terminée.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.moderationNlpCategoryContent" datatype="html">

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -14747,7 +14747,7 @@
           <context context-type="linenumber">1441,1442</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1017989655370592681" datatype="html">
+      <trans-unit id="sessionHost.lastQuestionBadge" datatype="html">
         <source>Letzte Frage</source>
         <target>Ultima domanda</target>
         <context-group purpose="location">
@@ -15315,12 +15315,12 @@
           <context context-type="linenumber">3279,3281</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7435414614973406916" datatype="html">
-        <source> Keine Frage aktiv. Mit „Nächste Frage“ starten.</source>
-        <target>Nessuna domanda attiva. Inizia con “Domanda successiva”.</target>
+      <trans-unit id="sessionHost.noActiveQuestion" datatype="html">
+        <source>Keine Frage aktiv.</source>
+        <target>Nessuna domanda attiva.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3283,3285</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -15672,8 +15672,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
-        <source>Zeigt die letzte Frage mit Ergebnis und richtiger Lösung erneut an (ohne neue Abstimmung).</source>
-        <target>Mostra di nuovo la domanda precedente con il risultato e la risposta corretta (senza una nuova votazione).</target>
+        <source>Zeigt die vorherige Frage mit ihrem Ergebnis erneut an (ohne neue Abstimmung).</source>
+        <target>Mostra di nuovo la domanda precedente con il risultato (senza una nuova votazione).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4146</context>
@@ -15795,6 +15795,30 @@
           <context context-type="linenumber">4319,4321</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorAria" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <target>Vai alla sintesi</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4337</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchor" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <target>Vai alla sintesi</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorCompact" datatype="html">
+        <source>Auswertung</source>
+        <target>Sintesi</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4347</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
         <source>Zur nächsten Frage ohne zweite Abstimmung</source>
         <target>Alla prossima domanda senza seconda votazione</target>
@@ -15809,6 +15833,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4346</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluationAria" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <target>Vai alla sintesi senza seconda votazione</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4403</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluation" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <target>Vai alla sintesi senza seconda votazione</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -18029,6 +18069,14 @@
           <context context-type="linenumber">7288</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionDialogEndsSession" datatype="html">
+        <source>Es folgt keine weitere Frage. Die Session wird beendet.</source>
+        <target>Non segue un’altra domanda. La sessione verrà chiusa.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7527</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipQuestionConfirm" datatype="html">
         <source>Frage auslassen</source>
         <target>Salta domanda</target>
@@ -18051,6 +18099,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">7330</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionSuccessFinished" datatype="html">
+        <source>Frage ausgelassen. Die Session ist beendet.</source>
+        <target>Domanda saltata. La sessione è terminata.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.moderationNlpCategoryContent" datatype="html">

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -13062,7 +13062,7 @@
           <context context-type="linenumber">1441,1442</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1017989655370592681" datatype="html">
+      <trans-unit id="sessionHost.lastQuestionBadge" datatype="html">
         <source>Letzte Frage</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
@@ -13563,11 +13563,11 @@
           <context context-type="linenumber">3279,3281</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7435414614973406916" datatype="html">
-        <source> Keine Frage aktiv. Mit „Nächste Frage“ starten. </source>
+      <trans-unit id="sessionHost.noActiveQuestion" datatype="html">
+        <source>Keine Frage aktiv.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
-          <context context-type="linenumber">3283,3285</context>
+          <context context-type="linenumber">3274</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.emojiReactionsTitle" datatype="html">
@@ -13877,7 +13877,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.prevQuestionTooltip" datatype="html">
-        <source>Zeigt die letzte Frage mit Ergebnis und richtiger Lösung erneut an (ohne neue Abstimmung).</source>
+        <source>Zeigt die vorherige Frage mit ihrem Ergebnis erneut an (ohne neue Abstimmung).</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4146</context>
@@ -13985,6 +13985,27 @@
           <context context-type="linenumber">4319,4321</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorAria" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4337</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchor" datatype="html">
+        <source>Zur Gesamtauswertung</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4342</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.finishEvaluationAnchorCompact" datatype="html">
+        <source>Auswertung</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4347</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipDiscussionNextQuestionAria" datatype="html">
         <source>Zur nächsten Frage ohne zweite Abstimmung</source>
         <context-group purpose="location">
@@ -13997,6 +14018,20 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
           <context context-type="linenumber">4346</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluationAria" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4403</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipDiscussionFinishEvaluation" datatype="html">
+        <source>Zur Gesamtauswertung ohne zweite Abstimmung</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.html</context>
+          <context context-type="linenumber">4406</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5482759156748483613" datatype="html">
@@ -15897,6 +15932,13 @@
           <context context-type="linenumber">7288</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionDialogEndsSession" datatype="html">
+        <source>Es folgt keine weitere Frage. Die Session wird beendet.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7527</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sessionHost.skipQuestionConfirm" datatype="html">
         <source>Frage auslassen</source>
         <context-group purpose="location">
@@ -15916,6 +15958,13 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
           <context context-type="linenumber">7330</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sessionHost.skipQuestionSuccessFinished" datatype="html">
+        <source>Frage ausgelassen. Die Session ist beendet.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/session/session-host/session-host.component.ts</context>
+          <context context-type="linenumber">7575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sessionHost.moderationNlpCategoryContent" datatype="html">

--- a/docs/APP-FUNKTIONSUEBERSICHT.md
+++ b/docs/APP-FUNKTIONSUEBERSICHT.md
@@ -651,7 +651,8 @@ Abschlussansicht. Ohne verwertbare Ergebnisse bleibt auf der Fragenkarte der
 statische Hinweis **Letzte Frage** (kein Button). Nach einem Rückblick auf eine
 vorherige Frage erscheint dieser Hinweis nicht.
 Nach einem Rückblick von der letzten Frage gilt dasselbe: Weiter beendet die Session,
-statt nur die bereits gezeigte letzte Frage erneut zu öffnen. In der Diskussionsphase ersetzt
+statt nur die bereits gezeigte letzte Frage erneut zu öffnen. Nach einem Reload bleiben
+die Folgemarker im Host-DTO maßgeblich, nicht nur der lokale Rückblick-Zustand. In der Diskussionsphase ersetzt
 **Zur Gesamtauswertung ohne zweite Abstimmung** den Sprung zur nächsten Frage.
 
 ### 7.4 Belohnungs- und Motivationssystem

--- a/docs/APP-FUNKTIONSUEBERSICHT.md
+++ b/docs/APP-FUNKTIONSUEBERSICHT.md
@@ -630,11 +630,29 @@ Der Ablauf ist jeweils:
 
 Während Lese- und Abstimmungsphase kann der Host eine Frage über die sichtbare Aktion
 **Frage auslassen** aus dem laufenden Durchlauf entfernen. Eine Bestätigung weist darauf
-hin, dass die Frage und bereits abgegebene Antworten nicht ausgewertet werden. Danach
-startet atomar die nächste Frage; bei der letzten Frage endet die Session regulär.
+hin, dass die Frage und bereits abgegebene Antworten nicht ausgewertet werden. Gibt es
+keine Folgefrage, nennt die Bestätigung, dass die Session danach endet. Sonst startet
+atomar die nächste Frage.
 Ausgelassene und nie geöffnete Fragen zählen nicht für Score, Ranglisten,
 Selbsteinschätzung, Bonuscodes, Nachbesprechung, PDF oder CSV. Geöffnete Fragen ohne
 Antworten bleiben als durchgeführte Fragen erhalten.
+
+Aus **Ergebnisse** oder **Diskussion** kann der Host **Letztes Ergebnis** nutzen, um die
+vorherige durchgeführte Frage ohne neue Abstimmung erneut anzuzeigen. Das gilt auch für
+Fragen ohne Musterlösung (Umfrage, Freitext, Reihenfolge, Bewertung). Auf der ersten
+durchgeführten Frage oder nach einem Rückblick ist die Aktion nicht sichtbar.
+Dasselbe gilt nach **Ab hier** in der Vorschau: Fragen vor dem Startpunkt bleiben ungeöffnet
+und sind kein Vorgänger für **Letztes Ergebnis**.
+
+**Nächste Frage** erscheint nur, wenn noch eine nicht ausgelassene Frage folgt – auch
+wenn die letzte Vorlagenfrage übersprungen wurde. Gibt es keine nächste Frage und
+liegen verwertbare Ergebnisse vor, führt **Zur Gesamtauswertung** in die
+Abschlussansicht. Ohne verwertbare Ergebnisse bleibt auf der Fragenkarte der
+statische Hinweis **Letzte Frage** (kein Button). Nach einem Rückblick auf eine
+vorherige Frage erscheint dieser Hinweis nicht.
+Nach einem Rückblick von der letzten Frage gilt dasselbe: Weiter beendet die Session,
+statt nur die bereits gezeigte letzte Frage erneut zu öffnen. In der Diskussionsphase ersetzt
+**Zur Gesamtauswertung ohne zweite Abstimmung** den Sprung zur nächsten Frage.
 
 ### 7.4 Belohnungs- und Motivationssystem
 

--- a/libs/shared-types/src/schemas.ts
+++ b/libs/shared-types/src/schemas.ts
@@ -3162,8 +3162,21 @@ export type GetSessionConfidenceSummaryOutput = z.infer<
 export const HostCurrentQuestionDTOSchema = z.object({
   questionId: z.string().uuid(),
   order: z.number().int().min(0),
-  /** Gesamtanzahl Fragen im Quiz (für Host-Button „Nächste Frage“ vs. „Session beenden“). */
+  /** Gesamtanzahl Fragen im Quiz (Host-Anzeige Frage n / m). */
   totalQuestions: z.number().int().min(1).optional(),
+  /**
+   * Ob der Host aus RESULTS/DISCUSSION auf eine fachlich enthaltene Vorgängerfrage
+   * zurückblättern kann. Unabhängig von Musterlösung (Umfrage, Freitext, Reihenfolge).
+   */
+  canShowPreviousResult: z.boolean().optional(),
+  /** Ob nach der aktuellen Frage noch eine nicht ausgelassene Frage folgt. */
+  hasNextQuestion: z.boolean().optional(),
+  /**
+   * Ob nach einem Rückblick („Letztes Ergebnis“) noch eine Frage folgt, wenn
+   * die bereits gezeigte aktuelle Frage übersprungen wird. Sonst führt Weiter
+   * zur Abschlussauswertung.
+   */
+  hasUnopenedFollowingQuestion: z.boolean().optional(),
   text: z.string(),
   type: QuestionTypeEnum,
   difficulty: DifficultyEnum,


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Host-Steuerung versprach „Nächste Frage“ oder „Letztes Ergebnis“, obwohl keine Folgefrage bzw. keine durchgeführte Vorgängerfrage existierte. Auf der letzten Frage und nach „Ab hier“ in der Vorschau stimmten Labels und Ziele nicht.
- **Lösung:** Host-DTO liefert `canShowPreviousResult`, `hasNextQuestion` und `hasUnopenedFollowingQuestion`. Die Aktionsleiste zeigt **Nächste Frage** nur bei echter Folgefrage, sonst **Zur Gesamtauswertung**; **Letzte Frage** ist ein statischer Hinweis. Auslassen und Rückblick nennen das tatsächliche Ziel (Session-Ende bzw. keine neue Abstimmung).
- **Bewusste Nicht-Ziele:** Teilnehmer-Abstimmung, Präsentationsansicht, Session-beenden-Dialog, Wortwolke.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

- Shared Zod-Vertrag `HostCurrentQuestionDTO`; Session-Fortschritt (`questionProgressComplete`) zählt nur geöffnete/abgeschlossene Fragen.
- Host-only-Steuerung über `hostProcedure`; Teilnehmenden-Payloads ohne Lösungsdaten unverändert.
- Effektive Peer-Instruction-Wertung unverändert.
- Nie geöffnete Fragen vor „Ab hier“ und ausgelassene Fragen sind kein Vorgänger für **Letztes Ergebnis**.

**Betroffene externe Verträge:**

Keine (internes tRPC/Zod-Host-DTO, additive optionale Felder).

## Implementierung

- Schema-first: optionale Flags im Host-Fragen-DTO.
- Backend: Folgemarker aus `findFollowingQuestionIndex` / `findPreviousIncludedQuestionIndex`; `nextQuestion`/`skipQuestion`/`prevQuestion` unverändert in der Semantik, aber für Start ab hier und letzte Frage abgesichert.
- Frontend: Steuerleiste nach Status; XOR Nächste Frage / Gesamtauswertung; Letzte Frage als `role="status"` auf der Karte; Auslassen-Dialog nennt Session-Ende, wenn keine Folgefrage bleibt.
- i18n `de`/`en`/`fr`/`es`/`it`; Funktionsübersicht §7.3.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [x] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [x] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [x] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` | bestanden (Pre-Commit) |
| `npm test` | bestanden (Pre-Commit: shared-types 87, export-report 81, backend 1088, frontend 1427) |
| `npm run lint` | bestanden |
| `npx prettier --check` auf geänderte TS/HTML/SCSS/MD | bestanden |
| `git diff --check` | bestanden |
| Backend-Navigationstests (`session.steering`, `session.current-question-host`, `sessionQuestionProgress`) | 94 bestanden |
| `npm run build:prod` | lokal gestartet, Ergebnis folgt in CI |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [ ] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [ ] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [ ] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [ ] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Host-Quiz-Steuerung (Labels und Sichtbarkeit). Session-Statusmaschine unverändert; neue DTO-Felder optional.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Unverändert (bestehende tRPC-Fehlerpfade, Host-Steering-Callout).
- **Rollback:** Revert dieses Commits; Host-Clients ohne Flags fallen auf Vorlagenreihenfolge zurück.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Pre-Commit: vollständiger Typecheck und `npm test`.
- Neue Tests: letzte Frage / Gesamtauswertung, Peek, Start ab hier, Auslassen-Dialog bei Session-Ende, `prevQuestion` ohne Vorgänger.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** `build:prod` zum PR-Zeitpunkt noch laufend (CI und lokaler Lauf). Reconnect/Token/Migration/Last/WebSocket nicht betroffen. Reflow/Zoom/Kontrast: kompakte Labels für schmale Viewports, kein neues Farbschema. Prisma-Migration nicht nötig. Doppelklick: `controlPending`. Offline-Steuerung: bestehender Retry-Callout. Fokus nach Skip auf Fragenkarte bzw. Finished-Heading. Legacy: `questionProgressComplete=false` behält Vollvorlagen-Navigation.
- **Verbleibende Risiken:** Ohne DTO-Flags fällt die UI auf `order`/`totalQuestions` zurück (`Letztes Ergebnis` bei `order !== 0`). Alte Backends ohne Flags könnten nach „Ab hier“ fälschlich Vorgänger anbieten; aktuelles Backend setzt die Flags.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)