### PR TITLE
fix(host): Presenter-Button vertikal zentrieren

### DIFF
--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -9,6 +9,7 @@
   - Angular standalone components and Signals for UI state.
   - RxJS is for async streams/operators, not default local component stores; do not introduce `BehaviorSubject` for ordinary UI state.
   - Use Angular Material 3 and project tokens; no Tailwind in `apps/frontend`.
+  - Do not use `::ng-deep` (deprecated). Style host-owned elements, Material override mixins, or scoped `panelClass`/global rules instead.
   - Keep specs colocated as `<name>.spec.ts`; update nearest specs for changed behavior.
   - UI/copy changes sync all locales (`de`, `en`, `fr`, `es`, `it`), including ARIA, placeholders, validation, and legal text when relevant.
   - Treat 320px/mobile and localized string length as first-class UI constraints.

--- a/.serena/memories/frontend/core.md
+++ b/.serena/memories/frontend/core.md
@@ -15,4 +15,5 @@
 - Production frontend build is not just `ng build`: `build:localize` runs Angular browser/server builds, prerenders localized routes, patches noscript/sitemap/PWA manifests/ngsw, writes root index, and checks MOTD assets.
 - Frontend Vitest config uses jsdom, Angular Vite plugin, `src/test-setup.ts`, and aliases `@arsnova/shared-types` to `libs/shared-types/src/index.workspace.ts`.
 - UI work must follow `docs/ui/` and Angular Material 3 tokens; no Tailwind classes/system in this app.
+- Do not use `::ng-deep` (deprecated). Style host-owned markup, official Material override mixins, or tightly scoped global/`panelClass` rules. Canonical: `docs/ui/TOKENS.md`, `docs/ui/PR-CHECKLIST-UI.md`.
 - Quiz editor persisted metadata/settings/question changes use a centralized `hasPendingChanges()` + `saveAll()` contract; read `mem:frontend/quiz-editor-save-flow` before changing quiz-edit forms, handlers, presets, or question-type parameters.

--- a/.serena/memories/frontend/i18n-ui.md
+++ b/.serena/memories/frontend/i18n-ui.md
@@ -9,6 +9,7 @@
 - Locale subpaths reload the app. Avoid accidental loss of unsaved edit state; quiz edit/new flows are the high-risk language-switch cases.
 - UI must handle 320px/mobile and longer localized strings. Reduced-motion-sensitive micro-interactions belong in `@media (prefers-reduced-motion: no-preference)`.
 - UI implementation follows Angular Material 3 tokens and docs under `docs/ui/`.
+- Do not use `::ng-deep` (deprecated).
 
 ## Verwandte Memories:
 

--- a/.serena/memories/modules/frontend.md
+++ b/.serena/memories/modules/frontend.md
@@ -9,7 +9,7 @@
 - Dev proxy: `/trpc` -> `127.0.0.1:3000`; `/trpc-ws` -> `127.0.0.1:3001`; `/yjs-ws` -> `127.0.0.1:3002`.
 - Scripts: `start:de`, `start:en`, `build`, `build:localize`, `serve:localize:api`, `check:viewport`, smoke scripts, `test`, `typecheck`, `sync-i18n`.
 - UI state convention: Signals for component/app UI state; RxJS only for real streams/operators, not default local state stores.
-- Tailwind is not part of this app; use Angular Material 3 tokens and existing SCSS patterns.
+- Tailwind is not part of this app; use Angular Material 3 tokens and existing SCSS patterns. Do not use `::ng-deep`.
 - Word-cloud host UX: Freitext maximize in-place on `app-word-cloud`; Q&A uses a separate dialog. Optional smoothing is host-only (`mem:session/word-cloud-spacy`).
 
 ## Verwandte Memories:

--- a/.serena/memories/quality/dod.md
+++ b/.serena/memories/quality/dod.md
@@ -4,7 +4,7 @@
 - API changes are complete across shared schema, backend implementation, frontend usage, and tests.
 - DTO pattern is preserved; participant-facing `ACTIVE` payloads never expose solution data such as `isCorrect`.
 - Security-sensitive behavior has rejection/error tests as well as success cases.
-- Frontend uses Standalone Components, Signals, Angular Material 3 tokens, `@if`/`@for`, mobile-first layout, keyboard/focus accessibility, dark/light compatibility, reduced-motion guard for animations.
+- Frontend uses Standalone Components, Signals, Angular Material 3 tokens, `@if`/`@for`, mobile-first layout, keyboard/focus accessibility, dark/light compatibility, reduced-motion guard for animations. Do not use `::ng-deep`.
 - UI/copy changes sync `de`, `en`, `fr`, `es`, `it` and preserve relevant ARIA/placeholder/error text.
 - Docs are updated when setup, env, deployment, security, tests, admin flow, routes, or user-visible behavior changes.
 - Production/operator changes require production-style validation and focused documentation review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,9 @@ Critical instructions for AI coding agents working in arsnova.eu.
   bonus codes, analytics, and exports.
 - In `apps/frontend`, use Angular standalone components, Signals, and Angular
   Material 3 tokens. Do not introduce `BehaviorSubject` or RxJS-only state
