### PR TITLE
fix(session): Demo-Quiz an teamlose Sessions anhängen

### DIFF
--- a/.github/trpc-dod-baseline.json
+++ b/.github/trpc-dod-baseline.json
@@ -324,7 +324,7 @@
     },
     "session.attachQuizToSession": {
       "kind": "mutation",
-      "fingerprint": "sha256:4edc3e9f9902390e15ebaed1b47d28176d952c776de20a9fe0d8042e95faab6a",
+      "fingerprint": "sha256:d4ec8a94e91a05809c2d256f461cd8f36913f9ecc42ac37a2b4035b1e6a90497",
       "missing": []
     },
     "session.bindQuizHistoryScope": {
@@ -514,7 +514,7 @@
     },
     "session.join": {
       "kind": "mutation",
-      "fingerprint": "sha256:bd5a3e6dbf2fddb402b76e485d853e39d63efde4b65bb4776678d42b684bf643",
+      "fingerprint": "sha256:eb5874f721640ebac6c90d15cc500a1761b56df6a6be5d560cc6530924d2a26a",
       "missing": []
     },
     "session.markParticipantOffline": {

--- a/.github/trpc-dod-baseline.json
+++ b/.github/trpc-dod-baseline.json
@@ -324,7 +324,7 @@
     },
     "session.attachQuizToSession": {
       "kind": "mutation",
-      "fingerprint": "sha256:d92fbe295dcd1cab389e1eeff18f30b7d17075999c08ebec37727001074b2a4b",
+      "fingerprint": "sha256:4edc3e9f9902390e15ebaed1b47d28176d952c776de20a9fe0d8042e95faab6a",
       "missing": []
     },
     "session.bindQuizHistoryScope": {

--- a/apps/backend/src/__tests__/session.attach-quiz.test.ts
+++ b/apps/backend/src/__tests__/session.attach-quiz.test.ts
@@ -22,6 +22,8 @@ const { prismaMock, hostAuthMocks } = vi.hoisted(() => ({
     vote: {
       count: vi.fn(),
     },
+    $transaction: vi.fn(),
+    $executeRaw: vi.fn().mockResolvedValue(1),
   },
   hostAuthMocks: {
     extractHostTokenMock: vi.fn(),
@@ -68,6 +70,9 @@ describe('session.attachQuizToSession', () => {
     ]);
     prismaMock.participant.findMany.mockResolvedValue([]);
     prismaMock.vote.count.mockResolvedValue(0);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
   });
 
   trpcDodIt(

--- a/apps/backend/src/__tests__/session.attach-quiz.test.ts
+++ b/apps/backend/src/__tests__/session.attach-quiz.test.ts
@@ -377,4 +377,137 @@ describe('session.attachQuizToSession', () => {
 
     expect(prismaMock.session.update).not.toHaveBeenCalled();
   });
+
+  it('hängt das Showcase-Demo-Quiz an eine teamlose Session an und verteilt Teilnehmende auf Apfel/Birne', async () => {
+    const { DEMO_QUIZ_HISTORY_SCOPE_ID } = await import('@arsnova/shared-types');
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: SESSION_ID,
+      type: 'QUIZ',
+      status: 'LOBBY',
+      currentQuestion: null,
+      quizId: null,
+      qaEnabled: true,
+      qaOpen: true,
+      qaTitle: 'Fragen',
+      qaModerationMode: true,
+      title: null,
+      moderationMode: false,
+      quickFeedbackEnabled: false,
+      quickFeedbackOpen: false,
+      onboardingProfileConfigured: true,
+      onboardingAllowCustomNicknames: false,
+      onboardingAnonymousMode: false,
+      onboardingTeamMode: false,
+      onboardingTeamCount: null,
+      onboardingTeamAssignment: 'AUTO',
+      onboardingTeamNames: [],
+      onboardingNicknameTheme: 'HIGH_SCHOOL',
+      _count: { participants: 3 },
+    });
+    prismaMock.quiz.findUnique.mockResolvedValue({
+      id: QUIZ_ID,
+      historyScopeId: DEMO_QUIZ_HISTORY_SCOPE_ID,
+      nicknameTheme: 'KINDERGARTEN',
+      allowCustomNicknames: false,
+      anonymousMode: false,
+      teamMode: true,
+      teamCount: 2,
+      teamAssignment: 'AUTO',
+      teamNames: ['Team 🍎', 'Team 🍐'],
+    });
+    prismaMock.team.findMany.mockResolvedValue([
+      { id: TEAM_A, name: 'Team 🍎', color: '#1E88E5', _count: { participants: 0 } },
+      { id: TEAM_B, name: 'Team 🍐', color: '#43A047', _count: { participants: 0 } },
+    ]);
+    prismaMock.participant.findMany.mockResolvedValue([
+      { id: 'p-1', teamId: null },
+      { id: 'p-2', teamId: null },
+      { id: 'p-3', teamId: null },
+    ]);
+    prismaMock.session.update.mockResolvedValue({
+      id: SESSION_ID,
+      type: 'QUIZ',
+      quizId: QUIZ_ID,
+      qaEnabled: true,
+      qaOpen: true,
+      qaTitle: 'Fragen',
+      qaModerationMode: true,
+      title: null,
+      moderationMode: false,
+      quickFeedbackEnabled: false,
+      quickFeedbackOpen: false,
+    });
+
+    await caller.attachQuizToSession({ code: 'ABC123', quizId: QUIZ_ID });
+
+    expect(prismaMock.session.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          quizId: QUIZ_ID,
+          onboardingTeamMode: true,
+          onboardingTeamCount: 2,
+          onboardingTeamNames: ['Team 🍎', 'Team 🍐'],
+          onboardingNicknameTheme: 'HIGH_SCHOOL',
+        }),
+      }),
+    );
+    expect(prismaMock.participant.update).toHaveBeenNthCalledWith(1, {
+      where: { id: 'p-1' },
+      data: { teamId: TEAM_A },
+    });
+    expect(prismaMock.participant.update).toHaveBeenNthCalledWith(2, {
+      where: { id: 'p-2' },
+      data: { teamId: TEAM_B },
+    });
+    expect(prismaMock.participant.update).toHaveBeenNthCalledWith(3, {
+      where: { id: 'p-3' },
+      data: { teamId: TEAM_A },
+    });
+  });
+
+  it('lehnt ein gewöhnliches Team-Quiz an teamlosen Sessions mit Teilnehmenden weiter ab', async () => {
+    prismaMock.session.findUnique.mockResolvedValue({
+      id: SESSION_ID,
+      type: 'QUIZ',
+      status: 'LOBBY',
+      currentQuestion: null,
+      quizId: null,
+      qaEnabled: true,
+      qaOpen: true,
+      qaTitle: 'Fragen',
+      qaModerationMode: true,
+      title: null,
+      moderationMode: false,
+      quickFeedbackEnabled: false,
+      quickFeedbackOpen: false,
+      onboardingProfileConfigured: true,
+      onboardingAllowCustomNicknames: false,
+      onboardingAnonymousMode: false,
+      onboardingTeamMode: false,
+      onboardingTeamCount: null,
+      onboardingTeamAssignment: 'AUTO',
+      onboardingTeamNames: [],
+      onboardingNicknameTheme: 'HIGH_SCHOOL',
+      _count: { participants: 2 },
+    });
+    prismaMock.quiz.findUnique.mockResolvedValue({
+      id: QUIZ_ID,
+      historyScopeId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      nicknameTheme: 'KINDERGARTEN',
+      allowCustomNicknames: false,
+      anonymousMode: false,
+      teamMode: true,
+      teamCount: 2,
+      teamAssignment: 'AUTO',
+      teamNames: ['Team 🍎', 'Team 🍐'],
+    });
+
+    await expect(
+      caller.attachQuizToSession({ code: 'ABC123', quizId: QUIZ_ID }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Dieses Quiz passt nicht zur Teamsituation der laufenden Session.',
+    });
+    expect(prismaMock.session.update).not.toHaveBeenCalled();
+  });
 });

