### PR TITLE
fix(backend): pg-Queries pro PoolClient in Transaktionen serialisieren

### DIFF
--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1,27 +1,72 @@
 /**
  * Prisma-Client-Singleton (Story 2.1a, 4.7).
  * Prisma 7: Client-Engine benötigt Driver-Adapter (@prisma/adapter-pg).
+ *
+ * Expliziter pg.Pool + Query-Serialisierung pro ausgechecktem Client:
+ * Prisma holt Relation-Joins in Transaktionen per Promise.all auf einem
+ * gepinnten PoolClient; paralleles client.query() ist in pg deprecated
+ * und wird in pg@9 zum Fehler.
  */
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
+import pg from 'pg';
+import { serializeQueriesOnClient } from './lib/serializePgClientQueries';
 
 const connectionString =
   process.env['DATABASE_URL'] ??
   'postgresql://arsnova_user:secretpassword@localhost:5432/arsnova_v3_dev?schema=public';
 
-const adapter = new PrismaPg({ connectionString });
-const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+function createPgPool(): pg.Pool {
+  const pool = new pg.Pool({ connectionString });
+  const originalConnect = pool.connect.bind(pool);
 
+  pool.connect = ((
+    callback?: (
+      err: Error | undefined,
+      client: pg.PoolClient | undefined,
+      done: (release?: unknown) => void,
+    ) => void,
+  ) => {
+    if (typeof callback === 'function') {
+      return originalConnect((err, client, done) => {
+        if (client) {
+          serializeQueriesOnClient(client);
+        }
+        callback(err, client, done);
+      });
+    }
+
+    return originalConnect().then((client) => serializeQueriesOnClient(client));
+  }) as typeof pool.connect;
+
+  return pool;
+}
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+  pgPool?: pg.Pool;
+};
+
+export const pgPool = globalForPrisma.pgPool ?? createPgPool();
+
+const adapter = new PrismaPg(pgPool);
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
     adapter,
-    log:
-      process.env['NODE_ENV'] === 'development'
-        ? ['query', 'error', 'warn']
-        : [], // In Production keine Prisma-Logs; Health-Stats fangen DB-Ausfall ab und liefern Fallback
+    log: process.env['NODE_ENV'] === 'development' ? ['query', 'error', 'warn'] : [], // In Production keine Prisma-Logs; Health-Stats fangen DB-Ausfall ab und liefern Fallback
   });
 
 if (process.env['NODE_ENV'] !== 'production') {
   globalForPrisma.prisma = prisma;
+  globalForPrisma.pgPool = pgPool;
+}
+
+export async function disconnectDatabase(): Promise<void> {
+  await prisma.$disconnect();
+  await pgPool.end();
+  if (process.env['NODE_ENV'] !== 'production') {
+    delete globalForPrisma.prisma;
+    delete globalForPrisma.pgPool;
+  }
 }

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -10,6 +10,7 @@ import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import { applyWSSHandler } from '@trpc/server/adapters/ws';
 import { appRouter } from './routers';
 import { getRedis, closeRedis } from './redis';
+import { disconnectDatabase } from './db';
 import { logger } from './lib/logger';
 import { shutdownAbuseTelemetry } from './lib/abuseTelemetry';
 import { shutdownPdfTelemetry } from './lib/pdfTelemetry';
@@ -233,6 +234,7 @@ async function shutdown(): Promise<void> {
     shutdownPdfTelemetry(),
   ]);
   await closeRedis();
+  await disconnectDatabase();
   process.exit(0);
 }
 

--- a/apps/backend/src/lib/serializePgClientQueries.test.ts
+++ b/apps/backend/src/lib/serializePgClientQueries.test.ts
@@ -42,4 +42,19 @@ describe('serializeQueriesOnClient', () => {
     await expect(fakeClient.query('select ok')).resolves.toEqual({ rows: [{ ok: true }] });
     expect(querySpy).toHaveBeenCalledTimes(2);
   });