-  stores for ordinary UI state. Do not add Tailwind CSS.
+  stores for ordinary UI state. Do not add Tailwind CSS. Do not use
+  `::ng-deep`; it is deprecated. Style host-owned elements, official Material
+  override mixins, or tightly scoped global/`panelClass` rules instead.
 - Keep all user-facing text synchronized across `de`, `en`, `fr`, `es`, and
   `it`.
 - Preserve the established WCAG 2.2 AA accessibility level. UI changes must

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.html
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.html
@@ -156,24 +156,23 @@
                 matTooltip="Presenter-Ansicht (Beamer)"
                 matTooltipTouchGestures="off"
               >
-                <span class="session-host__view-toggle-content">
-                  <svg
-                    class="session-host__view-toggle-icon"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                    focusable="false"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
-                    />
-                  </svg>
-                  <span
-                    class="session-host__view-toggle-label"
-                    i18n="@@sessionHost.presenterViewLabel"
-                    >Presenter-Ansicht</span
-                  >
-                </span>
+                <svg
+                  matButtonIcon
+                  class="session-host__view-toggle-icon"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <path
+                    fill="currentColor"
+                    d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                  />
+                </svg>
+                <span
+                  class="session-host__view-toggle-label"
+                  i18n="@@sessionHost.presenterViewLabel"
+                  >Presenter-Ansicht</span
+                >
               </button>
             }
 
@@ -420,24 +419,23 @@
                         matTooltip="Presenter-Ansicht (Beamer)"
                         matTooltipTouchGestures="off"
                       >
-                        <span class="session-host__view-toggle-content">
-                          <svg
-                            class="session-host__view-toggle-icon"
-                            viewBox="0 0 24 24"
-                            aria-hidden="true"
-                            focusable="false"
-                          >
-                            <path
-                              fill="currentColor"
-                              d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
-                            />
-                          </svg>
-                          <span
-                            class="session-host__view-toggle-label"
-                            i18n="@@sessionHost.presenterViewLabel"
-                            >Presenter-Ansicht</span
-                          >
-                        </span>
+                        <svg
+                          matButtonIcon
+                          class="session-host__view-toggle-icon"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                          focusable="false"
+                        >
+                          <path
+                            fill="currentColor"
+                            d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+                          />
+                        </svg>
+                        <span
+                          class="session-host__view-toggle-label"
+                          i18n="@@sessionHost.presenterViewLabel"
+                          >Presenter-Ansicht</span
+                        >
                       </button>
                     }
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.scss
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.scss
@@ -418,12 +418,13 @@
     width: auto;
     min-width: 2.75rem;
     overflow: visible;
+    padding-block: 0;
     padding-inline: 0.75rem;
     gap: 0.4rem;
     font-family: inherit;
     font-size: var(--mat-sys-label-medium-size, 0.875rem);
     font-weight: 600;
-    line-height: 1.125rem;
+    line-height: 1;
     letter-spacing: 0.01em;
     white-space: nowrap;
     hyphens: none;
@@ -446,23 +447,12 @@
   flex-wrap: nowrap;
   align-items: center;
   justify-content: center;
+  gap: 0.45rem;
   width: auto;
   min-width: 2.75rem;
   overflow: visible;
-}
-
-.session-host__view-toggle--labeled .mdc-button__label {
-  display: contents;
-}
-
-.session-host__view-toggle-content {
-  display: inline-flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  align-items: center;
-  gap: 0.45rem;
-  min-width: 0;
-  line-height: 1.125rem;
+  padding-block: 0;
+  padding-inline: 0.75rem;
 }
 
 .session-host__view-toggle-icon {
@@ -478,7 +468,7 @@
 
 .session-host__view-toggle-label {
   display: block;
-  line-height: 1.125rem;
+  line-height: 1;
 }
 
 @media (max-width: 599px) {
@@ -549,10 +539,6 @@
     align-items: center;
     justify-content: center;
     gap: 0.35rem;
-  }
-
-  .session-host__view-toggle--labeled .mdc-button__label {
-    display: contents;
   }
 
   .session-host__channel-visibility-label {

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -952,7 +952,11 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     ) as HTMLButtonElement | null;
     expect(presenterButton).not.toBeNull();
     expect(presenterButton?.textContent).toContain('Presenter-Ansicht');
-    expect(presenterButton?.querySelector('svg.session-host__view-toggle-icon')).not.toBeNull();
+    expect(
+      presenterButton?.querySelector(':scope > svg.session-host__view-toggle-icon'),
+    ).not.toBeNull();
+    expect(presenterButton?.querySelector('.session-host__view-toggle-content')).toBeNull();
+    expect(getComputedStyle(presenterButton!).alignItems).toBe('center');
     fixture.destroy();
   });
 
