### PR TITLE
fix(present): Projektionswechsel vollständig ordnen

### DIFF
--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -2480,6 +2480,70 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     fixture.destroy();
   });
 
+  it('ordnet einen Kanalwechsel nach einer noch laufenden Wortwolken-Aktivierung ein', async () => {
+    const visibleQuestion = {
+      id: '11111111-1111-4111-8111-111111111111',
+      text: 'Welche Frage wird projiziert?',
+      upvoteCount: 2,
+      status: 'ACTIVE' as const,
+      createdAt: '2026-08-24T18:00:00.000Z',
+      myVote: null,
+      isOwn: false,
+      hasUpvoted: false,
+    };
+    getInfoQueryMock.mockResolvedValue({
+      ...defaultSession,
+      status: 'ACTIVE',
+      preferredChannel: 'qa',
+      presenterSurface: 'default',
+      channels: {
+        quiz: { enabled: true },
+        qa: { enabled: true, open: true, title: 'Fragen', moderationMode: false },
+        quickFeedback: { enabled: false, open: false },
+      },
+    });
+    qaListQueryMock.mockResolvedValue([visibleQuestion]);
+
+    let releaseQuizChannel!: () => void;
+    const quizChannelPending = new Promise<void>((resolve) => {
+      releaseQuizChannel = resolve;
+    });
+    setPreferredLiveChannelMutateMock
+      .mockImplementationOnce(async ({ channel }: { channel: 'quiz' }) => {
+        await quizChannelPending;
+        return { preferredChannel: channel };
+      })
+      .mockImplementation(async ({ channel }: { channel: 'quiz' | 'qa' | 'quickFeedback' }) => ({
+        preferredChannel: channel,
+      }));
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const component = fixture.componentInstance;
+    component.qaQuestions.set([visibleQuestion]);
+
+    component.maximizeFreetextWordCloud();
+    const switchToQa = component.selectChannel('qa');
+
+    await vi.waitUntil(() => setPreferredLiveChannelMutateMock.mock.calls.length === 1);
+    expect(setPreferredLiveChannelMutateMock).toHaveBeenNthCalledWith(1, {
+      code: 'ABC123',
+      channel: 'quiz',
+    });
+
+    releaseQuizChannel();
+    await switchToQa;
+
+    expect(setPreferredLiveChannelMutateMock).toHaveBeenNthCalledWith(2, {
+      code: 'ABC123',
+      channel: 'qa',
+    });
+    expect(component.session()?.preferredChannel).toBe('qa');
+    expect(component.session()?.presenterSurface).toBe('default');
+    fixture.destroy();
+  });
+
   it('schliesst die Freitext-Vollansicht beim Wechsel des Live-Kanals', async () => {
     getInfoQueryMock.mockResolvedValue({
       ...defaultSession,
@@ -3922,6 +3986,61 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
         delete (documentRef.documentElement as Partial<HTMLElement>).requestFullscreen;
       }
     }
+    fixture.destroy();
+  });
+
+  it('oeffnet den lokalen Q&A-Dialog ohne auf die Presenter-Synchronisierung zu warten', async () => {
+    getInfoQueryMock.mockResolvedValue({
+      ...defaultSession,
+      status: 'ACTIVE',
+      preferredChannel: 'qa',
+      presenterSurface: 'default',
+      channels: {
+        quiz: { enabled: true },
+        qa: { enabled: true, open: true, title: 'Fragen aus dem Publikum', moderationMode: true },
+        quickFeedback: { enabled: false, open: false },
+      },
+    });
+    qaListQueryMock.mockResolvedValue([
+      {
+        id: '44444444-4444-4444-8444-444444444444',
+        text: 'Welche Frage gewinnt?',
+        upvoteCount: 2,
+        status: 'ACTIVE',
+        createdAt: '2026-03-13T12:00:00.000Z',
+        myVote: null,
+        isOwn: false,
+        hasUpvoted: false,
+      },
+    ]);
+
+    let releaseProjection!: () => void;
+    const projectionPending = new Promise<void>((resolve) => {
+      releaseProjection = resolve;
+    });
+    setPresenterSurfaceMutateMock.mockImplementationOnce(
+      async ({ surface }: { surface: 'default' | 'qaWordCloud' | 'freetextWordCloud' }) => {
+        await projectionPending;
+        return { presenterSurface: surface };
+      },
+    );
+    dialogOpenMock.mockReturnValueOnce({ afterClosed: () => NEVER });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await flushComponentAfterStable(fixture, 50);
+    const component = fixture.componentInstance;
+    component.activeChannel.set('qa');
+    dialogOpenMock.mockClear();
+
+    await component.openQaWordCloudDialog();
+
+    expect(dialogOpenMock).toHaveBeenCalledTimes(1);
+    expect(component.qaWordCloudDialogOpen()).toBe(true);
+    await vi.waitUntil(() => setPresenterSurfaceMutateMock.mock.calls.length === 1);
+
+    releaseProjection();
+    await vi.waitUntil(() => component.session()?.presenterSurface === 'qaWordCloud');
     fixture.destroy();
   });
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -857,7 +857,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   private qaWordCloudLemmaAnalysisRunId = 0;
   private freetextWordCloudLemmaAnalysisRunId = 0;
   private freetextWordCloudSemanticAnalysisRunId = 0;
-  private presenterSurfaceSyncQueue: Promise<void> = Promise.resolve();
+  private presenterProjectionSyncQueue: Promise<void> = Promise.resolve();
   private lastQaWordCloudAnalysisRequestKey: string | null = null;
   private lastQaWordCloudSemanticAnalyzedKey: string | null = null;
   private lastFreetextWordCloudSemanticRequestKey: string | null = null;
