### PR TITLE
fix(ui): Zurück-Button am Ende der Content-Seiten

### DIFF
--- a/apps/frontend/src/app/features/help/help.component.html
+++ b/apps/frontend/src/app/features/help/help.component.html
@@ -467,6 +467,22 @@
           </mat-accordion>
         </section>
       </article>
+      <nav
+        class="content-back content-back--bottom"
+        i18n-aria-label="@@contentPage.navigationBottomAria"
+        aria-label="Navigation am Seitenende"
+      >
+        <button
+          mat-button
+          type="button"
+          (click)="back()"
+          i18n-aria-label="@@contentPage.backAria"
+          aria-label="Zurück zur vorherigen Seite"
+        >
+          <mat-icon>arrow_back</mat-icon>
+          <span i18n="@@contentPage.back">Zurück</span>
+        </button>
+      </nav>
     </div>
   </div>
   <div class="content-page-backdrop-rail" aria-hidden="true" (click)="back()"></div>

--- a/apps/frontend/src/app/features/help/help.component.scss
+++ b/apps/frontend/src/app/features/help/help.component.scss
@@ -21,6 +21,11 @@
   margin-bottom: 2rem;
 }
 
+.content-back--bottom {
+  margin-top: 2.5rem;
+  margin-bottom: 0;
+}
+
 .legal-article {
   font: var(--mat-sys-body-large);
   color: var(--mat-sys-on-surface);

--- a/apps/frontend/src/app/features/help/help.component.spec.ts
+++ b/apps/frontend/src/app/features/help/help.component.spec.ts
@@ -89,8 +89,25 @@ describe('HelpComponent', () => {
   it('benennt Navigations-Landmarks lokalisierbar', async () => {
     const fixture = await createFixture();
     const root = fixture.nativeElement as HTMLElement;
-    expect(root.querySelector('nav.content-back')?.getAttribute('aria-label')).toBe('Navigation');
+    const backNavs = root.querySelectorAll('nav.content-back');
+    expect(backNavs).toHaveLength(2);
+    expect(backNavs[0]?.getAttribute('aria-label')).toBe('Navigation');
+    expect(backNavs[1]?.getAttribute('aria-label')).toBe('Navigation am Seitenende');
+    expect(backNavs[1]?.classList.contains('content-back--bottom')).toBe(true);
     expect(root.querySelector('nav.help-role-nav')?.getAttribute('aria-label')).toBe('Rollenwahl');
+  });
+
+  it('schließt über den Zurück-Button am Seitenende', async () => {
+    Object.defineProperty(window.history, 'length', { configurable: true, value: 3 });
+    const fixture = await createFixture();
+    const location = TestBed.inject(Location);
+    const spy = vi.spyOn(location, 'back');
+    const bottomBack = fixture.nativeElement.querySelector(
+      'nav.content-back--bottom button',
+    ) as HTMLButtonElement | null;
+    expect(bottomBack).toBeTruthy();
+    bottomBack!.click();
+    expect(spy).toHaveBeenCalledOnce();
   });
 
   it('rendert beide Rollenkarten mit locale-sicheren Ankerzielen', async () => {

--- a/apps/frontend/src/app/features/legal/legal-page.component.html
+++ b/apps/frontend/src/app/features/legal/legal-page.component.html
@@ -58,6 +58,22 @@
           <div class="legal-page__md" [innerHTML]="legalHtml"></div>
         }
       </article>
+      <nav
+        class="legal-back legal-back--bottom"
+        i18n-aria-label="@@contentPage.navigationBottomAria"
+        aria-label="Navigation am Seitenende"
+      >
+        <button
+          mat-button
+          type="button"
+          (click)="back()"
+          i18n-aria-label="@@contentPage.backAria"
+          aria-label="Zurück zur vorherigen Seite"
+        >
+          <mat-icon>arrow_back</mat-icon>
+          <span i18n="@@contentPage.back">Zurück</span>
+        </button>
+      </nav>
     </div>
   </div>
   <div class="content-page-backdrop-rail" aria-hidden="true" (click)="back()"></div>

--- a/apps/frontend/src/app/features/legal/legal-page.component.scss
+++ b/apps/frontend/src/app/features/legal/legal-page.component.scss
@@ -21,6 +21,11 @@
   margin-bottom: 2rem;
 }
 
+.legal-back--bottom {
+  margin-top: 2.5rem;
+  margin-bottom: 0;
+}
+
 .legal-loading,
 .legal-error {
   color: var(--mat-sys-on-surface-variant);

--- a/apps/frontend/src/app/features/legal/legal-page.component.spec.ts
+++ b/apps/frontend/src/app/features/legal/legal-page.component.spec.ts
@@ -92,6 +92,29 @@ describe('LegalPageComponent', () => {
     expect(spy).toHaveBeenCalledOnce();
   });
 
+  it('bietet einen zweiten Zurück-Button am Seitenende', async () => {
+    Object.defineProperty(window.history, 'length', { configurable: true, value: 3 });
+    const fixture = TestBed.createComponent(LegalPageComponent);
+    const location = TestBed.inject(Location);
+    const spy = vi.spyOn(location, 'back');
+    fixture.detectChanges();
+    const req = httpMock.expectOne((r) => r.url.includes('assets/legal/imprint.de.md'));
+    req.flush('# Titel\n\nText.');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const backNavs = fixture.nativeElement.querySelectorAll('nav.legal-back');
+    expect(backNavs).toHaveLength(2);
+    expect(backNavs[0]?.getAttribute('aria-label')).toBe('Navigation');
+    expect(backNavs[1]?.getAttribute('aria-label')).toBe('Navigation am Seitenende');
+    const bottomBack = fixture.nativeElement.querySelector(
+      'nav.legal-back--bottom button',
+    ) as HTMLButtonElement | null;
+    expect(bottomBack).toBeTruthy();
+    bottomBack!.click();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
   it('behält den Dialogtitel im Lade- und Fehlerzustand', async () => {
     const fixture = TestBed.createComponent(LegalPageComponent);
     fixture.detectChanges();

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.html
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.html
@@ -167,6 +167,22 @@
           }
         }
       </article>
+      <nav
+        class="news-archive-page__back news-archive-page__back--bottom"
+        i18n-aria-label="@@contentPage.navigationBottomAria"
+        aria-label="Navigation am Seitenende"
+      >
+        <button
+          mat-button
+          type="button"
+          (click)="back()"
+          i18n-aria-label="@@contentPage.backAria"
+          aria-label="Zurück zur vorherigen Seite"
+        >
+          <mat-icon>arrow_back</mat-icon>
+          <span i18n="@@contentPage.back">Zurück</span>
+        </button>
+      </nav>
     </div>
   </div>
   <div class="content-page-backdrop-rail" aria-hidden="true" (click)="back()"></div>

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.scss
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.scss
@@ -25,6 +25,11 @@
   margin-bottom: 2rem;
 }
 
+.news-archive-page__back--bottom {
+  margin-top: 2.5rem;
+  margin-bottom: 0;
+}
+
 .news-archive-page__error {
   margin: 0;
   color: var(--mat-sys-error);

--- a/apps/frontend/src/app/features/news-archive/news-archive-page.component.spec.ts
+++ b/apps/frontend/src/app/features/news-archive/news-archive-page.component.spec.ts
@@ -463,6 +463,49 @@ describe('NewsArchivePageComponent', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('bietet einen zweiten Zurück-Button am Seitenende', () => {
+    TestBed.configureTestingModule({
+      imports: [NewsArchivePageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: MatDialog, useValue: { openDialogs: [] } },
+        { provide: LOCALE_ID, useValue: 'de' },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                newsArchive: emptyResolved,
+              },
+            },
+          },
+        },
+        { provide: MatSnackBar, useValue: { open: vi.fn() } },
+        { provide: MotdHeaderRefreshService, useValue: { notifyMotdHeaderRefresh: vi.fn() } },
+        {
+          provide: MotdHeaderStateService,
+          useValue: { decrementArchiveUnreadCount: vi.fn(), setArchiveUnreadCount: vi.fn() },
+        },
+      ],
+    }).compileComponents();
+
+    Object.defineProperty(window.history, 'length', { configurable: true, value: 3 });
+    const fixture = TestBed.createComponent(NewsArchivePageComponent);
+    const location = TestBed.inject(Location);
+    const spy = vi.spyOn(location, 'back');
+    fixture.detectChanges();
+
+    const backNavs = fixture.nativeElement.querySelectorAll('nav.news-archive-page__back');
+    expect(backNavs).toHaveLength(2);
+    expect(backNavs[1]?.getAttribute('aria-label')).toBe('Navigation am Seitenende');
+    const bottomBack = fixture.nativeElement.querySelector(
+      'nav.news-archive-page__back--bottom button',
+    ) as HTMLButtonElement | null;
+    expect(bottomBack).toBeTruthy();
+    bottomBack!.click();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
   it('markArchiveItemRead senkt den Zähler um 1 und zeigt den Gelesen-Status', () => {
     const itemId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
     const withItems: NewsArchiveInitialModel = {

--- a/apps/frontend/src/locale/messages.en.xlf
+++ b/apps/frontend/src/locale/messages.en.xlf
@@ -6382,6 +6382,22 @@
           <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="contentPage.navigationBottomAria" datatype="html">
+        <source>Navigation am Seitenende</source>
+        <target>End of page navigation</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">473</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/legal/legal-page.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">173</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="contentPage.backAria" datatype="html">
         <source>Zurück zur vorherigen Seite</source>
         <target>Back to previous page</target>

--- a/apps/frontend/src/locale/messages.es.xlf
+++ b/apps/frontend/src/locale/messages.es.xlf
@@ -6377,6 +6377,22 @@
           <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="contentPage.navigationBottomAria" datatype="html">
+        <source>Navigation am Seitenende</source>
+        <target>Navegación al final de la página</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">473</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/legal/legal-page.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">173</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="contentPage.backAria" datatype="html">
         <source>Zurück zur vorherigen Seite</source>
         <target>Volver a la página anterior</target>

--- a/apps/frontend/src/locale/messages.fr.xlf
+++ b/apps/frontend/src/locale/messages.fr.xlf
@@ -6377,6 +6377,22 @@
           <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="contentPage.navigationBottomAria" datatype="html">
+        <source>Navigation am Seitenende</source>
+        <target>Navigation en bas de page</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">473</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/legal/legal-page.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">173</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="contentPage.backAria" datatype="html">
         <source>Zurück zur vorherigen Seite</source>
         <target>Retour à la page précédente</target>

--- a/apps/frontend/src/locale/messages.it.xlf
+++ b/apps/frontend/src/locale/messages.it.xlf
@@ -6377,6 +6377,22 @@
           <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="contentPage.navigationBottomAria" datatype="html">
+        <source>Navigation am Seitenende</source>
+        <target>Navigazione a fine pagina</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">473</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/legal/legal-page.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">173</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="contentPage.backAria" datatype="html">
         <source>Zurück zur vorherigen Seite</source>
         <target>Torna alla pagina precedente</target>

--- a/apps/frontend/src/locale/messages.xlf
+++ b/apps/frontend/src/locale/messages.xlf
@@ -5615,6 +5615,21 @@
           <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="contentPage.navigationBottomAria" datatype="html">
+        <source>Navigation am Seitenende</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">473</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/legal/legal-page.component.html</context>
+          <context context-type="linenumber">64</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">173</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="contentPage.backAria" datatype="html">
         <source>Zurück zur vorherigen Seite</source>
         <context-group purpose="location">
@@ -5622,12 +5637,24 @@
           <context context-type="linenumber">24</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">480</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/legal/legal-page.component.html</context>
           <context context-type="linenumber">24</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/legal/legal-page.component.html</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">180</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>
@@ -5641,12 +5668,24 @@
           <context context-type="linenumber">27</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/help/help.component.html</context>
+          <context context-type="linenumber">483</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/legal/legal-page.component.html</context>
           <context context-type="linenumber">27</context>
         </context-group>
         <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/legal/legal-page.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+        <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
           <context context-type="linenumber">28</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/news-archive/news-archive-page.component.html</context>
+          <context context-type="linenumber">183</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/quiz/quiz-preview/quiz-preview.component.html</context>


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Auf den Footer-Content-Seiten (Hilfe, Legal, News-Archiv) ist der Ausstieg nach dem Scrollen nach unten schwer erkennbar: Backdrop/Escape greifen durch die A11y-Overlay-Navigation oft nicht intuitiv, und der „Zurück“-Link sitzt nur oben links.
- **Lösung:** Denselben „Zurück“-Button zusätzlich unten links anbieten, mit eigenem Landmark-Label „Navigation am Seitenende“.
- **Bewusste Nicht-Ziele:** Keine Änderung an Escape-/Backdrop-Logik oder Focus-Trap; kein zusätzlicher Schließen-Button oben rechts.

## Risiko und Verträge

- [x] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [ ] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

Content-Overlay-Seiten (`isContentOverlayPath`) mit bestehendem oberen Zurück-Button; Fokus-Initialisierung bleibt nur oben (`cdkFocusInitial`).

**Betroffene externe Verträge:**

Keine.

## Implementierung

- Zweiter Zurück-Button unten in `help`, `legal-page` und `news-archive-page`
- Landmark `@@contentPage.navigationBottomAria` in `de`/`en`/`fr`/`es`/`it`
- Unit-Tests für Vorhandensein und Klick-Verhalten

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [x] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [ ] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [ ] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| Pre-commit: eslint + prettier | bestanden |
| `npm run typecheck` (pre-commit) | bestanden |
| `npm test` (pre-commit) | bestanden (1577 Frontend-Tests) |
| gezielte Specs help/legal/news-archive | 37/37 bestanden |

## Risikobezogene Prüfungen

- [ ] Keine Benutzeroberflächenänderung oder mobile Darstellung geprüft
- [x] Keine relevante Änderung oder Tastatursteuerung und Fokusverhalten geprüft
- [x] Keine relevante Änderung oder Screenreader-Semantik geprüft
- [x] Keine relevante Änderung oder Reflow, Zoom und Kontrast geprüft
- [x] Keine Realtime-Änderung oder WebSocket-/Yjs-Szenarien geprüft
- [x] Keine Migrationsänderung oder Prisma-Migrationskette auf einer frischen
      Datenbank geprüft
- [x] Keine lastrelevante Änderung oder Last-/Performance-Budget geprüft
- [x] Keine Textänderung oder alle Locales (`de`, `en`, `fr`, `es`, `it`)
      synchronisiert
- [x] Keine Änderung externer Verträge oder Vertrag anhand einer maßgeblichen
      Spezifikation beziehungsweise eines Contract-Tests geprüft
- [x] Keine sicherheitsrelevante Änderung oder erlaubte und abgelehnte
      Sicherheitsgrenze getestet

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Zusätzlicher sichtbarer Ausstiegs-CTA auf Content-Overlay-Seiten.
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Regulärer Frontend-Deploy inkl. lokalisierter Builds.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Keine.
- **Rollback:** Vorherigen Frontend-Build ausrollen.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

- Pre-commit typecheck + vollständiger Testlauf grün
- Neue Unit-Tests für unteren Zurück-Button in help/legal/news-archive

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** `npm run build:prod` und volles `npm run lint` nicht separat ausgeführt; Pre-commit deckt Format/Lint der geänderten Dateien ab.
- **Verbleibende Risiken:** Sehr lange Seiten bleiben scrollbar; der untere Button ist erst am Ende sichtbar (bewusst).

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft

Made with [Cursor](https://cursor.com)