@@ -4113,6 +4117,10 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
     const styles = readFileSync(join(componentDir, 'session-host.component.scss'), 'utf8');
 
     expect(styles).not.toMatch(/session-qa-sort-toggle[\s\S]{0,800}::ng-deep/);
+    expect(styles).not.toMatch(/view-toggle--labeled[\s\S]{0,1200}::ng-deep/);
+    expect(styles).toMatch(
+      /\.session-host__view-toggle\.session-host__view-toggle--labeled \{[^}]*align-items:\s*center/,
+    );
     expect(styles).toMatch(/\.session-host \{[^}]*min-width:\s*0/);
     expect(styles).toMatch(/\.session-qa-sort-toggle \{[^}]*flex-wrap:\s*wrap/);
     expect(styles).toMatch(/\.session-qa-sort-toggle \{[^}]*min-width:\s*0/);

--- a/docs/ui/PR-CHECKLIST-UI.md
+++ b/docs/ui/PR-CHECKLIST-UI.md
@@ -2,7 +2,7 @@
 
 Diese Checkliste ist für alle PRs mit UI-Änderungen in `apps/frontend` verpflichtend.
 
-**Stand:** 2026-05-31 — abgeglichen mit [STYLEGUIDE.md](STYLEGUIDE.md), [TOKENS.md](TOKENS.md), Angular 21.2, den aktuellen Frontend-Skripten und der i18n-Dokumentation.
+**Stand:** 2026-08-26 — abgeglichen mit [STYLEGUIDE.md](STYLEGUIDE.md), [TOKENS.md](TOKENS.md), Angular 21.2, den aktuellen Frontend-Skripten und der i18n-Dokumentation.
 
 ## 1) Design-System-Konformität
 
@@ -23,7 +23,7 @@ Diese Checkliste ist für alle PRs mit UI-Änderungen in `apps/frontend` verpfli
 
 - [ ] Anpassungen an Material-Komponenten erfolgen über `mat.theme-overrides(...)` oder `<component>-overrides(...)`.
 - [ ] Keine fragilen Overrides gegen interne Material-DOM-Strukturen.
-- [ ] Kein neues `::ng-deep`.
+- [ ] Kein `::ng-deep` (deprecated).
 - [ ] Globale Overlay-Regeln sind über enge `panelClass` / `backdropClass` begrenzt.
 - [ ] Standard-Dialoge nutzen `dialog-title-header`; Fullscreen-Tools (Word Cloud, Bild-Lightbox) sind als Ausnahme begründet und separat auf Fokus/Close/Scroll geprüft.
 

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -38,7 +38,7 @@ ADR-Grundlage: `docs/architecture/decisions/0005-use-angular-material-design.md`
 ## DoD Quick Check (UI)
 
 - Kein Tailwind; Tokens statt hardcoded Farben/Typo/Shape/Elevation
-- Keine fragilen Material-DOM-Overrides
+- Kein `::ng-deep`; keine fragilen Material-DOM-Overrides
 - Light/Dark, Fokus/Hover/Disabled/Error geprüft
 - 320px ohne horizontales Scrollen: `npm run check:viewport` (apps/frontend)
 - A11y-Gates passend zur Änderung: Template-Lint, statisches/dynamisches axe,