--- a/apps/backend/src/__tests__/session.join.test.ts
+++ b/apps/backend/src/__tests__/session.join.test.ts
@@ -23,7 +23,14 @@ const {
       findFirst: vi.fn(),
       create: vi.fn(),
       count: vi.fn(),
+      update: vi.fn(),
     },
+    team: {
+      findMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+    $executeRaw: vi.fn().mockResolvedValue(1),
   },
   rateLimitMocks: {
     checkSessionCreateRate: vi.fn(),
@@ -130,6 +137,9 @@ describe('session.join', () => {
     joinAdmissionMocks.awaitJoinAdmissionSlot.mockResolvedValue({ delayedMs: 0, attempts: 1 });
     prismaMock.session.findUnique.mockResolvedValue(buildSession());
     prismaMock.participant.count.mockResolvedValue(3);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
   });
 
   it('verwendet einen bestehenden Teilnehmer per rejoinToken erneut', async () => {
@@ -207,6 +217,58 @@ describe('session.join', () => {
       expect(statsMocks.updateDailyMaxParticipants).toHaveBeenCalledWith(4);
     },
   );
+
+  it('weist nach Create ein AUTO-Team zu, wenn Attach parallel Teams aktiviert hat', async () => {
+    const TEAM_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const TEAM_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    prismaMock.participant.create.mockResolvedValue({
+      id: PARTICIPANT_ID,
+    });
+    prismaMock.participant.count.mockResolvedValue(1);
+    prismaMock.session.findUnique.mockResolvedValueOnce(buildSession()).mockResolvedValueOnce({
+      ...buildSession(),
+      onboardingProfileConfigured: true,
+      onboardingTeamMode: true,
+      onboardingTeamCount: 2,
+      onboardingTeamAssignment: 'AUTO',
+      onboardingTeamNames: ['Team 🍎', 'Team 🍐'],
+      onboardingNicknameTheme: 'HIGH_SCHOOL',
+      quiz: {
+        ...buildSession().quiz,
+        teamMode: true,
+        teamCount: 2,
+        teamAssignment: 'AUTO',
+        teamNames: ['Team 🍎', 'Team 🍐'],
+      },
+      _count: { participants: 1 },
+    });
+    prismaMock.team.findMany.mockResolvedValue([
+      { id: TEAM_A, name: 'Team 🍎', color: '#1E88E5', _count: { participants: 0 } },
+      { id: TEAM_B, name: 'Team 🍐', color: '#43A047', _count: { participants: 0 } },
+    ]);
+
+    const result = await caller.join({
+      code: 'ABC123',
+      nickname: 'Late Joiner',
+      anonymousClientId: CLIENT_ID,
+    });
+
+    expect(prismaMock.participant.create).toHaveBeenCalledWith({
+      data: {
+        sessionId: SESSION_ID,
+        nickname: 'Late Joiner',
+        teamId: undefined,
+      },
+    });
+    expect(prismaMock.$executeRaw).toHaveBeenCalled();
+    expect(prismaMock.participant.update).toHaveBeenCalledWith({
+      where: { id: PARTICIPANT_ID },
+      data: { teamId: TEAM_A },
+    });
+    expect(result.teamId).toBe(TEAM_A);
+    expect(result.teamName).toBe('Team 🍎');
+    expect(result.teamMode).toBe(true);
+  });
 
   it('lässt Rejoins auch bei ausgefallenem oder ausgeschöpftem Globalbudget unverzögert', async () => {
     invalidSessionCodeMocks.rejectInvalidSessionCode.mockRejectedValue(

--- a/apps/backend/src/__tests__/session.teams.test.ts
+++ b/apps/backend/src/__tests__/session.teams.test.ts
@@ -16,6 +16,7 @@ const { prismaMock, hostAuthMocks, joinAdmissionMocks, invalidSessionCodeMock } 
         create: vi.fn(),
         count: vi.fn(),
         findMany: vi.fn(),
+        update: vi.fn(),
       },
       vote: {
         findMany: vi.fn(),
@@ -23,6 +24,7 @@ const { prismaMock, hostAuthMocks, joinAdmissionMocks, invalidSessionCodeMock } 
       qaQuestion: {
         findMany: vi.fn(),
       },
+      $transaction: vi.fn(),
       $executeRaw: vi.fn().mockResolvedValue(1),
     },
     hostAuthMocks: {
@@ -80,6 +82,9 @@ describe('session team mode (Story 7.1)', () => {
     hostAuthMocks.isHostSessionTokenValidMock.mockResolvedValue(true);
     invalidSessionCodeMock.mockRejectedValue(new TRPCError({ code: 'NOT_FOUND' }));
     prismaMock.$executeRaw.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: (tx: typeof prismaMock) => unknown) =>
+      fn(prismaMock),
+    );
     prismaMock.qaQuestion.findMany.mockResolvedValue([]);
   });
 

--- a/apps/backend/src/routers/session.ts
+++ b/apps/backend/src/routers/session.ts
@@ -97,6 +97,7 @@ import {
   SendEmojiReactionInputSchema,
   EMOJI_REACTIONS,
   DEFAULT_TEAM_COUNT,
+  DEMO_QUIZ_HISTORY_SCOPE_ID,
   NicknameThemeEnum,
   SHORT_TEXT_DEFAULT_EVALUATION_MODE,
   SHORT_TEXT_DEFAULT_TOLERANCE_LEVEL,
@@ -2840,6 +2841,20 @@ function areSessionOnboardingProfilesCompatible(
   return sessionProfile.teamMode === quizProfile.teamMode;
 }
 
+/** Showcase-Demo-Quiz: teamlose Session darf Teams (Apfel/Birne) per AUTO nachziehen. */
+function canBootstrapDemoQuizTeamsOntoTeamlessSession(
+  sessionProfile: SessionOnboardingProfile,
+  quizProfile: SessionOnboardingProfile,
+  quiz: { historyScopeId?: string | null },
+): boolean {
+  return (
+    quiz.historyScopeId === DEMO_QUIZ_HISTORY_SCOPE_ID &&
+    !sessionProfile.teamMode &&
+    quizProfile.teamMode &&
+    quizProfile.teamAssignment === 'AUTO'
+  );
+}
+
 async function ensureSessionTeams(
   sessionId: string,
   requestedTeamCount: number,
@@ -4912,6 +4927,7 @@ export const sessionRouter = router({
         where: { id: input.quizId },
         select: {
           id: true,
+          historyScopeId: true,
           nicknameTheme: true,
           allowCustomNicknames: true,
           anonymousMode: true,
@@ -4927,9 +4943,15 @@ export const sessionRouter = router({
 
       const sessionOnboardingProfile = resolveSessionOnboardingProfile(session, null);
       const quizOnboardingProfile = buildSessionOnboardingProfileFromQuiz(quiz);
+      const bootstrapDemoTeams = canBootstrapDemoQuizTeamsOntoTeamlessSession(
+        sessionOnboardingProfile,
+        quizOnboardingProfile,
+        quiz,
+      );
       if (
         session._count.participants > 0 &&
-        !areSessionOnboardingProfilesCompatible(sessionOnboardingProfile, quizOnboardingProfile)
+        !areSessionOnboardingProfilesCompatible(sessionOnboardingProfile, quizOnboardingProfile) &&
+        !bootstrapDemoTeams
       ) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
@@ -4953,6 +4975,18 @@ export const sessionRouter = router({
         });
       }
 
+      const onboardingForUpdate = bootstrapDemoTeams
+        ? {
+            ...sessionOnboardingProfile,
+            teamMode: true,
+            teamCount: quizOnboardingProfile.teamCount,
+            teamAssignment: quizOnboardingProfile.teamAssignment,
+            teamNames: quizOnboardingProfile.teamNames,
+          }
+        : hasStoredSessionOnboardingProfile(session)
+          ? sessionOnboardingProfile
+          : quizOnboardingProfile;
+
       const updated = await prisma.session.update({
         where: { id: session.id },
         data: {
@@ -4961,11 +4995,7 @@ export const sessionRouter = router({
           currentQuestion: null,
           currentRound: 1,
           answerDisplayOrder: Prisma.JsonNull,
-          ...buildSessionOnboardingUpdate(
-            hasStoredSessionOnboardingProfile(session)
-              ? sessionOnboardingProfile
-              : quizOnboardingProfile,
-          ),
+          ...buildSessionOnboardingUpdate(onboardingForUpdate),
         },
         select: {
           id: true,

--- a/apps/backend/src/routers/session.ts
+++ b/apps/backend/src/routers/session.ts
@@ -3030,6 +3030,98 @@ async function assignExistingParticipantsToTeams(
   }
 }
 
+const SESSION_ONBOARDING_LOCK_SELECT = {
+  onboardingProfileConfigured: true,
+  onboardingNicknameTheme: true,
+  onboardingAllowCustomNicknames: true,
+  onboardingAnonymousMode: true,
+  onboardingTeamMode: true,
+  onboardingTeamCount: true,
+  onboardingTeamAssignment: true,
+  onboardingTeamNames: true,
+  quiz: {
+    select: {
+      nicknameTheme: true,
+      allowCustomNicknames: true,
+      anonymousMode: true,
+      teamMode: true,
+      teamCount: true,
+      teamAssignment: true,
+      teamNames: true,
+    },
+  },
+  _count: { select: { participants: true } },
+} as const;
+
+/**
+ * Schließt die Race „Join liest teamlos → Attach aktiviert Teams → Create ohne teamId“.
+ * Unter Session-Row-Lock wird das aktuelle Profil gelesen und AUTO-Teams nachgezogen.
+ */
+async function reconcileParticipantAutoTeamUnderSessionLock(input: {
+  sessionId: string;
+  participantId: string;
+  teamId: string | null;
+  teamName: string | null;
+  fallbackProfile: SessionOnboardingProfile;
+}): Promise<{
+  teamId: string | null;
+  teamName: string | null;
+  profile: SessionOnboardingProfile;
+}> {
+  return prisma.$transaction(async (tx) => {
+    await lockSessionRow(tx, input.sessionId);
+    const lockedSession = await tx.session.findUnique({
+      where: { id: input.sessionId },
+      select: SESSION_ONBOARDING_LOCK_SELECT,
+    });
+    if (!lockedSession) {
+      return {
+        teamId: input.teamId,
+        teamName: input.teamName,
+        profile: input.fallbackProfile,
+      };
+    }
+
+    const profile = resolveSessionOnboardingProfile(lockedSession, lockedSession.quiz);
+    if (!profile.teamMode || profile.teamAssignment !== 'AUTO') {
+      return {
+        teamId: input.teamId,
+        teamName: input.teamName,
+        profile,
+      };
+    }
+
+    if (input.teamId) {
+      return {
+        teamId: input.teamId,
+        teamName: input.teamName,
+        profile,
+      };
+    }
+
+    const teams = await ensureSessionTeams(
+      input.sessionId,
+      profile.teamCount ?? DEFAULT_TEAM_COUNT,
+      profile.teamNames,
+    );
+    if (teams.length === 0) {
+      return { teamId: null, teamName: null, profile };
+    }
+
+    const participantIndex = Math.max(0, lockedSession._count.participants - 1);
+    const team = teams[participantIndex % teams.length]!;
+    await tx.participant.update({
+      where: { id: input.participantId },
+      data: { teamId: team.id },
+    });
+    return {
+      teamId: team.id,
+      teamName: team.name,
+      profile,
+    };
+  });
+}
+
 function buildSessionChannels(session: {
   type: 'QUIZ' | 'Q_AND_A';
   quizId?: string | null;
@@ -4987,44 +5079,49 @@ export const sessionRouter = router({
           ? sessionOnboardingProfile
           : quizOnboardingProfile;
 
-      const updated = await prisma.session.update({
-        where: { id: session.id },
-        data: {
-          type: 'QUIZ',
-          quizId: quiz.id,
-          currentQuestion: null,
-          currentRound: 1,
-          answerDisplayOrder: Prisma.JsonNull,
-          ...buildSessionOnboardingUpdate(onboardingForUpdate),
-        },
-        select: {
-          id: true,
-          type: true,
-          quizId: true,
-          qaEnabled: true,
-          qaOpen: true,
-          qaTitle: true,
-          qaModerationMode: true,
-          title: true,
-          moderationMode: true,
-          quickFeedbackEnabled: true,
-          quickFeedbackOpen: true,
-        },
-      });
+      const updated = await prisma.$transaction(async (tx) => {
+        await lockSessionRow(tx, session.id);
+        const next = await tx.session.update({
+          where: { id: session.id },
+          data: {
+            type: 'QUIZ',
+            quizId: quiz.id,
+            currentQuestion: null,
+            currentRound: 1,
+            answerDisplayOrder: Prisma.JsonNull,
+            ...buildSessionOnboardingUpdate(onboardingForUpdate),
+          },
+          select: {
+            id: true,
+            type: true,
+            quizId: true,
+            qaEnabled: true,
+            qaOpen: true,
+            qaTitle: true,
+            qaModerationMode: true,
+            title: true,
+            moderationMode: true,
+            quickFeedbackEnabled: true,
+            quickFeedbackOpen: true,
+          },
+        });
 
-      if (quizOnboardingProfile.teamMode) {
-        const teams = await ensureSessionTeams(
-          session.id,
-          quizOnboardingProfile.teamCount ?? DEFAULT_TEAM_COUNT,
-          quizOnboardingProfile.teamNames,
-        );
-        if (quizOnboardingProfile.teamAssignment === 'AUTO' && session._count.participants > 0) {
-          await assignExistingParticipantsToTeams(
+        if (quizOnboardingProfile.teamMode) {
+          const teams = await ensureSessionTeams(
             session.id,
-            teams.map((team) => team.id),
+            quizOnboardingProfile.teamCount ?? DEFAULT_TEAM_COUNT,
+            quizOnboardingProfile.teamNames,
           );
+          if (quizOnboardingProfile.teamAssignment === 'AUTO') {
+            await assignExistingParticipantsToTeams(
+              session.id,
+              teams.map((team) => team.id),
+            );
+          }
         }
-      }
+
+        return next;
+      });
 
       invalidateSessionStatusCachesForCode(code);
       return buildSessionChannels(updated);
@@ -7620,6 +7717,17 @@ export const sessionRouter = router({
         });
       }
 
+      const reconciled = await reconcileParticipantAutoTeamUnderSessionLock({
+        sessionId: session.id,
+        participantId,
+        teamId: assignedTeamId ?? null,
+        teamName: assignedTeamName,
+        fallbackProfile: onboardingProfile,
+      });
+      assignedTeamId = reconciled.teamId ?? undefined;
+      assignedTeamName = reconciled.teamName;
+      const responseProfile = reconciled.profile;
+
       // Nach Create zählen (nicht _count+1): bei gleichzeitigen Joins ist der Anfangssnapshot sonst zu niedrig — Rekord/Response falsch.
       const newParticipantCount = await prisma.participant.count({
         where: { sessionId: session.id },
@@ -7644,13 +7752,13 @@ export const sessionRouter = router({
         preferredChannel,
         presenterSurface: resolvePresenterSurface(session.code, preferredChannel),
         participantCount: newParticipantCount,
-        nicknameTheme: onboardingProfile.nicknameTheme,
-        allowCustomNicknames: onboardingProfile.allowCustomNicknames,
-        anonymousMode: onboardingProfile.anonymousMode,
-        teamMode: onboardingProfile.teamMode,
-        teamCount: onboardingProfile.teamCount,
-        teamAssignment: onboardingProfile.teamMode ? onboardingProfile.teamAssignment : null,
-        teamNames: onboardingProfile.teamMode ? buildEffectiveTeamNames(onboardingProfile) : [],
+        nicknameTheme: responseProfile.nicknameTheme,
+        allowCustomNicknames: responseProfile.allowCustomNicknames,
+        anonymousMode: responseProfile.anonymousMode,
+        teamMode: responseProfile.teamMode,
+        teamCount: responseProfile.teamCount,
+        teamAssignment: responseProfile.teamMode ? responseProfile.teamAssignment : null,
+        teamNames: responseProfile.teamMode ? buildEffectiveTeamNames(responseProfile) : [],
         participantId,
         rejoinToken: participantId,
         teamId: assignedTeamId ?? null,

--- a/apps/frontend/src/app/features/quiz/data/quiz-store.service.ts
+++ b/apps/frontend/src/app/features/quiz/data/quiz-store.service.ts
@@ -48,6 +48,7 @@ import {
   type TeamAssignment,
   type ToleranceLevel,
   type MatchingPairInput,
+  DEMO_QUIZ_HISTORY_SCOPE_ID,
   type OrderingItemInput,
   type CategorizationCategoryInput,
   type CategorizationItemInput,
@@ -977,7 +978,7 @@ const DEFAULT_QUIZ_SETTINGS: QuizSettings = parseQuizSettings({});
 type SyncConnectionState = 'connected' | 'connecting' | 'disconnected';
 export type LibrarySharingMode = 'local' | 'shared';
 
-export const DEMO_QUIZ_ID = 'de500000-0000-4000-a000-000000000001';
+export const DEMO_QUIZ_ID = DEMO_QUIZ_HISTORY_SCOPE_ID;
 
 /**
  * Erwarteter Demo-Seed aus Showcase-JSON (Locale + Version + Payload-Hash). Alte Keys

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.spec.ts
@@ -16,7 +16,7 @@ import { SessionHostComponent } from './session-host.component';
 import { WordCloudComponent } from '../session-present/word-cloud.component';
 import { SessionTokenStorageService } from '../session-present/session-token-storage.service';
 import { ThemePresetService } from '../../../core/theme-preset.service';
-import { QuizStoreService } from '../../quiz/data/quiz-store.service';
+import { QuizStoreService, DEMO_QUIZ_ID } from '../../quiz/data/quiz-store.service';
 import { resetServerClockSkew } from '../session-server-clock';
 
 const unsubscribeMock = vi.fn();
@@ -303,10 +303,41 @@ const quizStoreMock = {
             },
             questions: [],
           }
-        : null,
+        : id === DEMO_QUIZ_ID
+          ? {
+              id: DEMO_QUIZ_ID,
+              name: 'Demo Quiz',
+              description: 'Showcase',
+              motifImageUrl: null,
+              createdAt: '2026-03-21T12:00:00.000Z',
+              updatedAt: '2026-03-25T12:00:00.000Z',
+              settings: {
+                showLeaderboard: true,
+                allowCustomNicknames: false,
+                defaultTimer: 30,
+                enableSoundEffects: true,
+                enableRewardEffects: true,
+                enableMotivationMessages: true,
+                enableEmojiReactions: true,
+                showQuestionTypeIndicators: true,
+                anonymousMode: false,
+                teamMode: true,
+                teamCount: 2,
+                teamAssignment: 'AUTO',
+                teamNames: ['Team 🍎', 'Team 🍐'],
+                backgroundMusic: null,
+                nicknameTheme: 'KINDERGARTEN',
+                bonusTokenCount: 3,
+                readingPhaseEnabled: true,
+                preset: 'PLAYFUL',
+              },
+              questions: [],
+            }
+          : null,
   ),
   getUploadPayload: vi.fn(),
   setLastServerUploadAccess: vi.fn(),
+  ensureDemoQuiz: vi.fn(() => true),
 };
 
 describe('SessionHostComponent', { timeout: 30_000 }, () => {
@@ -1510,6 +1541,94 @@ describe('SessionHostComponent', { timeout: 30_000 }, () => {
       code: 'ABC123',
       quizId: '44444444-4444-4444-8444-444444444444',
     });
+    fixture.destroy();
+  });
+
+  it('bietet das Demo-Quiz in teamlosen Sessions trotz teamMode an', async () => {
+    getInfoQueryMock.mockResolvedValue({
+      ...defaultSession,
+      quizName: null,
+      teamMode: false,
+      teamCount: null,
+      teamAssignment: null,
+      teamNames: [],
+      preferredChannel: 'qa',
+      channels: {
+        quiz: { enabled: false },
+        qa: { enabled: true, open: true, title: 'Fragen', moderationMode: false },
+        quickFeedback: { enabled: false, open: false },
+      },
+    });
+    quizStoreMock.quizzes.set([
+      {
+        id: 'local-quiz-1',
+        name: 'Quiz Sammlung',
+        description: 'Mitgebrachte Fragen',
+        createdAt: '2026-03-20T12:00:00.000Z',
+        updatedAt: '2026-03-24T12:00:00.000Z',
+        questionCount: 3,
+        teamMode: false,
+        hasBonus: false,
+        lastServerQuizId: null,
+        lastServerQuizAccessProof: null,
+      },
+      {
+        id: DEMO_QUIZ_ID,
+        name: 'Demo Quiz',
+        description: 'Showcase',
+        createdAt: '2026-03-21T12:00:00.000Z',
+        updatedAt: '2026-03-25T12:00:00.000Z',
+        questionCount: 13,
+        teamMode: true,
+        hasBonus: true,
+        lastServerQuizId: null,
+        lastServerQuizAccessProof: null,
+      },
+      {
+        id: 'local-quiz-incompatible',
+        name: 'Team Quiz',
+        description: 'Nur für Teams',
+        createdAt: '2026-03-21T12:00:00.000Z',
+        updatedAt: '2026-03-25T12:00:00.000Z',
+        questionCount: 2,
+        teamMode: true,
+        hasBonus: false,
+        lastServerQuizId: null,
+        lastServerQuizAccessProof: null,
+      },
+    ]);
+    dialogOpenMock.mockReturnValueOnce({ afterClosed: () => of(undefined) });
+
+    const fixture = setup();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.componentInstance.activeChannel.set('qa');
+    fixture.detectChanges();
+
+    const toggles = Array.from(
+      fixture.nativeElement.querySelectorAll('mat-button-toggle'),
+    ) as HTMLElement[];
+    const quizToggle = toggles.find((toggle) => toggle.textContent?.includes('Quiz'));
+    (quizToggle?.querySelector('button') as HTMLButtonElement | null)?.click();
+
+    await vi.waitUntil(() => dialogOpenMock.mock.calls.length === 1);
+
+    expect(quizStoreMock.ensureDemoQuiz).toHaveBeenCalled();
+    expect(dialogOpenMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          quizzes: expect.arrayContaining([
+            expect.objectContaining({ id: 'local-quiz-1' }),
+            expect.objectContaining({ id: DEMO_QUIZ_ID }),
+          ]),
+        }),
+      }),
+    );
+    const offeredIds = (
+      dialogOpenMock.mock.calls[0]?.[1] as { data: { quizzes: Array<{ id: string }> } }
+    ).data.quizzes.map((quiz) => quiz.id);
+    expect(offeredIds).not.toContain('local-quiz-incompatible');
     fixture.destroy();
   });
 

--- a/apps/frontend/src/app/features/session/session-host/session-host.component.ts
+++ b/apps/frontend/src/app/features/session/session-host/session-host.component.ts
@@ -190,7 +190,7 @@ import {
   tempoTrendEmoji,
   tempoTrendLabel,
 } from '../../feedback/feedback.config';
-import { QuizStoreService } from '../../quiz/data/quiz-store.service';
+import { QuizStoreService, DEMO_QUIZ_ID } from '../../quiz/data/quiz-store.service';
 import {
   buildQaQuestionsCsvFilename,
   buildSessionResultsCsvFilename,
@@ -7570,6 +7570,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
   }
 
   private async chooseQuizForSession(): Promise<string | undefined> {
+    this.quizStore.ensureDemoQuiz();
     const quizzes = this.quizStore
       .quizzes()
       .filter((quiz) => this.isLocalQuizCompatibleWithSession(quiz.id));
@@ -7600,7 +7601,7 @@ export class SessionHostComponent implements OnInit, OnDestroy {
     if (!quiz) {
       return false;
     }
-    return this.areOnboardingProfilesCompatible(sessionProfile, {
+    const quizProfile = {
       nicknameTheme: quiz.settings.nicknameTheme,
       allowCustomNicknames: quiz.settings.allowCustomNicknames,
       anonymousMode: quiz.settings.anonymousMode,
@@ -7608,7 +7609,16 @@ export class SessionHostComponent implements OnInit, OnDestroy {
       teamCount: quiz.settings.teamMode ? quiz.settings.teamCount : null,
       teamAssignment: quiz.settings.teamMode ? quiz.settings.teamAssignment : 'AUTO',
       teamNames: quiz.settings.teamMode ? quiz.settings.teamNames : [],
-    });
+    };
+    if (
+      localQuizId === DEMO_QUIZ_ID &&
+      !sessionProfile.teamMode &&
+      quizProfile.teamMode &&
+      quizProfile.teamAssignment === 'AUTO'
+    ) {
+      return true;
+    }
+    return this.areOnboardingProfilesCompatible(sessionProfile, quizProfile);
   }
 
   private getSessionOnboardingProfile(): SessionOnboardingProfile | null {

--- a/docs/features/team-mode.md
+++ b/docs/features/team-mode.md
@@ -82,7 +82,7 @@ Besonderheiten:
 - `Participant.teamId` ist optional (`onDelete: SetNull`)
 - `Team.color` ist eine feste Hex-Farbe aus einer Palette von 8 Farben
 - Beim Session-Start kann ein **Session-Onboarding-Profil** die Quiz-Werte spiegeln; die laufende Session nutzt dann die `onboarding*`-Felder, damit spätere Quiz-Edits die Live-Session nicht nachträglich verändern.
-- **Sonderfall Showcase-Demo-Quiz** (`DEMO_QUIZ_HISTORY_SCOPE_ID`): Darf an eine **teamlose** Session mit Teilnehmenden angehängt werden. Pseudonyme bleiben (Session-Theme). Die Session aktiviert danach `teamMode` mit den Demo-Teams (Apfel/Birne, AUTO); Teilnehmende ohne `teamId` werden round-robin zugewiesen. Andere Team-Quizzes bleiben an die `teamMode`-Kompatibilität gebunden.
+- **Sonderfall Showcase-Demo-Quiz** (`DEMO_QUIZ_HISTORY_SCOPE_ID`): Darf an eine **teamlose** Session mit Teilnehmenden angehängt werden. Pseudonyme bleiben (Session-Theme). Die Session aktiviert danach `teamMode` mit den Demo-Teams (Apfel/Birne, AUTO); Teilnehmende ohne `teamId` werden round-robin zugewiesen. Andere Team-Quizzes bleiben an die `teamMode`-Kompatibilität gebunden. Attach und Join serialisieren den Team-Bootstrap über einen Session-Row-Lock; Joins ohne Team holen AUTO-Zuweisung nach dem Create nach.
 
 ---
 

--- a/docs/features/team-mode.md
+++ b/docs/features/team-mode.md
@@ -82,6 +82,7 @@ Besonderheiten:
 - `Participant.teamId` ist optional (`onDelete: SetNull`)
 - `Team.color` ist eine feste Hex-Farbe aus einer Palette von 8 Farben
 - Beim Session-Start kann ein **Session-Onboarding-Profil** die Quiz-Werte spiegeln; die laufende Session nutzt dann die `onboarding*`-Felder, damit spätere Quiz-Edits die Live-Session nicht nachträglich verändern.
+- **Sonderfall Showcase-Demo-Quiz** (`DEMO_QUIZ_HISTORY_SCOPE_ID`): Darf an eine **teamlose** Session mit Teilnehmenden angehängt werden. Pseudonyme bleiben (Session-Theme). Die Session aktiviert danach `teamMode` mit den Demo-Teams (Apfel/Birne, AUTO); Teilnehmende ohne `teamId` werden round-robin zugewiesen. Andere Team-Quizzes bleiben an die `teamMode`-Kompatibilität gebunden.
 
 ---
 

--- a/libs/shared-types/src/schemas.ts
+++ b/libs/shared-types/src/schemas.ts
@@ -5111,6 +5111,12 @@ export const SC_FORMAT_PRESETS: Record<ScFormat, { label: string; answers: strin
   ABCD: { label: 'A / B / C / D', answers: ['A', 'B', 'C', 'D'] },
 };
 
+/**
+ * Stabile ID des Showcase-Demo-Quiz (lokale Bibliothek + `historyScopeId` nach Upload).
+ * Ermöglicht Session-Sonderregeln (z. B. Team-Bootstrap auf teamlose Sessions).
+ */
+export const DEMO_QUIZ_HISTORY_SCOPE_ID = 'de500000-0000-4000-a000-000000000001';
+
 /** Preset-Konfigurationen (Story 1.11) — clientseitig angewandt */
 export const QUIZ_PRESETS: Record<QuizPreset, Partial<CreateQuizInput>> = {
   PLAYFUL: {


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** In Sessions ohne Teams (z. B. nach Q&A/Blitzlicht-Start) erscheint das Showcase-Demo-Quiz nicht in der Auswahl, weil `teamMode` Session/Quiz hart verglichen wird — obwohl das Demo genau für den Einstieg gedacht ist.
- **Lösung:** Nur für `DEMO_QUIZ_HISTORY_SCOPE_ID` die Kompatibilität lockern: Demo darf an teamlose Sessions; Pseudonyme bleiben; Session aktiviert Demo-Teams (Apfel/Birne, AUTO); Teilnehmende ohne `teamId` werden round-robin verteilt. Andere Team-Quizzes bleiben gesperrt.
- **Bewusste Nicht-Ziele:** Kein allgemeines Team-Count-/Namen-Matching, kein Pseudonym-Tausch, kein Team-Restore nach Quiz-Ende, kein Foyer-„Quiz wechseln“.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Session-Onboarding bleibt für Pseudonyme maßgeblich; Team-Bootstrap nur für das stabile Showcase-Demo (`historyScopeId` / lokale Demo-ID) mit `teamMode` + `AUTO`. Host-Autorisierung weiter über `hostProcedure`.

**Betroffene externe Verträge:**

Keine neuen öffentlichen API-Felder; Verhalten von `session.attachQuizToSession` für einen bekannten Demo-Scope erweitert.

## Implementierung

- `DEMO_QUIZ_HISTORY_SCOPE_ID` in `@arsnova/shared-types`; Frontend `DEMO_QUIZ_ID` daran gebunden
- Backend: Ausnahme + Onboarding-Merge (Nicknames Session, Teams Demo) + bestehende AUTO-Zuweisung
- Frontend-Picker: Demo trotz teamloser Session anbieten; `ensureDemoQuiz` vor Auswahl
- Doku in `docs/features/team-mode.md`

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

Begründung: Zustandsübergang ist der einmalige Attach-Pfad (teamlose Session → Demo mit Teams); abgedeckt durch Backend-/Host-Tests. Kein asynchrones UI-Pending über den bestehenden Picker hinaus.

## Validierung

- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm run build -w @arsnova/shared-types` | bestanden |
| `npm run test -w @arsnova/backend -- src/__tests__/session.attach-quiz.test.ts` | bestanden (7/7) |
| `npm run test -w @arsnova/frontend -- …/session-host.component.spec.ts` | bestanden (261/261) |
| Pre-commit typecheck/test | folgt beim Commit |
| `npm run build:prod` | CI |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Hosts können das Demo-Quiz nach Q&A/Blitzlicht in teamlosen Sessions anhängen; Voters behalten Pseudonyme und erhalten Team-Zuordnung.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine neuen.
- **Rollback:** Revert dieses PR.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Unit-Tests für Demo-Bootstrap und Ablehnung gewöhnlicher Team-Quizzes; Host-Picker-Test für Demo in teamloser Session.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** Keine i18n-Textänderung; kein DB-Migration; Attach bleibt Host-only. Vollständiger Prod-Build in CI.
- **Verbleibende Risiken:** Lokal verändertes Demo mit weiterhin `teamMode`+`AUTO` nutzt dieselbe Ausnahme (beabsichtigt). Session behält danach Teams (einmalige Quiz-Auswahl).

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)