+
+  it('wrappt denselben Client nur einmal (Pool-Wiederverwendung)', async () => {
+    const querySpy = vi.fn(async () => ({ rows: [] }));
+    const fakeClient = { query: querySpy } as unknown as pg.PoolClient;
+
+    serializeQueriesOnClient(fakeClient);
+    const wrappedOnce = fakeClient.query;
+    serializeQueriesOnClient(fakeClient);
+    serializeQueriesOnClient(fakeClient);
+
+    expect(fakeClient.query).toBe(wrappedOnce);
+
+    await Promise.all([fakeClient.query('a'), fakeClient.query('b')]);
+    expect(querySpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/backend/src/lib/serializePgClientQueries.test.ts
+++ b/apps/backend/src/lib/serializePgClientQueries.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import type pg from 'pg';
+import { serializeQueriesOnClient } from './serializePgClientQueries';
+
+describe('serializeQueriesOnClient', () => {
+  it('führt überlappende query()-Aufrufe strikt nacheinander aus', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const querySpy = vi.fn(async (sql: string) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return { rows: [{ sql }] };
+    });
+
+    const fakeClient = { query: querySpy } as unknown as pg.PoolClient;
+    serializeQueriesOnClient(fakeClient);
+
+    const results = await Promise.all([
+      fakeClient.query('select 1'),
+      fakeClient.query('select 2'),
+      fakeClient.query('select 3'),
+    ]);
+
+    expect(querySpy).toHaveBeenCalledTimes(3);
+    expect(maxInFlight).toBe(1);
+    expect(results.map((row) => row.rows[0]?.sql)).toEqual(['select 1', 'select 2', 'select 3']);
+  });
+
+  it('blockiert die Queue nicht, wenn eine Query fehlschlägt', async () => {
+    const querySpy = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ rows: [{ ok: true }] });
+
+    const fakeClient = { query: querySpy } as unknown as pg.PoolClient;
+    serializeQueriesOnClient(fakeClient);
+
+    await expect(fakeClient.query('select fail')).rejects.toThrow('boom');
+    await expect(fakeClient.query('select ok')).resolves.toEqual({ rows: [{ ok: true }] });
+    expect(querySpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/src/lib/serializePgClientQueries.ts
+++ b/apps/backend/src/lib/serializePgClientQueries.ts
@@ -3,14 +3,24 @@ import type pg from 'pg';
 type PgQueryArgs = Parameters<pg.PoolClient['query']>;
 type PgQueryResult = ReturnType<pg.PoolClient['query']>;
 
+const SERIALIZED_QUERY_FLAG = Symbol.for('arsnova.pg.serializeQueriesOnClient');
+
 /**
  * Stellt sicher, dass auf einem physischen Client höchstens eine Query
  * gleichzeitig aktiv ist. Pool-Level-Concurrency bleibt erhalten.
  *
  * Braucht es, weil Prisma in Transaktionen Relation-Joins per Promise.all
  * auf einem gepinnten PoolClient startet; pg warnt dabei und wirft ab pg@9.
+ *
+ * Idempotent: Pool-Clients werden wiederverwendet; wiederholte Aufrufe
+ * stapeln keinen weiteren Wrapper.
  */
 export function serializeQueriesOnClient<T extends pg.PoolClient>(client: T): T {
+  const flagged = client as T & { [SERIALIZED_QUERY_FLAG]?: true };
+  if (flagged[SERIALIZED_QUERY_FLAG]) {
+    return client;
+  }
+
   let tail: Promise<unknown> = Promise.resolve();
   const originalQuery = client.query.bind(client) as (...args: PgQueryArgs) => PgQueryResult;
 
@@ -27,5 +37,6 @@ export function serializeQueriesOnClient<T extends pg.PoolClient>(client: T): T 
     return run as unknown as PgQueryResult;
   }) as pg.PoolClient['query'];
 
+  flagged[SERIALIZED_QUERY_FLAG] = true;
   return client;
 }

--- a/apps/backend/src/lib/serializePgClientQueries.ts
+++ b/apps/backend/src/lib/serializePgClientQueries.ts
@@ -1,0 +1,31 @@
+import type pg from 'pg';
+
+type PgQueryArgs = Parameters<pg.PoolClient['query']>;
+type PgQueryResult = ReturnType<pg.PoolClient['query']>;
+
+/**
+ * Stellt sicher, dass auf einem physischen Client höchstens eine Query
+ * gleichzeitig aktiv ist. Pool-Level-Concurrency bleibt erhalten.
+ *
+ * Braucht es, weil Prisma in Transaktionen Relation-Joins per Promise.all
+ * auf einem gepinnten PoolClient startet; pg warnt dabei und wirft ab pg@9.
+ */
+export function serializeQueriesOnClient<T extends pg.PoolClient>(client: T): T {
+  let tail: Promise<unknown> = Promise.resolve();
+  const originalQuery = client.query.bind(client) as (...args: PgQueryArgs) => PgQueryResult;
+
+  client.query = ((...args: PgQueryArgs) => {
+    const run = tail.then(
+      () => originalQuery(...args),
+      () => originalQuery(...args),
+    );
+    // Fehler dürfen die Queue nicht blockieren; der Caller sieht sie weiter.
+    tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run as unknown as PgQueryResult;
+  }) as pg.PoolClient['query'];
+
+  return client;
+}


### PR DESCRIPTION
## Zusammenfassung

- **Problem:** Prisma/`@prisma/adapter-pg` startet in Transaktionen Relation-Joins per `Promise.all` auf einem gepinnten `PoolClient`. Paralleles `client.query()` ist in `pg` deprecated und wird in `pg@9` zum Fehler (`DeprecationWarning: Calling client.query() …`). Ein naiver Connect-Wrapper würde zudem bei Pool-Wiederverwendung Wrapper stapeln.
- **Lösung:** Expliziter `pg.Pool`; Queries werden pro ausgechecktem Client serialisiert (idempotent markiert). Sauberes `disconnectDatabase()` beim Shutdown.
- **Bewusste Nicht-Ziele:** Kein Wechsel des ORM; keine Schema-/Migrationsänderung; keine globale Serialisierung über den gesamten Pool.

## Risiko und Verträge

- [ ] Niedrig – Dokumentation, Texte oder isolierte Änderung ohne geändertes Verhalten
- [x] Mittel – Benutzeroberfläche, Anwendungslogik, Schema, Persistenz oder Konfiguration
- [ ] Hoch – Authentifizierung, Autorisierung, Tokens, WebSockets, Yjs, Redis,
      Datenbankmigrationen, Datenschutz, Deployment oder Sicherheitskonfiguration

**Maßgebliche Quelle und relevante Invarianten:**

`pg` erlaubt nicht mehrere gleichzeitige `query()`-Aufrufe auf demselben Client. Prisma-Transaktionen pinnen einen Client; Relation-Loads nutzen `Promise.all`. Pool-Clients werden wiederverwendet.

**Betroffene externe Verträge:**

`pg` Client-API / `@prisma/adapter-pg` Pool-Adapter. Keine öffentlichen API-Verträge.

## Implementierung

- `createPgPool()` mit Wrapper um `pool.connect`, der `serializeQueriesOnClient` anwendet
- Modul `serializePgClientQueries.ts` mit Queue pro Client und Symbol-Flag gegen Mehrfach-Wrap
- `disconnectDatabase()` schließt Prisma und den Pool
- Unit-Tests für Serialisierung, Fehler-Weitergabe und Idempotenz

## Verhaltens- und Abdeckungsprüfung

- [x] Gewünschtes Verhalten und maßgebliche Quelle wurden vor der Implementierung geklärt
- [x] Vergleichbare Implementierungen und betroffene Aufrufpfade wurden geprüft
- [x] Erfolgsfall wurde getestet
- [x] Ablehnungs-, Fehler- oder ungültiger Eingabepfad wurde getestet oder unter
      „Nicht zutreffend“ begründet
- [x] Ein Regressionstest bildet bei einer Fehlerbehebung den ursprünglichen
      Fehler ab
- [x] Relevante Zustandsübergänge wurden geprüft

### Relevante Zustandsübergänge

- [ ] Nicht zustandsbehaftete Änderung
- [ ] Wiederholung oder doppelte Anfrage
- [ ] Neuladen und Wiederherstellung
- [ ] Reconnect oder Verbindungsersetzung
- [ ] Token- oder Capability-Rotation
- [x] Ablauf und Bereinigung
- [ ] Migration oder Legacy-Daten
- [x] Parallelität oder Race Conditions
- [ ] Abhängigkeit vorübergehend nicht verfügbar
- [ ] Asynchroner Ablauf: Pending → Erfolg → Ablehnung/Timeout → Retry oder Abbruch
- [ ] DOM-Ersetzung: nach Erfolg und Fehler existiert ein sichtbares,
      nicht verdecktes und fachlich sinnvolles Fokusziel

Shutdown schließt Pool; parallele Queries auf einem Client werden strikt nacheinander ausgeführt; wiederholte Connects stapeln keinen Wrapper.

## Validierung

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] `npm run build:prod` bei Frontend-, i18n-, Build- oder Produktionsänderungen
- [x] Betroffene Unit-, Integrations- oder Contract-Tests ergänzt beziehungsweise aktualisiert

### Ausgeführte Prüfungen und Ergebnisse

| Prüfung/Befehl | Ergebnis |
| -------------- | -------- |
| `npm test -w @arsnova/backend -- src/lib/serializePgClientQueries.test.ts` | bestanden |
| `npm run typecheck -w @arsnova/backend` | bestanden (Pre-Commit / vorheriger Lauf) |
| Pre-commit: full typecheck + `npm test` | bestanden beim ersten Commit |

Lint läuft in CI.

## Risikobezogene Prüfungen

- [ ] Authentifizierung, Autorisierung und Token-Grenzen geprüft
- [ ] Rate-Limits und Shared-IP-/NAT-Verhalten geprüft
- [ ] WebSocket-/Yjs-Reconnect und Capability-Verlust geprüft
- [x] Persistenz, Migrationen oder Redis-Key-Kompatibilität geprüft
- [ ] Deployment-, Rollback- oder Operator-Auswirkung geprüft
- [ ] Accessibility (WCAG 2.2 AA) für geänderte UI geprüft
- [ ] i18n in `de`/`en`/`fr`/`es`/`it` synchron gehalten
- [ ] Mobile Layout und relevante Textlängen geprüft

### Nachweise

Nur Verbindungs-/Query-Pfad geändert; keine Redis-Keys oder Migrationen. Shutdown endet den Pool explizit. Idempotenz-Test deckt Pool-Wiederverwendung ab.

## Betrieb und Rollback

- **Auswirkung auf Produktion:** Behebt DeprecationWarning und bereitet `pg@9` vor; Query-Latenz in Transaktionen kann leicht serialisiert steigen (korrekte Semantik).
- **Erforderliche Konfigurations- oder Deployment-Schritte:** Keine.
- **Beobachtbarkeit beziehungsweise relevante Logs/Metriken:** Ausbleiben der `client.query()`-DeprecationWarning in Backend-Logs.
- **Rollback:** Revert dieses PR.

- [x] Keine neuen Secrets, Zugangsdaten, `.env`-Inhalte, Dumps oder lokalen
      Artefakte eingecheckt
- [x] `.env.production.example`, Deployment-Dateien und Betriebsdokumentation
      sind aktuell oder nicht betroffen
- [x] Shared-NAT-Betrieb und mindestens 500 gleichzeitige Hörsaal-Clients sind
      nicht betroffen oder wurden berücksichtigt

## Nachweise

Unit-Tests in `serializePgClientQueries.test.ts`; CI auf dem Branch.

## Nicht zutreffend und verbleibende Risiken

- **Nicht zutreffende Prüfungen:** UI/i18n/a11y, Rate-Limits, Tokens, WebSocket/Yjs; `npm run lint` lokal (CI).
- **Verbleibende Risiken:** Wenn der Adapter Clients ohne `pool.connect` nutzt, greift der Wrapper nicht. Keine weiteren bekannt.

## Selbstreview

- [x] Der vollständige Diff wurde unabhängig noch einmal geprüft
- [x] Aufgabenstellung und Akzeptanzkriterien wurden erneut mit dem Ergebnis verglichen
- [x] Code, Tests, Schemas, Dokumentation, Konfiguration, Übersetzungen und
      PR-Beschreibung widersprechen sich nicht
- [x] Vergleichbare Pfade enthalten den behobenen Fehler nicht weiterhin
- [x] Temporärer Code, Debug-Ausgaben und überholte Kommentare wurden entfernt
- [x] Sicherheits-, Barrierefreiheits-, Kompatibilitäts- und
      Performanceaussagen sind durch Nachweise gedeckt
- [x] Der PR ist vollständig und bereit für ein Review
- [x] Keine asynchrone UI-Änderung oder Erfolg, Pending, Fehler und Fokus wurden
      anhand des tatsächlichen DOM-Ablaufs geprüft