--- a/docs/ui/STYLEGUIDE.md
+++ b/docs/ui/STYLEGUIDE.md
@@ -33,6 +33,7 @@ Ergänzend zur ADR `docs/architecture/decisions/0005-use-angular-material-design
 - Eigenkomponenten sind erlaubt, wenn Material funktional nicht reicht.
 - Eigene Komponenten müssen dieselben Tokens verwenden wie Material-Komponenten.
 - Keine CSS-Selektoren gegen interne Material-DOM-Strukturen.
+- `::ng-deep` nicht verwenden (deprecated). Weder neu einführen noch bestehende Vorkommen erweitern.
 - Komponentenanpassungen nur über offizielle Override-APIs.
 - Globale Overlay-Regeln sind nur mit enger `panelClass` / `backdropClass` zulässig, z. B. für MOTD-Archiv, Admin-MOTD-Template, Server-Status-Hilfe, Markdown-Bild-Lightbox und Word-Cloud-Fullscreen-Dialoge.
 

--- a/docs/ui/TOKENS.md
+++ b/docs/ui/TOKENS.md
@@ -103,7 +103,7 @@ Preset-Umschaltung läuft über die CSS-Klasse `html.preset-playful`.
 
 - hardcoded Hex-/RGB-Farben in Feature-SCSS für Standard-UI-Semantik
 - direkte Material-DOM-Overrides mit fragilen Selektoren
-- `::ng-deep` für neue Feature-Styles
+- `::ng-deep` (deprecated; nicht verwenden, auch nicht für Material-Interna)
 - Token-Bypass durch ad-hoc Inline-Styles
 - neue globale Tokens ohne Dokumentation in dieser Datei
 


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Icon und Label des Host-Buttons „Presenter-Ansicht“ saßen optisch zu hoch in der Pill-Fläche. Ein naheliegender Fix über `::ng-deep` auf `.mdc-button__label` ist deprecated und durch View-Encapsulation ohnehin unzuverlässig.
- **Lösung:** Das Icon wird per `matButtonIcon` als Material-Content-Projection neben dem Label gesetzt. Der Button zentriert beide Flex-Kinder mit host-eigenen Styles. `::ng-deep` ist in AGENTS.md, Serena-Memories und der UI-Doku als verboten festgehalten.
- **Bewusste Nicht-Ziele:** Keine Änderung der Presenter-Projektion, keine i18n-Texte, kein Rückbau bestehender `::ng-deep`-Vorkommen außerhalb dieses Buttons.

## Risiko und Verträge

- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Host-Toolbar-Layout in `session-host.component`; Angular Material Button-Projektion (`matButtonIcon` / `.mdc-button__label`); UI-Regel gegen `::ng-deep` in `docs/ui/TOKENS.md` und `docs/ui/PR-CHECKLIST-UI.md`. Der Button bleibt ein passiver Opener der Presenter-Ansicht ohne Host-Steuerung in der Projektion.

**Betroffene externe Verträge:**

Keine.

## Implementierung

- Presenter-Button: SVG mit `matButtonIcon` als direktes Kind, Label daneben; Wrapper `session-host__view-toggle-content` entfernt.
- Styles: `align-items: center`, `line-height: 1`, symmetrisches `padding-block: 0`; keine Selektoren auf `.mdc-button__label`.
- Tests prüfen Direktkind-Icon, fehlenden Content-Wrapper, `align-items: center` und dass die Button-Styles kein `::ng-deep` enthalten.
- Agenten- und UI-Regeln: `AGENTS.md`, Serena-Memories, Styleguide, Tokens, PR-Checkliste.

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [x] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run typecheck` (pre-commit) | bestanden |
| `npm test` (pre-commit) | bestanden (u. a. Frontend 1562 Tests) |
| lint-staged ESLint/Prettier auf den gestagten Dateien | bestanden |
| Host-Spec: immersive Presenter-Button-Zentrierung und kein `::ng-deep` | bestanden |
| Manuell im Browser auf `/session/:code/host`: Icon-/Label-Mitte, gleicher Abstand oben/unten | bestätigt |
| `npx prettier --check` und `git diff --check` für die UI-Docs | bestanden |

## Risikobezogene Prüfungen

- [x] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [ ] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Nur Host-Toolbar-Optik des Presenter-Buttons; keine API-, Token- oder Deploy-Änderung.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Nicht betroffen.
- **Rollback:** Revert dieses Commits.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Pre-commit: `npm run typecheck` und `npm test` grün.
- Browser: Host-Ansicht, Presenter-Button geometrisch zentriert (Icon- und Label-Mitte auf der Button-Mitte, gleicher Abstand oben/unten).
- Specs in `session-host.component.spec.ts` für Direktkind-Icon und fehlendes `::ng-deep`.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Kein Zustandsautomat, keine Tokens/Reconnect/Migration/Parallelität. `npm run lint` und `npm run build:prod` wurden lokal nicht vollständig ausgeführt; Pre-commit hat Typecheck, Tests und lint-staged auf den geänderten Dateien ausgeführt. Produktionsbundle und i18n-Strings sind unverändert. Der Presenter-Button bleibt auf Smartphones und bei geringer Höhe ausgeblendet; die Zentrierung gilt für Tablet/Desktop, wo der Button sichtbar ist. Reflow/Zoom/Kontrast sind durch Token-Nutzung und unveränderte Farben nicht neu betroffen. Fokusziel ändert sich nicht (derselbe Button).
- **Verbleibende Risiken:** Optische Feinjustierung je nach Schriftmetrik in anderen Locales ist gering, weil `line-height: 1` und Flex-Zentrierung unabhängig von der Label-Länge gelten.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft


Made with [Cursor](https://cursor.com)