@@ -1971,7 +1971,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     this.moderationCompassFocusedTerm.set(focusedTerm);
     this.tryEnterWordCloudFullscreenFromUserGesture();
     this.qaWordCloudDialogOpen.set(true);
-    await this.activatePresenterSurface('qaWordCloud', 'qa');
+    void this.activatePresenterSurface('qaWordCloud', 'qa');
     const request = this.qaWordCloudAnalysisRequest();
     if (request) {
       if (request.mode === 'SEMANTIC') {
@@ -7609,7 +7609,11 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async syncPreferredLiveChannel(channel: SessionChannelTab): Promise<void> {
+  private syncPreferredLiveChannel(channel: SessionChannelTab): Promise<void> {
+    return this.enqueuePresenterProjectionSync(() => this.syncPreferredLiveChannelNow(channel));
+  }
+
+  private async syncPreferredLiveChannelNow(channel: SessionChannelTab): Promise<void> {
     if (
       !this.code ||
       !this.isPresenterChannelReady(channel) ||
@@ -7637,7 +7641,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   }
 
   private syncPresenterSurface(surface: SessionPresenterSurface): Promise<void> {
-    return this.enqueuePresenterSurfaceSync(() => this.syncPresenterSurfaceNow(surface));
+    return this.enqueuePresenterProjectionSync(() => this.syncPresenterSurfaceNow(surface));
   }
 
   private async syncPresenterSurfaceNow(surface: SessionPresenterSurface): Promise<void> {
@@ -7661,15 +7665,15 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     surface: SessionPresenterSurface,
     channel: SessionChannelTab,
   ): Promise<void> {
-    await this.enqueuePresenterSurfaceSync(async () => {
-      await this.syncPreferredLiveChannel(channel);
+    await this.enqueuePresenterProjectionSync(async () => {
+      await this.syncPreferredLiveChannelNow(channel);
       await this.syncPresenterSurfaceNow(surface);
     });
   }
 
-  private enqueuePresenterSurfaceSync(operation: () => Promise<void>): Promise<void> {
-    const queued = this.presenterSurfaceSyncQueue.then(operation, operation);
-    this.presenterSurfaceSyncQueue = queued;
+  private enqueuePresenterProjectionSync(operation: () => Promise<void>): Promise<void> {
+    const queued = this.presenterProjectionSyncQueue.then(operation, operation);
+    this.presenterProjectionSyncQueue = queued;
     return queued;
   }
 


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Zwei nach dem Merge von #319 eingegangene Review-Findings zeigen weitere Race Conditions: Kanalwechsel liefen außerhalb der Presenter-Queue, und ein langsamer Projektionsaufruf blockierte das lokale Öffnen des Q&A-Dialogs.
- **Lösung:** Kanal- und Flächenmutationen werden gemeinsam serialisiert. Der lokale Q&A-Dialog öffnet sofort; die öffentliche Projektion synchronisiert unabhängig im Hintergrund.
- **Bewusste Nicht-Ziele:** Keine Änderung des Presenter-Vertrags, der Backend-Persistenz oder der Kanalberechtigungen.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Die zuletzt ausgelöste Host-Aktion muss nach Abschluss aller älteren Projektionsmutationen den sichtbaren Presenter-Zustand bestimmen. Lokale Host-Dialoge dürfen nicht von Netzwerklatenz oder einer ausstehenden Presenter-Synchronisierung blockiert werden.

**Betroffene externe Verträge:**

Keine.

## Implementierung

- `setPreferredLiveChannel` und `setPresenterSurface` über dieselbe Promise-Queue geordnet.
- Kombinierte Wortwolken-Aktivierung nutzt die nicht erneut einreihenden internen Operationen.
- Q&A-Dialog wird lokal geöffnet, während die Projektion unabhängig synchronisiert.
- Zwei Regressionstests für überholende Kanalwechsel und ausstehende Q&A-Projektion ergänzt.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [x] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [x] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [x] Parallelität oder Race Conditions
- [x] Abhängigkeit vorübergehend nicht verfügbar
- [x] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [x] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run test -w @arsnova/frontend -- --run src/app/features/session/session-host/session-host.component.spec.ts` | 253 Tests bestanden |
| `npm run typecheck -w @arsnova/frontend` | Erfolgreich |
| Pre-commit `npm run typecheck` | Erfolgreich |
| Pre-commit `npm test` | Shared Types 92, Export Report 81, Backend 1101 und Frontend 1539 Tests bestanden |
| lint-staged ESLint und Prettier | Erfolgreich |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [ ] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Schnell aufeinanderfolgende Host-Aktionen behalten ihre Reihenfolge; der Q&A-Dialog reagiert unabhängig von der Presenter-Verbindung.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Bestehende tRPC-Fehlerbeobachtung.
- **Rollback:** Diesen Follow-up-Commit zurückrollen.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Regressionstests halten Mutationen gezielt offen und verifizieren Reihenfolge, finalen Kanal sowie sofortiges lokales Öffnen.
- Follow-up zu den Review-Threads aus #319.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Keine Migration, neuen Texte, externen Verträge oder Sicherheitsgrenzen. Der vollständige Produktionsbuild ist durch die reine Änderung am lazy geladenen Host-Ablauf nicht zusätzlich erforderlich und läuft in CI.
- **Verbleibende Risiken:** Eine dauerhaft nie abschließende Netzwerkmutation hält nachfolgende Projektionssynchronisierungen weiterhin in der Queue; die lokale Host-Bedienung und das Schließen des Dialogs bleiben davon unabhängig.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)